### PR TITLE
Consolidate SettingsKey usage and fix @AppStorage default mismatches

### DIFF
--- a/wurstfinger/AspectRatioSettingsView.swift
+++ b/wurstfinger/AspectRatioSettingsView.swift
@@ -10,11 +10,11 @@ import SwiftUI
 struct AspectRatioSettingsView: View {
     @Binding var aspectRatio: Double
     
-    @AppStorage("keyboardScale", store: SharedDefaults.store)
-    private var keyboardScale = 1.0
+    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
+    private var keyboardScale = DeviceLayoutUtils.defaultKeyboardScale
 
-    @AppStorage("keyboardHorizontalPosition", store: SharedDefaults.store)
-    private var keyboardHorizontalPosition = 0.5
+    @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
+    private var keyboardHorizontalPosition = DeviceLayoutUtils.defaultKeyboardPosition
 
     var body: some View {
         VStack(spacing: 20) {

--- a/wurstfinger/ExpertSettingsView.swift
+++ b/wurstfinger/ExpertSettingsView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct ExpertSettingsView: View {
-    @AppStorage("expertModeEnabled", store: SharedDefaults.store)
+    @AppStorage(SettingsKey.expertModeEnabled.rawValue, store: SharedDefaults.store)
     private var expertModeEnabled = false
 
     // MARK: - Preprocessing Settings

--- a/wurstfinger/HapticSettingsView.swift
+++ b/wurstfinger/HapticSettingsView.swift
@@ -1,26 +1,26 @@
 import SwiftUI
 
 struct HapticSettingsView: View {
-    @AppStorage(KeyboardViewModel.hapticTapIntensityKey, store: SharedDefaults.store)
-    private var tapIntensity = Double(KeyboardViewModel.defaultTapIntensity)
+    @AppStorage(SettingsKey.hapticIntensityTap.rawValue, store: SharedDefaults.store)
+    private var tapIntensity = Double(HapticSettings.defaultTapIntensity)
 
-    @AppStorage(KeyboardViewModel.hapticModifierIntensityKey, store: SharedDefaults.store)
-    private var modifierIntensity = Double(KeyboardViewModel.defaultModifierIntensity)
+    @AppStorage(SettingsKey.hapticIntensityModifier.rawValue, store: SharedDefaults.store)
+    private var modifierIntensity = Double(HapticSettings.defaultModifierIntensity)
 
-    @AppStorage(KeyboardViewModel.hapticDragIntensityKey, store: SharedDefaults.store)
-    private var dragIntensity = Double(KeyboardViewModel.defaultDragIntensity)
+    @AppStorage(SettingsKey.hapticIntensityDrag.rawValue, store: SharedDefaults.store)
+    private var dragIntensity = Double(HapticSettings.defaultDragIntensity)
 
-    @AppStorage("hapticEnabled", store: SharedDefaults.store)
+    @AppStorage(SettingsKey.hapticEnabled.rawValue, store: SharedDefaults.store)
     private var hapticEnabled = true
 
-    @AppStorage("keyAspectRatio", store: SharedDefaults.store)
-    private var previewAspectRatio = 1.0
+    @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
+    private var previewAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 
-    @AppStorage("keyboardScale", store: SharedDefaults.store)
-    private var previewScale = 1.0
+    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
+    private var previewScale = DeviceLayoutUtils.defaultKeyboardScale
 
-    @AppStorage("keyboardHorizontalPosition", store: SharedDefaults.store)
-    private var previewPosition = 0.5
+    @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
+    private var previewPosition = DeviceLayoutUtils.defaultKeyboardPosition
 
     var body: some View {
         VStack(spacing: 20) {
@@ -71,9 +71,9 @@ struct HapticSettingsView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("Reset") {
-                    tapIntensity = Double(KeyboardViewModel.defaultTapIntensity)
-                    modifierIntensity = Double(KeyboardViewModel.defaultModifierIntensity)
-                    dragIntensity = Double(KeyboardViewModel.defaultDragIntensity)
+                    tapIntensity = Double(HapticSettings.defaultTapIntensity)
+                    modifierIntensity = Double(HapticSettings.defaultModifierIntensity)
+                    dragIntensity = Double(HapticSettings.defaultDragIntensity)
                     hapticEnabled = true
                 }
             }

--- a/wurstfinger/KeyboardSizePositionSettingsView.swift
+++ b/wurstfinger/KeyboardSizePositionSettingsView.swift
@@ -11,8 +11,8 @@ struct KeyboardSizePositionSettingsView: View {
     @Binding var scale: Double
     @Binding var position: Double
     
-    @AppStorage("keyAspectRatio", store: SharedDefaults.store)
-    private var keyAspectRatio = 1.0
+    @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
+    private var keyAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 
     var body: some View {
         VStack(spacing: 20) {

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -10,39 +10,39 @@ import SwiftUI
 struct SettingsView: View {
     @StateObject private var languageSettings = LanguageSettings.shared
 
-    @AppStorage("utilityColumnLeading", store: SharedDefaults.store)
+    @AppStorage(SettingsKey.utilityColumnLeading.rawValue, store: SharedDefaults.store)
     private var utilityColumnLeading = false
 
-    @AppStorage("keyAspectRatio", store: SharedDefaults.store)
-    private var keyAspectRatio = 1.0
+    @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
+    private var keyAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 
-    @AppStorage("keyboardScale", store: SharedDefaults.store)
-    private var keyboardScale = 1.0
+    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
+    private var keyboardScale = DeviceLayoutUtils.defaultKeyboardScale
 
-    @AppStorage("keyboardHorizontalPosition", store: SharedDefaults.store)
-    private var keyboardHorizontalPosition = 0.5
+    @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
+    private var keyboardHorizontalPosition = DeviceLayoutUtils.defaultKeyboardPosition
 
-    @AppStorage(KeyboardViewModel.hapticTapIntensityKey, store: SharedDefaults.store)
-    private var hapticTapIntensity = Double(KeyboardViewModel.defaultTapIntensity)
+    @AppStorage(SettingsKey.hapticIntensityTap.rawValue, store: SharedDefaults.store)
+    private var hapticTapIntensity = Double(HapticSettings.defaultTapIntensity)
 
-    @AppStorage(KeyboardViewModel.hapticModifierIntensityKey, store: SharedDefaults.store)
-    private var hapticModifierIntensity = Double(KeyboardViewModel.defaultModifierIntensity)
+    @AppStorage(SettingsKey.hapticIntensityModifier.rawValue, store: SharedDefaults.store)
+    private var hapticModifierIntensity = Double(HapticSettings.defaultModifierIntensity)
 
-    @AppStorage(KeyboardViewModel.hapticDragIntensityKey, store: SharedDefaults.store)
-    private var hapticDragIntensity = Double(KeyboardViewModel.defaultDragIntensity)
+    @AppStorage(SettingsKey.hapticIntensityDrag.rawValue, store: SharedDefaults.store)
+    private var hapticDragIntensity = Double(HapticSettings.defaultDragIntensity)
 
-    @AppStorage(KeyboardViewModel.numpadStyleKey, store: SharedDefaults.store)
+    @AppStorage(SettingsKey.numpadStyle.rawValue, store: SharedDefaults.store)
     private var numpadStyleRaw = NumpadStyle.phone.rawValue
 
-    @AppStorage("keyboardStyle", store: SharedDefaults.store)
+    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
     private var keyboardStyleRaw = KeyboardStyle.classic.rawValue
 
-    @AppStorage("autoCapitalizeEnabled", store: SharedDefaults.store)
+    @AppStorage(SettingsKey.autoCapitalizeEnabled.rawValue, store: SharedDefaults.store)
     private var autoCapitalizeEnabled = false
 
     private let licenseURL = URL(string: "https://github.com/cl445/wurstfinger/blob/main/LICENSE")!
 
-    @AppStorage("expertModeEnabled", store: SharedDefaults.store)
+    @AppStorage(SettingsKey.expertModeEnabled.rawValue, store: SharedDefaults.store)
     private var expertModeEnabled = false
 
     var body: some View {
@@ -202,9 +202,9 @@ struct SettingsView: View {
     }
 
     private func hapticModeDescription() -> String {
-        let tap = formatIntensity(hapticTapIntensity)
-        let modifier = formatIntensity(hapticModifierIntensity)
-        let drag = formatIntensity(hapticDragIntensity)
+        let tap: String = formatIntensity(hapticTapIntensity)
+        let modifier: String = formatIntensity(hapticModifierIntensity)
+        let drag: String = formatIntensity(hapticDragIntensity)
         return "Tap: \(tap) • Modifiers: \(modifier) • Drags: \(drag)"
     }
 

--- a/wurstfinger/SharedDefaults.swift
+++ b/wurstfinger/SharedDefaults.swift
@@ -15,7 +15,5 @@ enum SharedDefaults {
 
     /// The shared UserDefaults instance
     /// Falls back to standard UserDefaults if app group is not available (should never happen in production)
-    static var store: UserDefaults {
-        UserDefaults(suiteName: suiteName) ?? .standard
-    }
+    static let store: UserDefaults = UserDefaults(suiteName: suiteName) ?? .standard
 }

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -8,17 +8,17 @@
 import SwiftUI
 
 struct StyleSettingsView: View {
-    @AppStorage("keyboardStyle", store: SharedDefaults.store)
+    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
     private var keyboardStyleRaw = KeyboardStyle.classic.rawValue
 
-    @AppStorage("keyAspectRatio", store: SharedDefaults.store)
-    private var previewAspectRatio = 1.0
+    @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
+    private var previewAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 
-    @AppStorage("keyboardScale", store: SharedDefaults.store)
-    private var previewScale = 1.0
+    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
+    private var previewScale = DeviceLayoutUtils.defaultKeyboardScale
 
-    @AppStorage("keyboardHorizontalPosition", store: SharedDefaults.store)
-    private var previewPosition = 0.5
+    @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
+    private var previewPosition = DeviceLayoutUtils.defaultKeyboardPosition
 
     private var keyboardStyle: KeyboardStyle {
         get { KeyboardStyle(rawValue: keyboardStyleRaw) ?? .classic }

--- a/wurstfinger/wurstfingerApp.swift
+++ b/wurstfinger/wurstfingerApp.swift
@@ -19,9 +19,9 @@ struct wurstfingerApp: App {
 
     init() {
         let defaults: [String: Any] = [
-            "keyAspectRatio": DeviceLayoutUtils.defaultKeyAspectRatio,
-            "keyboardScale": DeviceLayoutUtils.defaultKeyboardScale,
-            "keyboardHorizontalPosition": DeviceLayoutUtils.defaultKeyboardPosition
+            SettingsKey.keyAspectRatio.rawValue: DeviceLayoutUtils.defaultKeyAspectRatio,
+            SettingsKey.keyboardScale.rawValue: DeviceLayoutUtils.defaultKeyboardScale,
+            SettingsKey.keyboardHorizontalPosition.rawValue: DeviceLayoutUtils.defaultKeyboardPosition
         ]
         SharedDefaults.store.register(defaults: defaults)
 

--- a/wurstfingerKeyboard/KeyboardButtonComponents.swift
+++ b/wurstfingerKeyboard/KeyboardButtonComponents.swift
@@ -50,7 +50,7 @@ struct KeyCap<Content: View>: View {
     let fontSize: CGFloat
     private let content: Content
 
-    @AppStorage("keyboardStyle", store: SharedDefaults.store)
+    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
     private var keyboardStyleRaw = KeyboardStyle.classic.rawValue
 
     private var keyboardStyle: KeyboardStyle {

--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -15,7 +15,7 @@ struct KeyboardRootView: View {
     var frameAlignment: Alignment = .bottom
     var overrideWidth: CGFloat? = nil
 
-    @AppStorage("keyboardStyle", store: SharedDefaults.store)
+    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
     private var keyboardStyleRaw = KeyboardStyle.classic.rawValue
 
     private var keyboardStyle: KeyboardStyle {

--- a/wurstfingerKeyboard/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/KeyboardSettings.swift
@@ -25,6 +25,9 @@ enum SettingsKey: String {
     case keyboardHorizontalPosition
     case numpadStyle
     case selectedLanguageId
+    case autoCapitalizeEnabled
+    case expertModeEnabled
+    case keyboardStyle
 }
 
 // MARK: - Haptic Settings

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -100,7 +100,7 @@ final class KeyboardViewController: UIInputViewController {
             textDocumentProxy.insertText(text)
             // Spanish sentence-opening punctuation triggers immediate capitalization
             if AutoCapitalization.shouldCapitalizeImmediately(after: text) &&
-               SharedDefaults.store.bool(forKey: "autoCapitalizeEnabled") {
+               SharedDefaults.store.bool(forKey: SettingsKey.autoCapitalizeEnabled.rawValue) {
                 viewModel.setLayer(.upper)
             }
         case .deleteBackward:
@@ -170,7 +170,7 @@ final class KeyboardViewController: UIInputViewController {
 
     private func checkAutoCapitalization() {
         // Check if auto-capitalize is enabled
-        guard SharedDefaults.store.bool(forKey: "autoCapitalizeEnabled") else { return }
+        guard SharedDefaults.store.bool(forKey: SettingsKey.autoCapitalizeEnabled.rawValue) else { return }
 
         if AutoCapitalization.shouldCapitalize(context: textDocumentProxy.documentContextBeforeInput) {
             viewModel.setLayer(.upper)

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -200,7 +200,7 @@ final class KeyboardViewModel: ObservableObject {
 
     private func reloadLanguage() {
         // Read language ID directly from UserDefaults to catch changes from host app
-        let languageId = sharedDefaults.string(forKey: "selectedLanguageId") ?? LanguageSettings.detectSystemLanguage()
+        let languageId = sharedDefaults.string(forKey: SettingsKey.selectedLanguageId.rawValue) ?? LanguageSettings.detectSystemLanguage()
 
         if languageId != locale.identifier {
             // Notify SwiftUI that we're about to change the model
@@ -479,7 +479,7 @@ final class KeyboardViewModel: ObservableObject {
         feedbackModifier()
         utilityColumnLeading.toggle()
         if shouldPersistSettings {
-            sharedDefaults.set(utilityColumnLeading, forKey: "utilityColumnLeading")
+            sharedDefaults.set(utilityColumnLeading, forKey: SettingsKey.utilityColumnLeading.rawValue)
         }
     }
 

--- a/wurstfingerKeyboard/LanguageSettings.swift
+++ b/wurstfingerKeyboard/LanguageSettings.swift
@@ -18,17 +18,10 @@ class LanguageSettings: ObservableObject {
     }
 
     private let userDefaults: UserDefaults
-    private let languageKey = "selectedLanguageId"
-    private let appGroupId = "group.de.akator.wurstfinger.shared"
+    private let languageKey = SettingsKey.selectedLanguageId.rawValue
 
-    init() {
-        // Use App Group for sharing between app and extension
-        if let groupDefaults = UserDefaults(suiteName: appGroupId) {
-            self.userDefaults = groupDefaults
-        } else {
-            self.userDefaults = UserDefaults.standard
-            print("Warning: Could not access App Group UserDefaults")
-        }
+    private init() {
+        self.userDefaults = SharedDefaults.store
 
         // Load saved language or detect from system
         self.selectedLanguageId = userDefaults.string(forKey: languageKey) ?? Self.detectSystemLanguage()
@@ -64,7 +57,7 @@ class LanguageSettings: ObservableObject {
     }
 
     var selectedLanguage: LanguageConfig {
-        LanguageConfig.language(withId: selectedLanguageId) ?? .german
+        LanguageConfig.language(withId: selectedLanguageId) ?? .english
     }
 
     func selectLanguage(_ language: LanguageConfig) {
@@ -73,6 +66,5 @@ class LanguageSettings: ObservableObject {
 
     private func save() {
         userDefaults.set(selectedLanguageId, forKey: languageKey)
-        userDefaults.synchronize()
     }
 }

--- a/wurstfingerKeyboard/SharedDefaults.swift
+++ b/wurstfingerKeyboard/SharedDefaults.swift
@@ -15,7 +15,5 @@ enum SharedDefaults {
 
     /// The shared UserDefaults instance
     /// Falls back to standard UserDefaults if app group is not available (should never happen in production)
-    static var store: UserDefaults {
-        UserDefaults(suiteName: suiteName) ?? .standard
-    }
+    static let store: UserDefaults = UserDefaults(suiteName: suiteName) ?? .standard
 }


### PR DESCRIPTION
## Summary
- Extend `SettingsKey` enum with `autoCapitalizeEnabled`, `expertModeEnabled`, `keyboardStyle`
- Replace all raw `@AppStorage` key strings with `SettingsKey.*.rawValue`
- Fix `@AppStorage` defaults to use `DeviceLayoutUtils` constants instead of hardcoded 1.0 values
- Change `SharedDefaults.store` from `var` (computed) to `let` (cached)
- Make `LanguageSettings.init()` private (singleton pattern)
- Remove deprecated `userDefaults.synchronize()` call
- Fix `selectedLanguage` fallback from `.german` to `.english` for consistency

## Test plan
- [x] Build succeeds
- [x] Existing tests pass