### PR TITLE
Fix: Add missing entitlements file for Keyboard Extension

### DIFF
--- a/wurstfinger.xcodeproj/project.pbxproj
+++ b/wurstfinger.xcodeproj/project.pbxproj
@@ -666,7 +666,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_ENTITLEMENTS = Wurstfinger/Wurstfinger.entitlements;
+				CODE_SIGN_ENTITLEMENTS = wurstfingerKeyboard/wurstfingerKeyboard.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -696,7 +696,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_ENTITLEMENTS = Wurstfinger/Wurstfinger.entitlements;
+				CODE_SIGN_ENTITLEMENTS = wurstfingerKeyboard/wurstfingerKeyboard.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/wurstfingerKeyboard/wurstfingerKeyboard.entitlements
+++ b/wurstfingerKeyboard/wurstfingerKeyboard.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.de.akator.wurstfinger.shared</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
- Create wurstfingerKeyboard.entitlements with App Group entitlement
- Fix CODE_SIGN_ENTITLEMENTS path in project.pbxproj (was referencing
  non-existent Wurstfinger/Wurstfinger.entitlements)
- App Group: group.de.akator.wurstfinger.shared

This fixes the build error that prevented app signing.