### PR TITLE
Add missing å to Swedish keyboard layout

### DIFF
--- a/wurstfingerKeyboard/LanguageConfig.swift
+++ b/wurstfingerKeyboard/LanguageConfig.swift
@@ -488,6 +488,7 @@ extension LanguageConfig {
             ["t", "e", "s"]
         ],
         specialCharacters: [
+            "0_0_up": "å",
             "0_0_down": "ä",
             "0_0_downRight": "v",
             "0_1_down": "l",


### PR DESCRIPTION
## Summary
- Adds the missing å (ring-a) character to the Swedish keyboard layout
- The character is now accessible via swipe-up on the 'a' key (position 0_0)
- Swedish uses three special vowels: ä, ö, and å - all three are now present

## Test plan
- [ ] Switch to Swedish keyboard layout
- [ ] Verify å appears when swiping up on the 'a' key
- [ ] Verify ä still works when swiping down on 'a' key