### PR TITLE
Improve App Store screenshot generation

### DIFF
--- a/scripts/generate-appstore-screenshots.sh
+++ b/scripts/generate-appstore-screenshots.sh
@@ -30,7 +30,11 @@ cd "$PROJECT_ROOT"
 
 # Configuration
 SCHEME="Wurstfinger"
-TEST_TARGET="WurstfingerUITests/ScreenshotTests/testGenerateAppStoreScreenshots"
+# Run both App Store screenshot tests
+TEST_TARGETS=(
+    "WurstfingerUITests/ScreenshotTests/testGenerateAppStoreScreenshots"
+    "WurstfingerUITests/ScreenshotTests/testGenerateKeyboardShowcaseScreenshots"
+)
 OUTPUT_DIR="$PROJECT_ROOT/appstore-screenshots"
 DERIVED_DATA="/tmp/WurstfingerAppStoreScreenshots"
 
@@ -90,11 +94,17 @@ run_tests_on_device() {
     echo "  Running screenshot tests..."
     local device_derived="$DERIVED_DATA/$display_size"
 
+    # Build the -only-testing arguments for all test targets
+    local only_testing_args=""
+    for target in "${TEST_TARGETS[@]}"; do
+        only_testing_args="$only_testing_args -only-testing:$target"
+    done
+
     set +e
     xcodebuild test \
         -scheme "$SCHEME" \
         -destination "platform=iOS Simulator,id=$udid" \
-        -only-testing:"$TEST_TARGET" \
+        $only_testing_args \
         -derivedDataPath "$device_derived" \
         CODE_SIGNING_ALLOWED=NO \
         2>&1 | if command -v xcpretty >/dev/null; then xcpretty --color; else cat; fi

--- a/wurstfingerUITests/ScreenshotTests.swift
+++ b/wurstfingerUITests/ScreenshotTests.swift
@@ -21,6 +21,8 @@ final class ScreenshotTests: XCTestCase {
         app.launchEnvironment["FORCE_LANGUAGE"] = languageId
     }
 
+    // MARK: - README Screenshots (keyboard-only, cropped)
+
     @MainActor
     func testGenerateScreenshots() throws {
         let keyboard = app.otherElements["showcaseKeyboard"]
@@ -52,7 +54,7 @@ final class ScreenshotTests: XCTestCase {
 
     // MARK: - App Store Screenshots
 
-    /// Generate App Store screenshots for the current device
+    /// Generate App Store screenshots showing the full app experience
     /// Run this test on different simulators to get all required sizes:
     /// - iPhone 15 Plus (6.7" - 1290x2796)
     /// - iPhone 11 Pro Max (6.5" - 1242x2688)
@@ -60,6 +62,71 @@ final class ScreenshotTests: XCTestCase {
     /// - iPad Pro 12.9" (2048x2732)
     @MainActor
     func testGenerateAppStoreScreenshots() throws {
+        // Get device identifier for naming
+        let deviceName = UIDevice.current.name
+            .replacingOccurrences(of: " ", with: "-")
+            .lowercased()
+
+        // Screenshot 1: Home screen - first impression
+        app.launchEnvironment["FORCE_APPEARANCE"] = "light"
+        app.launch()
+
+        // Wait for app to load and navigate to Home tab
+        let homeTab = app.tabBars.buttons["Home"]
+        XCTAssertTrue(homeTab.waitForExistence(timeout: 5))
+        homeTab.tap()
+        Thread.sleep(forTimeInterval: 1.0)
+
+        takeAppStoreScreenshot(name: "appstore-\(deviceName)-01-home")
+
+        // Screenshot 2: Test area with keyboard preview (light mode)
+        let testTab = app.tabBars.buttons["Test"]
+        testTab.tap()
+        Thread.sleep(forTimeInterval: 1.0)
+
+        takeAppStoreScreenshot(name: "appstore-\(deviceName)-02-test-light")
+
+        app.terminate()
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // Screenshot 3: Test area (dark mode)
+        app.launchEnvironment["FORCE_APPEARANCE"] = "dark"
+        app.launch()
+
+        XCTAssertTrue(testTab.waitForExistence(timeout: 5))
+        testTab.tap()
+        Thread.sleep(forTimeInterval: 1.0)
+
+        takeAppStoreScreenshot(name: "appstore-\(deviceName)-03-test-dark")
+
+        app.terminate()
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // Screenshot 4: Settings view
+        app.launchEnvironment["FORCE_APPEARANCE"] = "light"
+        app.launch()
+
+        let settingsTab = app.tabBars.buttons["Settings"]
+        XCTAssertTrue(settingsTab.waitForExistence(timeout: 5))
+        settingsTab.tap()
+        Thread.sleep(forTimeInterval: 1.0)
+
+        takeAppStoreScreenshot(name: "appstore-\(deviceName)-04-settings")
+
+        // Screenshot 5: Onboarding/Setup view
+        let setupTab = app.tabBars.buttons["Setup"]
+        setupTab.tap()
+        Thread.sleep(forTimeInterval: 1.0)
+
+        takeAppStoreScreenshot(name: "appstore-\(deviceName)-05-setup")
+
+        app.terminate()
+    }
+
+    // MARK: - Keyboard Showcase Screenshots (for App Store, showing keyboard layers)
+
+    @MainActor
+    func testGenerateKeyboardShowcaseScreenshots() throws {
         let keyboard = app.otherElements["showcaseKeyboard"]
 
         // Get device identifier for naming
@@ -67,71 +134,36 @@ final class ScreenshotTests: XCTestCase {
             .replacingOccurrences(of: " ", with: "-")
             .lowercased()
 
-        // Screenshot 1: Keyboard showcase (light mode, letters)
-        app.launchEnvironment["FORCE_LAYER"] = "lower"
-        app.launchEnvironment["FORCE_APPEARANCE"] = "light"
-        app.launch()
+        // Keyboard layouts to capture
+        let configurations: [(layer: String, appearance: String, number: String)] = [
+            ("lower", "light", "06"),
+            ("lower", "dark", "07"),
+            ("numbers", "light", "08"),
+            ("symbols", "light", "09")
+        ]
 
-        XCTAssertTrue(keyboard.waitForExistence(timeout: 5))
-        Thread.sleep(forTimeInterval: 1.0)
+        for config in configurations {
+            app.launchEnvironment["FORCE_LAYER"] = config.layer
+            app.launchEnvironment["FORCE_APPEARANCE"] = config.appearance
+            app.launch()
 
-        var screenshot = app.screenshot()
-        var attachment = XCTAttachment(screenshot: screenshot)
-        attachment.name = "appstore-\(deviceName)-01-keyboard-light"
+            XCTAssertTrue(keyboard.waitForExistence(timeout: 5))
+            Thread.sleep(forTimeInterval: 1.0)
+
+            takeAppStoreScreenshot(name: "appstore-\(deviceName)-\(config.number)-keyboard-\(config.layer)-\(config.appearance)")
+
+            app.terminate()
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func takeAppStoreScreenshot(name: String) {
+        let screenshot = app.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
         attachment.lifetime = .keepAlways
         add(attachment)
-
-        app.terminate()
-        Thread.sleep(forTimeInterval: 0.5)
-
-        // Screenshot 2: Keyboard showcase (dark mode, letters)
-        app.launchEnvironment["FORCE_LAYER"] = "lower"
-        app.launchEnvironment["FORCE_APPEARANCE"] = "dark"
-        app.launch()
-
-        XCTAssertTrue(keyboard.waitForExistence(timeout: 5))
-        Thread.sleep(forTimeInterval: 1.0)
-
-        screenshot = app.screenshot()
-        attachment = XCTAttachment(screenshot: screenshot)
-        attachment.name = "appstore-\(deviceName)-02-keyboard-dark"
-        attachment.lifetime = .keepAlways
-        add(attachment)
-
-        app.terminate()
-        Thread.sleep(forTimeInterval: 0.5)
-
-        // Screenshot 3: Numbers layer (light mode)
-        app.launchEnvironment["FORCE_LAYER"] = "numbers"
-        app.launchEnvironment["FORCE_APPEARANCE"] = "light"
-        app.launch()
-
-        XCTAssertTrue(keyboard.waitForExistence(timeout: 5))
-        Thread.sleep(forTimeInterval: 1.0)
-
-        screenshot = app.screenshot()
-        attachment = XCTAttachment(screenshot: screenshot)
-        attachment.name = "appstore-\(deviceName)-03-numbers-light"
-        attachment.lifetime = .keepAlways
-        add(attachment)
-
-        app.terminate()
-        Thread.sleep(forTimeInterval: 0.5)
-
-        // Screenshot 4: Symbols layer (light mode)
-        app.launchEnvironment["FORCE_LAYER"] = "symbols"
-        app.launchEnvironment["FORCE_APPEARANCE"] = "light"
-        app.launch()
-
-        XCTAssertTrue(keyboard.waitForExistence(timeout: 5))
-        Thread.sleep(forTimeInterval: 1.0)
-
-        screenshot = app.screenshot()
-        attachment = XCTAttachment(screenshot: screenshot)
-        attachment.name = "appstore-\(deviceName)-04-symbols-light"
-        attachment.lifetime = .keepAlways
-        add(attachment)
-
-        app.terminate()
     }
 }


### PR DESCRIPTION
## Summary
Enhance the App Store screenshot generation to capture the full app experience, not just isolated keyboard views.

## Changes

### New Screenshots (testGenerateAppStoreScreenshots)
1. **Home screen** - First impression with tagline
2. **Test area (light)** - Keyboard in action
3. **Test area (dark)** - Dark mode support
4. **Settings view** - Customization options
5. **Setup/Onboarding** - Easy setup instructions

### Keyboard Showcase (testGenerateKeyboardShowcaseScreenshots)
6. Keyboard letters (light)
7. Keyboard letters (dark)
8. Numbers layer
9. Symbols layer

### Script Updates
- `generate-appstore-screenshots.sh` now runs both test methods
- Supports multiple `-only-testing` arguments

## Test Plan
- [ ] Run `./scripts/generate-appstore-screenshots.sh` on a simulator
- [ ] Verify screenshots are generated in `appstore-screenshots/` directory
- [ ] Review screenshot quality and content

Related to #38