### PR TITLE
Persist Onboarding Toggle States

### DIFF
--- a/wurstfinger/OnboardingView.swift
+++ b/wurstfinger/OnboardingView.swift
@@ -33,16 +33,18 @@ struct OnboardingView: View {
                         isCompleted: $keyboardInstalled
                     )
 
-                    HStack {
-                        Spacer()
-                        Button("Open Settings", systemImage: "gear") {
-                            openURL(settingsURL)
+                    Button {
+                        openURL(settingsURL)
+                    } label: {
+                        HStack {
+                            Image(systemName: "gear")
+                            Text("Open Settings")
                         }
-                        .buttonStyle(.borderedProminent)
-                        .tint(.accentColor)
-                        Spacer()
+                        .frame(maxWidth: .infinity)
                     }
-                    .listRowInsets(EdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0))
+                    .buttonStyle(.borderedProminent)
+                    .tint(.accentColor)
+                    .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
 
                     SetupStepView(
                         number: 2,


### PR DESCRIPTION
## Summary
- Replaces @State with @AppStorage for onboarding toggle persistence
- Setup assistant progress now persists across app launches
- Uses shared App Group UserDefaults for consistency with other settings

## Changes
- Replace `@State` with `@AppStorage` for three onboarding toggles:
  - `keyboardInstalled`
  - `fullAccessEnabled`
  - `practiced`
- Use App Group UserDefaults (`group.de.akator.wurstfinger.shared`)
- Add persistent keys: `onboarding.keyboardInstalled`, `onboarding.fullAccessEnabled`, `onboarding.practiced`

## Behavior
Previously, toggle states were lost when the app was closed. Now, when users mark a setup step as complete, the state persists and will still show as complete when they reopen the app.

## Test Plan
- [ ] Build and run the app
- [ ] Toggle setup steps in onboarding view
- [ ] Close and reopen the app
- [ ] Verify toggle states persist