### PR TITLE
Fix iOS reporting wrong keyboard language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix non-deterministic accent cycle order
 - Replace `fatalError` with `assertionFailure` in layout creation to prevent production crashes
 - Fix hardcoded version "1.0.0" in settings — now reads from bundle
+- Set `PrimaryLanguage` to `mul` (multi-language) and read active language directly from SharedDefaults so iOS Settings shows the correct keyboard language (#96)
 
 ### Added
 

--- a/wurstfingerKeyboard/Info.plist
+++ b/wurstfingerKeyboard/Info.plist
@@ -25,7 +25,7 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>PrimaryLanguage</key>
-			<string>de</string>
+			<string>mul</string>
 			<key>RequestsOpenAccess</key>
 			<true/>
 		</dict>

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -14,13 +14,16 @@ final class KeyboardViewController: UIInputViewController {
     private lazy var viewModel = KeyboardViewModel()
     private var heightConstraint: NSLayoutConstraint?
 
-    /// Tells iOS which language this keyboard is typing in for spell-check and autocorrect
+    /// Reports the active keyboard language to iOS (shown in Settings > Keyboards).
+    /// Reads directly from SharedDefaults to pick up language changes made in the host app,
+    /// since the LanguageSettings singleton may hold a stale value from its init.
     override var primaryLanguage: String? {
         get {
-            return LanguageSettings.shared.selectedLanguageId
+            let languageId = SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue)
+            let config = languageId.flatMap { LanguageConfig.language(withId: $0) } ?? .english
+            return config.locale.identifier
         }
         set {
-            // iOS may try to set this, but we ignore it and use our settings
             super.primaryLanguage = newValue
         }
     }

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -5,6 +5,7 @@
 //  Created by Claas Flint on 06.11.25.
 //
 
+import Foundation
 import Testing
 @testable import WurstfingerApp
 
@@ -143,5 +144,119 @@ struct LanguageSettingsTests {
 
         let resultAR = LanguageSettings.detectSystemLanguage(preferredLanguages: ["es-AR"])
         #expect(resultAR == "es_ES")
+    }
+}
+
+// MARK: - Primary Language Resolution Tests
+
+/// Tests the logic that resolves a language ID from UserDefaults into a locale identifier,
+/// matching the primaryLanguage getter in KeyboardViewController.
+struct PrimaryLanguageResolutionTests {
+
+    /// Helper that mirrors the primaryLanguage getter logic:
+    /// read language ID from UserDefaults → resolve to LanguageConfig → return locale identifier
+    private func resolvePrimaryLanguage(from defaults: UserDefaults) -> String {
+        let languageId = defaults.string(forKey: SettingsKey.selectedLanguageId.rawValue)
+        let config = languageId.flatMap { LanguageConfig.language(withId: $0) } ?? .english
+        return config.locale.identifier
+    }
+
+    private func createTestDefaults() -> (UserDefaults, String) {
+        let suiteName = "test.primaryLanguage.\(UUID().uuidString)"
+        return (UserDefaults(suiteName: suiteName)!, suiteName)
+    }
+
+    @Test("Returns German locale when German is selected")
+    func resolveGerman() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set("de_DE", forKey: SettingsKey.selectedLanguageId.rawValue)
+        #expect(resolvePrimaryLanguage(from: defaults) == "de_DE")
+    }
+
+    @Test("Returns French locale when French is selected")
+    func resolveFrench() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set("fr_FR", forKey: SettingsKey.selectedLanguageId.rawValue)
+        #expect(resolvePrimaryLanguage(from: defaults) == "fr_FR")
+    }
+
+    @Test("Returns Russian locale when Russian is selected")
+    func resolveRussian() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set("ru_RU", forKey: SettingsKey.selectedLanguageId.rawValue)
+        #expect(resolvePrimaryLanguage(from: defaults) == "ru_RU")
+    }
+
+    @Test("Falls back to English when no language is stored")
+    func fallbackWhenNoLanguageStored() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        // Don't set any value — should fall back to English
+        #expect(resolvePrimaryLanguage(from: defaults) == "en_US")
+    }
+
+    @Test("Falls back to English for unknown language ID")
+    func fallbackForUnknownLanguageId() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set("xx_XX", forKey: SettingsKey.selectedLanguageId.rawValue)
+        #expect(resolvePrimaryLanguage(from: defaults) == "en_US")
+    }
+
+    @Test("Picks up language change from UserDefaults without restart")
+    func picksUpLanguageChange() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set("de_DE", forKey: SettingsKey.selectedLanguageId.rawValue)
+        #expect(resolvePrimaryLanguage(from: defaults) == "de_DE")
+
+        // Simulate host app changing language
+        defaults.set("fr_FR", forKey: SettingsKey.selectedLanguageId.rawValue)
+        #expect(resolvePrimaryLanguage(from: defaults) == "fr_FR")
+    }
+
+    @Test("All supported languages resolve to valid locale identifiers")
+    func allLanguagesResolveToValidLocale() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        for language in LanguageConfig.allLanguages {
+            defaults.set(language.id, forKey: SettingsKey.selectedLanguageId.rawValue)
+            let resolved = resolvePrimaryLanguage(from: defaults)
+            #expect(resolved == language.locale.identifier,
+                    "Language \(language.name) (\(language.id)) should resolve to \(language.locale.identifier), got \(resolved)")
+        }
+    }
+}
+
+// MARK: - Info.plist PrimaryLanguage Tests
+
+struct InfoPlistLanguageTests {
+
+    @Test("Keyboard extension Info.plist has PrimaryLanguage set to mul")
+    func primaryLanguageIsMul() throws {
+        // Read the keyboard extension's Info.plist directly from the source tree
+        // This catches accidental changes before they ship
+        let testFile = URL(fileURLWithPath: #filePath)
+        let projectDir = testFile.deletingLastPathComponent().deletingLastPathComponent()
+        let plistURL = projectDir.appendingPathComponent("wurstfingerKeyboard/Info.plist")
+
+        let data = try Data(contentsOf: plistURL)
+        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+        let dict = try #require(plist as? [String: Any])
+        let extensionDict = try #require(dict["NSExtension"] as? [String: Any])
+        let attributes = try #require(extensionDict["NSExtensionAttributes"] as? [String: Any])
+        let primaryLanguage = try #require(attributes["PrimaryLanguage"] as? String)
+        #expect(primaryLanguage == "mul",
+                "PrimaryLanguage should be 'mul' (multi-language), not a single language code")
     }
 }


### PR DESCRIPTION
## Summary
- Change `PrimaryLanguage` in keyboard extension's `Info.plist` from `"de"` to `"en"` so iOS doesn't hardcode German for spell-check and autocorrect
- The runtime `primaryLanguage` property already correctly returns the user-selected language via `LanguageSettings`

## Test plan
- [ ] Switch keyboard language to French/English/etc. in settings
- [ ] Verify iOS shows correct language indicator for the keyboard
- [ ] Verify spell-check uses the correct dictionary for the selected language

Fixes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keyboard now correctly reports its active language to iOS by declaring multi-language support and reporting the actual selected language, improving spell-check and autocorrect behavior.
* **Tests**
  * Added unit tests covering language resolution and the keyboard’s declared primary-language setting to guard against regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->