### PR TITLE
Add public TestFlight beta configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@ layout to Apple devices, including circular gestures for uppercase letters,
 return swipes for typographic punctuation, and compose rules to generate
 accented characters.
 
+## Join the Beta
+
+Want to try Wurstfinger before the official release? Join our public TestFlight beta!
+
+[![Join TestFlight Beta](https://img.shields.io/badge/TestFlight-Join%20Beta-blue?logo=apple&logoColor=white)](https://testflight.apple.com/join/trX4rBPf)
+
+**Beta Features:**
+- Nightly builds with the latest features from the `develop` branch
+- Help shape the keyboard with your feedback
+- Early access to experimental features
+
+**Requirements:**
+- iOS 17.0 or later
+- TestFlight app ([free download from App Store](https://apps.apple.com/app/testflight/id899247664))
+
+**Note:** Beta builds are automatically generated every night at 2 AM UTC when there are new changes. The first build after joining may take 1-2 hours for Apple's beta review process.
+
 ## Preview
 
 <table>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -89,7 +89,7 @@ platform :ios do
     begin
       upload_to_testflight(
         api_key: api_key,
-        groups: ["Internal"],
+        groups: ["Internal", "Public Beta"],
         distribute_external: true,
         submit_beta_review: true,
         uses_non_exempt_encryption: false,


### PR DESCRIPTION
## Summary

Configures public TestFlight beta distribution for Wurstfinger:

- Adds prominent "Join the Beta" section to README with TestFlight join link
- Updates Fastlane configuration to automatically distribute nightly builds to "Public Beta" group
- Documents beta features, requirements, and review timing expectations

## Changes

### README.md
- Added new "Join the Beta" section after the preview section
- Included TestFlight badge with join link: https://testflight.apple.com/join/trX4rBPf
- Listed beta features (nightly builds, feedback, early access)
- Added iOS 17.0+ requirement
- Noted timing expectations for beta builds and Apple review process

### fastlane/Fastfile
- Updated `upload_to_testflight` groups parameter to include "Public Beta" alongside "Internal"
- This ensures all nightly builds from develop branch are automatically distributed to public beta testers

## Setup Required

After merging, one manual step is needed in App Store Connect:
1. Go to the first build in TestFlight
2. Manually add "Public Beta" to the list of groups for that build
3. All subsequent builds will automatically distribute to "Public Beta"

This is a one-time setup limitation of the TestFlight API.

## Test Plan

- [x] Verified Fastlane syntax is correct
- [x] Confirmed README renders properly with badge and link
- [ ] After merge: Test that nightly builds auto-distribute to Public Beta group (after initial manual setup)