### PR TITLE
Add App Store screenshot generation infrastructure

### DIFF
--- a/.github/workflows/generate-appstore-screenshots.yml
+++ b/.github/workflows/generate-appstore-screenshots.yml
@@ -1,0 +1,115 @@
+name: Generate App Store Screenshots
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload_artifact:
+        description: 'Upload screenshots as artifact'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  generate-screenshots:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: List available simulators
+        run: |
+          echo "Available iOS Simulators:"
+          xcrun simctl list devices available | grep -E "(iPhone|iPad)"
+
+      - name: Install required simulators
+        run: |
+          # Check if required simulators are available
+          echo "Checking for required simulators..."
+
+          # The macos-latest runner should have these simulators
+          # If not, we'll use the closest available ones
+
+          declare -a REQUIRED_DEVICES=(
+            "iPhone 15 Plus"
+            "iPhone 11 Pro Max"
+            "iPhone 8 Plus"
+            "iPad Pro (12.9-inch)"
+          )
+
+          for device in "${REQUIRED_DEVICES[@]}"; do
+            if xcrun simctl list devices available | grep -q "$device"; then
+              echo "✓ Found: $device"
+            else
+              echo "⚠ Not found: $device (will try alternatives)"
+            fi
+          done
+
+      - name: Boot simulators
+        run: |
+          # Boot one simulator at a time to avoid resource issues
+          # We'll boot them in sequence as needed in the test runs
+
+          # Get first available iPhone 15 Plus or similar
+          IPHONE_67=$(xcrun simctl list devices available | grep "iPhone 15 Plus\|iPhone 14 Plus\|iPhone 15 Pro Max" | head -n 1 | grep -oE '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}')
+          if [ -n "$IPHONE_67" ]; then
+            echo "Booting 6.7\" device: $IPHONE_67"
+            xcrun simctl boot "$IPHONE_67" 2>/dev/null || true
+          fi
+
+      - name: Cache Python venv
+        uses: actions/cache@v4
+        with:
+          path: venv
+          key: ${{ runner.os }}-venv-appstore-${{ hashFiles('scripts/generate-appstore-screenshots.sh') }}
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install --upgrade pip
+          pip install Pillow numpy
+
+      - name: Generate App Store screenshots
+        run: |
+          source venv/bin/activate
+          chmod +x ./scripts/generate-appstore-screenshots.sh
+          ./scripts/generate-appstore-screenshots.sh
+        timeout-minutes: 30
+
+      - name: List generated screenshots
+        run: |
+          echo "Generated screenshots:"
+          find appstore-screenshots -type f -name "*.png" | sort
+
+          echo ""
+          echo "Screenshot sizes:"
+          for file in $(find appstore-screenshots -type f -name "*.png"); do
+            size=$(file "$file" | grep -oE '[0-9]+ x [0-9]+' || echo "unknown")
+            echo "  $file: $size"
+          done
+
+      - name: Upload screenshots artifact
+        if: ${{ inputs.upload_artifact }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: appstore-screenshots
+          path: appstore-screenshots/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Summary
+        run: |
+          echo "## App Store Screenshots Generated" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Device | Size | Resolution |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|------|------------|" >> $GITHUB_STEP_SUMMARY
+          echo "| iPhone 6.7\" | 6.7-inch | 1290 x 2796 |" >> $GITHUB_STEP_SUMMARY
+          echo "| iPhone 6.5\" | 6.5-inch | 1242 x 2688 |" >> $GITHUB_STEP_SUMMARY
+          echo "| iPhone 5.5\" | 5.5-inch | 1242 x 2208 |" >> $GITHUB_STEP_SUMMARY
+          echo "| iPad Pro 12.9\" | 12.9-inch | 2048 x 2732 |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Download the artifact to get all screenshots." >> $GITHUB_STEP_SUMMARY

--- a/scripts/generate-appstore-screenshots.sh
+++ b/scripts/generate-appstore-screenshots.sh
@@ -1,0 +1,244 @@
+#!/bin/bash
+#
+# generate-appstore-screenshots.sh
+# Generate App Store screenshots for all required device sizes
+#
+# Required sizes:
+# - iPhone 6.7" (1290 x 2796) - iPhone 15 Plus
+# - iPhone 6.5" (1242 x 2688) - iPhone 11 Pro Max
+# - iPhone 5.5" (1242 x 2208) - iPhone 8 Plus
+# - iPad Pro 12.9" (2048 x 2732)
+#
+# Usage: ./scripts/generate-appstore-screenshots.sh
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}📱 Wurstfinger App Store Screenshot Generator${NC}"
+echo ""
+
+# Change to project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Configuration
+SCHEME="Wurstfinger"
+TEST_TARGET="WurstfingerUITests/ScreenshotTests/testGenerateAppStoreScreenshots"
+OUTPUT_DIR="$PROJECT_ROOT/appstore-screenshots"
+DERIVED_DATA="/tmp/WurstfingerAppStoreScreenshots"
+
+# Device configurations for App Store
+# Format: "Device Name|Display Size|Resolution"
+declare -a DEVICES=(
+    "iPhone 15 Plus|6.7|1290x2796"
+    "iPhone 11 Pro Max|6.5|1242x2688"
+    "iPhone 8 Plus|5.5|1242x2208"
+    "iPad Pro (12.9-inch) (6th generation)|12.9|2048x2732"
+)
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+echo -e "${BLUE}📋 Configuration:${NC}"
+echo "  Scheme: $SCHEME"
+echo "  Output: $OUTPUT_DIR"
+echo ""
+echo -e "${BLUE}📱 Target Devices:${NC}"
+for device_config in "${DEVICES[@]}"; do
+    IFS='|' read -r name size resolution <<< "$device_config"
+    echo "  - $name ($size\" - $resolution)"
+done
+echo ""
+
+# Function to get device UDID
+get_device_udid() {
+    local device_name="$1"
+    xcrun simctl list devices available | grep "$device_name" | head -n 1 | grep -oE '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}' || true
+}
+
+# Function to run tests on a specific device
+run_tests_on_device() {
+    local device_name="$1"
+    local display_size="$2"
+    local resolution="$3"
+
+    echo -e "${BLUE}🔄 Processing: $device_name${NC}"
+
+    # Get device UDID
+    local udid=$(get_device_udid "$device_name")
+
+    if [ -z "$udid" ]; then
+        echo -e "${YELLOW}  ⚠️  Device not available: $device_name${NC}"
+        return 1
+    fi
+
+    echo "  UDID: $udid"
+
+    # Boot simulator
+    echo "  Booting simulator..."
+    xcrun simctl boot "$udid" 2>/dev/null || true
+    xcrun simctl bootstatus "$udid" -b 2>/dev/null || true
+
+    # Run UI tests
+    echo "  Running screenshot tests..."
+    local device_derived="$DERIVED_DATA/$display_size"
+
+    set +e
+    xcodebuild test \
+        -scheme "$SCHEME" \
+        -destination "platform=iOS Simulator,id=$udid" \
+        -only-testing:"$TEST_TARGET" \
+        -derivedDataPath "$device_derived" \
+        CODE_SIGNING_ALLOWED=NO \
+        2>&1 | if command -v xcpretty >/dev/null; then xcpretty --color; else cat; fi
+    local test_result=$?
+    set -e
+
+    if [ $test_result -ne 0 ]; then
+        echo -e "${YELLOW}  ⚠️  Tests may have failed, checking for screenshots...${NC}"
+    fi
+
+    # Shutdown simulator
+    xcrun simctl shutdown "$udid" 2>/dev/null || true
+
+    # Extract screenshots
+    local results_bundle=$(find "$device_derived" -name "*.xcresult" -type d | head -n 1)
+
+    if [ -z "$results_bundle" ]; then
+        echo -e "${RED}  ❌ No results bundle found${NC}"
+        return 1
+    fi
+
+    # Create device output directory
+    local device_output="$OUTPUT_DIR/${display_size}-inch"
+    mkdir -p "$device_output"
+
+    # Export attachments
+    local temp_export="/tmp/appstore-screenshot-export-$display_size"
+    rm -rf "$temp_export"
+    xcrun xcresulttool export attachments --path "$results_bundle" --output-path "$temp_export"
+
+    # Copy screenshots with proper names
+    if [ -f "$temp_export/manifest.json" ]; then
+        local count=0
+        while IFS= read -r file; do
+            if [[ "$file" == *.png ]]; then
+                # Extract screenshot number and type from filename
+                local basename=$(basename "$file")
+                if [[ "$basename" == *"appstore"* ]]; then
+                    # Copy to output directory
+                    cp "$file" "$device_output/"
+                    ((count++))
+                fi
+            fi
+        done < <(find "$temp_export" -name "*.png" -type f)
+
+        # Also process via manifest for proper naming
+        export TEMP_EXPORT="$temp_export"
+        export DEVICE_OUTPUT="$device_output"
+        python3 << 'EOF'
+import json
+import os
+import shutil
+
+temp_export = os.environ['TEMP_EXPORT']
+device_output = os.environ['DEVICE_OUTPUT']
+manifest_path = os.path.join(temp_export, 'manifest.json')
+
+if os.path.exists(manifest_path):
+    with open(manifest_path, 'r') as f:
+        manifest = json.load(f)
+
+    for test_result in manifest:
+        for attachment in test_result.get('attachments', []):
+            exported_file = attachment['exportedFileName']
+            suggested_name = attachment['suggestedHumanReadableName']
+
+            # Skip non-image files
+            if not exported_file.lower().endswith(('.png', '.jpg', '.jpeg')):
+                continue
+
+            # Only process appstore screenshots
+            if 'appstore' not in suggested_name.lower():
+                continue
+
+            src_path = os.path.join(temp_export, exported_file)
+
+            # Extract meaningful name
+            # Format: appstore-device-01-keyboard-light_0_UUID.png
+            parts = suggested_name.split('_')[0]
+            name_parts = parts.split('-')
+            if len(name_parts) >= 4:
+                # Get screenshot type: 01-keyboard-light
+                screenshot_type = '-'.join(name_parts[-3:])
+                dest_name = f"{screenshot_type}.png"
+            else:
+                dest_name = f"{parts}.png"
+
+            dest_path = os.path.join(device_output, dest_name)
+
+            if os.path.exists(src_path):
+                shutil.copy2(src_path, dest_path)
+                print(f"    ✓ {dest_name}")
+EOF
+    fi
+
+    # Clean up temp export
+    rm -rf "$temp_export"
+
+    echo -e "${GREEN}  ✓ Screenshots saved to $device_output${NC}"
+}
+
+# Process each device
+success_count=0
+for device_config in "${DEVICES[@]}"; do
+    IFS='|' read -r name size resolution <<< "$device_config"
+    echo ""
+    if run_tests_on_device "$name" "$size" "$resolution"; then
+        ((success_count++))
+    fi
+done
+
+# Clean up derived data
+echo ""
+echo -e "${BLUE}🧹 Cleaning up...${NC}"
+rm -rf "$DERIVED_DATA"
+
+# Summary
+echo ""
+echo -e "${BLUE}📊 Summary:${NC}"
+echo "  Processed: ${success_count}/${#DEVICES[@]} devices"
+echo ""
+
+if [ -d "$OUTPUT_DIR" ]; then
+    echo -e "${BLUE}📁 Output Structure:${NC}"
+    find "$OUTPUT_DIR" -type f -name "*.png" | while read -r file; do
+        echo "  $file"
+    done
+fi
+
+echo ""
+if [ $success_count -gt 0 ]; then
+    echo -e "${GREEN}✅ App Store screenshots generated successfully!${NC}"
+    echo ""
+    echo -e "${BLUE}📋 Next Steps:${NC}"
+    echo "  1. Review screenshots in $OUTPUT_DIR"
+    echo "  2. Upload to App Store Connect"
+else
+    echo -e "${RED}❌ No screenshots were generated${NC}"
+    echo ""
+    echo "Troubleshooting:"
+    echo "  - Ensure simulators are installed for target devices"
+    echo "  - Run: xcrun simctl list devices available"
+    exit 1
+fi
+
+echo ""
+echo -e "${GREEN}✨ Done!${NC}"

