### PR TITLE
Fix: Add scripts and workflow file to trigger paths

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - 'wurstfinger/**/*.swift'
       - 'wurstfingerKeyboard/**/*.swift'
+      - 'scripts/**'
+      - '.github/workflows/update-screenshots.yml'
 
 jobs:
   update-screenshots:


### PR DESCRIPTION
This PR updates the workflow configuration to ensure the screenshot automation runs when:
- Scripts in `scripts/` are modified.
- The workflow file itself is modified.

Previously, the workflow only triggered on changes to Swift files, causing it to skip runs when only the automation scripts were updated.