### PR TITLE
Remove Space Key Text Selection Mode

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -25,12 +25,18 @@ jobs:
       - name: Install xcpretty
         run: gem install xcpretty
 
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+
+      - name: List available simulators
+        run: xcrun simctl list devices available
+
       - name: Build and Run Tests
         run: |
           set -o pipefail && xcodebuild test \
             -scheme Wurstfinger \
             -project Wurstfinger.xcodeproj \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,name=iPhone 15' \
             -only-testing:WurstfingerTests \
             -resultBundlePath TestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO \

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -25,18 +25,12 @@ jobs:
       - name: Install xcpretty
         run: gem install xcpretty
 
-      - name: Select Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
-
-      - name: List available simulators
-        run: xcrun simctl list devices available
-
       - name: Build and Run Tests
         run: |
           set -o pipefail && xcodebuild test \
             -scheme Wurstfinger \
             -project Wurstfinger.xcodeproj \
-            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
             -only-testing:WurstfingerTests \
             -resultBundlePath TestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO \

--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -24,7 +24,12 @@ struct KeyboardRootView: View {
         let availableSpace = screenWidth * (1 - viewModel.keyboardScale)
         let horizontalOffset = availableSpace * (viewModel.keyboardHorizontalPosition - 0.5)
 
-        Grid(horizontalSpacing: KeyboardConstants.Layout.gridHorizontalSpacing,
+        ZStack {
+            // Background layer that always fills the entire space
+            Color(.systemBackground)
+                .ignoresSafeArea()
+
+            Grid(horizontalSpacing: KeyboardConstants.Layout.gridHorizontalSpacing,
              verticalSpacing: KeyboardConstants.Layout.gridVerticalSpacing) {
                 GridRow {
                 if viewModel.utilityColumnLeading {
@@ -117,13 +122,23 @@ struct KeyboardRootView: View {
                     )
                 }
             }
+            }
+            .padding(.horizontal, KeyboardConstants.Layout.horizontalPadding)
+            .padding(.vertical, KeyboardConstants.Layout.verticalPadding)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: frameAlignment)
+            .scaleEffect(viewModel.keyboardScale, anchor: scaleAnchor)
+            .offset(x: horizontalOffset)
         }
-        .padding(.horizontal, KeyboardConstants.Layout.horizontalPadding)
-        .padding(.vertical, KeyboardConstants.Layout.verticalPadding)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: frameAlignment)
-        .background(Color(.systemBackground))
-        .scaleEffect(viewModel.keyboardScale, anchor: scaleAnchor)
-        .offset(x: horizontalOffset)
+    }
+
+    private func scaledMainLabelSize(for keyHeight: CGFloat) -> CGFloat {
+        // Base size at reference height of 54pt
+        let baseSize: CGFloat = 26
+        let referenceHeight: CGFloat = 54
+
+        // Scale proportionally with key height
+        let scaledSize = baseSize * (keyHeight / referenceHeight)
+        return min(max(scaledSize, 20), 34) // min 20pt, max 34pt
     }
 
     private func scaledMainLabelSize(for keyHeight: CGFloat) -> CGFloat {

--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -141,16 +141,6 @@ struct KeyboardRootView: View {
         return min(max(scaledSize, 20), 34) // min 20pt, max 34pt
     }
 
-    private func scaledMainLabelSize(for keyHeight: CGFloat) -> CGFloat {
-        // Base size at reference height of 54pt
-        let baseSize: CGFloat = 26
-        let referenceHeight: CGFloat = 54
-
-        // Scale proportionally with key height
-        let scaledSize = baseSize * (keyHeight / referenceHeight)
-        return min(max(scaledSize, 20), 34) // min 20pt, max 34pt
-    }
-
     @ViewBuilder
     private func keyCells(forRow index: Int, keyHeight: CGFloat) -> some View {
         if index < viewModel.rows.count {

--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -354,7 +354,6 @@ private struct SpaceKeyButton: View {
     @State private var isActive = false
     @State private var dragStarted = false
     @State private var hasDragged = false
-    @State private var isSelecting = false
     @State private var lastTranslation: CGSize = .zero
 
     var body: some View {
@@ -375,18 +374,11 @@ private struct SpaceKeyButton: View {
                     }
 
                     let deltaX = value.translation.width - lastTranslation.width
-
-                    if !isSelecting, abs(value.translation.height) >= KeyboardConstants.SpaceGestures.selectionActivationThreshold {
-                        isSelecting = true
-                        hasDragged = true
-                        viewModel.beginSpaceSelection()
-                    }
-
                     viewModel.updateSpaceDrag(deltaX: deltaX)
 
                     lastTranslation = value.translation
 
-                    if !hasDragged, !isSelecting, abs(value.translation.width) >= KeyboardConstants.SpaceGestures.dragActivationThreshold {
+                    if !hasDragged, abs(value.translation.width) >= KeyboardConstants.SpaceGestures.dragActivationThreshold {
                         hasDragged = true
                     }
 
@@ -397,7 +389,7 @@ private struct SpaceKeyButton: View {
                         viewModel.endSpaceDrag()
                     }
 
-                    if !hasDragged, !isSelecting {
+                    if !hasDragged {
                         viewModel.handleSpace()
                     }
 
@@ -410,7 +402,6 @@ private struct SpaceKeyButton: View {
         isActive = false
         dragStarted = false
         hasDragged = false
-        isSelecting = false
         lastTranslation = .zero
     }
 }

--- a/wurstfingerTests/wurstfingerTests.swift
+++ b/wurstfingerTests/wurstfingerTests.swift
@@ -134,33 +134,6 @@ struct wurstfingerTests {
         #expect(moves == [1, 1, -1, -1])
     }
 
-    @Test func spaceSelectionEmitsSelectionActions() async throws {
-        let viewModel = KeyboardViewModel()
-        var sequence: [String] = []
-
-        viewModel.bindActionHandler { action in
-            switch action {
-            case .startSelection:
-                sequence.append("start")
-            case .updateSelection(let offset):
-                sequence.append("update:\(offset)")
-            case .endSelection:
-                sequence.append("end")
-            default:
-                break
-            }
-        }
-
-        viewModel.beginSpaceDrag()
-        viewModel.beginSpaceSelection()
-        viewModel.updateSpaceDrag(deltaX: 20)
-        viewModel.updateSpaceDrag(deltaX: 20)
-        viewModel.updateSpaceDrag(deltaX: -40)
-        viewModel.endSpaceDrag()
-
-        #expect(sequence == ["start", "update:1", "update:1", "update:-1", "update:-1", "end"])
-    }
-
     @Test func deleteDragEmitsRepeatedDeletes() async throws {
         let viewModel = KeyboardViewModel()
         var deletes = 0


### PR DESCRIPTION
## Summary
- Removes non-functional text selection mode from space key (vertical swipe)
- Space key now only handles horizontal swipe for cursor movement
- Simplifies gesture handling and removes ~120 lines of unused code

## Changes
- Remove selection state and gesture handling from `SpaceKeyButton`
- Remove `KeyboardAction` cases for selection (startSelection, updateSelection, endSelection)
- Remove selection state variables from `KeyboardViewModel` (isSpaceSelecting, spaceSelectionResidual)
- Remove selection handler functions from `KeyboardViewController` (beginSelection, updateSelection, endSelection, applySelection)
- Simplify space drag functions to only handle cursor movement

## Test Plan
- [ ] Build and run keyboard extension
- [ ] Test space key tap inserts space
- [ ] Test horizontal swipe on space key moves cursor left/right
- [ ] Verify no crashes or unexpected behavior