### PR TITLE
Add FAQ section documenting iOS limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Want to try the latest features before they hit the App Store? Join our public T
 - **Customizable settings**: Adjust haptic feedback intensity, keyboard scale, and key aspect ratio
 - **Onboarding flow** with interactive setup guide
 
+## FAQ
+
+Have questions about iOS limitations or keyboard behavior? Check out the [Frequently Asked Questions](docs/FAQ.md).
+
 ## Getting Started
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Want to try the latest features before they hit the App Store? Join our public T
 
 ## FAQ
 
-Have questions about iOS limitations or keyboard behavior? Check out the [Frequently Asked Questions](docs/FAQ.md).
+Wondering why something doesn't work as expected? Check out the [Frequently Asked Questions](docs/FAQ.md) for common issues and their solutions.
 
 ## Getting Started
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,17 @@
+# Frequently Asked Questions
+
+## Why is there a bar below the keyboard with globe and microphone buttons?
+
+The bar at the bottom of the keyboard is the **UIKeyboardDockView**, a system-controlled area that iOS displays below all third-party keyboard extensions. It contains the globe button (to switch keyboards) and the microphone button (for dictation).
+
+This area is managed entirely by iOS — keyboard extensions are placed *above* it and cannot remove, resize, or draw into this space. This is a fundamental limitation of the iOS keyboard extension architecture.
+
+> *Reference: [App Extension Programming Guide: Custom Keyboard](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/CustomKeyboard.html) — "a custom keyboard can draw only within the primary view of its UIInputViewController object"*
+
+## Why can't I select text with the keyboard?
+
+**Text selection is controlled by the app**, not the keyboard. Keyboard extensions cannot programmatically select text — they can only move the cursor and read nearby text. To select text, use the standard iOS gestures (long-press, double-tap) directly in the text field.
+
+Wurstfinger supports **Copy, Cut, and Paste** via swipe gestures on the return key (requires Full Access to be enabled).
+
+> *Reference: [App Extension Programming Guide: Custom Keyboard](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/CustomKeyboard.html) — "a custom keyboard cannot select text"*

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,16 +2,18 @@
 
 ## Why is there a bar below the keyboard with globe and microphone buttons?
 
-The bar at the bottom of the keyboard is the **UIKeyboardDockView**, a system-controlled area that iOS displays below all third-party keyboard extensions. It contains the globe button (to switch keyboards) and the microphone button (for dictation).
+The bar at the bottom of the keyboard is a system-controlled area that iOS displays below all third-party keyboard extensions. It sits within the device's **Safe Area** and contains the globe button (to switch keyboards) and the microphone button (for dictation).
 
-This area is managed entirely by iOS — keyboard extensions are placed *above* it and cannot remove, resize, or draw into this space. This is a fundamental limitation of the iOS keyboard extension architecture.
+This area is managed entirely by iOS — keyboard extensions are placed *above* it and cannot remove, resize, or draw into this space. Third-party keyboards can only draw within the primary view of their `UIInputViewController`.
 
-> *Reference: [App Extension Programming Guide: Custom Keyboard](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/CustomKeyboard.html) — "a custom keyboard can draw only within the primary view of its UIInputViewController object"*
+> *References:*
+> - *[Positioning content relative to the safe area](https://developer.apple.com/documentation/uikit/positioning-content-relative-to-the-safe-area) — Apple Developer Documentation*
+> - *[Custom Keyboard Programming Guide](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/CustomKeyboard.html) — "a custom keyboard can draw only within the primary view of its UIInputViewController object"*
 
 ## Why can't I select text with the keyboard?
 
 **Text selection is controlled by the app**, not the keyboard. Keyboard extensions cannot programmatically select text — they can only move the cursor and read nearby text. To select text, use the standard iOS gestures (long-press, double-tap) directly in the text field.
 
-Wurstfinger supports **Copy, Cut, and Paste** via swipe gestures on the return key (requires Full Access to be enabled).
+Wurstfinger supports **Copy, Cut, and Paste** via swipe gestures on the symbols toggle key (123/ABC): swipe up to copy, up-right to cut, and down to paste. Full Access must be enabled.
 
-> *Reference: [App Extension Programming Guide: Custom Keyboard](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/CustomKeyboard.html) — "a custom keyboard cannot select text"*
+> *Reference: [Custom Keyboard Programming Guide](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/CustomKeyboard.html) — "a custom keyboard cannot select text"*


### PR DESCRIPTION
## Summary

- Add `docs/FAQ.md` with frequently asked questions
- Document the iOS Safe Area limitation (bottom bar below keyboard)
- Include screenshot from #85 and references to Apple documentation
- Add FAQ link in README

## Background

Users have asked about the empty space below the keyboard (#85). This is the iOS Safe Area for the Home Indicator, which cannot be removed by third-party keyboard extensions. The FAQ explains this limitation and links to Apple's official documentation.

## References

- Closes #85
- [Positioning content relative to the safe area](https://developer.apple.com/documentation/uikit/positioning-content-relative-to-the-safe-area) — Apple Developer Documentation
- [Layout — Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/layout)

## Test plan

- [ ] Verify FAQ.md renders correctly on GitHub
- [ ] Verify links to Apple documentation work
- [ ] Verify README FAQ link works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an FAQ section to the README linking to an expanded FAQ document.
  * Explains the iOS system-controlled bottom bar and Safe Area constraints affecting third‑party keyboards, with links to official guidance.
  * Clarifies that text selection is controlled by the host app (keyboards cannot programmatically select text) and documents Wurstfinger swipe gestures for Copy/Cut/Paste when Full Access is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->