### PR TITLE
Add App Store keyboard screenshots with chat UI

### DIFF
--- a/wurstfinger/AppStoreScreenshotView.swift
+++ b/wurstfinger/AppStoreScreenshotView.swift
@@ -1,0 +1,174 @@
+//
+//  AppStoreScreenshotView.swift
+//  wurstfinger
+//
+//  Screenshot view for App Store showing keyboard with sample text
+//
+
+import SwiftUI
+
+struct AppStoreScreenshotView: View {
+    @StateObject private var viewModel = KeyboardViewModel(shouldPersistSettings: false)
+    @StateObject private var languageSettings = LanguageSettings.shared
+    @State private var colorScheme: ColorScheme?
+
+    // Sample text to display - can be overridden via environment
+    @State private var displayText: String = "Hello Wurstfinger!"
+
+    var body: some View {
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                // Text display area (simulated text field)
+                textDisplayArea
+                    .frame(maxWidth: .infinity)
+                    .frame(height: geometry.size.height * 0.35)
+
+                Spacer()
+
+                // Keyboard
+                KeyboardRootView(viewModel: viewModel)
+                    .frame(maxWidth: .infinity)
+                    .accessibilityIdentifier("screenshotKeyboard")
+            }
+        }
+        .background(Color(.systemBackground))
+        .preferredColorScheme(colorScheme)
+        .statusBarHidden(true)
+        .onAppear {
+            configureFromEnvironment()
+        }
+    }
+
+    private var textDisplayArea: some View {
+        VStack(spacing: 0) {
+            // App header bar (simulated)
+            HStack {
+                Text("Messages")
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            Divider()
+
+            // Chat-style message display
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    // Received message
+                    HStack(alignment: .bottom, spacing: 8) {
+                        receivedMessageBubble("Hey! How's the new keyboard?")
+                        Spacer(minLength: 60)
+                    }
+
+                    // Sent message (our text)
+                    HStack(alignment: .bottom, spacing: 8) {
+                        Spacer(minLength: 60)
+                        sentMessageBubble(displayText)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            }
+
+            Divider()
+
+            // Text input area (simulated, shows cursor)
+            HStack(spacing: 12) {
+                HStack {
+                    Text(viewModel.activeLayer == .numbers || viewModel.activeLayer == .symbols ? "123" : "Aa")
+                        .foregroundColor(.secondary)
+                        .font(.system(size: 14))
+
+                    Rectangle()
+                        .fill(Color.accentColor)
+                        .frame(width: 2, height: 20)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Color(.secondarySystemBackground))
+                .cornerRadius(20)
+
+                Spacer()
+
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 32))
+                    .foregroundColor(.accentColor)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+        }
+    }
+
+    private func receivedMessageBubble(_ text: String) -> some View {
+        Text(text)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(Color(.secondarySystemBackground))
+            .foregroundColor(.primary)
+            .cornerRadius(18)
+    }
+
+    private func sentMessageBubble(_ text: String) -> some View {
+        Text(text)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(Color.accentColor)
+            .foregroundColor(.white)
+            .cornerRadius(18)
+    }
+
+    private func configureFromEnvironment() {
+        let env = ProcessInfo.processInfo.environment
+
+        // Set language
+        if let forcedLanguage = env["FORCE_LANGUAGE"] {
+            languageSettings.selectedLanguageId = forcedLanguage
+        }
+
+        // Set keyboard layer
+        if let forcedLayer = env["FORCE_LAYER"] {
+            switch forcedLayer {
+            case "numbers":
+                viewModel.setLayer(.numbers)
+            case "symbols":
+                viewModel.setLayer(.symbols)
+            case "upper":
+                viewModel.setLayer(.upper)
+            case "lower":
+                viewModel.setLayer(.lower)
+            default:
+                break
+            }
+        }
+
+        // Set appearance
+        if let forcedAppearance = env["FORCE_APPEARANCE"] {
+            switch forcedAppearance {
+            case "dark":
+                colorScheme = .dark
+            case "light":
+                colorScheme = .light
+            default:
+                colorScheme = nil
+            }
+        }
+
+        // Set display text
+        if let forcedText = env["FORCE_TEXT"] {
+            displayText = forcedText
+        }
+    }
+}
+
+#Preview("Light - Letters") {
+    AppStoreScreenshotView()
+        .preferredColorScheme(.light)
+}
+
+#Preview("Dark - Letters") {
+    AppStoreScreenshotView()
+        .preferredColorScheme(.dark)
+}

