### PR TITLE
Add numpad style switcher with phone and classic layouts

### DIFF
--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -31,6 +31,9 @@ struct SettingsView: View {
     @AppStorage(KeyboardViewModel.hapticDragIntensityKey, store: UserDefaults(suiteName: "group.de.akator.wurstfinger.shared"))
     private var hapticDragIntensity = Double(KeyboardViewModel.defaultDragIntensity)
 
+    @AppStorage(KeyboardViewModel.numpadStyleKey, store: UserDefaults(suiteName: "group.de.akator.wurstfinger.shared"))
+    private var numpadStyleRaw = NumpadStyle.phone.rawValue
+
     private let licenseURL = URL(string: "https://github.com/cl445/wurstfinger/blob/main/LICENSE")!
 
     var body: some View {
@@ -54,6 +57,20 @@ struct SettingsView: View {
                                 .font(.body)
 
                             Text("Places globe, symbols, delete and return on the left")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+
+                    Picker(selection: $numpadStyleRaw) {
+                        Text("Phone (1-2-3)").tag(NumpadStyle.phone.rawValue)
+                        Text("Classic (7-8-9)").tag(NumpadStyle.classic.rawValue)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Numpad Style")
+                                .font(.body)
+
+                            Text(numpadStyleDescription)
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                         }
@@ -131,6 +148,16 @@ struct SettingsView: View {
                 }
             }
             .navigationTitle("Settings")
+        }
+    }
+
+    private var numpadStyleDescription: String {
+        let style = NumpadStyle(rawValue: numpadStyleRaw) ?? .phone
+        switch style {
+        case .phone:
+            return "Phone layout with numbers starting at 1-2-3 on top"
+        case .classic:
+            return "Classic calculator layout with 7-8-9 on top"
         }
     }
 

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -46,6 +46,7 @@ final class KeyboardViewModel: ObservableObject {
     static let hapticTapIntensityKey = "hapticIntensityTap"
     static let hapticModifierIntensityKey = "hapticIntensityModifier"
     static let hapticDragIntensityKey = "hapticIntensityDrag"
+    static let numpadStyleKey = "numpadStyle"
     static let defaultTapIntensity: CGFloat = 0.5
     static let defaultModifierIntensity: CGFloat = 0.5
     static let defaultDragIntensity: CGFloat = 0.5
@@ -149,7 +150,10 @@ final class KeyboardViewModel: ObservableObject {
             self.locale = Locale(identifier: "de_DE")
         } else {
             let selectedLanguage = LanguageSettings.shared.selectedLanguage
-            self.layout = KeyboardLayout.layout(for: selectedLanguage)
+            // Read numpad style from UserDefaults (default to phone style)
+            let numpadStyleRaw = defaults.string(forKey: Self.numpadStyleKey) ?? NumpadStyle.phone.rawValue
+            let numpadStyle = NumpadStyle(rawValue: numpadStyleRaw) ?? .phone
+            self.layout = KeyboardLayout.layout(for: selectedLanguage, numpadStyle: numpadStyle)
             self.locale = selectedLanguage.locale
         }
 
@@ -261,7 +265,10 @@ final class KeyboardViewModel: ObservableObject {
             objectWillChange.send()
 
             if let newLanguage = LanguageConfig.language(withId: languageId) {
-                layout = KeyboardLayout.layout(for: newLanguage)
+                // Read numpad style from UserDefaults (default to phone style)
+                let numpadStyleRaw = sharedDefaults.string(forKey: Self.numpadStyleKey) ?? NumpadStyle.phone.rawValue
+                let numpadStyle = NumpadStyle(rawValue: numpadStyleRaw) ?? .phone
+                layout = KeyboardLayout.layout(for: newLanguage, numpadStyle: numpadStyle)
                 locale = newLanguage.locale
                 // Reset to lower layer when language changes
                 activeLayer = .lower

--- a/wurstfingerTests/wurstfingerTests.swift
+++ b/wurstfingerTests/wurstfingerTests.swift
@@ -42,7 +42,7 @@ struct wurstfingerTests {
         #expect(rows.count == 4)
 
         let firstKey = try #require(rows.first?.first)
-        #expect(firstKey.center == "7")
+        #expect(firstKey.center == "1")
 
         let zeroKey = try #require(rows[3].first)
         #expect(zeroKey.center == "0")
@@ -88,15 +88,15 @@ struct wurstfingerTests {
 
         viewModel.toggleSymbols()
 
-        let sevenKey = try #require(viewModel.rows.first?.first)
-        viewModel.handleKeyTap(sevenKey)
+        let oneKey = try #require(viewModel.rows.first?.first)
+        viewModel.handleKeyTap(oneKey)
 
         #expect(viewModel.rows.count == 4)
 
         let zeroKey = try #require(viewModel.rows[3].first)
         viewModel.handleKeyTap(zeroKey)
 
-        #expect(inserted == ["7", "0"])
+        #expect(inserted == ["1", "0"])
     }
 
     @Test(.disabled("Requires UI context - to be fixed later"))


### PR DESCRIPTION
## Summary

Implements a MessagEase-compatible feature allowing users to switch between two numpad layouts:
- **Phone style** (1-2-3 on top) - now the default
- **Classic calculator style** (7-8-9 on top)

## Changes

### KeyboardLayout.swift
- Added `NumpadStyle` enum with `.phone` and `.classic` cases
- Modified `createNumberRows()` to swap center numbers and circular gestures based on style
- Created `swapCenterAndCircular()` helper function
- Swipe gestures remain at their physical positions (only center numbers and circular gestures move)

### KeyboardViewModel.swift
- Added `numpadStyleKey` constant for UserDefaults persistence
- Updated `init()` to read numpad style from UserDefaults (defaults to `.phone`)
- Updated `reloadLanguage()` to respect numpad style when rebuilding layout

### SettingsView.swift
- Added numpad style picker in Layout section
- Shows current selection with descriptive text
- Two options: "Phone (1-2-3)" and "Classic (7-8-9)"

### wurstfingerTests.swift
- Updated tests to expect phone layout as default
- Changed expected first key from "7" to "1"

## Test Plan

- [x] Build succeeds
- [x] All unit tests pass
- [x] Phone layout shows 1-2-3 on top row by default
- [x] Classic layout shows 7-8-9 on top row when selected
- [x] Circular gestures (¹, ², ³, etc.) move with their numbers
- [x] Swipe gestures stay at physical positions
- [x] Setting persists in UserDefaults
- [x] Settings UI shows both options correctly

## Screenshots

The numpad style picker is located in Settings → Layout section.