### PR TITLE
Fix French return swipe on center key producing U instead of H

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fix French layout return swipe on center key producing U instead of H; all center key return overrides are now config-driven (#94)
 - Fix angle boundary overlap in swipe direction detection (half-open ranges)
 - Fix non-deterministic accent cycle order
 - Replace `fatalError` with `assertionFailure` in layout creation to prevent production crashes

--- a/wurstfingerTests/ReturnSwipeLanguageTests.swift
+++ b/wurstfingerTests/ReturnSwipeLanguageTests.swift
@@ -1,0 +1,58 @@
+//
+//  ReturnSwipeLanguageTests.swift
+//  wurstfingerTests
+//
+//  Tests that return swipe overrides on the center key produce the correct
+//  uppercased variant for every language, not hardcoded English values.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct ReturnSwipeLanguageTests {
+    /// Bug #94: French layout return swipe up on center key (O) should produce "H",
+    /// because the French up-swipe character is "h" — not "U" (the English default).
+    @Test func frenchReturnSwipeUpOnCenterKeyProducesH() throws {
+        let frenchLayout = KeyboardLayout.layout(for: .french)
+        let viewModel = KeyboardViewModel(layout: frenchLayout, shouldPersistSettings: false)
+        var inserted: [String] = []
+
+        viewModel.bindActionHandler { action in
+            if case let .insert(value) = action {
+                inserted.append(value)
+            }
+        }
+
+        let centerKey = try #require(viewModel.rows[1][1])
+        viewModel.handleKeySwipeReturn(centerKey, direction: .up)
+
+        #expect(inserted.last == "H",
+                "French return swipe up on center key should produce H, got \(inserted.last ?? "nil")")
+    }
+
+    /// Regression guard: for every language, the center key's return swipe overrides
+    /// should match the uppercased version of the regular swipe output.
+    @Test func centerKeyReturnSwipeMatchesUppercasedSwipeForAllLanguages() throws {
+        for config in LanguageConfig.allLanguages {
+            let layout = KeyboardLayout.layout(for: config)
+            let viewModel = KeyboardViewModel(layout: layout, shouldPersistSettings: false)
+            viewModel.bindActionHandler { _ in }
+
+            let centerKey = try #require(viewModel.rows[1][1])
+
+            for direction in KeyboardDirection.allCases where direction != .center {
+                // Get the regular swipe output
+                guard case let .text(swipeText)? = centerKey.output(for: direction) else { continue }
+                // Get the return swipe output
+                guard case let .text(returnText)? = centerKey.output(for: direction, returning: true) else { continue }
+                // Only check letter outputs
+                guard swipeText.first?.isLetter == true else { continue }
+
+                let expected = swipeText.uppercased(with: config.locale)
+                #expect(returnText == expected,
+                        "[\(config.id)] center key return swipe \(direction): expected '\(expected)', got '\(returnText)'")
+            }
+        }
+    }
+}

--- a/wurstfingerTests/ReturnSwipeLanguageTests.swift
+++ b/wurstfingerTests/ReturnSwipeLanguageTests.swift
@@ -27,8 +27,10 @@ struct ReturnSwipeLanguageTests {
         let centerKey = try #require(viewModel.rows[1][1])
         viewModel.handleKeySwipeReturn(centerKey, direction: .up)
 
-        #expect(inserted.last == "H",
-                "French return swipe up on center key should produce H, got \(inserted.last ?? "nil")")
+        #expect(
+            inserted.last == "H",
+            "French return swipe up on center key should produce H, got \(inserted.last ?? "nil")"
+        )
     }
 
     /// Regression guard: for every language, the center key's return swipe overrides
@@ -50,8 +52,10 @@ struct ReturnSwipeLanguageTests {
                 guard swipeText.first?.isLetter == true else { continue }
 
                 let expected = swipeText.uppercased(with: config.locale)
-                #expect(returnText == expected,
-                        "[\(config.id)] center key return swipe \(direction): expected '\(expected)', got '\(returnText)'")
+                #expect(
+                    returnText == expected,
+                    "[\(config.id)] center key return swipe \(direction): expected '\(expected)', got '\(returnText)'"
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- The center key's return swipe overrides were hardcoded to English defaults (e.g. `"U"` for up) instead of using each language's `specialCharacters` config
- French defines `"1_1_up": "h"`, so return-swipe-up should produce `"H"` — but it produced `"U"`
- Now all 8 directions use config-driven lookups with `uppercased(with: config.locale)`, matching the pattern already used for the `.down` direction
- Also prevents the same class of bug for Russian, Hebrew, and future languages

## Test plan
- [x] Added `ReturnSwipeLanguageTests.swift` with French-specific test and a regression test across all languages
- [x] Tests fail before the fix (red), pass after (green)
- [x] All 212 unit tests pass

Fixes #94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed French keyboard return swipe behavior on center key (was producing "U" instead of "H")
  * Center-key return override behavior now driven by configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->