### PR TITLE
Add app review contact information to release lane

### DIFF
--- a/.github/workflows/appstore-release.yml
+++ b/.github/workflows/appstore-release.yml
@@ -32,5 +32,9 @@ jobs:
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          REVIEW_CONTACT_FIRST_NAME: ${{ secrets.REVIEW_CONTACT_FIRST_NAME }}
+          REVIEW_CONTACT_LAST_NAME: ${{ secrets.REVIEW_CONTACT_LAST_NAME }}
+          REVIEW_CONTACT_EMAIL: ${{ secrets.REVIEW_CONTACT_EMAIL }}
+          REVIEW_CONTACT_PHONE: ${{ secrets.REVIEW_CONTACT_PHONE }}
           CI: true
         run: bundle exec fastlane ios release

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -214,10 +214,10 @@ platform :ios do
       },
       precheck_include_in_app_purchases: false,
       app_review_information: {
-        first_name: ENV.fetch("REVIEW_CONTACT_FIRST_NAME", "Developer"),
-        last_name: ENV.fetch("REVIEW_CONTACT_LAST_NAME", "Akator"),
-        email_address: ENV.fetch("REVIEW_CONTACT_EMAIL", "info@akator.de"),
-        phone_number: ENV.fetch("REVIEW_CONTACT_PHONE", "+49 000 000000"),
+        first_name: ENV.fetch("REVIEW_CONTACT_FIRST_NAME"),
+        last_name: ENV.fetch("REVIEW_CONTACT_LAST_NAME"),
+        email_address: ENV.fetch("REVIEW_CONTACT_EMAIL"),
+        phone_number: ENV.fetch("REVIEW_CONTACT_PHONE"),
         demo_user: "",
         demo_password: "",
         notes: File.read("fastlane/metadata/review_information/notes.txt")


### PR DESCRIPTION
Fix App Store upload failing due to missing required contact
attributes (contactFirstName, contactLastName, contactEmail,
contactPhone) by adding app_review_information parameter.