### PR TITLE
Fix privacy URL to point to develop branch

### DIFF
--- a/fastlane/metadata/en-US/privacy_url.txt
+++ b/fastlane/metadata/en-US/privacy_url.txt
@@ -1,1 +1,1 @@
-https://github.com/cl445/wurstfinger/blob/main/PRIVACY.md
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md


### PR DESCRIPTION
## Summary
Fix the privacy policy URL from `main` to `develop` branch.

## Problem
The URL `https://github.com/cl445/wurstfinger/blob/main/PRIVACY.md` returns 404 because:
- The default branch is `develop`, not `main`
- `PRIVACY.md` only exists on `develop`

## Solution
Change URL to `https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md`

## Test Plan
- [x] Verified URL is accessible: https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

Closes #40