### PR TITLE
Fix: Improve screenshot workflow robustness

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -38,8 +38,13 @@ jobs:
 
       - name: Boot iOS Simulator
         run: |
-          DEVICE=$(xcrun simctl list devices available | grep "iPhone" | grep -v "SE" | head -n 1 | sed 's/.*(\([^)]*\)).*/\1/' | head -n 1)
-          xcrun simctl boot "$DEVICE" 2>/dev/null || true
+          # Get device UDID
+          DEVICE_UDID=$(xcrun simctl list devices available | grep "iPhone 16 Pro" | head -n 1 | grep -oE '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}')
+          echo "Booting simulator: $DEVICE_UDID"
+          xcrun simctl boot "$DEVICE_UDID" 2>/dev/null || true
+          # Wait for simulator to be ready
+          xcrun simctl bootstatus "$DEVICE_UDID" -b
+          echo "Simulator ready"
 
       - name: Generate screenshots
         run: |

--- a/scripts/generate-screenshots.sh
+++ b/scripts/generate-screenshots.sh
@@ -101,6 +101,11 @@ for test_result in manifest:
         exported_file = attachment['exportedFileName']
         suggested_name = attachment['suggestedHumanReadableName']
 
+        # Skip non-image files (videos, etc.)
+        if not exported_file.lower().endswith(('.png', '.jpg', '.jpeg')):
+            print(f"  ⏭ Skipping non-image: {exported_file}")
+            continue
+
         # Extract base name (e.g., "keyboard-lower-light" from "keyboard-lower-light_0_UUID.png")
         base_name = suggested_name.split('_')[0]
 


### PR DESCRIPTION
## Summary
- Enable screenshot workflow on `main` branch (previously only `develop`)
- Add `workflow_dispatch` for manual triggering
- Add `permissions: contents: write` to fix push permission error
- Add Python venv caching for faster runs
- Pre-boot iOS Simulator with `bootstatus` wait
- Skip non-image files (mp4) in export script to prevent crashes

## Test plan
- [ ] Manually trigger workflow via GitHub Actions UI
- [ ] Verify screenshots are generated and committed