### PR TITLE
Fix UserDefaults CGFloat casting and eliminate static mutable gesture state

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -56,7 +56,7 @@ jobs:
           xcrun simctl bootstatus "$SIMULATOR_ID"
 
       - name: Build and Run Tests
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: |
           set -o pipefail && xcodebuild test \
             -scheme Wurstfinger \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Fix hardcoded version "1.0.0" in settings — now reads from bundle
 - Set `PrimaryLanguage` to `mul` (multi-language) and read active language directly from SharedDefaults so iOS Settings shows the correct keyboard language (#96)
 - Auto-capitalization now re-evaluates after deleting characters (#88)
+- Fix UserDefaults `as? CGFloat` casting with `double(forKey:)` for reliable settings loading
+- Lower height constraint priority to `.defaultHigh` to prevent Auto Layout conflicts
 
 ### Added
 
@@ -28,6 +30,8 @@
 - Create HapticFeedbackManager for centralized haptic feedback (#90)
 - Add Vector2D type with division-by-zero guard (#90)
 - Extract GestureCalculations helpers and centralize GeometryUtils (#90)
+- Convert `GestureFeatures.thresholds` from `static var` to instance `let`
+- Filter `UserDefaults.didChangeNotification` to shared defaults instance only
 
 ## v1.1.1 — 2025-12-28
 

--- a/wurstfinger/GesturePlaygroundView.swift
+++ b/wurstfinger/GesturePlaygroundView.swift
@@ -202,7 +202,7 @@ struct GesturePlaygroundView: View {
                             ) {
                                 VStack(alignment: .leading) {
                                     criterion("ratio", val: features.returnRatio, op: "<", limit: features.thresholds.maxReturnRatio, pass: features.returnRatio < features.thresholds.maxReturnRatio)
-                                    criterion("progress", val: features.maxDisplacementProgress, op: "in", limit: 0, pass: features.thresholds.returnDisplacementRange.contains(features.maxDisplacementProgress))
+                                    rangeCriterion("progress", val: features.maxDisplacementProgress, range: features.thresholds.returnDisplacementRange)
                                 }
                             }
 
@@ -280,6 +280,20 @@ struct GesturePlaygroundView: View {
                 .foregroundColor(pass ? .green : .red)
             Text(op)
             Text("\(f(limit))\(unit)")
+        }
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+
+    private func rangeCriterion(_ name: String, val: CGFloat, range: ClosedRange<CGFloat>) -> some View {
+        let pass = range.contains(val)
+        return HStack(spacing: 4) {
+            Text(name)
+            Text(f(val))
+                .bold()
+                .foregroundColor(pass ? .green : .red)
+            Text("in")
+            Text("\(f(range.lowerBound))...\(f(range.upperBound))")
         }
         .font(.caption)
         .foregroundColor(.secondary)

--- a/wurstfinger/GesturePlaygroundView.swift
+++ b/wurstfinger/GesturePlaygroundView.swift
@@ -43,7 +43,7 @@ struct GesturePlaygroundView: View {
                 .stroke(Color.gray.opacity(0.3), style: StrokeStyle(lineWidth: 1, dash: [5]))
 
                 // Sector lines (for swipe angles)
-                ForEach(0..<8) { i in
+                ForEach(0 ..< 8) { i in
                     Path { path in
                         let angle = Double(i) * 45.0 * .pi / 180.0
                         path.move(to: CGPoint(x: 150, y: 150))
@@ -91,7 +91,7 @@ struct GesturePlaygroundView: View {
                 .stroke(Color.green, lineWidth: 4)
 
                 // Key Points
-                if let features = features {
+                if let features {
                     // Start
                     Circle()
                         .fill(Color.blue)
@@ -172,7 +172,7 @@ struct GesturePlaygroundView: View {
                     .background(Color.blue.opacity(0.1))
                     .cornerRadius(8)
 
-                    if let features = features {
+                    if let features {
                         // Decision Tree Breakdown
                         VStack(alignment: .leading, spacing: 8) {
                             Text("Decision Logic").font(.headline)
@@ -181,7 +181,13 @@ struct GesturePlaygroundView: View {
                                 "1. Tap?",
                                 passed: features.isTap
                             ) {
-                                criterion("maxDisp", val: features.maxDisplacement, op: "<", limit: features.thresholds.minSwipeLength, pass: features.maxDisplacement < features.thresholds.minSwipeLength)
+                                criterion(
+                                    "maxDisp",
+                                    val: features.maxDisplacement,
+                                    op: "<",
+                                    limit: features.thresholds.minSwipeLength,
+                                    pass: features.maxDisplacement < features.thresholds.minSwipeLength
+                                )
                             }
 
                             decisionRow(
@@ -189,10 +195,35 @@ struct GesturePlaygroundView: View {
                                 passed: features.isCircular
                             ) {
                                 VStack(alignment: .leading) {
-                                    criterion("circ", val: features.circularity, op: ">", limit: features.thresholds.minCircularity, pass: features.circularity > features.thresholds.minCircularity)
-                                    criterion("angle", val: abs(features.angularSpan) * 180 / .pi, op: ">", limit: features.thresholds.minAngularSpan * 180 / .pi, unit: "°", pass: abs(features.angularSpan) > features.thresholds.minAngularSpan)
-                                    criterion("turn", val: features.turnConsistency, op: ">", limit: features.thresholds.minTurnConsistency, pass: features.turnConsistency > features.thresholds.minTurnConsistency)
-                                    criterion("compact", val: features.orientedCompactness, op: ">", limit: features.thresholds.minOrientedCompactness, pass: features.orientedCompactness > features.thresholds.minOrientedCompactness)
+                                    criterion(
+                                        "circ",
+                                        val: features.circularity,
+                                        op: ">",
+                                        limit: features.thresholds.minCircularity,
+                                        pass: features.circularity > features.thresholds.minCircularity
+                                    )
+                                    criterion(
+                                        "angle",
+                                        val: abs(features.angularSpan) * 180 / .pi,
+                                        op: ">",
+                                        limit: features.thresholds.minAngularSpan * 180 / .pi,
+                                        unit: "°",
+                                        pass: abs(features.angularSpan) > features.thresholds.minAngularSpan
+                                    )
+                                    criterion(
+                                        "turn",
+                                        val: features.turnConsistency,
+                                        op: ">",
+                                        limit: features.thresholds.minTurnConsistency,
+                                        pass: features.turnConsistency > features.thresholds.minTurnConsistency
+                                    )
+                                    criterion(
+                                        "compact",
+                                        val: features.orientedCompactness,
+                                        op: ">",
+                                        limit: features.thresholds.minOrientedCompactness,
+                                        pass: features.orientedCompactness > features.thresholds.minOrientedCompactness
+                                    )
                                 }
                             }
 
@@ -201,8 +232,18 @@ struct GesturePlaygroundView: View {
                                 passed: features.isReturn
                             ) {
                                 VStack(alignment: .leading) {
-                                    criterion("ratio", val: features.returnRatio, op: "<", limit: features.thresholds.maxReturnRatio, pass: features.returnRatio < features.thresholds.maxReturnRatio)
-                                    rangeCriterion("progress", val: features.maxDisplacementProgress, range: features.thresholds.returnDisplacementRange)
+                                    criterion(
+                                        "ratio",
+                                        val: features.returnRatio,
+                                        op: "<",
+                                        limit: features.thresholds.maxReturnRatio,
+                                        pass: features.returnRatio < features.thresholds.maxReturnRatio
+                                    )
+                                    rangeCriterion(
+                                        "progress",
+                                        val: features.maxDisplacementProgress,
+                                        range: features.thresholds.returnDisplacementRange
+                                    )
                                 }
                             }
 
@@ -261,7 +302,7 @@ struct GesturePlaygroundView: View {
         String(format: "%.1f", value)
     }
 
-    private func decisionRow<Content: View>(_ label: String, passed: Bool, @ViewBuilder content: () -> Content) -> some View {
+    private func decisionRow(_ label: String, passed: Bool, @ViewBuilder content: () -> some View) -> some View {
         HStack(alignment: .top) {
             Image(systemName: passed ? "checkmark.circle.fill" : "circle")
                 .foregroundColor(passed ? .green : .gray)
@@ -326,7 +367,7 @@ struct GesturePlaygroundView: View {
         // 3. Extract Features
         let thresholds = GestureClassificationThresholds.fromUserDefaults()
         let feats = GestureFeatures.extract(from: processedPoints, thresholds: thresholds)
-        self.features = feats
+        features = feats
 
         // 4. Classify
         var result = ""
@@ -346,7 +387,7 @@ struct GesturePlaygroundView: View {
             detectedDirection = KeyboardDirection.direction(for: swipeSize, tolerance: 0)
         }
 
-        self.classificationResult = result
+        classificationResult = result
     }
 }
 

--- a/wurstfinger/GesturePlaygroundView.swift
+++ b/wurstfinger/GesturePlaygroundView.swift
@@ -43,7 +43,7 @@ struct GesturePlaygroundView: View {
                 .stroke(Color.gray.opacity(0.3), style: StrokeStyle(lineWidth: 1, dash: [5]))
 
                 // Sector lines (for swipe angles)
-                ForEach(0 ..< 8) { i in
+                ForEach(0..<8) { i in
                     Path { path in
                         let angle = Double(i) * 45.0 * .pi / 180.0
                         path.move(to: CGPoint(x: 150, y: 150))
@@ -91,7 +91,7 @@ struct GesturePlaygroundView: View {
                 .stroke(Color.green, lineWidth: 4)
 
                 // Key Points
-                if let features {
+                if let features = features {
                     // Start
                     Circle()
                         .fill(Color.blue)
@@ -172,7 +172,7 @@ struct GesturePlaygroundView: View {
                     .background(Color.blue.opacity(0.1))
                     .cornerRadius(8)
 
-                    if let features {
+                    if let features = features {
                         // Decision Tree Breakdown
                         VStack(alignment: .leading, spacing: 8) {
                             Text("Decision Logic").font(.headline)
@@ -181,11 +181,7 @@ struct GesturePlaygroundView: View {
                                 "1. Tap?",
                                 passed: features.isTap
                             ) {
-                                criterion(
-                                    "maxDisp", val: features.maxDisplacement, op: "<",
-                                    limit: GestureFeatures.thresholds.minSwipeLength,
-                                    pass: features.maxDisplacement < GestureFeatures.thresholds.minSwipeLength
-                                )
+                                criterion("maxDisp", val: features.maxDisplacement, op: "<", limit: features.thresholds.minSwipeLength, pass: features.maxDisplacement < features.thresholds.minSwipeLength)
                             }
 
                             decisionRow(
@@ -193,26 +189,10 @@ struct GesturePlaygroundView: View {
                                 passed: features.isCircular
                             ) {
                                 VStack(alignment: .leading) {
-                                    criterion(
-                                        "circ", val: features.circularity, op: ">",
-                                        limit: GestureFeatures.thresholds.minCircularity,
-                                        pass: features.circularity > GestureFeatures.thresholds.minCircularity
-                                    )
-                                    criterion(
-                                        "angle", val: abs(features.angularSpan) * 180 / .pi, op: ">",
-                                        limit: GestureFeatures.thresholds.minAngularSpan * 180 / .pi, unit: "°",
-                                        pass: abs(features.angularSpan) > GestureFeatures.thresholds.minAngularSpan
-                                    )
-                                    criterion(
-                                        "turn", val: features.turnConsistency, op: ">",
-                                        limit: GestureFeatures.thresholds.minTurnConsistency,
-                                        pass: features.turnConsistency > GestureFeatures.thresholds.minTurnConsistency
-                                    )
-                                    criterion(
-                                        "compact", val: features.orientedCompactness, op: ">",
-                                        limit: GestureFeatures.thresholds.minOrientedCompactness,
-                                        pass: features.orientedCompactness > GestureFeatures.thresholds.minOrientedCompactness
-                                    )
+                                    criterion("circ", val: features.circularity, op: ">", limit: features.thresholds.minCircularity, pass: features.circularity > features.thresholds.minCircularity)
+                                    criterion("angle", val: abs(features.angularSpan) * 180 / .pi, op: ">", limit: features.thresholds.minAngularSpan * 180 / .pi, unit: "°", pass: abs(features.angularSpan) > features.thresholds.minAngularSpan)
+                                    criterion("turn", val: features.turnConsistency, op: ">", limit: features.thresholds.minTurnConsistency, pass: features.turnConsistency > features.thresholds.minTurnConsistency)
+                                    criterion("compact", val: features.orientedCompactness, op: ">", limit: features.thresholds.minOrientedCompactness, pass: features.orientedCompactness > features.thresholds.minOrientedCompactness)
                                 }
                             }
 
@@ -221,17 +201,8 @@ struct GesturePlaygroundView: View {
                                 passed: features.isReturn
                             ) {
                                 VStack(alignment: .leading) {
-                                    criterion(
-                                        "ratio", val: features.returnRatio, op: "<",
-                                        limit: GestureFeatures.thresholds.maxReturnRatio,
-                                        pass: features.returnRatio < GestureFeatures.thresholds.maxReturnRatio
-                                    )
-                                    // Simplified range display
-                                    criterion(
-                                        "progress", val: features.maxDisplacementProgress, op: "in",
-                                        limit: 0,
-                                        pass: features.maxDisplacementProgress > 0.2 && features.maxDisplacementProgress < 0.8
-                                    )
+                                    criterion("ratio", val: features.returnRatio, op: "<", limit: features.thresholds.maxReturnRatio, pass: features.returnRatio < features.thresholds.maxReturnRatio)
+                                    criterion("progress", val: features.maxDisplacementProgress, op: "in", limit: 0, pass: features.maxDisplacementProgress > 0.2 && features.maxDisplacementProgress < 0.8) // Simplified range display
                                 }
                             }
 
@@ -290,7 +261,7 @@ struct GesturePlaygroundView: View {
         String(format: "%.1f", value)
     }
 
-    private func decisionRow(_ label: String, passed: Bool, @ViewBuilder content: () -> some View) -> some View {
+    private func decisionRow<Content: View>(_ label: String, passed: Bool, @ViewBuilder content: () -> Content) -> some View {
         HStack(alignment: .top) {
             Image(systemName: passed ? "checkmark.circle.fill" : "circle")
                 .foregroundColor(passed ? .green : .gray)
@@ -339,9 +310,9 @@ struct GesturePlaygroundView: View {
         processedPoints = preprocessor.preprocess(rawPoints)
 
         // 3. Extract Features
-        GestureFeatures.thresholds = GestureClassificationThresholds.fromUserDefaults()
-        let feats = GestureFeatures.extract(from: processedPoints)
-        features = feats
+        let thresholds = GestureClassificationThresholds.fromUserDefaults()
+        let feats = GestureFeatures.extract(from: processedPoints, thresholds: thresholds)
+        self.features = feats
 
         // 4. Classify
         var result = ""
@@ -361,7 +332,7 @@ struct GesturePlaygroundView: View {
             detectedDirection = KeyboardDirection.direction(for: swipeSize, tolerance: 0)
         }
 
-        classificationResult = result
+        self.classificationResult = result
     }
 }
 

--- a/wurstfinger/GesturePlaygroundView.swift
+++ b/wurstfinger/GesturePlaygroundView.swift
@@ -202,7 +202,7 @@ struct GesturePlaygroundView: View {
                             ) {
                                 VStack(alignment: .leading) {
                                     criterion("ratio", val: features.returnRatio, op: "<", limit: features.thresholds.maxReturnRatio, pass: features.returnRatio < features.thresholds.maxReturnRatio)
-                                    criterion("progress", val: features.maxDisplacementProgress, op: "in", limit: 0, pass: features.maxDisplacementProgress > 0.2 && features.maxDisplacementProgress < 0.8) // Simplified range display
+                                    criterion("progress", val: features.maxDisplacementProgress, op: "in", limit: 0, pass: features.thresholds.returnDisplacementRange.contains(features.maxDisplacementProgress))
                                 }
                             }
 

--- a/wurstfingerKeyboard/GesturePreprocessor.swift
+++ b/wurstfingerKeyboard/GesturePreprocessor.swift
@@ -125,10 +125,17 @@ struct GesturePreprocessorConfig {
         return GesturePreprocessorConfig(
             jitterThreshold: jitter,
             maxJumpDistance: maxJump,
-            smoothingWindow: store.object(forKey: smoothingWindowKey) as? Int ?? defaultSmoothingWindow,
+            smoothingWindow: validSmoothingWindow(from: store),
             smoothingOrder: 2,
             aspectRatio: 1.0
         )
+    }
+
+    /// Reads smoothingWindow from defaults, ensuring it's a positive odd integer.
+    private static func validSmoothingWindow(from store: UserDefaults) -> Int {
+        let raw = store.object(forKey: smoothingWindowKey) as? Int ?? defaultSmoothingWindow
+        let clamped = max(3, raw)
+        return clamped.isMultiple(of: 2) ? clamped + 1 : clamped
     }
 
     private static func finiteCGFloat(from store: UserDefaults, key: String, default defaultValue: CGFloat) -> CGFloat {

--- a/wurstfingerKeyboard/GesturePreprocessor.swift
+++ b/wurstfingerKeyboard/GesturePreprocessor.swift
@@ -119,9 +119,15 @@ struct GesturePreprocessorConfig {
     /// Loads config from SharedDefaults with fallback to defaults
     static func fromUserDefaults() -> GesturePreprocessorConfig {
         let store = SharedDefaults.store
+        let jitter: CGFloat = store.object(forKey: jitterThresholdKey) != nil
+            ? CGFloat(store.double(forKey: jitterThresholdKey))
+            : defaultJitterThreshold
+        let maxJump: CGFloat = store.object(forKey: maxJumpDistanceKey) != nil
+            ? CGFloat(store.double(forKey: maxJumpDistanceKey))
+            : defaultMaxJumpDistance
         return GesturePreprocessorConfig(
-            jitterThreshold: store.object(forKey: jitterThresholdKey) as? CGFloat ?? defaultJitterThreshold,
-            maxJumpDistance: store.object(forKey: maxJumpDistanceKey) as? CGFloat ?? defaultMaxJumpDistance,
+            jitterThreshold: jitter,
+            maxJumpDistance: maxJump,
             smoothingWindow: store.object(forKey: smoothingWindowKey) as? Int ?? defaultSmoothingWindow,
             smoothingOrder: 2,
             aspectRatio: 1.0
@@ -163,7 +169,9 @@ struct GesturePreprocessor {
         let normalized = normalizeAspectRatio(cleaned)
 
         // Step 4: Savitzky-Golay smoothing
-        return smoothSavitzkyGolay(normalized)
+        let smoothed = smoothSavitzkyGolay(normalized)
+
+        return smoothed
     }
 
     // MARK: - Step 1: Jitter Filter
@@ -174,7 +182,7 @@ struct GesturePreprocessor {
 
         var filtered: [CGPoint] = [points[0]]
 
-        for i in 1 ..< points.count {
+        for i in 1..<points.count {
             // Safe: filtered always has at least one element (initialized with points[0])
             guard let last = filtered.last else { continue }
             let current = points[i]
@@ -202,7 +210,7 @@ struct GesturePreprocessor {
 
         var filtered: [CGPoint] = [points[0]]
 
-        for i in 1 ..< points.count {
+        for i in 1..<points.count {
             // Safe: filtered always has at least one element (initialized with points[0])
             guard let prev = filtered.last else { continue }
             let current = points[i]
@@ -243,11 +251,11 @@ struct GesturePreprocessor {
         let halfWindow = config.smoothingWindow / 2
         var smoothed: [CGPoint] = []
 
-        for i in 0 ..< points.count {
+        for i in 0..<points.count {
             var sumX: CGFloat = 0
             var sumY: CGFloat = 0
 
-            for j in 0 ..< config.smoothingWindow {
+            for j in 0..<config.smoothingWindow {
                 let idx = i - halfWindow + j
                 let clampedIdx = max(0, min(points.count - 1, idx))
                 sumX += coefficients[j] * points[clampedIdx].x
@@ -308,10 +316,10 @@ struct GestureClassificationThresholds {
     static let defaultReturnDisplacementStart: CGFloat = 0.2
     static let defaultReturnDisplacementEnd: CGFloat = 0.8
     static let defaultMinCircularity: CGFloat = 0.3
-    static let defaultMinAngularSpan: CGFloat = .pi * 1.5 // 270°
+    static let defaultMinAngularSpan: CGFloat = .pi * 1.5  // 270°
     static let defaultMinPathSeparation: CGFloat = 0.5
-    static let defaultMinTurnConsistency: CGFloat = 0.8 // 80% turns in same direction
-    static let defaultMinOrientedCompactness: CGFloat = 0.4 // width must be at least 40% of length
+    static let defaultMinTurnConsistency: CGFloat = 0.8  // 80% turns in same direction
+    static let defaultMinOrientedCompactness: CGFloat = 0.4  // width must be at least 40% of length
 
     // MARK: - UserDefaults Keys
 
@@ -328,7 +336,7 @@ struct GestureClassificationThresholds {
     static let `default` = GestureClassificationThresholds(
         minSwipeLength: defaultMinSwipeLength,
         maxReturnRatio: defaultMaxReturnRatio,
-        returnDisplacementRange: defaultReturnDisplacementStart ... defaultReturnDisplacementEnd,
+        returnDisplacementRange: defaultReturnDisplacementStart...defaultReturnDisplacementEnd,
         minCircularity: defaultMinCircularity,
         minAngularSpan: defaultMinAngularSpan,
         minPathSeparation: defaultMinPathSeparation,
@@ -336,20 +344,25 @@ struct GestureClassificationThresholds {
         minOrientedCompactness: defaultMinOrientedCompactness
     )
 
+    /// Loads a CGFloat from UserDefaults using double(forKey:) with a nil check
+    private static func loadCGFloat(from store: UserDefaults, key: String, default defaultValue: CGFloat) -> CGFloat {
+        store.object(forKey: key) != nil ? CGFloat(store.double(forKey: key)) : defaultValue
+    }
+
     /// Loads thresholds from SharedDefaults with fallback to defaults
     static func fromUserDefaults() -> GestureClassificationThresholds {
         let store = SharedDefaults.store
-        let start = store.object(forKey: returnDisplacementStartKey) as? CGFloat ?? defaultReturnDisplacementStart
-        let end = store.object(forKey: returnDisplacementEndKey) as? CGFloat ?? defaultReturnDisplacementEnd
+        let start = loadCGFloat(from: store, key: returnDisplacementStartKey, default: defaultReturnDisplacementStart)
+        let end = loadCGFloat(from: store, key: returnDisplacementEndKey, default: defaultReturnDisplacementEnd)
         return GestureClassificationThresholds(
-            minSwipeLength: store.object(forKey: minSwipeLengthKey) as? CGFloat ?? defaultMinSwipeLength,
-            maxReturnRatio: store.object(forKey: maxReturnRatioKey) as? CGFloat ?? defaultMaxReturnRatio,
-            returnDisplacementRange: start ... end,
-            minCircularity: store.object(forKey: minCircularityKey) as? CGFloat ?? defaultMinCircularity,
-            minAngularSpan: store.object(forKey: minAngularSpanKey) as? CGFloat ?? defaultMinAngularSpan,
-            minPathSeparation: store.object(forKey: minPathSeparationKey) as? CGFloat ?? defaultMinPathSeparation,
-            minTurnConsistency: store.object(forKey: minTurnConsistencyKey) as? CGFloat ?? defaultMinTurnConsistency,
-            minOrientedCompactness: store.object(forKey: minOrientedCompactnessKey) as? CGFloat ?? defaultMinOrientedCompactness
+            minSwipeLength: loadCGFloat(from: store, key: minSwipeLengthKey, default: defaultMinSwipeLength),
+            maxReturnRatio: loadCGFloat(from: store, key: maxReturnRatioKey, default: defaultMaxReturnRatio),
+            returnDisplacementRange: start...end,
+            minCircularity: loadCGFloat(from: store, key: minCircularityKey, default: defaultMinCircularity),
+            minAngularSpan: loadCGFloat(from: store, key: minAngularSpanKey, default: defaultMinAngularSpan),
+            minPathSeparation: loadCGFloat(from: store, key: minPathSeparationKey, default: defaultMinPathSeparation),
+            minTurnConsistency: loadCGFloat(from: store, key: minTurnConsistencyKey, default: defaultMinTurnConsistency),
+            minOrientedCompactness: loadCGFloat(from: store, key: minOrientedCompactnessKey, default: defaultMinOrientedCompactness)
         )
     }
 }
@@ -358,7 +371,7 @@ struct GestureClassificationThresholds {
 
 struct GestureFeatures {
     /// Thresholds used for classification
-    static var thresholds = GestureClassificationThresholds.default
+    let thresholds: GestureClassificationThresholds
 
     // Geometric features
     let pathLength: CGFloat
@@ -366,32 +379,30 @@ struct GestureFeatures {
     let boundingBox: CGRect
     let maxDisplacement: CGFloat
     let maxDisplacementPoint: CGPoint
-    let maxDisplacementProgress: CGFloat // 0.0-1.0: where in the path maxDisplacement occurs
+    let maxDisplacementProgress: CGFloat  // 0.0-1.0: where in the path maxDisplacement occurs
     let centroid: CGPoint
 
     // Ratio features
-    let returnRatio: CGFloat // chordLength / pathLength (low = returned to start)
-    let aspectRatio: CGFloat // boundingBox width / height
+    let returnRatio: CGFloat  // chordLength / pathLength (low = returned to start)
+    let aspectRatio: CGFloat  // boundingBox width / height
 
     // Direction features
-    let dominantAngle: CGFloat // angle from start to end
-    let maxDisplacementAngle: CGFloat // angle from start to max displacement
+    let dominantAngle: CGFloat      // angle from start to end
+    let maxDisplacementAngle: CGFloat  // angle from start to max displacement
 
     // Circularity features
-    let angularSpan: CGFloat // total angle traversed (positive = CW, negative = CCW)
-    let circularity: CGFloat // how circular (0-1, 1 = perfect circle)
+    let angularSpan: CGFloat    // total angle traversed (positive = CW, negative = CCW)
+    let circularity: CGFloat    // how circular (0-1, 1 = perfect circle)
     let pathSeparation: CGFloat // how separated are mirrored points (spiral > 0.5, return < 0.3)
     let turnConsistency: CGFloat // how consistent turn direction is (1.0 = all same direction, 0.5 = half each)
     let orientedCompactness: CGFloat // width/length along principal axis (1.0 = square, 0 = line)
 
     // Derived classifications (using configurable thresholds)
-    var isTap: Bool {
-        maxDisplacement < Self.thresholds.minSwipeLength
-    }
+    var isTap: Bool { maxDisplacement < thresholds.minSwipeLength }
 
     /// Return-swipe: maxDisplacement in the middle of the path (not at the end) AND finger returned to start
     var isReturn: Bool {
-        let t = Self.thresholds
+        let t = thresholds
         // Must have significant movement
         guard maxDisplacement > t.minSwipeLength else { return false }
         // Must have returned close to start (low chord/path ratio)
@@ -401,24 +412,22 @@ struct GestureFeatures {
     }
 
     var isCircular: Bool {
-        let t = Self.thresholds
+        let t = thresholds
         // Require minimum size (2x swipe length) to avoid small wiggles being detected as circles
         // Also require high turn consistency and compactness to distinguish from return swipes
         // (circle: turns consistently one direction AND is not a narrow arc)
         return pathLength > t.minSwipeLength * 2 &&
-            circularity > t.minCircularity &&
-            abs(angularSpan) > t.minAngularSpan &&
-            turnConsistency > t.minTurnConsistency &&
-            orientedCompactness > t.minOrientedCompactness
+               circularity > t.minCircularity &&
+               abs(angularSpan) > t.minAngularSpan &&
+               turnConsistency > t.minTurnConsistency &&
+               orientedCompactness > t.minOrientedCompactness
     }
 
-    var isClockwise: Bool {
-        angularSpan > 0
-    }
+    var isClockwise: Bool { angularSpan > 0 }
 
     /// Extracts features from preprocessed points.
     /// Uses GestureCalculations helper functions for cleaner, testable code.
-    static func extract(from points: [CGPoint]) -> GestureFeatures {
+    static func extract(from points: [CGPoint], thresholds: GestureClassificationThresholds = .default) -> GestureFeatures {
         guard points.count >= 2 else {
             return GestureFeatures.empty
         }
@@ -454,6 +463,7 @@ struct GestureFeatures {
         let bboxAspect = bbox.height > 0 ? bbox.width / bbox.height : 1
 
         return GestureFeatures(
+            thresholds: thresholds,
             pathLength: pathLen,
             chordLength: chordLen,
             boundingBox: bbox,
@@ -474,6 +484,7 @@ struct GestureFeatures {
     }
 
     static let empty = GestureFeatures(
+        thresholds: .default,
         pathLength: 0,
         chordLength: 0,
         boundingBox: .zero,

--- a/wurstfingerKeyboard/GesturePreprocessor.swift
+++ b/wurstfingerKeyboard/GesturePreprocessor.swift
@@ -172,9 +172,7 @@ struct GesturePreprocessor {
         let normalized = normalizeAspectRatio(cleaned)
 
         // Step 4: Savitzky-Golay smoothing
-        let smoothed = smoothSavitzkyGolay(normalized)
-
-        return smoothed
+        return smoothSavitzkyGolay(normalized)
     }
 
     // MARK: - Step 1: Jitter Filter
@@ -185,7 +183,7 @@ struct GesturePreprocessor {
 
         var filtered: [CGPoint] = [points[0]]
 
-        for i in 1..<points.count {
+        for i in 1 ..< points.count {
             // Safe: filtered always has at least one element (initialized with points[0])
             guard let last = filtered.last else { continue }
             let current = points[i]
@@ -213,7 +211,7 @@ struct GesturePreprocessor {
 
         var filtered: [CGPoint] = [points[0]]
 
-        for i in 1..<points.count {
+        for i in 1 ..< points.count {
             // Safe: filtered always has at least one element (initialized with points[0])
             guard let prev = filtered.last else { continue }
             let current = points[i]
@@ -254,11 +252,11 @@ struct GesturePreprocessor {
         let halfWindow = config.smoothingWindow / 2
         var smoothed: [CGPoint] = []
 
-        for i in 0..<points.count {
+        for i in 0 ..< points.count {
             var sumX: CGFloat = 0
             var sumY: CGFloat = 0
 
-            for j in 0..<config.smoothingWindow {
+            for j in 0 ..< config.smoothingWindow {
                 let idx = i - halfWindow + j
                 let clampedIdx = max(0, min(points.count - 1, idx))
                 sumX += coefficients[j] * points[clampedIdx].x
@@ -319,10 +317,10 @@ struct GestureClassificationThresholds {
     static let defaultReturnDisplacementStart: CGFloat = 0.2
     static let defaultReturnDisplacementEnd: CGFloat = 0.8
     static let defaultMinCircularity: CGFloat = 0.3
-    static let defaultMinAngularSpan: CGFloat = .pi * 1.5  // 270°
+    static let defaultMinAngularSpan: CGFloat = .pi * 1.5 // 270°
     static let defaultMinPathSeparation: CGFloat = 0.5
-    static let defaultMinTurnConsistency: CGFloat = 0.8  // 80% turns in same direction
-    static let defaultMinOrientedCompactness: CGFloat = 0.4  // width must be at least 40% of length
+    static let defaultMinTurnConsistency: CGFloat = 0.8 // 80% turns in same direction
+    static let defaultMinOrientedCompactness: CGFloat = 0.4 // width must be at least 40% of length
 
     // MARK: - UserDefaults Keys
 
@@ -339,7 +337,7 @@ struct GestureClassificationThresholds {
     static let `default` = GestureClassificationThresholds(
         minSwipeLength: defaultMinSwipeLength,
         maxReturnRatio: defaultMaxReturnRatio,
-        returnDisplacementRange: defaultReturnDisplacementStart...defaultReturnDisplacementEnd,
+        returnDisplacementRange: defaultReturnDisplacementStart ... defaultReturnDisplacementEnd,
         minCircularity: defaultMinCircularity,
         minAngularSpan: defaultMinAngularSpan,
         minPathSeparation: defaultMinPathSeparation,
@@ -363,7 +361,7 @@ struct GestureClassificationThresholds {
         return GestureClassificationThresholds(
             minSwipeLength: loadCGFloat(from: store, key: minSwipeLengthKey, default: defaultMinSwipeLength),
             maxReturnRatio: loadCGFloat(from: store, key: maxReturnRatioKey, default: defaultMaxReturnRatio),
-            returnDisplacementRange: min(start, end)...max(start, end),
+            returnDisplacementRange: min(start, end) ... max(start, end),
             minCircularity: loadCGFloat(from: store, key: minCircularityKey, default: defaultMinCircularity),
             minAngularSpan: loadCGFloat(from: store, key: minAngularSpanKey, default: defaultMinAngularSpan),
             minPathSeparation: loadCGFloat(from: store, key: minPathSeparationKey, default: defaultMinPathSeparation),
@@ -385,26 +383,28 @@ struct GestureFeatures {
     let boundingBox: CGRect
     let maxDisplacement: CGFloat
     let maxDisplacementPoint: CGPoint
-    let maxDisplacementProgress: CGFloat  // 0.0-1.0: where in the path maxDisplacement occurs
+    let maxDisplacementProgress: CGFloat // 0.0-1.0: where in the path maxDisplacement occurs
     let centroid: CGPoint
 
     // Ratio features
-    let returnRatio: CGFloat  // chordLength / pathLength (low = returned to start)
-    let aspectRatio: CGFloat  // boundingBox width / height
+    let returnRatio: CGFloat // chordLength / pathLength (low = returned to start)
+    let aspectRatio: CGFloat // boundingBox width / height
 
     // Direction features
-    let dominantAngle: CGFloat      // angle from start to end
-    let maxDisplacementAngle: CGFloat  // angle from start to max displacement
+    let dominantAngle: CGFloat // angle from start to end
+    let maxDisplacementAngle: CGFloat // angle from start to max displacement
 
     // Circularity features
-    let angularSpan: CGFloat    // total angle traversed (positive = CW, negative = CCW)
-    let circularity: CGFloat    // how circular (0-1, 1 = perfect circle)
+    let angularSpan: CGFloat // total angle traversed (positive = CW, negative = CCW)
+    let circularity: CGFloat // how circular (0-1, 1 = perfect circle)
     let pathSeparation: CGFloat // how separated are mirrored points (spiral > 0.5, return < 0.3)
     let turnConsistency: CGFloat // how consistent turn direction is (1.0 = all same direction, 0.5 = half each)
     let orientedCompactness: CGFloat // width/length along principal axis (1.0 = square, 0 = line)
 
     // Derived classifications (using configurable thresholds)
-    var isTap: Bool { maxDisplacement < thresholds.minSwipeLength }
+    var isTap: Bool {
+        maxDisplacement < thresholds.minSwipeLength
+    }
 
     /// Return-swipe: maxDisplacement in the middle of the path (not at the end) AND finger returned to start
     var isReturn: Bool {
@@ -423,13 +423,15 @@ struct GestureFeatures {
         // Also require high turn consistency and compactness to distinguish from return swipes
         // (circle: turns consistently one direction AND is not a narrow arc)
         return pathLength > t.minSwipeLength * 2 &&
-               circularity > t.minCircularity &&
-               abs(angularSpan) > t.minAngularSpan &&
-               turnConsistency > t.minTurnConsistency &&
-               orientedCompactness > t.minOrientedCompactness
+            circularity > t.minCircularity &&
+            abs(angularSpan) > t.minAngularSpan &&
+            turnConsistency > t.minTurnConsistency &&
+            orientedCompactness > t.minOrientedCompactness
     }
 
-    var isClockwise: Bool { angularSpan > 0 }
+    var isClockwise: Bool {
+        angularSpan > 0
+    }
 
     /// Extracts features from preprocessed points.
     /// Uses GestureCalculations helper functions for cleaner, testable code.

--- a/wurstfingerKeyboard/GesturePreprocessor.swift
+++ b/wurstfingerKeyboard/GesturePreprocessor.swift
@@ -357,7 +357,7 @@ struct GestureClassificationThresholds {
         return GestureClassificationThresholds(
             minSwipeLength: loadCGFloat(from: store, key: minSwipeLengthKey, default: defaultMinSwipeLength),
             maxReturnRatio: loadCGFloat(from: store, key: maxReturnRatioKey, default: defaultMaxReturnRatio),
-            returnDisplacementRange: start...end,
+            returnDisplacementRange: min(start, end)...max(start, end),
             minCircularity: loadCGFloat(from: store, key: minCircularityKey, default: defaultMinCircularity),
             minAngularSpan: loadCGFloat(from: store, key: minAngularSpanKey, default: defaultMinAngularSpan),
             minPathSeparation: loadCGFloat(from: store, key: minPathSeparationKey, default: defaultMinPathSeparation),
@@ -429,7 +429,7 @@ struct GestureFeatures {
     /// Uses GestureCalculations helper functions for cleaner, testable code.
     static func extract(from points: [CGPoint], thresholds: GestureClassificationThresholds = .default) -> GestureFeatures {
         guard points.count >= 2 else {
-            return GestureFeatures.empty
+            return GestureFeatures.empty(thresholds: thresholds)
         }
 
         let start = points[0]
@@ -483,25 +483,27 @@ struct GestureFeatures {
         )
     }
 
-    static let empty = GestureFeatures(
-        thresholds: .default,
-        pathLength: 0,
-        chordLength: 0,
-        boundingBox: .zero,
-        maxDisplacement: 0,
-        maxDisplacementPoint: .zero,
-        maxDisplacementProgress: 0,
-        centroid: .zero,
-        returnRatio: 1,
-        aspectRatio: 1,
-        dominantAngle: 0,
-        maxDisplacementAngle: 0,
-        angularSpan: 0,
-        circularity: 0,
-        pathSeparation: 0,
-        turnConsistency: 1,
-        orientedCompactness: 0
-    )
+    static func empty(thresholds: GestureClassificationThresholds = .default) -> GestureFeatures {
+        GestureFeatures(
+            thresholds: thresholds,
+            pathLength: 0,
+            chordLength: 0,
+            boundingBox: .zero,
+            maxDisplacement: 0,
+            maxDisplacementPoint: .zero,
+            maxDisplacementProgress: 0,
+            centroid: .zero,
+            returnRatio: 1,
+            aspectRatio: 1,
+            dominantAngle: 0,
+            maxDisplacementAngle: 0,
+            angularSpan: 0,
+            circularity: 0,
+            pathSeparation: 0,
+            turnConsistency: 1,
+            orientedCompactness: 0
+        )
+    }
 }
 
 // MARK: - Debug Logging

--- a/wurstfingerKeyboard/GesturePreprocessor.swift
+++ b/wurstfingerKeyboard/GesturePreprocessor.swift
@@ -116,15 +116,12 @@ struct GesturePreprocessorConfig {
         aspectRatio: 1.0
     )
 
-    /// Loads config from SharedDefaults with fallback to defaults
+    /// Loads config from SharedDefaults with fallback to defaults.
+    /// Non-finite values (NaN, Inf) are replaced with defaults.
     static func fromUserDefaults() -> GesturePreprocessorConfig {
         let store = SharedDefaults.store
-        let jitter: CGFloat = store.object(forKey: jitterThresholdKey) != nil
-            ? CGFloat(store.double(forKey: jitterThresholdKey))
-            : defaultJitterThreshold
-        let maxJump: CGFloat = store.object(forKey: maxJumpDistanceKey) != nil
-            ? CGFloat(store.double(forKey: maxJumpDistanceKey))
-            : defaultMaxJumpDistance
+        let jitter = finiteCGFloat(from: store, key: jitterThresholdKey, default: defaultJitterThreshold)
+        let maxJump = finiteCGFloat(from: store, key: maxJumpDistanceKey, default: defaultMaxJumpDistance)
         return GesturePreprocessorConfig(
             jitterThreshold: jitter,
             maxJumpDistance: maxJump,
@@ -132,6 +129,12 @@ struct GesturePreprocessorConfig {
             smoothingOrder: 2,
             aspectRatio: 1.0
         )
+    }
+
+    private static func finiteCGFloat(from store: UserDefaults, key: String, default defaultValue: CGFloat) -> CGFloat {
+        guard store.object(forKey: key) != nil else { return defaultValue }
+        let value = CGFloat(store.double(forKey: key))
+        return value.isFinite ? value : defaultValue
     }
 
     /// Creates a config with custom aspect ratio
@@ -344,9 +347,12 @@ struct GestureClassificationThresholds {
         minOrientedCompactness: defaultMinOrientedCompactness
     )
 
-    /// Loads a CGFloat from UserDefaults using double(forKey:) with a nil check
+    /// Loads a finite CGFloat from UserDefaults, falling back to the default
+    /// if the key is missing or the stored value is NaN/Inf.
     private static func loadCGFloat(from store: UserDefaults, key: String, default defaultValue: CGFloat) -> CGFloat {
-        store.object(forKey: key) != nil ? CGFloat(store.double(forKey: key)) : defaultValue
+        guard store.object(forKey: key) != nil else { return defaultValue }
+        let value = CGFloat(store.double(forKey: key))
+        return value.isFinite ? value : defaultValue
     }
 
     /// Loads thresholds from SharedDefaults with fallback to defaults

--- a/wurstfingerKeyboard/KeyboardButton.swift
+++ b/wurstfingerKeyboard/KeyboardButton.swift
@@ -72,18 +72,18 @@ struct KeyboardButton<Label: View, Overlay: View>: View {
 
     private func handleFeatureBasedRecognition() {
         // Load config from UserDefaults (for Expert Settings) and apply aspect ratio
-        let config = GesturePreprocessorConfig.fromUserDefaults().with(aspectRatio: aspectRatio)
-        let preprocessor = GesturePreprocessor(config: config)
+        let preprocessorConfig = GesturePreprocessorConfig.fromUserDefaults().with(aspectRatio: aspectRatio)
+        let preprocessor = GesturePreprocessor(config: preprocessorConfig)
 
         // Load classification thresholds from UserDefaults
-        GestureFeatures.thresholds = GestureClassificationThresholds.fromUserDefaults()
+        let thresholds = GestureClassificationThresholds.fromUserDefaults()
 
         // Preprocess: jitter filter, outlier filter, aspect normalization, smoothing
         // Convert RingBuffer to Array for processing
         let processed = preprocessor.preprocess(positions.elements)
 
-        // Extract features
-        let features = GestureFeatures.extract(from: processed)
+        // Extract features with thresholds
+        let features = GestureFeatures.extract(from: processed, thresholds: thresholds)
 
         // Determine swipe direction
         let direction = angleToDirection(features.maxDisplacementAngle)

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -63,7 +63,7 @@ final class KeyboardViewController: UIInputViewController {
             constraint.constant = finalHeight
         } else {
             let constraint = view.heightAnchor.constraint(equalToConstant: finalHeight)
-            constraint.priority = .required
+            constraint.priority = .defaultHigh
             constraint.isActive = true
             heightConstraint = constraint
         }

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -188,7 +188,7 @@ final class KeyboardViewModel: ObservableObject {
         // same process and across processes via App Group)
         userDefaultsObserver = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
-            object: nil,
+            object: sharedDefaults,
             queue: .main
         ) { [weak self] _ in
             self?.reloadSettings()

--- a/wurstfingerTests/wurstfingerTests.swift
+++ b/wurstfingerTests/wurstfingerTests.swift
@@ -356,7 +356,7 @@ struct wurstfingerTests {
     // MARK: - GestureFeatures.empty Tests
 
     @Test func gestureFeatureEmptyHasSensibleDefaults() {
-        let empty = GestureFeatures.empty
+        let empty = GestureFeatures.empty()
 
         #expect(empty.pathLength == 0)
         #expect(empty.chordLength == 0)


### PR DESCRIPTION
## Summary
- Replace unsafe \`as? CGFloat\` casts with \`double(forKey:)\` + nil check for reliable UserDefaults CGFloat loading
- Convert \`GestureFeatures.thresholds\` from \`static var\` to instance \`let\`, passing thresholds through \`extract()\` parameter instead
- Filter \`UserDefaults.didChangeNotification\` observer to only respond to the shared defaults instance
- Lower height constraint priority from \`.required\` to \`.defaultHigh\` to prevent Auto Layout conflicts

**Depends on:** #103, #104

## Test plan
- [x] Build succeeds
- [x] Existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable numeric settings loading (handles missing/invalid/non-finite values)
  * Reduced keyboard height constraint priority to avoid layout conflicts

* **Improvements**
  * Gesture thresholds applied per gesture instance for more predictable detection
  * Return-swipe evaluation now uses configured bounds instead of a hardcoded range
  * Settings reloads now trigger only for the shared settings store
<!-- end of auto-generated comment: release notes by coderabbit.ai -->