### PR TITLE
Add German App Store metadata

### DIFF
--- a/fastlane/metadata/de-DE/description.txt
+++ b/fastlane/metadata/de-DE/description.txt
@@ -1,0 +1,24 @@
+Wurstfinger - Die Tastatur für dicke Finger
+
+Genug von Tippfehlern? Wurstfinger ist eine innovative iOS-Tastatur, die speziell für die Einhandbedienung entwickelt wurde. Inspiriert vom bewährten MessagEase-Layout bietet sie große Tasten und intuitive Gesten für schnelles, präzises Tippen.
+
+FUNKTIONEN:
+
+• Große Tasten - Weniger Fehler, mehr Komfort
+• Wischgesten - Buchstaben durch Wischen in 8 Richtungen eingeben
+• 14 Sprachen - Deutsch, Englisch, Spanisch, Französisch, Portugiesisch, Italienisch, Niederländisch, Schwedisch, Norwegisch, Dänisch, Finnisch, Polnisch, Tschechisch und Vietnamesisch
+• Compose-Engine - Akzente und Sonderzeichen durch Kombinationen erstellen (z.B. ' + a = á)
+• Kreisbewegungen - Großbuchstaben durch kreisförmige Gesten
+• Cursor-Steuerung - Cursor durch Ziehen auf der Leertaste bewegen
+• Haptisches Feedback - Einstellbare Vibrationsintensität
+• Anpassbar - Tastaturgröße nach Wunsch skalieren
+
+PERFEKT FÜR:
+
+• Einhandbedienung unterwegs
+• Nutzer mit größeren Fingern
+• Alle, die eine ergonomische Alternative zur Standardtastatur suchen
+
+Wurstfinger erfordert eine kurze Eingewöhnungszeit, aber sobald du die Gesten beherrschst, tippst du schneller und genauer als je zuvor.
+
+Probier es aus - deine Daumen werden es dir danken!

--- a/fastlane/metadata/de-DE/keywords.txt
+++ b/fastlane/metadata/de-DE/keywords.txt
@@ -1,0 +1,1 @@
+Tastatur,Gesten,MessagEase,einhändig,tippen,wischen,Daumen,ergonomisch,barrierefrei

--- a/fastlane/metadata/de-DE/name.txt
+++ b/fastlane/metadata/de-DE/name.txt
@@ -1,0 +1,1 @@
+Wurstfinger

--- a/fastlane/metadata/de-DE/privacy_url.txt
+++ b/fastlane/metadata/de-DE/privacy_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

--- a/fastlane/metadata/de-DE/promotional_text.txt
+++ b/fastlane/metadata/de-DE/promotional_text.txt
@@ -1,0 +1,1 @@
+Die perfekte Tastatur für große Daumen - tippe schneller und genauer mit intuitiven Wischgesten!

--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,0 +1,8 @@
+Erste Veröffentlichung von Wurstfinger!
+
+• MessagEase-inspiriertes Gestenlayout
+• 14 Sprachlayouts
+• Anpassbare Tastaturgröße
+• Haptisches Feedback
+• Cursor-Steuerung über die Leertaste
+• Open Source

--- a/fastlane/metadata/de-DE/subtitle.txt
+++ b/fastlane/metadata/de-DE/subtitle.txt
@@ -1,0 +1,1 @@
+Die Tastatur für dicke Finger

--- a/fastlane/metadata/de-DE/support_url.txt
+++ b/fastlane/metadata/de-DE/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/issues

--- a/fastlane/metadata/en-US/promotional_text.txt
+++ b/fastlane/metadata/en-US/promotional_text.txt
@@ -1,0 +1,1 @@
+The perfect keyboard for big thumbs - type faster and more accurately with intuitive swipe gestures!

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,0 +1,8 @@
+First release of Wurstfinger!
+
+• MessagEase-inspired gesture layout
+• 14 language layouts
+• Customizable keyboard size
+• Haptic feedback
+• Cursor control via space bar
+• Open source


### PR DESCRIPTION
## Summary
Add complete German localization for App Store metadata.

## New Files (de-DE)
- `description.txt` - Full German app description
- `keywords.txt` - German search keywords
- `name.txt` - App name (Wurstfinger)
- `subtitle.txt` - "Die Tastatur für dicke Finger"
- `release_notes.txt` - v1.0 release notes
- `promotional_text.txt` - Promotional text
- `privacy_url.txt` - Privacy policy URL
- `support_url.txt` - Support URL

## Also Added (en-US)
- `release_notes.txt` - Missing v1.0 release notes
- `promotional_text.txt` - Missing promotional text

## Test Plan
- [ ] Review German translations for accuracy
- [ ] Verify all required metadata files are present

Closes #39