### PR TITLE
Fix keyboard layout regressions from PR #28

### DIFF
--- a/wurstfingerKeyboard/KeyboardLayout.swift
+++ b/wurstfingerKeyboard/KeyboardLayout.swift
@@ -870,7 +870,10 @@ enum KeyboardConstants {
         static let gridHorizontalSpacing: CGFloat = 8
         static let gridVerticalSpacing: CGFloat = 8
         static let horizontalPadding: CGFloat = 12
-        static let verticalPadding: CGFloat = 10
+        /// Top padding - minimal since keyboard sits directly below text input
+        static let verticalPaddingTop: CGFloat = 4
+        /// Bottom padding - accounts for home indicator safe area
+        static let verticalPaddingBottom: CGFloat = 10
         static let hintMargin: CGFloat = 10
         static let hintMarginReturning: CGFloat = 22
     }
@@ -918,7 +921,7 @@ enum KeyboardConstants {
             let keyHeight = keyHeight(aspectRatio: aspectRatio)
             return (keyHeight * CGFloat(KeyDimensions.totalRows)) +
                    (Layout.gridVerticalSpacing * CGFloat(KeyDimensions.totalRows - 1)) +
-                   (Layout.verticalPadding * 2)
+                   Layout.verticalPaddingTop + Layout.verticalPaddingBottom
         }
     }
 }

--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -37,52 +37,34 @@ struct KeyboardRootView: View {
             Color(.systemBackground)
                 .ignoresSafeArea()
 
-            Grid(horizontalSpacing: KeyboardConstants.Layout.gridHorizontalSpacing,
-             verticalSpacing: KeyboardConstants.Layout.gridVerticalSpacing) {
-                GridRow {
-                    if viewModel.utilityColumnLeading {
-                        utilityButton(forRow: 0, keyHeight: keyHeight)
-                    }
+            VStack(spacing: KeyboardConstants.Layout.gridVerticalSpacing) {
+                // Rows 0-2: Standard letter/number rows
+                ForEach(0..<3, id: \.self) { rowIndex in
+                    HStack(spacing: KeyboardConstants.Layout.gridHorizontalSpacing) {
+                        if viewModel.utilityColumnLeading {
+                            utilityButton(forRow: rowIndex, keyHeight: keyHeight)
+                        }
 
-                    keyCells(forRow: 0, keyHeight: keyHeight)
+                        keyCells(forRow: rowIndex, keyHeight: keyHeight)
 
-                    if !viewModel.utilityColumnLeading {
-                        utilityButton(forRow: 0, keyHeight: keyHeight)
-                    }
-                }
-
-                GridRow {
-                    if viewModel.utilityColumnLeading {
-                        utilityButton(forRow: 1, keyHeight: keyHeight)
-                    }
-
-                    keyCells(forRow: 1, keyHeight: keyHeight)
-
-                    if !viewModel.utilityColumnLeading {
-                        utilityButton(forRow: 1, keyHeight: keyHeight)
+                        if !viewModel.utilityColumnLeading {
+                            utilityButton(forRow: rowIndex, keyHeight: keyHeight)
+                        }
                     }
                 }
 
-                GridRow {
-                    if viewModel.utilityColumnLeading {
-                        utilityButton(forRow: 2, keyHeight: keyHeight)
-                    }
-
-                    keyCells(forRow: 2, keyHeight: keyHeight)
-
-                    if !viewModel.utilityColumnLeading {
-                        utilityButton(forRow: 2, keyHeight: keyHeight)
-                    }
-                }
-
-                GridRow {
+                // Row 3: Space bar row
+                HStack(spacing: KeyboardConstants.Layout.gridHorizontalSpacing) {
                     if viewModel.utilityColumnLeading {
                         utilityButton(forRow: 3, keyHeight: keyHeight)
                     }
 
-                    keyCells(forRow: 3, keyHeight: keyHeight)
-                    SpaceKeyButton(viewModel: viewModel, keyHeight: keyHeight, aspectRatio: viewModel.keyAspectRatio)
-                        .gridCellColumns(viewModel.spaceColumnSpan)
+                    // For numbers layer: show "0" key cell + space
+                    // For letters layer: space spans full width
+                    if viewModel.activeLayer == .numbers {
+                        keyCells(forRow: 3, keyHeight: keyHeight)
+                    }
+                    SpaceKeyButton(viewModel: viewModel, keyHeight: keyHeight)
 
                     if !viewModel.utilityColumnLeading {
                         utilityButton(forRow: 3, keyHeight: keyHeight)
@@ -90,7 +72,8 @@ struct KeyboardRootView: View {
                 }
             }
             .padding(.horizontal, KeyboardConstants.Layout.horizontalPadding)
-            .padding(.vertical, KeyboardConstants.Layout.verticalPadding)
+            .padding(.top, KeyboardConstants.Layout.verticalPaddingTop)
+            .padding(.bottom, KeyboardConstants.Layout.verticalPaddingBottom)
             .frame(width: baseWidth, alignment: frameAlignment)
             .scaleEffect(viewModel.keyboardScale, anchor: scaleAnchor)
             .offset(x: horizontalOffset)

--- a/wurstfingerKeyboard/SpaceKeyButton.swift
+++ b/wurstfingerKeyboard/SpaceKeyButton.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct SpaceKeyButton: View {
     let viewModel: KeyboardViewModel
     let keyHeight: CGFloat
-    let aspectRatio: CGFloat
 
     @State private var isActive = false
     @State private var dragStarted = false
@@ -21,7 +20,9 @@ struct SpaceKeyButton: View {
     var body: some View {
         KeyCap(
             height: keyHeight,
-            aspectRatio: aspectRatio,
+            // Don't apply aspectRatio to space bar - it spans multiple grid columns
+            // and should fill the available width from .gridCellColumns()
+            aspectRatio: nil,
             background: isActive ? Color(.tertiarySystemFill) : Color(.secondarySystemBackground),
             fontSize: KeyboardConstants.FontSizes.keyLabel
         ) {


### PR DESCRIPTION
## Summary
Fixes layout issues introduced in PR #28 (iPad aspect ratio fix):

- **SpaceKeyButton aspectRatio removed**: The space bar spans multiple grid columns and should fill available width, not be constrained by aspectRatio
- **Grid → VStack/HStack**: SwiftUI Grid caused inconsistent vertical spacing when rows had different numbers of elements. Using VStack/HStack gives consistent 8pt spacing between all rows
- **Asymmetric vertical padding**: Split into 4pt top / 10pt bottom for better alignment with text input fields and home indicator

## Test plan
- [ ] Verify keyboard looks correct on iPhone (letters and numbers layer)
- [ ] Verify keyboard looks correct on iPad
- [ ] Verify consistent spacing between all rows
- [ ] Verify space bar fills correct width in both layers