### PR TITLE
Extend Touch Area to Cover Gaps Between Keys

### DIFF
--- a/wurstfingerKeyboard/KeyboardButton.swift
+++ b/wurstfingerKeyboard/KeyboardButton.swift
@@ -20,6 +20,13 @@ struct KeyboardButton<Label: View, Overlay: View>: View {
     @State private var positions: [CGPoint] = []
     @State private var maxOffset: CGPoint = .zero
 
+    /// Extra touch area extension to cover margins between keys
+    private var touchPadding: CGFloat {
+        // Extend touch area by half the grid spacing on each side
+        // This ensures the entire margin area is covered by adjacent keys
+        KeyboardConstants.Layout.gridHorizontalSpacing / 2 + 2
+    }
+
     var body: some View {
         KeyCap(
             height: height,
@@ -38,6 +45,8 @@ struct KeyboardButton<Label: View, Overlay: View>: View {
             view.accessibilityIdentifier(config.accessibilityIdentifier!)
         }
         .accessibilityAddTraits(.isButton)
+        // Extend the touch area beyond the visual bounds to cover margins
+        .contentShape(Rectangle().inset(by: -touchPadding))
         .gesture(
             DragGesture(minimumDistance: 0)
                 .onChanged { value in


### PR DESCRIPTION
## Summary
- Extend the touch-sensitive area of keyboard buttons beyond their visual bounds
- Touch targets now cover the gaps/margins between keys
- Taps in the margins are captured by the nearest button

## Implementation
- Added `touchPadding` computed property that calculates half the grid spacing + 2pt
- Applied `.contentShape(Rectangle().inset(by: -touchPadding))` to extend the hit area

## Test plan
- [ ] Test tapping directly on keys (should work as before)
- [ ] Test tapping in gaps between keys (should now register on nearest key)
- [ ] Verify no visual changes to the keyboard layout