### PR TITLE
Add clipboard actions and bidirectional delete

### DIFF
--- a/wurstfingerKeyboard/DeleteKeyButton.swift
+++ b/wurstfingerKeyboard/DeleteKeyButton.swift
@@ -76,16 +76,8 @@ struct DeleteKeyButton: View {
 
                     if isSliding {
                         viewModel.endDeleteDrag()
-                    } else {
-                        let translation = totalTranslation
-                        let isWordSwipe = translation.width <= -KeyboardConstants.DeleteGestures.wordSwipeThreshold &&
-                            abs(translation.height) <= KeyboardConstants.DeleteGestures.verticalTolerance
-
-                        if isWordSwipe {
-                            viewModel.handleDeleteWord()
-                        } else if !repeatTriggered && !hasDragged {
-                            viewModel.handleDelete()
-                        }
+                    } else if !repeatTriggered && !hasDragged {
+                        viewModel.handleDelete()
                     }
 
                     resetGestureState()

--- a/wurstfingerKeyboard/KeyHintOverlay.swift
+++ b/wurstfingerKeyboard/KeyHintOverlay.swift
@@ -190,3 +190,92 @@ struct GlobeKeyHintOverlay: View {
         .allowsHitTesting(false)
     }
 }
+
+/// Displays text editing swipe hints on the symbols toggle key (123/ABC)
+/// - Up: Copy
+/// - Up-Right: Cut
+/// - Down: Paste
+struct SymbolsKeyHintOverlay: View {
+    let keyHeight: CGFloat
+
+    private var hintFontSize: CGFloat {
+        let scaledSize = KeyboardConstants.FontSizes.hintBaseSize * (keyHeight / KeyboardConstants.FontSizes.hintReferenceHeight)
+        return min(max(scaledSize, KeyboardConstants.FontSizes.hintMinSize), KeyboardConstants.FontSizes.hintMaxSize)
+    }
+
+    private struct HintConfig {
+        let direction: KeyboardDirection
+        let iconName: String
+    }
+
+    private let hints: [HintConfig] = [
+        HintConfig(direction: .up, iconName: "doc.on.doc"),           // Copy
+        HintConfig(direction: .upRight, iconName: "scissors"),        // Cut
+        HintConfig(direction: .down, iconName: "doc.on.clipboard"),   // Paste
+    ]
+
+    var body: some View {
+        GeometryReader { proxy in
+            let size = proxy.size
+            let scaledHorizontalPadding = KeyboardConstants.FontSizes.hintBaseHorizontalPadding * (hintFontSize / KeyboardConstants.FontSizes.hintReferenceFontSize)
+            let scaledVerticalPadding = KeyboardConstants.FontSizes.hintBaseVerticalPadding * (hintFontSize / KeyboardConstants.FontSizes.hintReferenceFontSize)
+
+            ForEach(hints, id: \.direction) { hint in
+                Image(systemName: hint.iconName)
+                    .font(.system(size: hintFontSize * 0.6, weight: .regular))
+                    .foregroundStyle(Color.secondary.opacity(0.45))
+                    .padding(edgePadding(for: hint.direction,
+                                        horizontal: scaledHorizontalPadding,
+                                        vertical: scaledVerticalPadding))
+                    .frame(width: size.width, height: size.height, alignment: alignment(for: hint.direction))
+            }
+        }
+        .allowsHitTesting(false)
+    }
+
+    private func edgePadding(for direction: KeyboardDirection, horizontal: CGFloat, vertical: CGFloat) -> EdgeInsets {
+        switch direction {
+        case .up:
+            return EdgeInsets(top: vertical, leading: 0, bottom: 0, trailing: 0)
+        case .down:
+            return EdgeInsets(top: 0, leading: 0, bottom: vertical, trailing: 0)
+        case .left:
+            return EdgeInsets(top: 0, leading: horizontal, bottom: 0, trailing: 0)
+        case .right:
+            return EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: horizontal)
+        case .upLeft:
+            return EdgeInsets(top: vertical, leading: horizontal, bottom: 0, trailing: 0)
+        case .upRight:
+            return EdgeInsets(top: vertical, leading: 0, bottom: 0, trailing: horizontal)
+        case .downLeft:
+            return EdgeInsets(top: 0, leading: horizontal, bottom: vertical, trailing: 0)
+        case .downRight:
+            return EdgeInsets(top: 0, leading: 0, bottom: vertical, trailing: horizontal)
+        case .center:
+            return EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+        }
+    }
+
+    private func alignment(for direction: KeyboardDirection) -> Alignment {
+        switch direction {
+        case .up:
+            return .top
+        case .down:
+            return .bottom
+        case .left:
+            return .leading
+        case .right:
+            return .trailing
+        case .upLeft:
+            return .topLeading
+        case .upRight:
+            return .topTrailing
+        case .downLeft:
+            return .bottomLeading
+        case .downRight:
+            return .bottomTrailing
+        case .center:
+            return .center
+        }
+    }
+}

