### PR TITLE
Reorganize Globe Key with Swipe Gestures

### DIFF
--- a/wurstfinger.xcodeproj/xcuserdata/claas.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/wurstfinger.xcodeproj/xcuserdata/claas.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Wurstfinger.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>WurstfingerApp.xcscheme_^#shared#^_</key>
 		<dict>

--- a/wurstfingerKeyboard/KeyHintOverlay.swift
+++ b/wurstfingerKeyboard/KeyHintOverlay.swift
@@ -155,3 +155,38 @@ struct KeyHintOverlay: View {
         }
     }
 }
+
+/// Overlay for globe key showing swipe hints (globe left, keyboard dismiss down)
+struct GlobeKeyHintOverlay: View {
+    let keyHeight: CGFloat
+
+    // SF Symbols need smaller size than text hints to appear proportional
+    private var symbolFontSize: CGFloat {
+        let scaledSize = KeyboardConstants.FontSizes.hintBaseSize * (keyHeight / KeyboardConstants.FontSizes.hintReferenceHeight)
+        let baseSize = min(max(scaledSize, KeyboardConstants.FontSizes.hintMinSize), KeyboardConstants.FontSizes.hintMaxSize)
+        return baseSize * 0.75  // SF Symbols are visually larger than text
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            let size = proxy.size
+            let horizontalPadding: CGFloat = 4
+            let verticalPadding: CGFloat = 3
+
+            // Globe icon at left (swipe left for next keyboard)
+            Image(systemName: "globe")
+                .font(.system(size: symbolFontSize, weight: .medium))
+                .foregroundStyle(Color.primary.opacity(0.5))
+                .padding(.leading, horizontalPadding)
+                .frame(width: size.width, height: size.height, alignment: .leading)
+
+            // Keyboard dismiss icon at bottom (swipe down to dismiss)
+            Image(systemName: "keyboard.chevron.compact.down")
+                .font(.system(size: symbolFontSize, weight: .medium))
+                .foregroundStyle(Color.primary.opacity(0.5))
+                .padding(.bottom, verticalPadding)
+                .frame(width: size.width, height: size.height, alignment: .bottom)
+        }
+        .allowsHitTesting(false)
+    }
+}

--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -98,15 +98,15 @@ struct KeyboardRootView: View {
     @ViewBuilder
     private func utilityButton(forRow row: Int, keyHeight: CGFloat) -> some View {
         switch row {
-        case 0: // Globe button
+        case 0: // Globe button - swipe left: next keyboard, swipe down: dismiss, center: reserved for emoji
             KeyboardButton(
                 height: keyHeight,
                 aspectRatio: viewModel.keyAspectRatio,
-                label: Image(systemName: "globe"),
-                overlay: EmptyView(),
+                label: Text(""),
+                overlay: GlobeKeyHintOverlay(keyHeight: keyHeight),
                 config: KeyboardButtonConfig(),
                 callbacks: KeyboardButtonCallbacks(
-                    onTap: viewModel.handleAdvanceToNextInputMode,
+                    onSwipe: viewModel.handleGlobeSwipe,
                     onCircular: { viewModel.handleUtilityCircularGesture(.globe, direction: $0) }
                 )
             )

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -419,6 +419,18 @@ final class KeyboardViewModel: ObservableObject {
         actionHandler?(.dismissKeyboard)
     }
 
+    func handleGlobeSwipe(direction: KeyboardDirection) {
+        switch direction {
+        case .left:
+            handleAdvanceToNextInputMode()
+        case .down:
+            handleDismissKeyboard()
+        default:
+            // Center and other directions reserved for future use (e.g., emoji)
+            break
+        }
+    }
+
     func toggleShift() {
         switch activeLayer {
         case .lower:


### PR DESCRIPTION
## Summary
- Move next keyboard action from tap to swipe left
- Add swipe down gesture to dismiss keyboard
- Add `GlobeKeyHintOverlay` showing gesture hints (globe left, dismiss down)
- Keep center empty (reserved for future emoji toggle)

## Changes
- `KeyHintOverlay.swift`: New `GlobeKeyHintOverlay` component
- `KeyboardRootView.swift`: Updated globe button with overlay and swipe handler
- `KeyboardViewModel.swift`: New `handleGlobeSwipe()` function

## Test plan
- [x] Swipe left on globe key → switches to next keyboard
- [x] Swipe down on globe key → dismisses keyboard
- [x] Tap on globe key → no action (reserved for emoji)
- [x] Verify hint icons display correctly (globe left, keyboard-dismiss bottom)