### PR TITLE
Add SwiftLint with CI integration and pre-commit hook

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -5,6 +5,19 @@ on:
     branches: [ "develop" ]
 
 jobs:
+  swiftlint:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Run SwiftLint
+        run: swiftlint lint --strict --reporter github-actions-logging
+
   test:
     runs-on: macos-latest
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -50,3 +50,4 @@ cyclomatic_complexity:
 
 disabled_rules:
   - trailing_comma  # Trailing commas improve diffs
+  - implicit_optional_initialization  # Removing = nil breaks memberwise initializers

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,12 @@ included:
   - wurstfingerTests
   - wurstfingerUITests
 
+excluded:
+  - DerivedData
+  - build
+  - .build
+  - Pods
+
 # Rules tuned for a gesture-based keyboard with lots of geometry code
 identifier_name:
   min_length:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,52 @@
+# SwiftLint Configuration for Wurstfinger
+
+included:
+  - wurstfinger
+  - wurstfingerKeyboard
+  - wurstfingerTests
+  - wurstfingerUITests
+
+# Rules tuned for a gesture-based keyboard with lots of geometry code
+identifier_name:
+  min_length:
+    warning: 1
+  excluded:
+    - id
+
+line_length:
+  warning: 150
+  error: 200
+  ignores_comments: true
+  ignores_urls: true
+
+type_name:
+  excluded:
+    - wurstfingerApp
+    - wurstfingerUITests
+    - wurstfingerUITestsLaunchTests
+    - wurstfingerTests
+
+file_length:
+  warning: 1100
+  error: 1500
+
+type_body_length:
+  warning: 500
+  error: 800
+
+function_body_length:
+  warning: 250
+  error: 400
+
+large_tuple:
+  warning: 4
+
+function_parameter_count:
+  warning: 7
+
+cyclomatic_complexity:
+  warning: 15
+  error: 25
+
+disabled_rules:
+  - trailing_comma  # Trailing commas improve diffs

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -7,7 +7,7 @@ HOOKS_DIR="$REPO_ROOT/.git/hooks"
 
 # Handle worktrees: .git may be a file pointing to the actual git dir
 if [ -f "$REPO_ROOT/.git" ]; then
