### PR TITLE
Fix auto-capitalization not updating after delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Replace `fatalError` with `assertionFailure` in layout creation to prevent production crashes
 - Fix hardcoded version "1.0.0" in settings — now reads from bundle
 - Set `PrimaryLanguage` to `mul` (multi-language) and read active language directly from SharedDefaults so iOS Settings shows the correct keyboard language (#96)
+- Auto-capitalization now re-evaluates after deleting characters (#88)
 
 ### Added
 

--- a/wurstfingerKeyboard/ComposeEngine.swift
+++ b/wurstfingerKeyboard/ComposeEngine.swift
@@ -167,10 +167,8 @@ struct ComposeEngine {
             }
 
             // Each variant also maps to the same cycle (first assignment wins)
-            for variant in variants {
-                if completeCycles[variant] == nil {
-                    completeCycles[variant] = cycle
-                }
+            for variant in variants where completeCycles[variant] == nil {
+                completeCycles[variant] = cycle
             }
         }
 

--- a/wurstfingerKeyboard/ComposeEngine.swift
+++ b/wurstfingerKeyboard/ComposeEngine.swift
@@ -156,14 +156,21 @@ struct ComposeEngine {
         }
 
         // Build complete cycles: base → [base, variant1, variant2, ...]
+        // Characters like "â" can be both a variant of "a" and a base for
+        // Vietnamese sub-variants. The first assignment wins so that cycling
+        // from "a" through its variants always round-trips back to "a".
         var completeCycles: [String: [String]] = [:]
         for (base, variants) in cycles.sorted(by: { $0.key < $1.key }) where !variants.isEmpty {
-            var cycle = [base] + variants
-            completeCycles[base] = cycle
+            let cycle = [base] + variants
+            if completeCycles[base] == nil {
+                completeCycles[base] = cycle
+            }
 
-            // Each variant also maps to the same cycle
+            // Each variant also maps to the same cycle (first assignment wins)
             for variant in variants {
-                completeCycles[variant] = cycle
+                if completeCycles[variant] == nil {
+                    completeCycles[variant] = cycle
+                }
             }
         }
 
@@ -182,10 +189,13 @@ struct ComposeEngine {
         ]
 
         for (base, cycle) in numberCycles.sorted(by: { $0.key < $1.key }) {
-            completeCycles[base] = cycle
-            // Each variant also maps to the same cycle
+            if completeCycles[base] == nil {
+                completeCycles[base] = cycle
+            }
             for variant in cycle where variant != base {
-                completeCycles[variant] = cycle
+                if completeCycles[variant] == nil {
+                    completeCycles[variant] = cycle
+                }
             }
         }
 

--- a/wurstfingerKeyboard/ComposeEngine.swift
+++ b/wurstfingerKeyboard/ComposeEngine.swift
@@ -157,7 +157,7 @@ struct ComposeEngine {
 
         // Build complete cycles: base → [base, variant1, variant2, ...]
         var completeCycles: [String: [String]] = [:]
-        for (base, variants) in cycles where variants.count > 0 {
+        for (base, variants) in cycles.sorted(by: { $0.key < $1.key }) where !variants.isEmpty {
             var cycle = [base] + variants
             completeCycles[base] = cycle
 
@@ -181,7 +181,7 @@ struct ComposeEngine {
             "9": ["9", "⁹"]
         ]
 
-        for (base, cycle) in numberCycles {
+        for (base, cycle) in numberCycles.sorted(by: { $0.key < $1.key }) {
             completeCycles[base] = cycle
             // Each variant also maps to the same cycle
             for variant in cycle where variant != base {

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -108,8 +108,10 @@ final class KeyboardViewController: UIInputViewController {
             }
         case .deleteBackward:
             textDocumentProxy.deleteBackward()
+            updateAutoCapitalization()
         case .deleteForward:
             deleteForward()
+            updateAutoCapitalization()
         case .advanceToNextInputMode:
             advanceToNextInputMode()
         case .space:
@@ -177,6 +179,19 @@ final class KeyboardViewController: UIInputViewController {
 
         if AutoCapitalization.shouldCapitalize(context: textDocumentProxy.documentContextBeforeInput) {
             viewModel.setLayer(.upper)
+        }
+    }
+
+    /// Re-evaluates auto-capitalization after text changes (e.g. delete).
+    /// Enables uppercase if at sentence start, disables it if no longer at sentence start.
+    private func updateAutoCapitalization() {
+        guard SharedDefaults.store.bool(forKey: SettingsKey.autoCapitalizeEnabled.rawValue) else { return }
+
+        let shouldCapitalize = AutoCapitalization.shouldCapitalize(context: textDocumentProxy.documentContextBeforeInput)
+        if shouldCapitalize {
+            viewModel.setLayer(.upper)
+        } else if viewModel.activeLayer == .upper && !viewModel.isCapsLockActive {
+            viewModel.setLayer(.lower)
         }
     }
 

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -110,8 +110,9 @@ final class KeyboardViewController: UIInputViewController {
             textDocumentProxy.deleteBackward()
             updateAutoCapitalization()
         case .deleteForward:
-            deleteForward()
-            updateAutoCapitalization()
+            if deleteForward() {
+                updateAutoCapitalization()
+            }
         case .advanceToNextInputMode:
             advanceToNextInputMode()
         case .space:
@@ -139,14 +140,15 @@ final class KeyboardViewController: UIInputViewController {
         }
     }
 
-    /// Delete one character after cursor
-    private func deleteForward() {
-        // Only delete if there's text after the cursor
+    /// Delete one character after cursor. Returns `true` if a character was deleted.
+    @discardableResult
+    private func deleteForward() -> Bool {
         guard let after = textDocumentProxy.documentContextAfterInput, !after.isEmpty else {
-            return
+            return false
         }
         textDocumentProxy.adjustTextPosition(byCharacterOffset: 1)
         textDocumentProxy.deleteBackward()
+        return true
     }
 
     /// Copy selected text to clipboard

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -100,12 +100,7 @@ final class KeyboardViewController: UIInputViewController {
     private func perform(action: KeyboardAction) {
         switch action {
         case let .insert(text):
-            textDocumentProxy.insertText(text)
-            // Spanish sentence-opening punctuation triggers immediate capitalization
-            if AutoCapitalization.shouldCapitalizeImmediately(after: text) &&
-                SharedDefaults.store.bool(forKey: SettingsKey.autoCapitalizeEnabled.rawValue) {
-                viewModel.setLayer(.upper)
-            }
+            insertText(text)
         case .deleteBackward:
             textDocumentProxy.deleteBackward()
             updateAutoCapitalization()
@@ -137,6 +132,15 @@ final class KeyboardViewController: UIInputViewController {
             handlePaste()
         case .cut:
             handleCut()
+        }
+    }
+
+    private func insertText(_ text: String) {
+        textDocumentProxy.insertText(text)
+        // Spanish sentence-opening punctuation triggers immediate capitalization
+        if AutoCapitalization.shouldCapitalizeImmediately(after: text),
+           SharedDefaults.store.bool(forKey: SettingsKey.autoCapitalizeEnabled.rawValue) {
+            viewModel.setLayer(.upper)
         }
     }
 

--- a/wurstfingerKeyboard/LanguageSettings.swift
+++ b/wurstfingerKeyboard/LanguageSettings.swift
@@ -21,10 +21,18 @@ class LanguageSettings: ObservableObject {
     private let languageKey = SettingsKey.selectedLanguageId.rawValue
 
     private init() {
-        userDefaults = SharedDefaults.store
+        self.userDefaults = SharedDefaults.store
 
-        // Load saved language or detect from system
-        selectedLanguageId = userDefaults.string(forKey: languageKey) ?? Self.detectSystemLanguage()
+        // Load saved language or detect from system, then normalize
+        let storedLanguageId = userDefaults.string(forKey: languageKey) ?? Self.detectSystemLanguage()
+        let resolvedLanguageId = LanguageConfig.language(withId: storedLanguageId)?.id ?? LanguageConfig.english.id
+        self.selectedLanguageId = resolvedLanguageId
+
+        // Persist the resolved ID so other readers (e.g. KeyboardViewModel.reloadLanguage)
+        // see the same normalized value
+        if resolvedLanguageId != storedLanguageId {
+            userDefaults.set(resolvedLanguageId, forKey: languageKey)
+        }
     }
 
     /// Detects the system language and returns matching language ID, or English as fallback

--- a/wurstfingerKeyboard/LanguageSettings.swift
+++ b/wurstfingerKeyboard/LanguageSettings.swift
@@ -21,12 +21,12 @@ class LanguageSettings: ObservableObject {
     private let languageKey = SettingsKey.selectedLanguageId.rawValue
 
     private init() {
-        self.userDefaults = SharedDefaults.store
+        userDefaults = SharedDefaults.store
 
         // Load saved language or detect from system, then normalize
         let storedLanguageId = userDefaults.string(forKey: languageKey) ?? Self.detectSystemLanguage()
         let resolvedLanguageId = LanguageConfig.language(withId: storedLanguageId)?.id ?? LanguageConfig.english.id
-        self.selectedLanguageId = resolvedLanguageId
+        selectedLanguageId = resolvedLanguageId
 
         // Persist the resolved ID so other readers (e.g. KeyboardViewModel.reloadLanguage)
         // see the same normalized value

--- a/wurstfingerTests/KeyboardSettingsTests.swift
+++ b/wurstfingerTests/KeyboardSettingsTests.swift
@@ -103,6 +103,34 @@ struct HapticSettingsTests {
         #expect(abs(settings.tapIntensity - 0.2) < 0.01)
     }
 
+    // MARK: - Non-numeric Defaults Safety Tests
+
+    @Test func nonNumericDefaultsFallBackToDefaults() {
+        let defaults = createTestDefaults()
+
+        // Store non-numeric values that could corrupt settings
+        defaults.set("not_a_number", forKey: SettingsKey.hapticIntensityTap.rawValue)
+        defaults.set(true, forKey: SettingsKey.hapticIntensityModifier.rawValue)
+
+        let settings = HapticSettings(defaults: defaults, shouldPersist: false)
+
+        // Should fall back to defaults, not use 0.0
+        #expect(settings.tapIntensity == HapticSettings.defaultTapIntensity)
+        // Boolean stored as NSNumber: true -> 1.0, clamped to 1.0
+        #expect(settings.modifierIntensity == 1.0)
+    }
+
+    @Test func missingDefaultsFallBackCorrectly() {
+        let defaults = createTestDefaults()
+        // Don't set any values — all should be defaults
+        let settings = HapticSettings(defaults: defaults, shouldPersist: false)
+
+        #expect(settings.tapIntensity == HapticSettings.defaultTapIntensity)
+        #expect(settings.modifierIntensity == HapticSettings.defaultModifierIntensity)
+        #expect(settings.dragIntensity == HapticSettings.defaultDragIntensity)
+        #expect(settings.enabled == true)
+    }
+
     // MARK: - Intensity For Event Tests
 
     @Test func intensityForEventReturnsCorrectValue() {

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -144,6 +144,32 @@ struct LanguageSettingsTests {
         let resultAR = LanguageSettings.detectSystemLanguage(preferredLanguages: ["es-AR"])
         #expect(resultAR == "es_ES")
     }
+
+    // MARK: - Language ID Normalization Tests
+
+    @Test("Unknown language ID resolves to English via LanguageConfig")
+    func unknownLanguageIdResolvesToEnglish() {
+        // If a stale or unknown language ID is stored, LanguageConfig.language(withId:) returns nil
+        let unknownId = "zz_ZZ"
+        let resolved = LanguageConfig.language(withId: unknownId)?.id ?? LanguageConfig.english.id
+        #expect(resolved == "en_US")
+    }
+
+    @Test("Valid language ID resolves to itself")
+    func validLanguageIdResolvesToItself() {
+        let validId = "de_DE"
+        let resolved = LanguageConfig.language(withId: validId)?.id ?? LanguageConfig.english.id
+        #expect(resolved == "de_DE")
+    }
+
+    @Test("All known language IDs resolve correctly")
+    func allKnownLanguageIdsResolve() {
+        for language in LanguageConfig.allLanguages {
+            let resolved = LanguageConfig.language(withId: language.id)
+            #expect(resolved != nil, "Language \(language.id) should resolve")
+            #expect(resolved?.id == language.id)
+        }
+    }
 }
 
 // MARK: - Primary Language Resolution Tests

--- a/wurstfingerTests/wurstfingerTests.swift
+++ b/wurstfingerTests/wurstfingerTests.swift
@@ -10,12 +10,11 @@ import Testing
 @testable import WurstfingerApp
 
 struct wurstfingerTests {
-
-    @Test func example() async throws {
+    @Test func example() {
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
     }
 
-    @Test func circularGestureInsertsUppercaseForBothDirections() async throws {
+    @Test func circularGestureInsertsUppercaseForBothDirections() throws {
         let viewModel = KeyboardViewModel()
         var inserted: [String] = []
 
@@ -33,7 +32,7 @@ struct wurstfingerTests {
         #expect(inserted == ["A", "A"])
     }
 
-    @Test func toggleSymbolsShowsNumericLayout() async throws {
+    @Test func toggleSymbolsShowsNumericLayout() throws {
         let viewModel = KeyboardViewModel()
         viewModel.toggleSymbols()
 
@@ -48,7 +47,7 @@ struct wurstfingerTests {
         #expect(zeroKey.center == "0")
     }
 
-    @Test func symbolsLayerFollowsNumericLayer() async throws {
+    @Test func symbolsLayerFollowsNumericLayer() throws {
         let viewModel = KeyboardViewModel()
 
         // First toggle: lower → numbers
@@ -64,7 +63,7 @@ struct wurstfingerTests {
         #expect(aKey.primaryLabel(for: .downLeft) == "$")
     }
 
-    @Test func circularGestureOnGlobeTogglesUtilityColumn() async throws {
+    @Test func circularGestureOnGlobeTogglesUtilityColumn() {
         let viewModel = KeyboardViewModel()
 
         #expect(!viewModel.utilityColumnLeading)
@@ -76,7 +75,7 @@ struct wurstfingerTests {
         #expect(!viewModel.utilityColumnLeading)
     }
 
-    @Test func numericLayerInsertsDigits() async throws {
+    @Test func numericLayerInsertsDigits() throws {
         let viewModel = KeyboardViewModel()
         var inserted: [String] = []
 
@@ -99,7 +98,7 @@ struct wurstfingerTests {
         #expect(inserted == ["1", "0"])
     }
 
-    @Test func letterLayerProvidesAdditionalSymbols() async throws {
+    @Test func letterLayerProvidesAdditionalSymbols() throws {
         let viewModel = KeyboardViewModel()
         let firstRow = try #require(viewModel.rows.first)
         let aKey = try #require(firstRow.first)
@@ -120,7 +119,7 @@ struct wurstfingerTests {
         #expect(sKey.primaryLabel(for: .right) == ">")
     }
 
-    @Test func spaceDragEmitsCursorMovements() async throws {
+    @Test func spaceDragEmitsCursorMovements() {
         let viewModel = KeyboardViewModel()
         var moves: [Int] = []
 
@@ -139,7 +138,7 @@ struct wurstfingerTests {
         #expect(moves == [1, 1, -1, -1])
     }
 
-    @Test func deleteDragEmitsRepeatedDeletes() async throws {
+    @Test func deleteDragEmitsRepeatedDeletes() {
         let viewModel = KeyboardViewModel()
         var deletes = 0
 
@@ -157,7 +156,7 @@ struct wurstfingerTests {
         #expect(deletes == 2)
     }
 
-    @Test @MainActor func hapticIntensitiesPersistToDefaults() async throws {
+    @Test @MainActor func hapticIntensitiesPersistToDefaults() throws {
         let suite = "group.de.akator.wurstfinger.tests.hapticsPersist"
         let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
@@ -177,7 +176,7 @@ struct wurstfingerTests {
         #expect(abs(dragDefault - 1.0) < 0.0001)
     }
 
-    @Test @MainActor func previewViewModelDoesNotPersist() async throws {
+    @Test @MainActor func previewViewModelDoesNotPersist() throws {
         let suite = "group.de.akator.wurstfinger.tests.preview"
         let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
@@ -193,7 +192,7 @@ struct wurstfingerTests {
         #expect(abs(persistedTap - 0.3) < 0.0001)
     }
 
-    @Test @MainActor func hapticIntensityClampsWithinBounds() async throws {
+    @Test @MainActor func hapticIntensityClampsWithinBounds() throws {
         let suite = "group.de.akator.wurstfinger.tests.clamp"
         let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
@@ -210,7 +209,7 @@ struct wurstfingerTests {
         #expect(abs(storedDrag - 1.0) < 0.0001)
     }
 
-    @Test func composeSwipeEmitsComposeAction() async throws {
+    @Test func composeSwipeEmitsComposeAction() throws {
         let viewModel = KeyboardViewModel()
         var captured: String?
 
@@ -228,13 +227,13 @@ struct wurstfingerTests {
         #expect(captured == "'")
     }
 
-    @Test func composeEngineProducesReplacement() async throws {
+    @Test func composeEngineProducesReplacement() {
         #expect(ComposeEngine.compose(previous: "a", trigger: "¨") == "ä")
         #expect(ComposeEngine.compose(previous: "l", trigger: "!") == "ł")
         #expect(ComposeEngine.compose(previous: "x", trigger: "~") == nil)
     }
 
-    @Test func returnSwipeOnPlusProducesTimes() async throws {
+    @Test func returnSwipeOnPlusProducesTimes() throws {
         let viewModel = KeyboardViewModel()
         var inserted: [String] = []
 
@@ -252,7 +251,7 @@ struct wurstfingerTests {
         #expect(inserted.last == "×")
     }
 
-    @Test func returnSwipesProduceTypographicVariants() async throws {
+    @Test func returnSwipesProduceTypographicVariants() throws {
         let viewModel = KeyboardViewModel()
         var inserted: [String] = []
 
@@ -285,16 +284,16 @@ struct wurstfingerTests {
         try trigger(row: 1, column: 0, direction: .upRight, expected: "‰") // % → ‰
     }
 
-    @Test func directPunctuationSwipeDoesNotCompose() async throws {
+    @Test func directPunctuationSwipeDoesNotCompose() throws {
         let viewModel = KeyboardViewModel()
         var inserts: [String] = []
         var composed: [String] = []
 
         viewModel.bindActionHandler { action in
             switch action {
-            case .insert(let value):
+            case let .insert(value):
                 inserts.append(value)
-            case .compose(let trigger):
+            case let .compose(trigger):
                 composed.append(trigger)
             default:
                 break
@@ -314,9 +313,9 @@ struct wurstfingerTests {
 
     // MARK: - ComposeEngine Determinism Tests
 
-    @Test func accentCycleOrderIsDeterministic() async throws {
+    @Test func accentCycleOrderIsDeterministic() {
         // Running cycleAccent multiple times should always produce the same sequence
-        let runs = (0..<5).map { _ in
+        let runs = (0 ..< 5).map { _ in
             ComposeEngine.cycleAccent(for: "a")
         }
         // All runs should return the same result
@@ -325,9 +324,9 @@ struct wurstfingerTests {
         }
     }
 
-    @Test func numberCycleOrderIsDeterministic() async throws {
+    @Test func numberCycleOrderIsDeterministic() {
         // Number cycles should always return the same next character
-        let runs = (0..<5).map { _ in
+        let runs = (0 ..< 5).map { _ in
             ComposeEngine.cycleAccent(for: "1")
         }
         #expect(runs[0] != nil, "cycleAccent should return a value for '1'")
@@ -336,12 +335,12 @@ struct wurstfingerTests {
         }
     }
 
-    @Test func accentCycleRoundTripsBackToBase() async throws {
+    @Test func accentCycleRoundTripsBackToBase() {
         // Starting from "a", cycling through all variants should return to "a"
         var current = "a"
         var visited: [String] = [current]
 
-        for _ in 0..<50 {  // Safety limit (generous for large compose tables)
+        for _ in 0 ..< 50 { // Safety limit (generous for large compose tables)
             guard let next = ComposeEngine.cycleAccent(for: current) else { break }
             if next == "a" {
                 // Successfully round-tripped
@@ -360,19 +359,19 @@ struct wurstfingerTests {
 
     // MARK: - GestureFeatures.empty Tests
 
-    @Test func gestureFeatureEmptyHasSensibleDefaults() async throws {
+    @Test func gestureFeatureEmptyHasSensibleDefaults() {
         let empty = GestureFeatures.empty
 
         #expect(empty.pathLength == 0)
         #expect(empty.chordLength == 0)
         #expect(empty.maxDisplacement == 0)
-        #expect(empty.returnRatio == 1)  // No movement = "returned"
-        #expect(empty.isTap == true)  // Zero displacement = tap
+        #expect(empty.returnRatio == 1) // No movement = "returned"
+        #expect(empty.isTap == true) // Zero displacement = tap
         #expect(empty.isReturn == false)
         #expect(empty.isCircular == false)
     }
 
-    @Test func gestureFeatureExtractHandlesEmptyPoints() async throws {
+    @Test func gestureFeatureExtractHandlesEmptyPoints() {
         let empty = GestureFeatures.extract(from: [])
         #expect(empty.pathLength == 0)
         #expect(empty.isTap == true)
@@ -381,5 +380,4 @@ struct wurstfingerTests {
         #expect(single.pathLength == 0)
         #expect(single.isTap == true)
     }
-
 }

--- a/wurstfingerTests/wurstfingerTests.swift
+++ b/wurstfingerTests/wurstfingerTests.swift
@@ -10,7 +10,12 @@ import Testing
 @testable import WurstfingerApp
 
 struct wurstfingerTests {
-    @Test func circularGestureInsertsUppercaseForBothDirections() throws {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+    @Test func circularGestureInsertsUppercaseForBothDirections() async throws {
         let viewModel = KeyboardViewModel()
         var inserted: [String] = []
 
@@ -28,7 +33,7 @@ struct wurstfingerTests {
         #expect(inserted == ["A", "A"])
     }
 
-    @Test func toggleSymbolsShowsNumericLayout() throws {
+    @Test func toggleSymbolsShowsNumericLayout() async throws {
         let viewModel = KeyboardViewModel()
         viewModel.toggleSymbols()
 
@@ -43,7 +48,7 @@ struct wurstfingerTests {
         #expect(zeroKey.center == "0")
     }
 
-    @Test func symbolsLayerFollowsNumericLayer() throws {
+    @Test func symbolsLayerFollowsNumericLayer() async throws {
         let viewModel = KeyboardViewModel()
 
         // First toggle: lower → numbers
@@ -59,7 +64,7 @@ struct wurstfingerTests {
         #expect(aKey.primaryLabel(for: .downLeft) == "$")
     }
 
-    @Test func circularGestureOnGlobeTogglesUtilityColumn() {
+    @Test func circularGestureOnGlobeTogglesUtilityColumn() async throws {
         let viewModel = KeyboardViewModel()
 
         #expect(!viewModel.utilityColumnLeading)
@@ -71,7 +76,7 @@ struct wurstfingerTests {
         #expect(!viewModel.utilityColumnLeading)
     }
 
-    @Test func numericLayerInsertsDigits() throws {
+    @Test func numericLayerInsertsDigits() async throws {
         let viewModel = KeyboardViewModel()
         var inserted: [String] = []
 
@@ -94,7 +99,7 @@ struct wurstfingerTests {
         #expect(inserted == ["1", "0"])
     }
 
-    @Test func letterLayerProvidesAdditionalSymbols() throws {
+    @Test func letterLayerProvidesAdditionalSymbols() async throws {
         let viewModel = KeyboardViewModel()
         let firstRow = try #require(viewModel.rows.first)
         let aKey = try #require(firstRow.first)
@@ -115,7 +120,7 @@ struct wurstfingerTests {
         #expect(sKey.primaryLabel(for: .right) == ">")
     }
 
-    @Test func spaceDragEmitsCursorMovements() {
+    @Test func spaceDragEmitsCursorMovements() async throws {
         let viewModel = KeyboardViewModel()
         var moves: [Int] = []
 
@@ -134,7 +139,7 @@ struct wurstfingerTests {
         #expect(moves == [1, 1, -1, -1])
     }
 
-    @Test func deleteDragEmitsRepeatedDeletes() {
+    @Test func deleteDragEmitsRepeatedDeletes() async throws {
         let viewModel = KeyboardViewModel()
         var deletes = 0
 
@@ -152,7 +157,7 @@ struct wurstfingerTests {
         #expect(deletes == 2)
     }
 
-    @Test func hapticIntensitiesPersistToDefaults() throws {
+    @Test @MainActor func hapticIntensitiesPersistToDefaults() async throws {
         let suite = "group.de.akator.wurstfinger.tests.hapticsPersist"
         let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
@@ -172,7 +177,7 @@ struct wurstfingerTests {
         #expect(abs(dragDefault - 1.0) < 0.0001)
     }
 
-    @Test func previewViewModelDoesNotPersist() throws {
+    @Test @MainActor func previewViewModelDoesNotPersist() async throws {
         let suite = "group.de.akator.wurstfinger.tests.preview"
         let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
@@ -188,7 +193,7 @@ struct wurstfingerTests {
         #expect(abs(persistedTap - 0.3) < 0.0001)
     }
 
-    @Test func hapticIntensityClampsWithinBounds() throws {
+    @Test @MainActor func hapticIntensityClampsWithinBounds() async throws {
         let suite = "group.de.akator.wurstfinger.tests.clamp"
         let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
@@ -205,7 +210,7 @@ struct wurstfingerTests {
         #expect(abs(storedDrag - 1.0) < 0.0001)
     }
 
-    @Test func composeSwipeEmitsComposeAction() throws {
+    @Test func composeSwipeEmitsComposeAction() async throws {
         let viewModel = KeyboardViewModel()
         var captured: String?
 
@@ -223,13 +228,13 @@ struct wurstfingerTests {
         #expect(captured == "'")
     }
 
-    @Test func composeEngineProducesReplacement() {
+    @Test func composeEngineProducesReplacement() async throws {
         #expect(ComposeEngine.compose(previous: "a", trigger: "¨") == "ä")
         #expect(ComposeEngine.compose(previous: "l", trigger: "!") == "ł")
         #expect(ComposeEngine.compose(previous: "x", trigger: "~") == nil)
     }
 
-    @Test func returnSwipeOnPlusProducesTimes() throws {
+    @Test func returnSwipeOnPlusProducesTimes() async throws {
         let viewModel = KeyboardViewModel()
         var inserted: [String] = []
 
@@ -247,7 +252,7 @@ struct wurstfingerTests {
         #expect(inserted.last == "×")
     }
 
-    @Test func returnSwipesProduceTypographicVariants() throws {
+    @Test func returnSwipesProduceTypographicVariants() async throws {
         let viewModel = KeyboardViewModel()
         var inserted: [String] = []
 
@@ -280,16 +285,16 @@ struct wurstfingerTests {
         try trigger(row: 1, column: 0, direction: .upRight, expected: "‰") // % → ‰
     }
 
-    @Test func directPunctuationSwipeDoesNotCompose() throws {
+    @Test func directPunctuationSwipeDoesNotCompose() async throws {
         let viewModel = KeyboardViewModel()
         var inserts: [String] = []
         var composed: [String] = []
 
         viewModel.bindActionHandler { action in
             switch action {
-            case let .insert(value):
+            case .insert(let value):
                 inserts.append(value)
-            case let .compose(trigger):
+            case .compose(let trigger):
                 composed.append(trigger)
             default:
                 break
@@ -306,4 +311,71 @@ struct wurstfingerTests {
         #expect(composed.isEmpty)
         #expect(inserts.suffix(2) == ["!", "?"])
     }
+
+    // MARK: - ComposeEngine Determinism Tests
+
+    @Test func accentCycleOrderIsDeterministic() async throws {
+        // Running cycleAccent multiple times should always produce the same sequence
+        let runs = (0..<5).map { _ in
+            ComposeEngine.cycleAccent(for: "a")
+        }
+        // All runs should return the same result
+        for run in runs {
+            #expect(run == runs[0], "Accent cycle should be deterministic across calls")
+        }
+    }
+
+    @Test func numberCycleOrderIsDeterministic() async throws {
+        // Number cycles should always return the same next character
+        let runs = (0..<5).map { _ in
+            ComposeEngine.cycleAccent(for: "1")
+        }
+        for run in runs {
+            #expect(run == runs[0], "Number cycle should be deterministic across calls")
+        }
+    }
+
+    @Test func accentCycleRoundTripsBackToBase() async throws {
+        // Starting from "a", cycling through all variants should return to "a"
+        var current = "a"
+        var visited: [String] = [current]
+
+        for _ in 0..<20 {  // Safety limit
+            guard let next = ComposeEngine.cycleAccent(for: current) else { break }
+            if next == "a" {
+                // Round-tripped back to base
+                break
+            }
+            current = next
+            visited.append(current)
+        }
+
+        // Should have cycled through variants and the last cycle should return to "a"
+        #expect(visited.count > 1, "Should have at least one accent variant for 'a'")
+    }
+
+    // MARK: - GestureFeatures.empty Tests
+
+    @Test func gestureFeatureEmptyHasSensibleDefaults() async throws {
+        let empty = GestureFeatures.empty
+
+        #expect(empty.pathLength == 0)
+        #expect(empty.chordLength == 0)
+        #expect(empty.maxDisplacement == 0)
+        #expect(empty.returnRatio == 1)  // No movement = "returned"
+        #expect(empty.isTap == true)  // Zero displacement = tap
+        #expect(empty.isReturn == false)
+        #expect(empty.isCircular == false)
+    }
+
+    @Test func gestureFeatureExtractHandlesEmptyPoints() async throws {
+        let empty = GestureFeatures.extract(from: [])
+        #expect(empty.pathLength == 0)
+        #expect(empty.isTap == true)
+
+        let single = GestureFeatures.extract(from: [.zero])
+        #expect(single.pathLength == 0)
+        #expect(single.isTap == true)
+    }
+
 }

--- a/wurstfingerTests/wurstfingerTests.swift
+++ b/wurstfingerTests/wurstfingerTests.swift
@@ -330,6 +330,7 @@ struct wurstfingerTests {
         let runs = (0..<5).map { _ in
             ComposeEngine.cycleAccent(for: "1")
         }
+        #expect(runs[0] != nil, "cycleAccent should return a value for '1'")
         for run in runs {
             #expect(run == runs[0], "Number cycle should be deterministic across calls")
         }
@@ -340,18 +341,21 @@ struct wurstfingerTests {
         var current = "a"
         var visited: [String] = [current]
 
-        for _ in 0..<20 {  // Safety limit
+        for _ in 0..<50 {  // Safety limit (generous for large compose tables)
             guard let next = ComposeEngine.cycleAccent(for: current) else { break }
             if next == "a" {
-                // Round-tripped back to base
+                // Successfully round-tripped
                 break
             }
+            #expect(!visited.contains(next), "Cycle should not revisit '\(next)' — would loop forever. Visited: \(visited)")
             current = next
             visited.append(current)
         }
 
-        // Should have cycled through variants and the last cycle should return to "a"
         #expect(visited.count > 1, "Should have at least one accent variant for 'a'")
+        // Verify the cycle actually returns to the base character
+        let lastStep = ComposeEngine.cycleAccent(for: current)
+        #expect(lastStep == "a", "Last variant '\(current)' should cycle back to 'a', got '\(lastStep ?? "nil")'. Full cycle: \(visited)")
     }
 
     // MARK: - GestureFeatures.empty Tests

--- a/wurstfingerTests/wurstfingerTests.swift
+++ b/wurstfingerTests/wurstfingerTests.swift
@@ -10,10 +10,6 @@ import Testing
 @testable import WurstfingerApp
 
 struct wurstfingerTests {
-    @Test func example() {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-    }
-
     @Test func circularGestureInsertsUppercaseForBothDirections() throws {
         let viewModel = KeyboardViewModel()
         var inserted: [String] = []


### PR DESCRIPTION
## Summary
- Add `updateAutoCapitalization()` method that re-evaluates capitalization state bidirectionally after text changes
- Call it after both `.deleteBackward` and `.deleteForward` actions
- Unlike `checkAutoCapitalization()` (which only activates uppercase), the new method also *deactivates* uppercase when the sentence boundary is removed

## Scenarios fixed
1. **"Hello. W" → delete "W"**: Keyboard stays uppercase (still at sentence start)
2. **"Hello." → delete "."**: Keyboard reverts to lowercase (no longer at sentence boundary)

## Test plan
- [ ] Type "Hello. " → verify uppercase is active → delete the space → verify uppercase stays
- [ ] Type "Hello. W" → delete "W" → verify keyboard returns to uppercase
- [ ] Type "Hello." → delete "." → verify keyboard returns to lowercase
- [ ] Verify caps lock is not affected by delete operations

Fixes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-capitalization is correctly re-evaluated after deletions and forward-deletes.
  * Accent and number variant cycling is now deterministic and avoids unintended overrides.
  * Text insertion preserves sentence-opening Spanish punctuation capitalization.
  * Language selection is normalized on startup and persisted, falling back to English when needed.

* **Tests**
  * Added and adjusted unit tests for cycles, gesture features, haptic defaults, and language normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->