### PR TITLE
Fix: Make screenshot generation script robust for CI

### DIFF
--- a/scripts/generate-screenshots.sh
+++ b/scripts/generate-screenshots.sh
@@ -23,7 +23,7 @@ cd "$PROJECT_ROOT"
 
 # Configuration
 SCHEME="Wurstfinger"
-DESTINATION="platform=iOS Simulator,name=iPhone 16,OS=18.6"
+DESTINATION="platform=iOS Simulator,name=iPhone 16"
 TEST_TARGET="WurstfingerUITests/ScreenshotTests"
 DOCS_DIR="$PROJECT_ROOT/docs/images"
 DERIVED_DATA="/tmp/WurstfingerScreenshots"
@@ -45,7 +45,7 @@ xcodebuild test \
   -only-testing:"$TEST_TARGET" \
   -derivedDataPath "$DERIVED_DATA" \
   CODE_SIGNING_ALLOWED=NO \
-  | xcpretty --color || true
+  | if command -v xcpretty >/dev/null; then xcpretty --color; else cat; fi || true
 
 echo ""
 echo -e "${BLUE}📤 Exporting screenshots...${NC}"


### PR DESCRIPTION
This PR fixes the screenshot generation script to be more robust in CI environments.

### Changes
- **Generic Destination**: Removed the specific OS version (`OS=18.6`) from the simulator destination. This allows the script to run on any runner with an iPhone 16 simulator, regardless of the exact OS version.
- **Conditional xcpretty**: Added a check for `xcpretty` availability. If it's missing (which can happen in some CI environments), the script will fall back to raw output instead of failing.