### PR TITLE
Implement Dynamic Label Scaling And MessagEase-Style Hint Priority

### DIFF
--- a/wurstfinger.xcodeproj/xcuserdata/claas.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/wurstfinger.xcodeproj/xcuserdata/claas.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Wurstfinger.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>WurstfingerApp.xcscheme_^#shared#^_</key>
 		<dict>

--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -126,6 +126,16 @@ struct KeyboardRootView: View {
         .offset(x: horizontalOffset)
     }
 
+    private func scaledMainLabelSize(for keyHeight: CGFloat) -> CGFloat {
+        // Base size at reference height of 54pt
+        let baseSize: CGFloat = 26
+        let referenceHeight: CGFloat = 54
+
+        // Scale proportionally with key height
+        let scaledSize = baseSize * (keyHeight / referenceHeight)
+        return min(max(scaledSize, 20), 34) // min 20pt, max 34pt
+    }
+
     @ViewBuilder
     private func keyCells(forRow index: Int, keyHeight: CGFloat) -> some View {
         if index < viewModel.rows.count {
@@ -133,8 +143,8 @@ struct KeyboardRootView: View {
                 KeyboardButton(
                     height: keyHeight,
                     label: Text(viewModel.displayText(for: key)),
-                    overlay: KeyHintOverlay(key: key, viewModel: viewModel),
-                    config: KeyboardButtonConfig(fontSize: KeyboardConstants.FontSizes.keyLabel),
+                    overlay: KeyHintOverlay(key: key, viewModel: viewModel, keyHeight: keyHeight),
+                    config: KeyboardButtonConfig(fontSize: scaledMainLabelSize(for: keyHeight)),
                     callbacks: KeyboardButtonCallbacks(
                         onSwipe: { viewModel.handleKeySwipe(key, direction: $0) },
                         onSwipeReturn: { viewModel.handleKeySwipeReturn(key, direction: $0) },
@@ -530,18 +540,46 @@ private struct DeleteKeyButton: View {
 private struct KeyHintOverlay: View {
     let key: MessagEaseKey
     @ObservedObject var viewModel: KeyboardViewModel
+    let keyHeight: CGFloat
 
     private let directions: [KeyboardDirection] = KeyboardDirection.allCases.filter { $0 != .center }
+
+    // Calculate dynamic font size based on available space
+    private var hintFontSize: CGFloat {
+        // Base size at reference height of 54pt (default)
+        let baseSize: CGFloat = 14
+        let referenceHeight: CGFloat = 54
+
+        // Scale proportionally with key height, but apply min/max bounds
+        let scaledSize = baseSize * (keyHeight / referenceHeight)
+        return min(max(scaledSize, 10), 22) // min 10pt, max 22pt
+    }
+
+    private var hintEmphasisSize: CGFloat {
+        return hintFontSize * 1.1 // 10% larger for emphasis
+    }
 
     var body: some View {
         GeometryReader { proxy in
             let size = proxy.size
+            // Scale padding proportionally with font size
+            let baseHorizontalPadding: CGFloat = 2
+            let baseVerticalPadding: CGFloat = 0.5  // Tighter for top/bottom
+            let referenceFontSize: CGFloat = 10
+            let scaledHorizontalPadding = baseHorizontalPadding * (hintFontSize / referenceFontSize)
+            let scaledVerticalPadding = baseVerticalPadding * (hintFontSize / referenceFontSize)
+
             ForEach(directions, id: \.self) { direction in
                 if let label = key.primaryLabel(for: direction, isCapsLock: viewModel.isCapsLockActive) {
                     // Hide down icon on r-key when not in caps mode
                     if shouldShowLabel(for: direction) {
-                        hintText(label, emphasis: false)
-                            .position(position(for: direction, returning: false, in: size))
+                        let displayLabel = transformLabel(label, activeLayer: viewModel.activeLayer)
+                        hintText(displayLabel, isLetter: isLetter(displayLabel))
+                            .fixedSize()
+                            .padding(edgePadding(for: direction,
+                                                horizontal: scaledHorizontalPadding,
+                                                vertical: scaledVerticalPadding))
+                            .frame(width: size.width, height: size.height, alignment: alignment(for: direction))
                     }
                 }
             }
@@ -557,40 +595,99 @@ private struct KeyHintOverlay: View {
         return true
     }
 
-    private func hintText(_ text: String, emphasis: Bool) -> some View {
-        Text(text)
-            .font(.system(size: emphasis ? KeyboardConstants.FontSizes.hintEmphasis : KeyboardConstants.FontSizes.hintNormal,
-                         weight: emphasis ? .semibold : .medium, design: .rounded))
-            .foregroundStyle(emphasis ? Color.primary.opacity(0.85) : Color.secondary.opacity(0.8))
+    private func transformLabel(_ label: String, activeLayer: KeyboardLayer) -> String {
+        // Transform label based on active layer (for shift/caps)
+        guard isLetter(label) else { return label }
+
+        switch activeLayer {
+        case .upper:
+            return label.uppercased()
+        case .lower:
+            return label.lowercased()
+        case .numbers, .symbols:
+            return label
+        }
+    }
+
+    private func isLetter(_ text: String) -> Bool {
+        // Check if the text is a letter (any alphabet, including non-Latin scripts)
+        guard let firstChar = text.first else { return false }
+        return firstChar.isLetter
+    }
+
+    private func hintText(_ text: String, isLetter: Bool) -> some View {
+        // Three-tier color system similar to MessagEase:
+        // 1. Center character (not shown here): primary color (highest priority)
+        // 2. Letter hints: medium priority - between primary and secondary
+        // 3. Symbol hints: lowest priority - more muted
+
+        let color: Color
+        let opacity: CGFloat
+        let weight: Font.Weight
+
+        if isLetter {
+            // Letters: medium priority, blend between primary and secondary
+            color = Color.primary
+            opacity = 0.65
+            weight = .medium
+        } else {
+            // Symbols: lower priority, more muted
+            color = Color.secondary
+            opacity = 0.55
+            weight = .regular
+        }
+
+        return Text(text)
+            .font(.system(size: hintFontSize, weight: weight, design: .rounded))
+            .foregroundStyle(color.opacity(opacity))
             .minimumScaleFactor(0.6)
             .lineLimit(1)
             .allowsHitTesting(false)
     }
 
-    private func position(for direction: KeyboardDirection, returning: Bool, in size: CGSize) -> CGPoint {
-        let width = size.width
-        let height = size.height
-        let margin: CGFloat = returning ? KeyboardConstants.Layout.hintMarginReturning : KeyboardConstants.Layout.hintMargin
-
+    private func edgePadding(for direction: KeyboardDirection, horizontal: CGFloat, vertical: CGFloat) -> EdgeInsets {
         switch direction {
         case .up:
-            return CGPoint(x: width / 2, y: margin)
+            return EdgeInsets(top: vertical, leading: 0, bottom: 0, trailing: 0)
         case .down:
-            return CGPoint(x: width / 2, y: height - margin)
+            return EdgeInsets(top: 0, leading: 0, bottom: vertical, trailing: 0)
         case .left:
-            return CGPoint(x: margin, y: height / 2)
+            return EdgeInsets(top: 0, leading: horizontal, bottom: 0, trailing: 0)
         case .right:
-            return CGPoint(x: width - margin, y: height / 2)
+            return EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: horizontal)
         case .upLeft:
-            return CGPoint(x: margin, y: margin)
+            return EdgeInsets(top: vertical, leading: horizontal, bottom: 0, trailing: 0)
         case .upRight:
-            return CGPoint(x: width - margin, y: margin)
+            return EdgeInsets(top: vertical, leading: 0, bottom: 0, trailing: horizontal)
         case .downLeft:
-            return CGPoint(x: margin, y: height - margin)
+            return EdgeInsets(top: 0, leading: horizontal, bottom: vertical, trailing: 0)
         case .downRight:
-            return CGPoint(x: width - margin, y: height - margin)
+            return EdgeInsets(top: 0, leading: 0, bottom: vertical, trailing: horizontal)
         case .center:
-            return CGPoint(x: width / 2, y: height / 2)
+            return EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+        }
+    }
+
+    private func alignment(for direction: KeyboardDirection) -> Alignment {
+        switch direction {
+        case .up:
+            return .top
+        case .down:
+            return .bottom
+        case .left:
+            return .leading
+        case .right:
+            return .trailing
+        case .upLeft:
+            return .topLeading
+        case .upRight:
+            return .topTrailing
+        case .downLeft:
+            return .bottomLeading
+        case .downRight:
+            return .bottomTrailing
+        case .center:
+            return .center
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds adaptive font sizing for keyboard labels that scales with aspect ratio, plus MessagEase-style visual hierarchy for hints.

## Changes

### Dynamic Scaling
- **Main labels**: Scale from 20pt to 34pt (base: 26pt)
- **Hint labels**: Scale from 10pt to 22pt (base: 14pt)
- Both scale proportionally with key height based on aspect ratio setting

### Visual Hierarchy (MessagEase-style)
Three-tier priority system for better readability:
1. **Center characters**: Primary color - highest priority
2. **Letter hints**: `primary.opacity(0.65)` + medium weight - medium priority  
3. **Symbol hints**: `secondary.opacity(0.55)` + regular weight - lower priority

### Benefits
- ✅ Better readability across all aspect ratios
- ✅ Letters visually stand out from symbols
- ✅ Proportional scaling maintains balance
- ✅ Language-agnostic (works for Hebrew, Arabic, etc.)

## Technical Details
- Uses `Character.isLetter` for letter detection
- Scales based on `keyHeight` which varies with aspect ratio
- Min/max bounds prevent labels from becoming too small or too large

## Test Plan
- [x] Build succeeds
- [x] All existing tests pass
- [ ] Test with different aspect ratios
- [ ] Verify readability on device