--- a/wurstfinger/wurstfingerApp.swift
+++ b/wurstfinger/wurstfingerApp.swift
@@ -9,7 +9,13 @@ import SwiftUI
 
 @main
 struct wurstfingerApp: App {
-    @State private var showScreenshotMode = ProcessInfo.processInfo.arguments.contains("SCREENSHOT_MODE")
+    private let screenshotMode: ScreenshotMode
+
+    private enum ScreenshotMode {
+        case none
+        case keyboardOnly      // SCREENSHOT_MODE - keyboard showcase only
+        case appStore          // APPSTORE_SCREENSHOT_MODE - keyboard with chat UI
+    }
 
     init() {
         let defaults: [String: Any] = [
@@ -18,13 +24,26 @@ struct wurstfingerApp: App {
             "keyboardHorizontalPosition": DeviceLayoutUtils.defaultKeyboardPosition
         ]
         SharedDefaults.store.register(defaults: defaults)
+
+        // Determine screenshot mode from launch arguments
+        let args = ProcessInfo.processInfo.arguments
+        if args.contains("APPSTORE_SCREENSHOT_MODE") {
+            screenshotMode = .appStore
+        } else if args.contains("SCREENSHOT_MODE") {
+            screenshotMode = .keyboardOnly
+        } else {
+            screenshotMode = .none
+        }
     }
 
     var body: some Scene {
         WindowGroup {
-            if showScreenshotMode {
+            switch screenshotMode {
+            case .appStore:
+                AppStoreScreenshotView()
+            case .keyboardOnly:
                 KeyboardShowcaseView()
-            } else {
+            case .none:
                 ContentView()
             }
         }

--- a/wurstfingerUITests/ScreenshotTests.swift
+++ b/wurstfingerUITests/ScreenshotTests.swift
@@ -163,6 +163,46 @@ final class ScreenshotTests: XCTestCase {
         }
     }
 
+    // MARK: - App Store Keyboard with Chat UI Screenshots
+
+    /// Generate App Store screenshots showing keyboard with chat interface and sample text
+    /// Uses APPSTORE_SCREENSHOT_MODE to show AppStoreScreenshotView
+    /// These are the primary screenshots showing the keyboard in action
+    @MainActor
+    func testGenerateAppStoreKeyboardScreenshots() throws {
+        app.launchArguments = ["APPSTORE_SCREENSHOT_MODE"]
+
+        let keyboard = app.otherElements["screenshotKeyboard"]
+
+        // Get device identifier for naming
+        let deviceName = UIDevice.current.name
+            .replacingOccurrences(of: " ", with: "-")
+            .lowercased()
+
+        // Configurations: layer, appearance, screenshot number, display text
+        let configurations: [(layer: String, appearance: String, number: String, text: String)] = [
+            ("lower", "light", "01", "Hello Wurstfinger!"),
+            ("lower", "dark", "02", "Hello Wurstfinger!"),
+            ("numbers", "light", "03", "Call me: 0800 123456"),
+            ("numbers", "dark", "04", "Call me: 0800 123456")
+        ]
+
+        for config in configurations {
+            app.launchEnvironment["FORCE_LAYER"] = config.layer
+            app.launchEnvironment["FORCE_APPEARANCE"] = config.appearance
+            app.launchEnvironment["FORCE_TEXT"] = config.text
+            app.launch()
+
+            XCTAssertTrue(keyboard.waitForExistence(timeout: 5), "Keyboard not found for \(config.layer)-\(config.appearance)")
+            Thread.sleep(forTimeInterval: 1.0)
+
+            takeAppStoreScreenshot(name: "appstore-\(deviceName)-keyboard-\(config.number)-\(config.layer)-\(config.appearance)")
+
+            app.terminate()
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+    }
+
     // MARK: - Helper Methods
 
     private func takeAppStoreScreenshot(name: String) {


### PR DESCRIPTION
## Summary
Add a new screenshot view that shows the Wurstfinger keyboard in a realistic chat context - much better for App Store marketing than isolated keyboard screenshots.

## New Screenshots

| # | Mode | Text | Preview |
|---|------|------|---------|
| 01 | Letters Light | "Hello Wurstfinger!" | Chat with keyboard |
| 02 | Letters Dark | "Hello Wurstfinger!" | Dark mode |
| 03 | Numbers Light | "Call me: 0800 123456" | Numpad |
| 04 | Numbers Dark | "Call me: 0800 123456" | Dark numpad |

## Implementation

### New Files
- `AppStoreScreenshotView.swift` - Chat UI mockup with:
  - "Messages" header
  - Received message bubble: "Hey! How's the new keyboard?"
  - Sent message bubble: Configurable text
  - Text input area with cursor
  - Full keyboard below

### Changes
- `wurstfingerApp.swift` - New `APPSTORE_SCREENSHOT_MODE` launch argument
- `ScreenshotTests.swift` - New `testGenerateAppStoreKeyboardScreenshots()` test

### Environment Variables
- `FORCE_LAYER` - lower/upper/numbers/symbols
- `FORCE_APPEARANCE` - light/dark
- `FORCE_TEXT` - Custom message text

## Test Plan
- [x] Build succeeds
- [x] UI test passes
- [x] All 4 screenshots generated correctly
- [x] Screenshots look professional

## Screenshots
Tested on iPhone 16 simulator - see attached images in PR description.

Related to #38