### PR TITLE
Fix angle boundary overlap, non-deterministic accent cycles, and fatalError

### DIFF
--- a/wurstfingerKeyboard/ComposeEngine.swift
+++ b/wurstfingerKeyboard/ComposeEngine.swift
@@ -121,8 +121,9 @@ struct ComposeEngine {
         var cycles: [String: [String]] = [:]
 
         // Build reverse mapping: character → all its accented variants
-        for (_, charMap) in composeMap {
-            for (base, accented) in charMap {
+        // Sort by key for deterministic iteration order across runs
+        for (_, charMap) in composeMap.sorted(by: { $0.key < $1.key }) {
+            for (base, accented) in charMap.sorted(by: { $0.key < $1.key }) {
                 // Skip self-mappings like " " → "\"" or composition mappings
                 if base == " " || base.count > 1 { continue }
 

--- a/wurstfingerKeyboard/KeyboardLayout.swift
+++ b/wurstfingerKeyboard/KeyboardLayout.swift
@@ -83,19 +83,19 @@ enum KeyboardDirection: CaseIterable {
         let angle = angleDir < 0 ? 360 + angleDir : angleDir
 
         switch angle {
-        case 22.5...67.5:
+        case 22.5..<67.5:
             return .downRight
-        case 67.5...112.5:
+        case 67.5..<112.5:
             return .right
-        case 112.5...157.5:
+        case 112.5..<157.5:
             return .upRight
-        case 157.5...202.5:
+        case 157.5..<202.5:
             return .up
-        case 202.5...247.5:
+        case 202.5..<247.5:
             return .upLeft
-        case 247.5...292.5:
+        case 247.5..<292.5:
             return .left
-        case 292.5...337.5:
+        case 292.5..<337.5:
             return .downLeft
         default:
             return .down
@@ -272,7 +272,8 @@ private extension KeyboardLayout {
     private static func createLetterRows(for config: LanguageConfig) -> [[MessagEaseKey]] {
         let centers = config.centerCharacters
         guard centers.count == 3 else {
-            fatalError("LanguageConfig must have exactly 3 rows")
+            assertionFailure("LanguageConfig must have exactly 3 rows")
+            return []
         }
 
         return [


### PR DESCRIPTION
## Summary
- Use half-open ranges (`..<`) instead of closed ranges (`...`) in `KeyboardDirection.direction()` to prevent overlapping boundaries at 22.5°, 67.5° etc.
- Sort dictionary iteration in `ComposeEngine.accentCycles` for deterministic cycle order across runs
- Replace `fatalError` with `assertionFailure` + `return []` in `createLetterRows` guard to prevent production crashes

## Test plan
- [x] Build succeeds
- [x] Existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard direction detection logic for more consistent input handling.
  * Enhanced error handling for invalid keyboard configurations, preventing critical failures and returning graceful fallbacks instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->