--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -110,14 +110,18 @@ struct KeyboardRootView: View {
                     onCircular: { viewModel.handleUtilityCircularGesture(.globe, direction: $0) }
                 )
             )
-        case 1: // Symbols toggle button
+        case 1: // Symbols toggle button with text editing swipes
             KeyboardButton(
                 height: keyHeight,
                 aspectRatio: viewModel.keyAspectRatio,
                 label: Text(viewModel.symbolToggleLabel),
-                overlay: EmptyView(),
+                overlay: SymbolsKeyHintOverlay(keyHeight: keyHeight),
                 config: KeyboardButtonConfig(highlighted: viewModel.isSymbolsToggleActive, accessibilityIdentifier: "symbols"),
-                callbacks: KeyboardButtonCallbacks(onTap: viewModel.toggleSymbols)
+                callbacks: KeyboardButtonCallbacks(
+                    onTap: viewModel.toggleSymbols,
+                    onSwipe: viewModel.handleSymbolsKeySwipe,
+                    onSwipeReturn: viewModel.handleSymbolsKeySwipe
+                )
             )
         case 2: // Delete button
             DeleteKeyButton(viewModel: viewModel, keyHeight: keyHeight, aspectRatio: viewModel.keyAspectRatio)

--- a/wurstfingerTests/wurstfingerTests.swift
+++ b/wurstfingerTests/wurstfingerTests.swift
@@ -157,21 +157,6 @@ struct wurstfingerTests {
         #expect(deletes == 2)
     }
 
-    @Test func deleteWordActionEmits() async throws {
-        let viewModel = KeyboardViewModel()
-        var didDeleteWord = false
-
-        viewModel.bindActionHandler { action in
-            if case .deleteWord = action {
-                didDeleteWord = true
-            }
-        }
-
-        viewModel.handleDeleteWord()
-
-        #expect(didDeleteWord)
-    }
-
     @Test func hapticIntensitiesPersistToDefaults() async throws {
         let suite = "group.de.akator.wurstfinger.tests.hapticsPersist"
         let defaults = try #require(UserDefaults(suiteName: suite))


### PR DESCRIPTION
## Summary

- Add **Copy/Cut/Paste** swipe gestures on the symbols toggle key (123/ABC)
  - Swipe ↑: Copy selected text to clipboard
  - Swipe ↗: Cut selected text
  - Swipe ↓: Paste from clipboard
- Add **bidirectional progressive delete** on backspace key
  - Drag ←: Delete backward (existing behavior)
  - Drag →: Delete forward (new)
- Remove word-swipe gestures from backspace (replaced by simpler bidirectional drag)
- Add visual hint icons on symbols key showing clipboard actions

## Test plan

- [x] Test Copy: Select text, swipe up on 123 key, verify text is in clipboard
- [x] Test Cut: Select text, swipe up-right on 123 key, verify text is removed and in clipboard
- [x] Test Paste: Copy text from another app, swipe down on 123 key, verify text is inserted
- [x] Test delete backward: Drag left on backspace, verify characters deleted backward
- [x] Test delete forward: Place cursor in middle of text, drag right on backspace, verify characters deleted forward
- [x] Test delete forward at end: Cursor at end of text, drag right should do nothing
- [x] Verify all existing tests pass