### PR TITLE
Remove WIP banner, add tagline

### DIFF
--- a/wurstfinger/HomeView.swift
+++ b/wurstfinger/HomeView.swift
@@ -26,22 +26,10 @@ struct HomeView: View {
                     .font(.largeTitle)
                     .fontWeight(.bold)
 
-                // Development Notice
-                VStack(spacing: 8) {
-                    Label("Work in Progress", systemImage: "exclamationmark.triangle")
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                        .foregroundColor(.orange)
-
-                    Text("This keyboard is in early development. Contributions welcome!")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .multilineTextAlignment(.center)
-                }
-                .padding()
-                .background(Color.orange.opacity(0.1))
-                .cornerRadius(12)
-                .padding(.horizontal)
+                // Tagline
+                Text("The Keyboard for Fat Fingers")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
 
                 Spacer()
 


### PR DESCRIPTION
## Summary
- Remove the orange "Work in Progress" development notice from HomeView
- Replace with clean tagline "The Keyboard for Fat Fingers"

## Why
The WIP banner is unprofessional for an App Store release.

## Test Plan
- [ ] Build and verify HomeView displays tagline instead of warning banner

Closes #41