### PR TITLE
Fix: Dynamically detect available iPhone simulator

### DIFF
--- a/scripts/generate-screenshots.sh
+++ b/scripts/generate-screenshots.sh
@@ -23,7 +23,17 @@ cd "$PROJECT_ROOT"
 
 # Configuration
 SCHEME="Wurstfinger"
-DESTINATION="platform=iOS Simulator,name=iPhone 16"
+# Detect available iPhone simulator
+DEVICE_NAME=$(xcrun simctl list devices available | grep "iPhone" | grep -v "SE" | head -n 1 | sed 's/    //g' | sed 's/ (.*//g' | xargs)
+
+if [ -z "$DEVICE_NAME" ]; then
+    DEVICE_NAME="iPhone 16"
+    echo "⚠️  Could not detect available simulator, falling back to $DEVICE_NAME"
+else
+    echo "📱 Detected simulator: $DEVICE_NAME"
+fi
+
+DESTINATION="platform=iOS Simulator,name=$DEVICE_NAME"
 TEST_TARGET="WurstfingerUITests/ScreenshotTests"
 DOCS_DIR="$PROJECT_ROOT/docs/images"
 DERIVED_DATA="/tmp/WurstfingerScreenshots"


### PR DESCRIPTION
This PR improves the screenshot generation script by dynamically detecting the first available iPhone simulator instead of using a hardcoded device name.

### Changes
- **Dynamic Detection**: Uses `xcrun simctl list devices available` to find an iPhone simulator.
- **Robustness**: Works on both local machines (e.g., with iPhone 17) and CI runners (e.g., with iPhone 15/16), preventing failures due to missing simulators.
- **Fallback**: Defaults to 'iPhone 16' if detection fails.