### PR TITLE
Fix: Use Python virtual environment in CI

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -22,11 +22,15 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3 -m pip install --upgrade pip
-          pip3 install Pillow numpy
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install --upgrade pip
+          pip install Pillow numpy
 
       - name: Generate screenshots
-        run: ./scripts/generate-screenshots.sh
+        run: |
+          source venv/bin/activate
+          ./scripts/generate-screenshots.sh
         timeout-minutes: 15
 
       - name: Check for screenshot changes


### PR DESCRIPTION
This PR updates the screenshot automation workflow to use a Python virtual environment.

### Changes
- **Virtual Environment**: Creates and activates a `venv` for installing Python dependencies.
- **PEP 668 Compliance**: Resolves the 'externally-managed-environment' error on the `macos-latest` runner by avoiding system-wide package installation.

This ensures the workflow runs correctly on GitHub Actions runners that enforce PEP 668.