-    GIT_DIR=$(sed 's/gitdir: //' "$REPO_ROOT/.git" | tr -d '[:space:]')
+    GIT_DIR=$(sed -n 's/^gitdir: //p' "$REPO_ROOT/.git" | head -n 1 | tr -d '\r')
     # Handle both absolute and relative paths
     if [[ "$GIT_DIR" = /* ]]; then
         HOOKS_DIR="$GIT_DIR/hooks"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Installs git hooks for the Wurstfinger project
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_DIR="$REPO_ROOT/.git/hooks"
+
+# Handle worktrees: .git may be a file pointing to the actual git dir
+if [ -f "$REPO_ROOT/.git" ]; then
+    GIT_DIR=$(sed 's/gitdir: //' "$REPO_ROOT/.git" | tr -d '[:space:]')
+    # Handle both absolute and relative paths
+    if [[ "$GIT_DIR" = /* ]]; then
+        HOOKS_DIR="$GIT_DIR/hooks"
+    else
+        HOOKS_DIR="$(cd "$REPO_ROOT/$GIT_DIR" && pwd)/hooks"
+    fi
+fi
+
+mkdir -p "$HOOKS_DIR"
+
+ln -sf "$REPO_ROOT/scripts/pre-commit" "$HOOKS_DIR/pre-commit"
+echo "Installed pre-commit hook to $HOOKS_DIR/pre-commit"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -12,7 +12,11 @@ if [ -f "$REPO_ROOT/.git" ]; then
     if [[ "$GIT_DIR" = /* ]]; then
         HOOKS_DIR="$GIT_DIR/hooks"
     else
-        HOOKS_DIR="$(cd "$REPO_ROOT/$GIT_DIR" && pwd)/hooks"
+        RESOLVED_GIT_DIR="$(cd "$REPO_ROOT/$GIT_DIR" 2>/dev/null && pwd)" || {
+            echo "error: cannot resolve gitdir path: $REPO_ROOT/$GIT_DIR"
+            exit 1
+        }
+        HOOKS_DIR="$RESOLVED_GIT_DIR/hooks"
     fi
 fi
 
@@ -21,6 +25,10 @@ mkdir -p "$HOOKS_DIR"
 if [ ! -f "$REPO_ROOT/scripts/pre-commit" ]; then
     echo "error: scripts/pre-commit not found"
     exit 1
+fi
+
+if [ -e "$HOOKS_DIR/pre-commit" ] && [ ! -L "$HOOKS_DIR/pre-commit" ]; then
+    echo "warning: overwriting existing pre-commit hook (was not a symlink)"
 fi
 
 ln -sf "$REPO_ROOT/scripts/pre-commit" "$HOOKS_DIR/pre-commit"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -18,5 +18,10 @@ fi
 
 mkdir -p "$HOOKS_DIR"
 
+if [ ! -f "$REPO_ROOT/scripts/pre-commit" ]; then
+    echo "error: scripts/pre-commit not found"
+    exit 1
+fi
+
 ln -sf "$REPO_ROOT/scripts/pre-commit" "$HOOKS_DIR/pre-commit"
 echo "Installed pre-commit hook to $HOOKS_DIR/pre-commit"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -18,6 +18,10 @@ echo "Running SwiftLint on staged files..."
 FAILED=0
 while IFS= read -r file; do
     if [ -f "$file" ]; then
+        # Warn about partially staged files (working tree differs from index)
+        if ! git diff --quiet -- "$file"; then
+            echo "warning: $file has unstaged changes — linting working tree version"
+        fi
         swiftlint lint --strict --quiet "$file"
         if [ $? -ne 0 ]; then
             FAILED=1

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -22,8 +22,7 @@ while IFS= read -r file; do
         if ! git diff --quiet -- "$file"; then
             echo "warning: $file has unstaged changes — linting working tree version"
         fi
-        swiftlint lint --strict --quiet "$file"
-        if [ $? -ne 0 ]; then
+        if ! swiftlint lint --strict --quiet "$file"; then
             FAILED=1
         fi
     fi

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Pre-commit hook: runs SwiftLint on staged Swift files
+
+if ! command -v swiftlint &> /dev/null; then
+    echo "warning: SwiftLint not installed, skipping lint (brew install swiftlint)"
+    exit 0
+fi
+
+# Get staged Swift files (added, copied, modified, renamed)
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR -- '*.swift')
+
+if [ -z "$STAGED_FILES" ]; then
+    exit 0
+fi
+
+echo "Running SwiftLint on staged files..."
+
+FAILED=0
+while IFS= read -r file; do
+    if [ -f "$file" ]; then
+        swiftlint lint --strict --quiet "$file"
+        if [ $? -ne 0 ]; then
+            FAILED=1
+        fi
+    fi
+done <<< "$STAGED_FILES"
+
+if [ $FAILED -ne 0 ]; then
+    echo ""
+    echo "SwiftLint found violations. Fix them before committing, or use --no-verify to skip."
+    exit 1
+fi

--- a/wurstfinger/AspectRatioSettingsView.swift
+++ b/wurstfinger/AspectRatioSettingsView.swift
@@ -65,11 +65,8 @@ struct AspectRatioSettingsView: View {
                     }
                 }
 
-                Text(
-                    "Adjust the width-to-height ratio of the keys. "
-                    + "1.0 creates square keys, 1.5 is the default appearance, "
-                    + "and 1.62 is the golden ratio (widest)."
-                )
+                // swiftlint:disable:next line_length
+                Text("Adjust the width-to-height ratio of the keys. 1.0 creates square keys, 1.5 is the default appearance, and 1.62 is the golden ratio (widest).")
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/wurstfinger/AspectRatioSettingsView.swift
+++ b/wurstfinger/AspectRatioSettingsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct AspectRatioSettingsView: View {
     @Binding var aspectRatio: Double
-    
+
     @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
     private var keyboardScale = DeviceLayoutUtils.defaultKeyboardScale
 
@@ -65,7 +65,11 @@ struct AspectRatioSettingsView: View {
                     }
                 }
 
-                Text("Adjust the width-to-height ratio of the keys. 1.0 creates square keys, 1.5 is the default appearance, and 1.62 is the golden ratio (widest).")
+                Text(
+                    "Adjust the width-to-height ratio of the keys. "
+                    + "1.0 creates square keys, 1.5 is the default appearance, "
+                    + "and 1.62 is the golden ratio (widest)."
+                )
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/wurstfinger/ExpertSettingsView.swift
+++ b/wurstfinger/ExpertSettingsView.swift
@@ -59,7 +59,7 @@ struct ExpertSettingsView: View {
                 tapDetectionSection
                 circularDetectionSection
                 returnSwipeDetectionSection
-                
+
                 Section {
                     NavigationLink("Gesture Playground") {
                         GesturePlaygroundView()
@@ -254,7 +254,8 @@ struct ExpertSettingsView: View {
                 range: 0.5...1.0,
                 step: 0.05,
                 unit: "",
-                description: "How consistently the path turns in one direction. 1.0 = all turns same direction (circle), 0.5 = half each (return-swipe)."
+                description: "How consistently the path turns in one direction. "
+                    + "1.0 = all turns same direction (circle), 0.5 = half each (return-swipe)."
             )
 
             parameterSlider(
@@ -268,7 +269,10 @@ struct ExpertSettingsView: View {
         } header: {
             Label("Step 2: Circular Detection", systemImage: "arrow.trianglehead.2.clockwise.rotate.90")
         } footer: {
-            Text("Distinguishes circles (for uppercase) from return-swipes. Turn Consistency detects direction reversals, Oriented Compactness filters narrow arcs.")
+            Text(
+                "Distinguishes circles (for uppercase) from return-swipes. "
+                + "Turn Consistency detects direction reversals, Oriented Compactness filters narrow arcs."
+            )
         }
     }
 
@@ -315,7 +319,10 @@ struct ExpertSettingsView: View {
                         .foregroundColor(.secondary)
                 }
 
-                Text("Max displacement must occur between \(Int(returnDisplacementStart * 100))% and \(Int(returnDisplacementEnd * 100))% of the path (not at the very end).")
+                Text(
+                    "Max displacement must occur between \(Int(returnDisplacementStart * 100))% "
+                    + "and \(Int(returnDisplacementEnd * 100))% of the path (not at the very end)."
+                )
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
@@ -323,7 +330,10 @@ struct ExpertSettingsView: View {
         } header: {
             Label("Step 3: Return-Swipe Detection", systemImage: "arrow.uturn.backward")
         } footer: {
-            Text("If the finger went out and came back (low return ratio) with max displacement in the middle of the path, it's a return-swipe. Otherwise, it's a normal swipe.")
+            Text(
+                "If the finger went out and came back (low return ratio) with max displacement "
+                + "in the middle of the path, it's a return-swipe. Otherwise, it's a normal swipe."
+            )
         }
     }
 

--- a/wurstfinger/ExpertSettingsView.swift
+++ b/wurstfinger/ExpertSettingsView.swift
@@ -269,10 +269,8 @@ struct ExpertSettingsView: View {
         } header: {
             Label("Step 2: Circular Detection", systemImage: "arrow.trianglehead.2.clockwise.rotate.90")
         } footer: {
-            Text(
-                "Distinguishes circles (for uppercase) from return-swipes. "
-                + "Turn Consistency detects direction reversals, Oriented Compactness filters narrow arcs."
-            )
+            // swiftlint:disable:next line_length
+            Text("Distinguishes circles (for uppercase) from return-swipes. Turn Consistency detects direction reversals, Oriented Compactness filters narrow arcs.")
         }
     }
 
@@ -319,10 +317,8 @@ struct ExpertSettingsView: View {
                         .foregroundColor(.secondary)
                 }
 
-                Text(
-                    "Max displacement must occur between \(Int(returnDisplacementStart * 100))% "
-                    + "and \(Int(returnDisplacementEnd * 100))% of the path (not at the very end)."
-                )
+                // swiftlint:disable:next line_length
+                Text("Max displacement must occur between \(Int(returnDisplacementStart * 100))% and \(Int(returnDisplacementEnd * 100))% of the path (not at the very end).")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
@@ -330,10 +326,8 @@ struct ExpertSettingsView: View {
         } header: {
             Label("Step 3: Return-Swipe Detection", systemImage: "arrow.uturn.backward")
         } footer: {
-            Text(
-                "If the finger went out and came back (low return ratio) with max displacement "
-                + "in the middle of the path, it's a return-swipe. Otherwise, it's a normal swipe."
-            )
+            // swiftlint:disable:next line_length
+            Text("If the finger went out and came back (low return ratio) with max displacement in the middle of the path, it's a return-swipe. Otherwise, it's a normal swipe.")
         }
     }
 

--- a/wurstfinger/GesturePlaygroundView.swift
+++ b/wurstfinger/GesturePlaygroundView.swift
@@ -352,16 +352,8 @@ struct GesturePlaygroundView: View {
             result = "Circular (\(feats.isClockwise ? "CW" : "CCW"))"
             detectedCircularDirection = feats.isClockwise ? .clockwise : .counterclockwise
             detectedDirection = .center
-        } else if feats.isReturn {
-            result = "Return Swipe"
-            // For return swipe, we still want the direction of the max displacement
-            let swipeSize = CGSize(
-                width: cos(feats.maxDisplacementAngle),
-                height: sin(feats.maxDisplacementAngle)
-            )
-            detectedDirection = KeyboardDirection.direction(for: swipeSize, tolerance: 0)
         } else {
-            result = "Swipe"
+            result = feats.isReturn ? "Return Swipe" : "Swipe"
             let swipeSize = CGSize(
                 width: cos(feats.maxDisplacementAngle),
                 height: sin(feats.maxDisplacementAngle)

--- a/wurstfinger/GesturePlaygroundView.swift
+++ b/wurstfinger/GesturePlaygroundView.swift
@@ -14,25 +14,25 @@ struct GesturePlaygroundView: View {
     @State private var features: GestureFeatures?
     @State private var detectedDirection: KeyboardDirection = .center
     @State private var detectedCircularDirection: KeyboardCircularDirection?
-    
+
     @AppStorage("keyAspectRatio", store: SharedDefaults.store)
     private var keyAspectRatio = 1.5
-    
+
     // Key dimensions for the input area (simulating a standard key)
     private let keyHeight: CGFloat = KeyboardConstants.KeyDimensions.height
-    
+
     private var keyWidth: CGFloat {
         KeyboardConstants.KeyDimensions.height * CGFloat(keyAspectRatio)
     }
-    
+
     @State private var isDragging = false
-    
+
     var body: some View {
         VStack(spacing: 20) {
             // 1. Magnified View (Top)
             ZStack {
                 Color.gray.opacity(0.1)
-                
+
                 // Grid lines
                 Path { path in
                     path.move(to: CGPoint(x: 150, y: 0))
@@ -41,7 +41,7 @@ struct GesturePlaygroundView: View {
                     path.addLine(to: CGPoint(x: 300, y: 150))
                 }
                 .stroke(Color.gray.opacity(0.3), style: StrokeStyle(lineWidth: 1, dash: [5]))
-                
+
                 // Sector lines (for swipe angles)
                 ForEach(0..<8) { i in
                     Path { path in
@@ -54,42 +54,42 @@ struct GesturePlaygroundView: View {
                     }
                     .stroke(Color.blue.opacity(0.1), lineWidth: 1)
                 }
-                
+
                 // Calculate scale to fit key + margin in 300x300
                 // Key is roughly 81x54 (1.5 AR). 300 width.
                 // Let's map keyWidth to 200pt (leaving 50pt margin on sides)
                 let scale = 200.0 / keyWidth
                 let offsetX = (300.0 - (keyWidth * scale)) / 2.0
                 let offsetY = (300.0 - (keyHeight * scale)) / 2.0
-                
+
                 // Visual Key Boundary in Magnified View
                 RoundedRectangle(cornerRadius: KeyboardConstants.KeyDimensions.cornerRadius * scale)
                     .stroke(Color.gray.opacity(0.3), lineWidth: 1)
                     .frame(width: keyWidth * scale, height: keyHeight * scale)
                     .position(x: 150, y: 150) // Center it
-                
+
                 // Raw Path (Red) - Scaled up
                 Path { path in
                     guard rawPoints.count > 1 else { return }
-                    
+
                     path.move(to: scalePoint(rawPoints[0], scale: scale, offsetX: offsetX, offsetY: offsetY))
                     for point in rawPoints.dropFirst() {
                         path.addLine(to: scalePoint(point, scale: scale, offsetX: offsetX, offsetY: offsetY))
                     }
                 }
                 .stroke(Color.red.opacity(0.5), lineWidth: 4)
-                
+
                 // Processed Path (Green) - Scaled up
                 Path { path in
                     guard processedPoints.count > 1 else { return }
-                    
+
                     path.move(to: scalePoint(processedPoints[0], scale: scale, offsetX: offsetX, offsetY: offsetY))
                     for point in processedPoints.dropFirst() {
                         path.addLine(to: scalePoint(point, scale: scale, offsetX: offsetX, offsetY: offsetY))
                     }
                 }
                 .stroke(Color.green, lineWidth: 4)
-                
+
                 // Key Points
                 if let features = features {
                     // Start
@@ -97,13 +97,13 @@ struct GesturePlaygroundView: View {
                         .fill(Color.blue)
                         .frame(width: 12, height: 12)
                         .position(scalePoint(rawPoints.first ?? .zero, scale: scale, offsetX: offsetX, offsetY: offsetY))
-                    
+
                     // End
                     Circle()
                         .fill(Color.red)
                         .frame(width: 12, height: 12)
                         .position(scalePoint(rawPoints.last ?? .zero, scale: scale, offsetX: offsetX, offsetY: offsetY))
-                        
+
                     // Max Displacement
                     Circle()
                         .fill(Color.orange)
@@ -117,18 +117,18 @@ struct GesturePlaygroundView: View {
                 RoundedRectangle(cornerRadius: 12)
                     .stroke(Color.gray.opacity(0.2), lineWidth: 1)
             )
-            
+
             // 2. Input Area (Realistic Key Size)
             VStack {
                 Text("Input Area")
                     .font(.caption)
                     .foregroundColor(.secondary)
-                
+
                 ZStack {
                     RoundedRectangle(cornerRadius: KeyboardConstants.KeyDimensions.cornerRadius)
                         .fill(Color.gray.opacity(0.2))
                         .frame(width: keyWidth, height: keyHeight)
-                    
+
                     Text("Key")
                         .font(.caption)
                         .foregroundColor(.secondary.opacity(0.5))
@@ -152,7 +152,7 @@ struct GesturePlaygroundView: View {
                         }
                 )
             }
-            
+
             // 3. Analytics & Classification
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
@@ -171,41 +171,70 @@ struct GesturePlaygroundView: View {
                     .padding()
                     .background(Color.blue.opacity(0.1))
                     .cornerRadius(8)
-                    
+
                     if let features = features {
                         // Decision Tree Breakdown
                         VStack(alignment: .leading, spacing: 8) {
                             Text("Decision Logic").font(.headline)
-                            
+
                             decisionRow(
                                 "1. Tap?",
                                 passed: features.isTap
                             ) {
-                                criterion("maxDisp", val: features.maxDisplacement, op: "<", limit: GestureFeatures.thresholds.minSwipeLength, pass: features.maxDisplacement < GestureFeatures.thresholds.minSwipeLength)
+                                criterion(
+                                    "maxDisp", val: features.maxDisplacement, op: "<",
+                                    limit: GestureFeatures.thresholds.minSwipeLength,
+                                    pass: features.maxDisplacement < GestureFeatures.thresholds.minSwipeLength
+                                )
                             }
-                            
+
                             decisionRow(
                                 "2. Circular?",
                                 passed: features.isCircular
                             ) {
                                 VStack(alignment: .leading) {
-                                    criterion("circ", val: features.circularity, op: ">", limit: GestureFeatures.thresholds.minCircularity, pass: features.circularity > GestureFeatures.thresholds.minCircularity)
-                                    criterion("angle", val: abs(features.angularSpan) * 180 / .pi, op: ">", limit: GestureFeatures.thresholds.minAngularSpan * 180 / .pi, unit: "°", pass: abs(features.angularSpan) > GestureFeatures.thresholds.minAngularSpan)
-                                    criterion("turn", val: features.turnConsistency, op: ">", limit: GestureFeatures.thresholds.minTurnConsistency, pass: features.turnConsistency > GestureFeatures.thresholds.minTurnConsistency)
-                                    criterion("compact", val: features.orientedCompactness, op: ">", limit: GestureFeatures.thresholds.minOrientedCompactness, pass: features.orientedCompactness > GestureFeatures.thresholds.minOrientedCompactness)
+                                    criterion(
+                                        "circ", val: features.circularity, op: ">",
+                                        limit: GestureFeatures.thresholds.minCircularity,
+                                        pass: features.circularity > GestureFeatures.thresholds.minCircularity
+                                    )
+                                    criterion(
+                                        "angle", val: abs(features.angularSpan) * 180 / .pi, op: ">",
+                                        limit: GestureFeatures.thresholds.minAngularSpan * 180 / .pi, unit: "°",
+                                        pass: abs(features.angularSpan) > GestureFeatures.thresholds.minAngularSpan
+                                    )
+                                    criterion(
+                                        "turn", val: features.turnConsistency, op: ">",
+                                        limit: GestureFeatures.thresholds.minTurnConsistency,
+                                        pass: features.turnConsistency > GestureFeatures.thresholds.minTurnConsistency
+                                    )
+                                    criterion(
+                                        "compact", val: features.orientedCompactness, op: ">",
+                                        limit: GestureFeatures.thresholds.minOrientedCompactness,
+                                        pass: features.orientedCompactness > GestureFeatures.thresholds.minOrientedCompactness
+                                    )
                                 }
                             }
-                            
+
                             decisionRow(
                                 "3. Return Swipe?",
                                 passed: features.isReturn
                             ) {
                                 VStack(alignment: .leading) {
-                                    criterion("ratio", val: features.returnRatio, op: "<", limit: GestureFeatures.thresholds.maxReturnRatio, pass: features.returnRatio < GestureFeatures.thresholds.maxReturnRatio)
-                                    criterion("progress", val: features.maxDisplacementProgress, op: "in", limit: 0, pass: features.maxDisplacementProgress > 0.2 && features.maxDisplacementProgress < 0.8) // Simplified range display
+                                    criterion(
+                                        "ratio", val: features.returnRatio, op: "<",
+                                        limit: GestureFeatures.thresholds.maxReturnRatio,
+                                        pass: features.returnRatio < GestureFeatures.thresholds.maxReturnRatio
+                                    )
+                                    // Simplified range display
+                                    criterion(
+                                        "progress", val: features.maxDisplacementProgress, op: "in",
+                                        limit: 0,
+                                        pass: features.maxDisplacementProgress > 0.2 && features.maxDisplacementProgress < 0.8
+                                    )
                                 }
                             }
-                            
+
                             decisionRow(
                                 "4. Swipe?",
                                 passed: !features.isTap && !features.isCircular && !features.isReturn
@@ -218,7 +247,7 @@ struct GesturePlaygroundView: View {
                         .padding()
                         .background(Color.gray.opacity(0.05))
                         .cornerRadius(8)
-                        
+
                         // Raw Metrics
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Metrics").font(.headline).padding(.bottom, 4)
@@ -243,7 +272,7 @@ struct GesturePlaygroundView: View {
             }
         }
     }
-    
+
     private func clear() {
         rawPoints = []
         processedPoints = []
@@ -252,15 +281,15 @@ struct GesturePlaygroundView: View {
         detectedDirection = .center
         detectedCircularDirection = nil
     }
-    
+
     private func scalePoint(_ point: CGPoint, scale: CGFloat, offsetX: CGFloat, offsetY: CGFloat) -> CGPoint {
         CGPoint(x: point.x * scale + offsetX, y: point.y * scale + offsetY)
     }
-    
+
     private func f(_ value: CGFloat) -> String {
         String(format: "%.1f", value)
     }
-    
+
     private func decisionRow<Content: View>(_ label: String, passed: Bool, @ViewBuilder content: () -> Content) -> some View {
         HStack(alignment: .top) {
             Image(systemName: passed ? "checkmark.circle.fill" : "circle")
@@ -271,7 +300,7 @@ struct GesturePlaygroundView: View {
             }
         }
     }
-    
+
     private func criterion(_ name: String, val: CGFloat, op: String, limit: CGFloat, unit: String = "", pass: Bool) -> some View {
         HStack(spacing: 4) {
             Text(name)
@@ -284,12 +313,12 @@ struct GesturePlaygroundView: View {
         .font(.caption)
         .foregroundColor(.secondary)
     }
-    
+
     private func angleToSector(_ angle: CGFloat) -> String {
         let dir = KeyboardDirection.direction(for: CGSize(width: cos(angle), height: sin(angle)), tolerance: 0)
         return String(describing: dir).capitalized
     }
-    
+
     private func featureRow(_ label: String, _ value: String) -> some View {
         HStack {
             Text(label).foregroundColor(.secondary)
@@ -297,23 +326,23 @@ struct GesturePlaygroundView: View {
             Text(value).bold().monospacedDigit()
         }
     }
-    
+
     private func processGesture() {
         // 1. Load Config (including aspect ratio, just like the real keyboard)
         let config = GesturePreprocessorConfig.fromUserDefaults().with(aspectRatio: keyAspectRatio)
         let preprocessor = GesturePreprocessor(config: config)
-        
+
         // 2. Preprocess
         // Note: The playground canvas is likely larger than a key, but we treat it as 1:1 for now
         // or we could scale points to simulate key size.
         // For debugging, seeing raw behavior is often better.
         processedPoints = preprocessor.preprocess(rawPoints)
-        
+
         // 3. Extract Features
         GestureFeatures.thresholds = GestureClassificationThresholds.fromUserDefaults()
         let feats = GestureFeatures.extract(from: processedPoints)
         self.features = feats
-        
+
         // 4. Classify
         var result = ""
         if feats.isTap {
@@ -326,12 +355,20 @@ struct GesturePlaygroundView: View {
         } else if feats.isReturn {
             result = "Return Swipe"
             // For return swipe, we still want the direction of the max displacement
-            detectedDirection = KeyboardDirection.direction(for: CGSize(width: cos(feats.maxDisplacementAngle), height: sin(feats.maxDisplacementAngle)), tolerance: 0)
+            let swipeSize = CGSize(
+                width: cos(feats.maxDisplacementAngle),
+                height: sin(feats.maxDisplacementAngle)
+            )
+            detectedDirection = KeyboardDirection.direction(for: swipeSize, tolerance: 0)
         } else {
             result = "Swipe"
-            detectedDirection = KeyboardDirection.direction(for: CGSize(width: cos(feats.maxDisplacementAngle), height: sin(feats.maxDisplacementAngle)), tolerance: 0)
+            let swipeSize = CGSize(
+                width: cos(feats.maxDisplacementAngle),
+                height: sin(feats.maxDisplacementAngle)
+            )
+            detectedDirection = KeyboardDirection.direction(for: swipeSize, tolerance: 0)
         }
-        
+
         self.classificationResult = result
     }
 }

--- a/wurstfinger/HapticSettingsView.swift
+++ b/wurstfinger/HapticSettingsView.swift
@@ -34,7 +34,7 @@ struct HapticSettingsView: View {
                     VStack(spacing: 8) {
                         Toggle("Haptic Feedback", isOn: $hapticEnabled)
                             .font(.headline)
-                        
+
                         Text("Enable or disable all haptic feedback vibrations.")
                             .font(.caption)
                             .foregroundColor(.secondary)
@@ -108,7 +108,7 @@ struct HapticSettingsView: View {
                         generator.impactOccurred(intensity: value.wrappedValue)
                     }
                 }
-                
+
                 HStack {
                     Text("Off")
                         .font(.caption)
@@ -119,7 +119,7 @@ struct HapticSettingsView: View {
                         .foregroundColor(.secondary)
                 }
             }
-            
+
             Text(description)
                 .font(.caption)
                 .foregroundColor(.secondary)
@@ -128,5 +128,3 @@ struct HapticSettingsView: View {
         .padding(.horizontal, 16)
     }
 }
-
-

--- a/wurstfinger/ImprintView.swift
+++ b/wurstfinger/ImprintView.swift
@@ -39,11 +39,8 @@ struct ImprintView: View {
                     Text("The provider assumes no liability for the accuracy, completeness and timeliness of the content provided.")
                         .font(.footnote)
 
-                    Text(
-                        "Liability claims against the provider relating to material or "
-                        + "immaterial damage caused by the use or non-use of the "
-                        + "information provided are excluded."
-                    )
+                    // swiftlint:disable:next line_length
+                    Text("Liability claims against the provider relating to material or immaterial damage caused by the use or non-use of the information provided are excluded.")
                         .font(.footnote)
                 }
                 .foregroundColor(.secondary)

--- a/wurstfinger/ImprintView.swift
+++ b/wurstfinger/ImprintView.swift
@@ -39,7 +39,11 @@ struct ImprintView: View {
                     Text("The provider assumes no liability for the accuracy, completeness and timeliness of the content provided.")
                         .font(.footnote)
 
-                    Text("Liability claims against the provider relating to material or immaterial damage caused by the use or non-use of the information provided are excluded.")
+                    Text(
+                        "Liability claims against the provider relating to material or "
+                        + "immaterial damage caused by the use or non-use of the "
+                        + "information provided are excluded."
+                    )
                         .font(.footnote)
                 }
                 .foregroundColor(.secondary)

--- a/wurstfinger/InteractiveKeyboardPreview.swift
+++ b/wurstfinger/InteractiveKeyboardPreview.swift
@@ -11,7 +11,7 @@ struct InteractiveKeyboardPreview: View {
     @Binding var aspectRatio: Double
     @Binding var scale: Double
     @Binding var position: Double
-    
+
     @StateObject private var previewViewModel = KeyboardViewModel(shouldPersistSettings: false)
     @State private var previewText = ""
 
@@ -27,7 +27,7 @@ struct InteractiveKeyboardPreview: View {
         // Calculate preview height based on aspect ratio and scale
         let baseHeight = KeyboardConstants.Calculations.baseHeight(aspectRatio: previewViewModel.keyAspectRatio)
         let scaledHeight = baseHeight * scale
-        
+
         // Determine height constraints based on usage
         // If scaling is involved (size settings), we clamp between min/max
         // If only aspect ratio changes (aspect settings), we allow it to grow naturally but cap it
@@ -85,20 +85,20 @@ struct InteractiveKeyboardPreview: View {
                         overrideWidth: geometry.size.width
                     )
 
-                    .onChange(of: aspectRatio) { oldValue, newValue in
+                    .onChange(of: aspectRatio) { _, newValue in
                         previewViewModel.keyAspectRatio = newValue
                     }
-                    .onChange(of: scale) { oldValue, newValue in
+                    .onChange(of: scale) { _, newValue in
                         previewViewModel.keyboardScale = newValue
                     }
-                    .onChange(of: position) { oldValue, newValue in
+                    .onChange(of: position) { _, newValue in
                         previewViewModel.keyboardHorizontalPosition = newValue
                     }
                     .onAppear {
                         previewViewModel.keyAspectRatio = aspectRatio
                         previewViewModel.keyboardScale = scale
                         previewViewModel.keyboardHorizontalPosition = position
-                        
+
                         previewViewModel.bindActionHandler { action in
                             switch action {
                             case .insert(let text):

--- a/wurstfinger/KeyboardSizePositionSettingsView.swift
+++ b/wurstfinger/KeyboardSizePositionSettingsView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct KeyboardSizePositionSettingsView: View {
     @Binding var scale: Double
     @Binding var position: Double
-    
+
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var keyAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -67,11 +67,19 @@ struct SettingsView: View {
             }
 
             Toggle(isOn: $utilityColumnLeading) {
-                SettingsRow(icon: "keyboard.badge.ellipsis", color: .indigo, title: "Utility Keys on Left", subtitle: "Places globe, symbols, delete and return on the left")
+                SettingsRow(
+                    icon: "keyboard.badge.ellipsis", color: .indigo,
+                    title: "Utility Keys on Left",
+                    subtitle: "Places globe, symbols, delete and return on the left"
+                )
             }
 
             Toggle(isOn: $autoCapitalizeEnabled) {
-                SettingsRow(icon: "textformat.size.larger", color: .teal, title: "Auto-Capitalize", subtitle: "Capitalize after sentence-ending punctuation")
+                SettingsRow(
+                    icon: "textformat.size.larger", color: .teal,
+                    title: "Auto-Capitalize",
+                    subtitle: "Capitalize after sentence-ending punctuation"
+                )
             }
         } header: {
             Text("General")
@@ -85,11 +93,20 @@ struct SettingsView: View {
             }
 
             NavigationLink(destination: AspectRatioSettingsView(aspectRatio: $keyAspectRatio)) {
-                SettingsRow(icon: "square.resize", color: .orange, title: "Key Aspect Ratio", subtitle: "Current: \(String(format: "%.2f", keyAspectRatio)):1")
+                SettingsRow(
+                    icon: "square.resize", color: .orange,
+                    title: "Key Aspect Ratio",
+                    subtitle: "Current: \(String(format: "%.2f", keyAspectRatio)):1"
+                )
             }
 
             NavigationLink(destination: KeyboardSizePositionSettingsView(scale: $keyboardScale, position: $keyboardHorizontalPosition)) {
-                SettingsRow(icon: "arrow.up.left.and.arrow.down.right", color: .green, title: "Size & Position", subtitle: "Scale: \(Int(keyboardScale * 100))%, Position: \(positionLabel(for: keyboardHorizontalPosition))")
+                SettingsRow(
+                    icon: "arrow.up.left.and.arrow.down.right",
+                    color: .green,
+                    title: "Size & Position",
+                    subtitle: "Scale: \(Int(keyboardScale * 100))%, Position: \(positionLabel(for: keyboardHorizontalPosition))"
+                )
             }
 
             Picker(selection: $numpadStyleRaw) {

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -44,9 +44,7 @@ struct StyleSettingsView: View {
                         }
 
                         if keyboardStyleRaw == KeyboardStyle.liquidGlass.rawValue {
-                            if #available(iOS 26.0, *) {
-                                // iOS 26+ available
-                            } else {
+                            if #unavailable(iOS 26.0) {
                                 Text("Liquid Glass requires iOS 26 or later. The classic style will be used on this device.")
                                     .font(.caption)
                                     .foregroundColor(.orange)

--- a/wurstfinger/TestAreaView.swift
+++ b/wurstfinger/TestAreaView.swift
@@ -72,7 +72,7 @@ struct TestAreaView: View {
                     }
 
                     // Quick Actions
-                    Button(action: { testText = "" }) {
+                    Button(action: { testText = "" }, label: {
                         HStack {
                             Image(systemName: "trash")
                             Text("Clear")
@@ -82,7 +82,7 @@ struct TestAreaView: View {
                         .background(Color(.systemGray5))
                         .foregroundColor(.primary)
                         .cornerRadius(12)
-                    }
+                    })
                     .padding(.horizontal)
 
                     Spacer()

--- a/wurstfingerKeyboard/KeyHintOverlay.swift
+++ b/wurstfingerKeyboard/KeyHintOverlay.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct KeyHintOverlay: View {
     let key: MessagEaseKey
     @ObservedObject var viewModel: KeyboardViewModel
+    let locale: Locale
     let keyHeight: CGFloat
 
     private let directions: [KeyboardDirection] = KeyboardDirection.allCases.filter { $0 != .center }
@@ -66,9 +67,9 @@ struct KeyHintOverlay: View {
 
         switch activeLayer {
         case .upper:
-            return label.uppercased()
+            return label.uppercased(with: locale)
         case .lower:
-            return label.lowercased()
+            return label.lowercased(with: locale)
         case .numbers, .symbols:
             return label
         }

--- a/wurstfingerKeyboard/KeyHintOverlay.swift
+++ b/wurstfingerKeyboard/KeyHintOverlay.swift
@@ -30,8 +30,9 @@ struct KeyHintOverlay: View {
         GeometryReader { proxy in
             let size = proxy.size
             // Scale padding proportionally with font size
-            let scaledHorizontalPadding = KeyboardConstants.FontSizes.hintBaseHorizontalPadding * (hintFontSize / KeyboardConstants.FontSizes.hintReferenceFontSize)
-            let scaledVerticalPadding = KeyboardConstants.FontSizes.hintBaseVerticalPadding * (hintFontSize / KeyboardConstants.FontSizes.hintReferenceFontSize)
+            let fontRatio = hintFontSize / KeyboardConstants.FontSizes.hintReferenceFontSize
+            let scaledHorizontalPadding = KeyboardConstants.FontSizes.hintBaseHorizontalPadding * fontRatio
+            let scaledVerticalPadding = KeyboardConstants.FontSizes.hintBaseVerticalPadding * fontRatio
 
             ForEach(directions, id: \.self) { direction in
                 if let label = key.primaryLabel(for: direction, isCapsLock: viewModel.isCapsLockActive) {
@@ -217,8 +218,9 @@ struct SymbolsKeyHintOverlay: View {
     var body: some View {
         GeometryReader { proxy in
             let size = proxy.size
-            let scaledHorizontalPadding = KeyboardConstants.FontSizes.hintBaseHorizontalPadding * (hintFontSize / KeyboardConstants.FontSizes.hintReferenceFontSize)
-            let scaledVerticalPadding = KeyboardConstants.FontSizes.hintBaseVerticalPadding * (hintFontSize / KeyboardConstants.FontSizes.hintReferenceFontSize)
+            let fontRatio = hintFontSize / KeyboardConstants.FontSizes.hintReferenceFontSize
+            let scaledHorizontalPadding = KeyboardConstants.FontSizes.hintBaseHorizontalPadding * fontRatio
+            let scaledVerticalPadding = KeyboardConstants.FontSizes.hintBaseVerticalPadding * fontRatio
 
             ForEach(hints, id: \.direction) { hint in
                 Image(systemName: hint.iconName)

--- a/wurstfingerKeyboard/KeyboardButton.swift
+++ b/wurstfingerKeyboard/KeyboardButton.swift
@@ -37,11 +37,11 @@ struct KeyboardButton<Label: View, Overlay: View>: View {
             label
         }
         .overlay(overlay)
-        .if(config.accessibilityLabel != nil) { view in
-            view.accessibilityLabel(config.accessibilityLabel!)
+        .ifLet(config.accessibilityLabel) { view, label in
+            view.accessibilityLabel(label)
         }
-        .if(config.accessibilityIdentifier != nil) { view in
-            view.accessibilityIdentifier(config.accessibilityIdentifier!)
+        .ifLet(config.accessibilityIdentifier) { view, id in
+            view.accessibilityIdentifier(id)
         }
         .accessibilityAddTraits(.isButton)
         // Extend the touch area beyond the visual bounds to cover margins

--- a/wurstfingerKeyboard/KeyboardButton.swift
+++ b/wurstfingerKeyboard/KeyboardButton.swift
@@ -57,7 +57,7 @@ struct KeyboardButton<Label: View, Overlay: View>: View {
 
                     let point = CGPoint(x: value.translation.width, y: value.translation.height)
                     positions.append(point)
-                    
+
                     isActive = true
                 }
                 .onEnded { _ in

--- a/wurstfingerKeyboard/KeyboardButtonComponents.swift
+++ b/wurstfingerKeyboard/KeyboardButtonComponents.swift
@@ -35,10 +35,10 @@ struct KeyboardButtonConfig {
 
 /// Callback closures for keyboard button interactions
 struct KeyboardButtonCallbacks {
-    var onTap: (() -> Void)? = nil
-    var onSwipe: ((KeyboardDirection) -> Void)? = nil
-    var onSwipeReturn: ((KeyboardDirection) -> Void)? = nil
-    var onCircular: ((KeyboardCircularDirection) -> Void)? = nil
+    var onTap: (() -> Void)?
+    var onSwipe: ((KeyboardDirection) -> Void)?
+    var onSwipeReturn: ((KeyboardDirection) -> Void)?
+    var onCircular: ((KeyboardCircularDirection) -> Void)?
 }
 
 /// Visual key cap component used as the base for all keyboard buttons
@@ -77,7 +77,12 @@ struct KeyCap<Content: View>: View {
         content
             .font(.system(size: fontSize, weight: .semibold, design: .rounded))
             .foregroundStyle(Color.primary)
-            .frame(minWidth: KeyboardConstants.KeyDimensions.minWidth, maxWidth: aspectRatio.map { height * $0 } ?? .infinity, minHeight: height, maxHeight: height)
+            .frame(
+                minWidth: KeyboardConstants.KeyDimensions.minWidth,
+                maxWidth: aspectRatio.map { height * $0 } ?? .infinity,
+                minHeight: height,
+                maxHeight: height
+            )
             .background(keyBackground)
     }
 

--- a/wurstfingerKeyboard/KeyboardButtonComponents.swift
+++ b/wurstfingerKeyboard/KeyboardButtonComponents.swift
@@ -35,10 +35,10 @@ struct KeyboardButtonConfig {
 
 /// Callback closures for keyboard button interactions
 struct KeyboardButtonCallbacks {
-    var onTap: (() -> Void)?
-    var onSwipe: ((KeyboardDirection) -> Void)?
-    var onSwipeReturn: ((KeyboardDirection) -> Void)?
-    var onCircular: ((KeyboardCircularDirection) -> Void)?
+    var onTap: (() -> Void)? = nil
+    var onSwipe: ((KeyboardDirection) -> Void)? = nil
+    var onSwipeReturn: ((KeyboardDirection) -> Void)? = nil
+    var onCircular: ((KeyboardCircularDirection) -> Void)? = nil
 }
 
 /// Visual key cap component used as the base for all keyboard buttons

--- a/wurstfingerKeyboard/KeyboardLayout.swift
+++ b/wurstfingerKeyboard/KeyboardLayout.swift
@@ -751,6 +751,7 @@ private extension KeyboardLayout {
         newCircular: [KeyboardCircularDirection: MessagEaseOutput]
     ) -> MessagEaseKey {
         return MessagEaseKey(
+            id: key.id,
             center: newCenter,
             swipeOutputs: key.swipeOutputs,
             swipeReturnOutputs: key.swipeReturnOutputs,

--- a/wurstfingerKeyboard/KeyboardLayout.swift
+++ b/wurstfingerKeyboard/KeyboardLayout.swift
@@ -271,8 +271,8 @@ private extension KeyboardLayout {
     /// Creates the 3x3 letter grid rows using the language configuration
     private static func createLetterRows(for config: LanguageConfig) -> [[MessagEaseKey]] {
         let centers = config.centerCharacters
-        guard centers.count == 3 else {
-            assertionFailure("LanguageConfig must have exactly 3 rows")
+        guard centers.count == 3, centers.allSatisfy({ $0.count == 3 }) else {
+            assertionFailure("LanguageConfig must be a 3x3 grid")
             return []
         }
 

--- a/wurstfingerKeyboard/KeyboardLayout.swift
+++ b/wurstfingerKeyboard/KeyboardLayout.swift
@@ -745,7 +745,11 @@ private extension KeyboardLayout {
     }
 
     /// Helper to create a new key with swapped center and circular gestures, keeping swipe outputs at physical position
-    private static func swapCenterAndCircular(_ key: MessagEaseKey, newCenter: String, newCircular: [KeyboardCircularDirection: MessagEaseOutput]) -> MessagEaseKey {
+    private static func swapCenterAndCircular(
+        _ key: MessagEaseKey,
+        newCenter: String,
+        newCircular: [KeyboardCircularDirection: MessagEaseOutput]
+    ) -> MessagEaseKey {
         return MessagEaseKey(
             center: newCenter,
             swipeOutputs: key.swipeOutputs,
@@ -1021,4 +1025,3 @@ enum KeyboardConstants {
         }
     }
 }
-

--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -13,7 +13,7 @@ struct KeyboardRootView: View {
     @ObservedObject var viewModel: KeyboardViewModel
     var scaleAnchor: UnitPoint = .bottom
     var frameAlignment: Alignment = .bottom
-    var overrideWidth: CGFloat? = nil
+    var overrideWidth: CGFloat?
 
     @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
     private var keyboardStyleRaw = KeyboardStyle.classic.rawValue
@@ -31,11 +31,11 @@ struct KeyboardRootView: View {
         let screenBounds = UIScreen.main.bounds
         let screenShortestSide = min(screenBounds.width, screenBounds.height)
         let currentWidth = overrideWidth ?? screenBounds.width
-        
+
         // Constrain the base width to the device's shortest side (portrait width)
         // This prevents the keyboard from stretching in landscape
         let baseWidth = min(currentWidth, screenShortestSide)
-        
+
         let availableSpace = currentWidth - (baseWidth * viewModel.keyboardScale)
         let horizontalOffset = availableSpace * (viewModel.keyboardHorizontalPosition - 0.5)
 

--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -153,7 +153,10 @@ struct KeyboardRootView: View {
                     height: keyHeight,
                     aspectRatio: viewModel.keyAspectRatio,
                     label: Text(viewModel.displayText(for: key)),
-                    overlay: KeyHintOverlay(key: key, viewModel: viewModel, keyHeight: keyHeight),
+                    overlay: KeyHintOverlay(
+                        key: key, viewModel: viewModel,
+                        locale: viewModel.currentLocale(), keyHeight: keyHeight
+                    ),
                     config: KeyboardButtonConfig(fontSize: scaledMainLabelSize(for: keyHeight)),
                     callbacks: KeyboardButtonCallbacks(
                         onSwipe: { viewModel.handleKeySwipe(key, direction: $0) },

--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -13,7 +13,7 @@ struct KeyboardRootView: View {
     @ObservedObject var viewModel: KeyboardViewModel
     var scaleAnchor: UnitPoint = .bottom
     var frameAlignment: Alignment = .bottom
-    var overrideWidth: CGFloat?
+    var overrideWidth: CGFloat? = nil
 
     @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
     private var keyboardStyleRaw = KeyboardStyle.classic.rawValue

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -52,18 +52,18 @@ struct DeviceLayoutUtils {
     static var defaultKeyboardScale: Double {
         let targetWidth: CGFloat = 270.0
         let screenWidth = UIScreen.main.bounds.width
-        
+
         // Avoid division by zero
         guard screenWidth > 0 else { return 1.0 }
-        
+
         // Calculate scale required to hit target width
         let calculatedScale = targetWidth / screenWidth
-        
+
         // Clamp between reasonable min/max (e.g., 0.26 to 1.0)
         // 0.26 is roughly iPad width (1024pt) -> 270/1024 = 0.26
         return min(1.0, max(0.25, calculatedScale))
     }
-    
+
     static let defaultKeyAspectRatio: Double = 1.0
     static let defaultKeyboardPosition: Double = 0.5
 }

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -454,7 +454,6 @@ final class KeyboardViewModel: ObservableObject {
         }
     }
 
-
     private func perform(_ output: MessagEaseOutput) {
         switch output {
         case .text(let value):

--- a/wurstfingerKeyboard/RingBuffer.swift
+++ b/wurstfingerKeyboard/RingBuffer.swift
@@ -11,14 +11,14 @@ struct RingBuffer<T> {
     private var array: [T?]
     private var writeIndex = 0
     private var count = 0
-    
+
     let capacity: Int
-    
+
     init(capacity: Int) {
         self.capacity = capacity
         self.array = Array(repeating: nil, count: capacity)
     }
-    
+
     mutating func append(_ element: T) {
         array[writeIndex] = element
         writeIndex = (writeIndex + 1) % capacity
@@ -26,7 +26,7 @@ struct RingBuffer<T> {
             count += 1
         }
     }
-    
+
     mutating func removeAll() {
         writeIndex = 0
         count = 0
@@ -34,11 +34,11 @@ struct RingBuffer<T> {
         // for value types. For reference types, we might want to nil them out
         // to avoid leaks, but CGPoint is a value type.
     }
-    
+
     var isEmpty: Bool {
         return count == 0
     }
-    
+
     /// Returns the elements in order, from oldest to newest.
     /// This is O(N) where N is the number of elements.
     var elements: [T] {
@@ -50,7 +50,7 @@ struct RingBuffer<T> {
             // Indices: 2, 3, 4, 0, 1
             var result = [T]()
             result.reserveCapacity(capacity)
-            
+
             for i in 0..<capacity {
                 let index = (writeIndex + i) % capacity
                 if let element = array[index] {

--- a/wurstfingerKeyboard/ViewExtensions.swift
+++ b/wurstfingerKeyboard/ViewExtensions.swift
@@ -7,12 +7,23 @@
 
 import SwiftUI
 
-/// Helper extension for conditional view modifiers
+/// Helper extensions for conditional view modifiers
 extension View {
+    /// Conditionally applies a modifier based on a boolean condition.
     @ViewBuilder
     func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
         if condition {
             transform(self)
+        } else {
+            self
+        }
+    }
+
+    /// Conditionally applies a modifier only when the optional value is non-nil.
+    @ViewBuilder
+    func ifLet<T, ModifiedView: View>(_ value: T?, transform: (Self, T) -> ModifiedView) -> some View {
+        if let value {
+            transform(self, value)
         } else {
             self
         }

--- a/wurstfingerUITests/ScreenshotTests.swift
+++ b/wurstfingerUITests/ScreenshotTests.swift
@@ -7,6 +7,14 @@
 
 import XCTest
 
+private struct ScreenshotConfig {
+    let layer: String
+    let appearance: String
+    let number: String
+    let sent: String
+    let received: String
+}
+
 final class ScreenshotTests: XCTestCase {
     var app: XCUIApplication!
 
@@ -179,12 +187,15 @@ final class ScreenshotTests: XCTestCase {
             .replacingOccurrences(of: " ", with: "-")
             .lowercased()
 
-        // Configurations: layer, appearance, screenshot number, sent text, received text
-        let configurations: [(layer: String, appearance: String, number: String, sent: String, received: String)] = [
-            ("lower", "light", "01", "So fast and precise! 🎯", "How do you like the new keyboard?"),
-            ("lower", "dark", "02", "Works great in dark mode too!", "Can you try it at night?"),
-            ("numbers", "light", "03", "Here: 555-0123", "What's your number?"),
-            ("numbers", "dark", "04", "Meeting at 7:30pm", "What time works for you?")
+        let configurations: [ScreenshotConfig] = [
+            .init(layer: "lower", appearance: "light", number: "01",
+                  sent: "So fast and precise! 🎯", received: "How do you like the new keyboard?"),
+            .init(layer: "lower", appearance: "dark", number: "02",
+                  sent: "Works great in dark mode too!", received: "Can you try it at night?"),
+            .init(layer: "numbers", appearance: "light", number: "03",
+                  sent: "Here: 555-0123", received: "What's your number?"),
+            .init(layer: "numbers", appearance: "dark", number: "04",
+                  sent: "Meeting at 7:30pm", received: "What time works for you?")
         ]
 
         for config in configurations {

--- a/wurstfingerUITests/ScreenshotTests.swift
+++ b/wurstfingerUITests/ScreenshotTests.swift
@@ -11,8 +11,8 @@ private struct ScreenshotConfig {
     let layer: String
     let appearance: String
     let number: String
-    let sent: String
-    let received: String
+    var sent: String = ""
+    var received: String = ""
 }
 
 final class ScreenshotTests: XCTestCase {
@@ -149,11 +149,11 @@ final class ScreenshotTests: XCTestCase {
             .lowercased()
 
         // Keyboard layouts to capture
-        let configurations: [(layer: String, appearance: String, number: String)] = [
-            ("lower", "light", "06"),
-            ("lower", "dark", "07"),
-            ("numbers", "light", "08"),
-            ("symbols", "light", "09")
+        let configurations: [ScreenshotConfig] = [
+            .init(layer: "lower", appearance: "light", number: "06"),
+            .init(layer: "lower", appearance: "dark", number: "07"),
+            .init(layer: "numbers", appearance: "light", number: "08"),
+            .init(layer: "symbols", appearance: "light", number: "09")
         ]
 
         for config in configurations {

--- a/wurstfingerUITests/wurstfingerUITestsLaunchTests.swift
+++ b/wurstfingerUITests/wurstfingerUITestsLaunchTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 final class wurstfingerUITestsLaunchTests: XCTestCase {
 
-    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+    override static var runsForEachTargetApplicationUIConfiguration: Bool {
         true
     }
 


### PR DESCRIPTION
## Summary
- Add SwiftLint configuration (`.swiftlint.yml`) tuned for the project: short variable names allowed for geometry code, relaxed limits for layout data tables, trailing commas permitted
- Add `swiftlint` job to CI pipeline (`pr-tests.yml`), runs in parallel with tests using `--strict` mode
- Add pre-commit hook (`scripts/pre-commit`) that lints only staged Swift files with `--strict`
- Add install script (`scripts/install-hooks.sh`) for easy hook setup — run `bash scripts/install-hooks.sh` once after cloning
- Fix all 306 existing violations across 22 files (trailing whitespace, line length, `#unavailable`, `static var`, string concatenation for long lines, etc.)
- Final result: **0 violations in strict mode** across 56 files

## Setup
```bash
brew install swiftlint
bash scripts/install-hooks.sh
```

## Test plan
- [ ] Run `swiftlint lint --strict` locally — should report 0 violations
- [ ] Verify CI `swiftlint` job passes on this PR
- [ ] Make a test commit with a Swift file change — pre-commit hook should run
- [ ] Build and run existing tests to confirm no regressions from formatting changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Locale-aware casing for keyboard hint labels.
  * New conditional view modifier to apply transformations when an optional value is present.

* **Bug Fixes**
  * Safer accessibility handling for button labels/identifiers.
  * Consolidated return-swipe detection to improve gesture classification.
  * Compile-time iOS availability check for a feature warning.
  * Stronger keyboard layout validation enforcing a 3×3 center grid.

* **Chores**
  * Added SwiftLint CI job, config, pre-commit hook and installer script.

* **Style**
  * Formatting and whitespace cleanup across views and components.

* **Tests**
  * Refactored screenshot test configurations and a minor test declaration form change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->