### PR TITLE
Fix auto-capitalization after delete canceling manual shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix French layout return swipe on center key producing U instead of H; all center key return overrides are now config-driven (#94)
+- Fix auto-capitalization after delete canceling manual temporary shift (#113)
 - Fix angle boundary overlap in swipe direction detection (half-open ranges)
 - Fix non-deterministic accent cycle order
 - Replace `fatalError` with `assertionFailure` in layout creation to prevent production crashes

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -199,7 +199,7 @@ final class KeyboardViewController: UIInputViewController {
         let shouldCapitalize = AutoCapitalization.shouldCapitalize(context: textDocumentProxy.documentContextBeforeInput)
         if shouldCapitalize {
             viewModel.setLayer(.upper)
-        } else if viewModel.activeLayer == .upper && !viewModel.isCapsLockActive {
+        } else if viewModel.activeLayer == .upper && !viewModel.isCapsLockActive && !viewModel.isManualShift {
             viewModel.setLayer(.lower)
         }
     }

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -90,6 +90,7 @@ final class KeyboardViewModel: ObservableObject {
 
     @Published private(set) var activeLayer: KeyboardLayer = .lower
     @Published private(set) var isCapsLockActive: Bool = false
+    @Published private(set) var isManualShift: Bool = false
     private var locale: Locale
 
     // MARK: - Settings (delegated to extracted classes)
@@ -236,6 +237,7 @@ final class KeyboardViewModel: ObservableObject {
                 // Reset to lower layer when language changes
                 activeLayer = .lower
                 isCapsLockActive = false
+                isManualShift = false
             }
         }
     }
@@ -406,6 +408,9 @@ final class KeyboardViewModel: ObservableObject {
 
     func setLayer(_ layer: KeyboardLayer) {
         activeLayer = layer
+        if layer != .upper {
+            isManualShift = false
+        }
     }
 
     private func setShiftState(active: Bool) {
@@ -415,14 +420,17 @@ final class KeyboardViewModel: ObservableObject {
             // If shift is already active, activate caps-lock
             if activeLayer == .upper && !isCapsLockActive {
                 isCapsLockActive = true
+                isManualShift = false
             } else {
                 // First activation - temporary shift
                 isCapsLockActive = false
                 activeLayer = .upper
+                isManualShift = true
             }
         } else {
             // Deactivate shift/caps-lock
             isCapsLockActive = false
+            isManualShift = false
             activeLayer = .lower
         }
     }
@@ -472,6 +480,7 @@ final class KeyboardViewModel: ObservableObject {
         // Only deactivate shift if it was already upper before insert and not caps-lock
         if wasUpper && !isCapsLockActive {
             activeLayer = .lower
+            isManualShift = false
         }
     }
 

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -370,7 +370,7 @@ final class KeyboardViewModel: ObservableObject {
         case .upper:
             setShiftState(active: false)
         case .numbers, .symbols:
-            activeLayer = .lower
+            setLayer(.lower)
         }
     }
 
@@ -378,9 +378,9 @@ final class KeyboardViewModel: ObservableObject {
         feedbackModifier()
         switch activeLayer {
         case .lower, .upper:
-            activeLayer = .numbers
+            setLayer(.numbers)
         case .numbers, .symbols:
-            activeLayer = .lower
+            setLayer(.lower)
         }
     }
 

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -474,14 +474,13 @@ final class KeyboardViewModel: ObservableObject {
     }
 
     private func performTextInsertion(_ value: String) {
-        // Capture layer state BEFORE the action handler (which may change it)
-        let wasUpper = activeLayer == .upper
-        actionHandler?(.insert(resolvedText(value)))
-        // Only deactivate shift if it was already upper before insert and not caps-lock
-        if wasUpper && !isCapsLockActive {
-            activeLayer = .lower
-            isManualShift = false
+        let resolvedValue = resolvedText(value)
+        // Deactivate one-shot shift BEFORE the handler, so auto-cap reactivation
+        // by the handler (e.g. after ¿/¡) is not stomped
+        if activeLayer == .upper && !isCapsLockActive {
+            setLayer(.lower)
         }
+        actionHandler?(.insert(resolvedValue))
     }
 
     private func perform(_ output: MessagEaseOutput) {

--- a/wurstfingerTests/AutoCapitalizationTests.swift
+++ b/wurstfingerTests/AutoCapitalizationTests.swift
@@ -220,6 +220,32 @@ struct AutoCapitalizationTests {
         #expect(viewModel.isManualShift == false, "isManualShift should clear when shift is toggled off")
     }
 
+    @Test func testReloadLanguageResetsShiftState() {
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        viewModel.bindActionHandler { _ in }
+
+        // Activate manual shift
+        viewModel.toggleShift()
+        #expect(viewModel.isManualShift == true)
+        #expect(viewModel.activeLayer == .upper)
+
+        // Change language ID in shared defaults so reloadLanguage detects a change
+        let store = SharedDefaults.store
+        let currentId = viewModel.currentLocale().identifier
+        let newId = (currentId == "en_US") ? "de_DE" : "en_US"
+        store.set(newId, forKey: SettingsKey.selectedLanguageId.rawValue)
+
+        // Call reloadSettings directly (in production, triggered by notification)
+        viewModel.reloadSettings()
+
+        #expect(viewModel.activeLayer == .lower, "reloadLanguage should reset to lower")
+        #expect(viewModel.isCapsLockActive == false, "reloadLanguage should clear caps-lock")
+        #expect(viewModel.isManualShift == false, "reloadLanguage should clear isManualShift")
+
+        // Restore original language
+        store.set(currentId, forKey: SettingsKey.selectedLanguageId.rawValue)
+    }
+
     @Test func testCapsLockDoesNotSetManualShift() {
         let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         viewModel.bindActionHandler { _ in }

--- a/wurstfingerTests/AutoCapitalizationTests.swift
+++ b/wurstfingerTests/AutoCapitalizationTests.swift
@@ -171,4 +171,70 @@ struct AutoCapitalizationTests {
         // After inserting a regular character, should reset to lower
         #expect(viewModel.activeLayer == .lower, "Layer should reset to lower after regular character")
     }
+
+    // MARK: - Bug #113: Manual shift should survive auto-capitalization reset
+
+    @Test func manualShiftIsTracked() {
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        viewModel.bindActionHandler { _ in }
+
+        // User manually activates shift via toggleShift
+        viewModel.toggleShift()
+        #expect(viewModel.activeLayer == .upper)
+        #expect(viewModel.isManualShift == true, "toggleShift should set isManualShift")
+    }
+
+    @Test func autoCapShiftIsNotManual() {
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        viewModel.bindActionHandler { _ in }
+
+        // Auto-capitalization sets layer via setLayer (not toggleShift)
+        viewModel.setLayer(.upper)
+        #expect(viewModel.activeLayer == .upper)
+        #expect(viewModel.isManualShift == false, "setLayer should not set isManualShift")
+    }
+
+    @Test func manualShiftClearsAfterInsertion() {
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        viewModel.bindActionHandler { _ in }
+
+        // User manually shifts, then types a character
+        viewModel.toggleShift()
+        #expect(viewModel.isManualShift == true)
+
+        viewModel.simulateTextInsertion("a")
+        #expect(viewModel.activeLayer == .lower, "Temporary shift should reset after insertion")
+        #expect(viewModel.isManualShift == false, "isManualShift should clear after insertion")
+    }
+
+    @Test func manualShiftClearsWhenDeactivated() {
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        viewModel.bindActionHandler { _ in }
+
+        viewModel.toggleShift()
+        #expect(viewModel.isManualShift == true)
+
+        // Deactivate shift
+        viewModel.toggleShift()
+        #expect(viewModel.activeLayer == .lower)
+        #expect(viewModel.isManualShift == false, "isManualShift should clear when shift is toggled off")
+    }
+
+    @Test func capsLockDoesNotSetManualShift() {
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        viewModel.bindActionHandler { _ in }
+
+        // First shift activation: temporary shift
+        viewModel.toggleShift()
+        #expect(viewModel.activeLayer == .upper)
+        #expect(viewModel.isManualShift == true)
+
+        // Simulate second shift-up swipe while already upper → caps-lock
+        // (In the real keyboard, this is a swipe-up on the shift key,
+        // which calls setShiftState(active: true) via .toggleShift(on: true))
+        let shiftKey = viewModel.rows[1][2]
+        viewModel.handleKeySwipe(shiftKey, direction: .up)
+        #expect(viewModel.isCapsLockActive == true)
+        #expect(viewModel.isManualShift == false, "Caps-lock should clear isManualShift")
+    }
 }

--- a/wurstfingerTests/AutoCapitalizationTests.swift
+++ b/wurstfingerTests/AutoCapitalizationTests.swift
@@ -174,7 +174,7 @@ struct AutoCapitalizationTests {
 
     // MARK: - Bug #113: Manual shift should survive auto-capitalization reset
 
-    @Test func manualShiftIsTracked() {
+    @Test func testManualShiftIsTracked() {
         let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         viewModel.bindActionHandler { _ in }
 
@@ -184,7 +184,7 @@ struct AutoCapitalizationTests {
         #expect(viewModel.isManualShift == true, "toggleShift should set isManualShift")
     }
 
-    @Test func autoCapShiftIsNotManual() {
+    @Test func testAutoCapShiftIsNotManual() {
         let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         viewModel.bindActionHandler { _ in }
 
@@ -194,7 +194,7 @@ struct AutoCapitalizationTests {
         #expect(viewModel.isManualShift == false, "setLayer should not set isManualShift")
     }
 
-    @Test func manualShiftClearsAfterInsertion() {
+    @Test func testManualShiftClearsAfterInsertion() {
         let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         viewModel.bindActionHandler { _ in }
 
@@ -207,7 +207,7 @@ struct AutoCapitalizationTests {
         #expect(viewModel.isManualShift == false, "isManualShift should clear after insertion")
     }
 
-    @Test func manualShiftClearsWhenDeactivated() {
+    @Test func testManualShiftClearsWhenDeactivated() {
         let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         viewModel.bindActionHandler { _ in }
 
@@ -220,7 +220,7 @@ struct AutoCapitalizationTests {
         #expect(viewModel.isManualShift == false, "isManualShift should clear when shift is toggled off")
     }
 
-    @Test func capsLockDoesNotSetManualShift() {
+    @Test func testCapsLockDoesNotSetManualShift() {
         let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         viewModel.bindActionHandler { _ in }
 


### PR DESCRIPTION
## Summary
- Added `isManualShift` flag to `KeyboardViewModel` to distinguish user-initiated shift (`toggleShift`) from auto-cap-initiated shift (`setLayer(.upper)`)
- `updateAutoCapitalization()` in `KeyboardViewController` now checks `!viewModel.isManualShift` before resetting to `.lower`, preserving user intent
- The flag is cleared in all appropriate paths: after text insertion, shift deactivation, caps-lock activation, and language reload

## Test plan
- [x] Added 5 tests to `AutoCapitalizationTests.swift`: manual shift tracking, auto-cap vs manual distinction, clearing after insertion, clearing on deactivation, caps-lock interaction
- [x] Tests fail before the fix (compile error — `isManualShift` didn't exist), pass after
- [x] All 215 unit tests pass

Fixes #113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keyboard now distinguishes manual vs automatic shift so auto-capitalization no longer lowers the keyboard when a manual shift is active; caps-lock takes precedence and shift reliably resets when switching layers, reloading language, deactivating shift, or after typing.
* **Tests**
  * Added integration tests covering manual vs auto shift tracking, toggle behavior, caps-lock interactions, and reset after text insertion.
* **Chores**
  * Updated changelog with the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->