--- a/wurstfingerUITests/ScreenshotTests.swift
+++ b/wurstfingerUITests/ScreenshotTests.swift
@@ -2,7 +2,7 @@
 //  ScreenshotTests.swift
 //  wurstfingerUITests
 //
-//  Automated screenshot generation for documentation
+//  Automated screenshot generation for documentation and App Store
 //
 
 import XCTest
@@ -48,5 +48,90 @@ final class ScreenshotTests: XCTestCase {
                 Thread.sleep(forTimeInterval: 0.5)
             }
         }
+    }
+
+    // MARK: - App Store Screenshots
+
+    /// Generate App Store screenshots for the current device
+    /// Run this test on different simulators to get all required sizes:
+    /// - iPhone 15 Plus (6.7" - 1290x2796)
+    /// - iPhone 11 Pro Max (6.5" - 1242x2688)
+    /// - iPhone 8 Plus (5.5" - 1242x2208)
+    /// - iPad Pro 12.9" (2048x2732)
+    @MainActor
+    func testGenerateAppStoreScreenshots() throws {
+        let keyboard = app.otherElements["showcaseKeyboard"]
+
+        // Get device identifier for naming
+        let deviceName = UIDevice.current.name
+            .replacingOccurrences(of: " ", with: "-")
+            .lowercased()
+
+        // Screenshot 1: Keyboard showcase (light mode, letters)
+        app.launchEnvironment["FORCE_LAYER"] = "lower"
+        app.launchEnvironment["FORCE_APPEARANCE"] = "light"
+        app.launch()
+
+        XCTAssertTrue(keyboard.waitForExistence(timeout: 5))
+        Thread.sleep(forTimeInterval: 1.0)
+
+        var screenshot = app.screenshot()
+        var attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = "appstore-\(deviceName)-01-keyboard-light"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        app.terminate()
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // Screenshot 2: Keyboard showcase (dark mode, letters)
+        app.launchEnvironment["FORCE_LAYER"] = "lower"
+        app.launchEnvironment["FORCE_APPEARANCE"] = "dark"
+        app.launch()
+
+        XCTAssertTrue(keyboard.waitForExistence(timeout: 5))
+        Thread.sleep(forTimeInterval: 1.0)
+
+        screenshot = app.screenshot()
+        attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = "appstore-\(deviceName)-02-keyboard-dark"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        app.terminate()
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // Screenshot 3: Numbers layer (light mode)
+        app.launchEnvironment["FORCE_LAYER"] = "numbers"
+        app.launchEnvironment["FORCE_APPEARANCE"] = "light"
+        app.launch()
+
+        XCTAssertTrue(keyboard.waitForExistence(timeout: 5))
+        Thread.sleep(forTimeInterval: 1.0)
+
+        screenshot = app.screenshot()
+        attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = "appstore-\(deviceName)-03-numbers-light"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        app.terminate()
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // Screenshot 4: Symbols layer (light mode)
+        app.launchEnvironment["FORCE_LAYER"] = "symbols"
+        app.launchEnvironment["FORCE_APPEARANCE"] = "light"
+        app.launch()
+
+        XCTAssertTrue(keyboard.waitForExistence(timeout: 5))
+        Thread.sleep(forTimeInterval: 1.0)
+
+        screenshot = app.screenshot()
+        attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = "appstore-\(deviceName)-04-symbols-light"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        app.terminate()
     }
 }


### PR DESCRIPTION
- Extend ScreenshotTests.swift with testGenerateAppStoreScreenshots()
  for generating full-screen screenshots on different device sizes
- Add generate-appstore-screenshots.sh script to automate running
  tests on multiple simulators (6.7", 6.5", 5.5", iPad 12.9")
- Add GitHub Actions workflow for manual App Store screenshot generation
  with artifact upload support

Required sizes:
- iPhone 6.7" (1290 x 2796) - iPhone 15 Plus
- iPhone 6.5" (1242 x 2688) - iPhone 11 Pro Max
- iPhone 5.5" (1242 x 2208) - iPhone 8 Plus
- iPad Pro 12.9" (2048 x 2732)