### PR TITLE
Fire haptic feedback on touch-down instead of release

### DIFF
--- a/wurstfinger/HapticSettingsView.swift
+++ b/wurstfinger/HapticSettingsView.swift
@@ -13,6 +13,12 @@ struct HapticSettingsView: View {
     @AppStorage(SettingsKey.keyboardFullAccess.rawValue, store: SharedDefaults.store)
     private var hasFullAccess = false
 
+    /// Whether the keyboard extension has synced its Full Access status at least once.
+    /// Prevents treating "unset" as "denied" on fresh installs.
+    private var hasSyncedFullAccess: Bool {
+        SharedDefaults.store.object(forKey: SettingsKey.keyboardFullAccess.rawValue) != nil
+    }
+
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var previewAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 
@@ -30,8 +36,8 @@ struct HapticSettingsView: View {
 
             ScrollView {
                 VStack(spacing: 24) {
-                    if hasFullAccess {
-                        // Global Toggle
+                    if !hasSyncedFullAccess || hasFullAccess {
+                        // Full Access granted or not yet synced — show full UI
                         VStack(spacing: 8) {
                             Toggle("Haptic Feedback", isOn: $hapticEnabled)
                                 .font(.headline)
@@ -40,6 +46,13 @@ struct HapticSettingsView: View {
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                                 .frame(maxWidth: .infinity, alignment: .leading)
+
+                            if !hasSyncedFullAccess {
+                                Text("Open the keyboard once to sync Full Access status.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
                         }
                         .padding(.horizontal, 16)
 
@@ -63,7 +76,7 @@ struct HapticSettingsView: View {
                             }
                         }
                     } else {
-                        // Full Access not granted
+                        // Full Access explicitly denied
                         VStack(spacing: 12) {
                             Toggle("Haptic Feedback", isOn: .constant(false))
                                 .font(.headline)
@@ -88,7 +101,7 @@ struct HapticSettingsView: View {
         .navigationTitle("Haptics")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            if hasFullAccess {
+            if !hasSyncedFullAccess || hasFullAccess {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Reset") {
                         tapIntensity = Double(HapticSettings.defaultTapIntensity)

--- a/wurstfinger/HapticSettingsView.swift
+++ b/wurstfinger/HapticSettingsView.swift
@@ -83,8 +83,12 @@ struct HapticSettingsView: View {
                                 .disabled(true)
 
                             Label {
-                                Text("Haptic feedback requires Full Access. Enable it in **Settings \u{203A} Wurstfinger \u{203A} Keyboards \u{203A} Wurstfinger \u{203A} Allow Full Access**.")
-                                    .font(.caption)
+                                Text(
+                                    "Haptic feedback requires Full Access. Enable it in " +
+                                        "**Settings \u{203A} Wurstfinger \u{203A} Keyboards " +
+                                        "\u{203A} Wurstfinger \u{203A} Allow Full Access**."
+                                )
+                                .font(.caption)
                             } icon: {
                                 Image(systemName: "exclamationmark.triangle.fill")
                                     .foregroundColor(.orange)

--- a/wurstfinger/HapticSettingsView.swift
+++ b/wurstfinger/HapticSettingsView.swift
@@ -4,14 +4,14 @@ struct HapticSettingsView: View {
     @AppStorage(SettingsKey.hapticIntensityTap.rawValue, store: SharedDefaults.store)
     private var tapIntensity = Double(HapticSettings.defaultTapIntensity)
 
-    @AppStorage(SettingsKey.hapticIntensityModifier.rawValue, store: SharedDefaults.store)
-    private var modifierIntensity = Double(HapticSettings.defaultModifierIntensity)
-
     @AppStorage(SettingsKey.hapticIntensityDrag.rawValue, store: SharedDefaults.store)
     private var dragIntensity = Double(HapticSettings.defaultDragIntensity)
 
     @AppStorage(SettingsKey.hapticEnabled.rawValue, store: SharedDefaults.store)
     private var hapticEnabled = true
+
+    @AppStorage(SettingsKey.keyboardFullAccess.rawValue, store: SharedDefaults.store)
+    private var hasFullAccess = false
 
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var previewAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
@@ -30,42 +30,55 @@ struct HapticSettingsView: View {
 
             ScrollView {
                 VStack(spacing: 24) {
-                    // Global Toggle
-                    VStack(spacing: 8) {
-                        Toggle("Haptic Feedback", isOn: $hapticEnabled)
-                            .font(.headline)
+                    if hasFullAccess {
+                        // Global Toggle
+                        VStack(spacing: 8) {
+                            Toggle("Haptic Feedback", isOn: $hapticEnabled)
+                                .font(.headline)
 
-                        Text("Enable or disable all haptic feedback vibrations.")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .padding(.horizontal, 16)
-
-                    if hapticEnabled {
-                        Divider()
-                            .padding(.horizontal, 16)
-
-                        // Sliders
-                        VStack(spacing: 24) {
-                            hapticControl(
-                                title: "Tap Feedback",
-                                value: $tapIntensity,
-                                description: "Applies when you press letters or utility buttons."
-                            )
-
-                            hapticControl(
-                                title: "Modifier Feedback",
-                                value: $modifierIntensity,
-                                description: "Applies when you press Shift, Symbols, or other modifier keys."
-                            )
-
-                            hapticControl(
-                                title: "Drag Feedback",
-                                value: $dragIntensity,
-                                description: "Applies when you drag the Space or Delete key to move the cursor or delete text."
-                            )
+                            Text("Enable or disable all haptic feedback vibrations.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
                         }
+                        .padding(.horizontal, 16)
+
+                        if hapticEnabled {
+                            Divider()
+                                .padding(.horizontal, 16)
+
+                            // Sliders
+                            VStack(spacing: 24) {
+                                hapticControl(
+                                    title: "Tap Feedback",
+                                    value: $tapIntensity,
+                                    description: "Applies when you touch any key."
+                                )
+
+                                hapticControl(
+                                    title: "Drag Feedback",
+                                    value: $dragIntensity,
+                                    description: "Applies when you drag the Space or Delete key to move the cursor or delete text."
+                                )
+                            }
+                        }
+                    } else {
+                        // Full Access not granted
+                        VStack(spacing: 12) {
+                            Toggle("Haptic Feedback", isOn: .constant(false))
+                                .font(.headline)
+                                .disabled(true)
+
+                            Label {
+                                Text("Haptic feedback requires Full Access. Enable it in **Settings \u{203A} Wurstfinger \u{203A} Keyboards \u{203A} Wurstfinger \u{203A} Allow Full Access**.")
+                                    .font(.caption)
+                            } icon: {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundColor(.orange)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .padding(.horizontal, 16)
                     }
                 }
                 .padding(.vertical, 8)
@@ -75,12 +88,13 @@ struct HapticSettingsView: View {
         .navigationTitle("Haptics")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button("Reset") {
-                    tapIntensity = Double(HapticSettings.defaultTapIntensity)
-                    modifierIntensity = Double(HapticSettings.defaultModifierIntensity)
-                    dragIntensity = Double(HapticSettings.defaultDragIntensity)
-                    hapticEnabled = true
+            if hasFullAccess {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Reset") {
+                        tapIntensity = Double(HapticSettings.defaultTapIntensity)
+                        dragIntensity = Double(HapticSettings.defaultDragIntensity)
+                        hapticEnabled = true
+                    }
                 }
             }
         }

--- a/wurstfinger/HapticSettingsView.swift
+++ b/wurstfinger/HapticSettingsView.swift
@@ -142,7 +142,6 @@ struct HapticSettingsView: View {
                     if !editing {
                         // Trigger feedback when user releases the slider
                         let generator = UIImpactFeedbackGenerator(style: .rigid)
-                        generator.prepare()
                         generator.impactOccurred(intensity: value.wrappedValue)
                     }
                 }

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -25,9 +25,6 @@ struct SettingsView: View {
     @AppStorage(SettingsKey.hapticIntensityTap.rawValue, store: SharedDefaults.store)
     private var hapticTapIntensity = Double(HapticSettings.defaultTapIntensity)
 
-    @AppStorage(SettingsKey.hapticIntensityModifier.rawValue, store: SharedDefaults.store)
-    private var hapticModifierIntensity = Double(HapticSettings.defaultModifierIntensity)
-
     @AppStorage(SettingsKey.hapticIntensityDrag.rawValue, store: SharedDefaults.store)
     private var hapticDragIntensity = Double(HapticSettings.defaultDragIntensity)
 
@@ -220,9 +217,8 @@ struct SettingsView: View {
 
     private func hapticModeDescription() -> String {
         let tap: String = formatIntensity(hapticTapIntensity)
-        let modifier: String = formatIntensity(hapticModifierIntensity)
         let drag: String = formatIntensity(hapticDragIntensity)
-        return "Tap: \(tap) • Modifiers: \(modifier) • Drags: \(drag)"
+        return "Tap: \(tap) • Drag: \(drag)"
     }
 
     private func formatIntensity(_ value: Double) -> String {

--- a/wurstfingerKeyboard/DeleteKeyButton.swift
+++ b/wurstfingerKeyboard/DeleteKeyButton.swift
@@ -58,6 +58,7 @@ struct DeleteKeyButton: View {
 
                     if !gesture.dragStarted {
                         gesture.dragStarted = true
+                        viewModel.feedbackTap()
                     }
 
                     gesture.totalTranslation = value.translation

--- a/wurstfingerKeyboard/HapticFeedbackManager.swift
+++ b/wurstfingerKeyboard/HapticFeedbackManager.swift
@@ -9,16 +9,26 @@
 import UIKit
 
 /// Manages haptic feedback generation for keyboard events.
-/// Uses UIImpactFeedbackGenerator with configurable intensity per event type.
+///
+/// Uses `UIImpactFeedbackGenerator.impactOccurred()` (without intensity parameter)
+/// because the intensity variant requires CHHapticEngine, which cannot initialize
+/// in the sandboxed keyboard extension process.
+/// Intensity is approximated by selecting different feedback styles.
+///
+/// Requires Full Access to be enabled — without it, `UIFeedbackGenerator` silently
+/// fails because the underlying `CHHapticEngine` is blocked by the keyboard sandbox.
+/// The host app settings UI prevents enabling haptics when Full Access is not granted.
 final class HapticFeedbackManager {
     private let settings: HapticSettings
 
-    /// Feedback style used for all haptic events.
-    /// Using .rigid provides a crisp, responsive feel that scales well with intensity.
-    private let feedbackStyle: UIImpactFeedbackGenerator.FeedbackStyle = .rigid
-
-    /// Cached generator to avoid per-event allocation overhead
-    private lazy var generator = UIImpactFeedbackGenerator(style: feedbackStyle)
+    /// Cached generators per feedback style to avoid per-event allocation
+    private lazy var generators: [UIImpactFeedbackGenerator.FeedbackStyle: UIImpactFeedbackGenerator] = {
+        var gens = [UIImpactFeedbackGenerator.FeedbackStyle: UIImpactFeedbackGenerator]()
+        for style in [UIImpactFeedbackGenerator.FeedbackStyle.light, .medium, .rigid, .heavy] {
+            gens[style] = UIImpactFeedbackGenerator(style: style)
+        }
+        return gens
+    }()
 
     init(settings: HapticSettings) {
         self.settings = settings
@@ -26,14 +36,9 @@ final class HapticFeedbackManager {
 
     // MARK: - Public API
 
-    /// Triggers haptic feedback for a key tap
+    /// Triggers haptic feedback for a key tap (touch-down)
     func tap() {
         trigger(.tap)
-    }
-
-    /// Triggers haptic feedback for modifier actions (shift, symbols, etc.)
-    func modifier() {
-        trigger(.modifier)
     }
 
     /// Triggers haptic feedback for drag operations (cursor movement, delete drag)
@@ -48,15 +53,28 @@ final class HapticFeedbackManager {
         let intensity = settings.intensity(for: event)
         guard intensity > 0 else { return }
 
+        let style = Self.style(for: intensity)
+
         let performFeedback = { [self] in
+            let generator = generators[style] ?? generators[.medium]!
             generator.prepare()
-            generator.impactOccurred(intensity: intensity)
+            generator.impactOccurred()
         }
 
         if Thread.isMainThread {
             performFeedback()
         } else {
             DispatchQueue.main.async(execute: performFeedback)
+        }
+    }
+
+    /// Maps a 0...1 intensity to a feedback style
+    private static func style(for intensity: CGFloat) -> UIImpactFeedbackGenerator.FeedbackStyle {
+        switch intensity {
+        case ..<0.3: .light
+        case ..<0.6: .medium
+        case ..<0.8: .rigid
+        default: .heavy
         }
     }
 }

--- a/wurstfingerKeyboard/HapticFeedbackManager.swift
+++ b/wurstfingerKeyboard/HapticFeedbackManager.swift
@@ -56,8 +56,7 @@ final class HapticFeedbackManager {
         let style = Self.style(for: intensity)
 
         let performFeedback = { [self] in
-            let generator = generators[style] ?? generators[.medium]!
-            generator.prepare()
+            guard let generator = generators[style] ?? generators[.medium] else { return }
             generator.impactOccurred()
         }
 

--- a/wurstfingerKeyboard/KeyboardButton.swift
+++ b/wurstfingerKeyboard/KeyboardButton.swift
@@ -50,7 +50,8 @@ struct KeyboardButton<Label: View, Overlay: View>: View {
             DragGesture(minimumDistance: 0)
                 .onChanged { value in
                     if positions.isEmpty {
-                        // Reset if starting new gesture (though onEnded should handle this)
+                        // First contact — fire haptic immediately
+                        callbacks.onTouchDown?()
                         positions.removeAll()
                         positions.append(.zero)
                     }

--- a/wurstfingerKeyboard/KeyboardButton.swift
+++ b/wurstfingerKeyboard/KeyboardButton.swift
@@ -52,7 +52,6 @@ struct KeyboardButton<Label: View, Overlay: View>: View {
                     if positions.isEmpty {
                         // First contact — fire haptic immediately
                         callbacks.onTouchDown?()
-                        positions.removeAll()
                         positions.append(.zero)
                     }
 

--- a/wurstfingerKeyboard/KeyboardButtonComponents.swift
+++ b/wurstfingerKeyboard/KeyboardButtonComponents.swift
@@ -39,6 +39,7 @@ struct KeyboardButtonCallbacks {
     var onSwipe: ((KeyboardDirection) -> Void)?
     var onSwipeReturn: ((KeyboardDirection) -> Void)?
     var onCircular: ((KeyboardCircularDirection) -> Void)?
+    var onTouchDown: (() -> Void)?
 }
 
 /// Visual key cap component used as the base for all keyboard buttons

--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -113,7 +113,8 @@ struct KeyboardRootView: View {
                 config: KeyboardButtonConfig(accessibilityLabel: NSLocalizedString("Next keyboard", comment: "Globe key accessibility label")),
                 callbacks: KeyboardButtonCallbacks(
                     onSwipe: viewModel.handleGlobeSwipe,
-                    onCircular: { viewModel.handleUtilityCircularGesture(.globe, direction: $0) }
+                    onCircular: { viewModel.handleUtilityCircularGesture(.globe, direction: $0) },
+                    onTouchDown: viewModel.feedbackTap
                 )
             )
         case 1: // Symbols toggle button with text editing swipes
@@ -126,7 +127,8 @@ struct KeyboardRootView: View {
                 callbacks: KeyboardButtonCallbacks(
                     onTap: viewModel.toggleSymbols,
                     onSwipe: viewModel.handleSymbolsKeySwipe,
-                    onSwipeReturn: viewModel.handleSymbolsKeySwipe
+                    onSwipeReturn: viewModel.handleSymbolsKeySwipe,
+                    onTouchDown: viewModel.feedbackTap
                 )
             )
         case 2: // Delete button
@@ -138,7 +140,7 @@ struct KeyboardRootView: View {
                 label: Text("⏎"),
                 overlay: EmptyView(),
                 config: KeyboardButtonConfig(accessibilityLabel: NSLocalizedString("Return", comment: "Return key accessibility label")),
-                callbacks: KeyboardButtonCallbacks(onTap: viewModel.handleReturn)
+                callbacks: KeyboardButtonCallbacks(onTap: viewModel.handleReturn, onTouchDown: viewModel.feedbackTap)
             )
         default:
             EmptyView()
@@ -164,7 +166,8 @@ struct KeyboardRootView: View {
                     callbacks: KeyboardButtonCallbacks(
                         onSwipe: { viewModel.handleKeySwipe(key, direction: $0) },
                         onSwipeReturn: { viewModel.handleKeySwipeReturn(key, direction: $0) },
-                        onCircular: { viewModel.handleCircularGesture(for: key, direction: $0) }
+                        onCircular: { viewModel.handleCircularGesture(for: key, direction: $0) },
+                        onTouchDown: viewModel.feedbackTap
                     )
                 )
             }

--- a/wurstfingerKeyboard/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/KeyboardSettings.swift
@@ -16,7 +16,6 @@ import Foundation
 /// Using an enum prevents typos and makes refactoring easier.
 enum SettingsKey: String {
     case hapticIntensityTap
-    case hapticIntensityModifier
     case hapticIntensityDrag
     case hapticEnabled
     case utilityColumnLeading
@@ -28,6 +27,7 @@ enum SettingsKey: String {
     case autoCapitalizeEnabled
     case expertModeEnabled
     case keyboardStyle
+    case keyboardFullAccess
 }
 
 // MARK: - Haptic Settings
@@ -37,7 +37,6 @@ enum SettingsKey: String {
 final class HapticSettings: ObservableObject {
     /// Default intensity values (0.0 - 1.0)
     static let defaultTapIntensity: CGFloat = 0.5
-    static let defaultModifierIntensity: CGFloat = 0.5
     static let defaultDragIntensity: CGFloat = 0.5
 
     private let defaults: UserDefaults
@@ -55,17 +54,6 @@ final class HapticSettings: ObservableObject {
                 return
             }
             persistIfNeeded(Double(clamped), forKey: .hapticIntensityTap)
-        }
-    }
-
-    @Published var modifierIntensity: CGFloat {
-        didSet {
-            let clamped = Self.clamp(modifierIntensity)
-            if clamped != modifierIntensity {
-                modifierIntensity = clamped
-                return
-            }
-            persistIfNeeded(Double(clamped), forKey: .hapticIntensityModifier)
         }
     }
 
@@ -87,7 +75,6 @@ final class HapticSettings: ObservableObject {
         // Load values with clamping
         enabled = defaults.object(forKey: SettingsKey.hapticEnabled.rawValue) as? Bool ?? true
         tapIntensity = Self.loadIntensity(from: defaults, key: .hapticIntensityTap, default: Self.defaultTapIntensity)
-        modifierIntensity = Self.loadIntensity(from: defaults, key: .hapticIntensityModifier, default: Self.defaultModifierIntensity)
         dragIntensity = Self.loadIntensity(from: defaults, key: .hapticIntensityDrag, default: Self.defaultDragIntensity)
     }
 
@@ -99,9 +86,6 @@ final class HapticSettings: ObservableObject {
         let newTap = Self.loadIntensity(from: defaults, key: .hapticIntensityTap, default: Self.defaultTapIntensity)
         if abs(tapIntensity - newTap) > 0.0001 { tapIntensity = newTap }
 
-        let newModifier = Self.loadIntensity(from: defaults, key: .hapticIntensityModifier, default: Self.defaultModifierIntensity)
-        if abs(modifierIntensity - newModifier) > 0.0001 { modifierIntensity = newModifier }
-
         let newDrag = Self.loadIntensity(from: defaults, key: .hapticIntensityDrag, default: Self.defaultDragIntensity)
         if abs(dragIntensity - newDrag) > 0.0001 { dragIntensity = newDrag }
     }
@@ -110,7 +94,6 @@ final class HapticSettings: ObservableObject {
     func intensity(for event: KeyboardHapticEvent) -> CGFloat {
         switch event {
         case .tap: tapIntensity
-        case .modifier: modifierIntensity
         case .drag: dragIntensity
         }
     }

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -47,6 +47,8 @@ final class KeyboardViewController: UIInputViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        // Persist Full Access status so the host app can show/hide haptic settings
+        SharedDefaults.store.set(hasFullAccess, forKey: SettingsKey.keyboardFullAccess.rawValue)
         // Reload settings every time keyboard appears
         viewModel.reloadSettings()
         updateKeyboardHeight()

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -42,7 +42,6 @@ enum UtilityKey {
 
 enum KeyboardHapticEvent {
     case tap
-    case modifier
     case drag
 }
 
@@ -79,11 +78,9 @@ final class KeyboardViewModel: ObservableObject {
     // MARK: - Settings Keys (kept for backward compatibility)
 
     static let hapticTapIntensityKey = SettingsKey.hapticIntensityTap.rawValue
-    static let hapticModifierIntensityKey = SettingsKey.hapticIntensityModifier.rawValue
     static let hapticDragIntensityKey = SettingsKey.hapticIntensityDrag.rawValue
     static let numpadStyleKey = SettingsKey.numpadStyle.rawValue
     static let defaultTapIntensity: CGFloat = HapticSettings.defaultTapIntensity
-    static let defaultModifierIntensity: CGFloat = HapticSettings.defaultModifierIntensity
     static let defaultDragIntensity: CGFloat = HapticSettings.defaultDragIntensity
 
     // MARK: - State
@@ -104,11 +101,6 @@ final class KeyboardViewModel: ObservableObject {
     var hapticIntensityTap: CGFloat {
         get { hapticSettings.tapIntensity }
         set { hapticSettings.tapIntensity = newValue }
-    }
-
-    var hapticIntensityModifier: CGFloat {
-        get { hapticSettings.modifierIntensity }
-        set { hapticSettings.modifierIntensity = newValue }
     }
 
     var hapticIntensityDrag: CGFloat {
@@ -327,27 +319,22 @@ final class KeyboardViewModel: ObservableObject {
     }
 
     func handleSpace() {
-        feedbackTap()
         actionHandler?(.space)
     }
 
     func handleDelete() {
-        feedbackTap()
         actionHandler?(.deleteBackward)
     }
 
     func handleReturn() {
-        feedbackModifier()
         actionHandler?(.newline)
     }
 
     func handleAdvanceToNextInputMode() {
-        feedbackModifier()
         actionHandler?(.advanceToNextInputMode)
     }
 
     func handleDismissKeyboard() {
-        feedbackModifier()
         actionHandler?(.dismissKeyboard)
     }
 
@@ -375,7 +362,6 @@ final class KeyboardViewModel: ObservableObject {
     }
 
     func toggleSymbols() {
-        feedbackModifier()
         switch activeLayer {
         case .lower, .upper:
             setLayer(.numbers)
@@ -392,16 +378,12 @@ final class KeyboardViewModel: ObservableObject {
     func handleSymbolsKeySwipe(_ direction: KeyboardDirection) {
         switch direction {
         case .up:
-            feedbackModifier()
             actionHandler?(.copy)
         case .upRight:
-            feedbackModifier()
             actionHandler?(.cut)
         case .down:
-            feedbackModifier()
             actionHandler?(.paste)
         default:
-            // All other directions toggle symbols
             toggleSymbols()
         }
     }
@@ -414,8 +396,6 @@ final class KeyboardViewModel: ObservableObject {
     }
 
     private func setShiftState(active: Bool) {
-        feedbackModifier()
-
         if active {
             // If shift is already active, activate caps-lock
             if activeLayer == .upper && !isCapsLockActive {
@@ -451,12 +431,9 @@ final class KeyboardViewModel: ObservableObject {
 
     // MARK: - Haptic Feedback (delegated to HapticFeedbackManager)
 
-    private func feedbackTap() {
+    /// Haptic feedback for key touch-down — called by button views on first contact
+    func feedbackTap() {
         hapticManager.tap()
-    }
-
-    private func feedbackModifier() {
-        hapticManager.modifier()
     }
 
     private func feedbackDrag() {
@@ -464,7 +441,6 @@ final class KeyboardViewModel: ObservableObject {
     }
 
     private func insertText(_ value: String) {
-        feedbackTap()
         performTextInsertion(value)
     }
 
@@ -492,19 +468,15 @@ final class KeyboardViewModel: ObservableObject {
         case .toggleSymbols:
             toggleSymbols()
         case let .capitalizeWord(uppercased):
-            feedbackModifier()
             actionHandler?(.capitalizeWord(uppercased ? .uppercased : .lowercased))
         case let .compose(trigger, _):
-            feedbackModifier()
             actionHandler?(.compose(trigger: trigger))
         case .cycleAccents:
-            feedbackModifier()
             actionHandler?(.cycleAccents)
         }
     }
 
     func toggleUtilityColumnPosition() {
-        feedbackModifier()
         utilityColumnLeading.toggle()
         if shouldPersistSettings {
             sharedDefaults.set(utilityColumnLeading, forKey: SettingsKey.utilityColumnLeading.rawValue)

--- a/wurstfingerKeyboard/SpaceKeyButton.swift
+++ b/wurstfingerKeyboard/SpaceKeyButton.swift
@@ -35,6 +35,7 @@ struct SpaceKeyButton: View {
                 .onChanged { value in
                     if !dragStarted {
                         dragStarted = true
+                        viewModel.feedbackTap()
                         viewModel.beginSpaceDrag()
                     }
 

--- a/wurstfingerTests/KeyboardSettingsTests.swift
+++ b/wurstfingerTests/KeyboardSettingsTests.swift
@@ -24,7 +24,6 @@ struct HapticSettingsTests {
 
         #expect(settings.enabled == true)
         #expect(settings.tapIntensity == HapticSettings.defaultTapIntensity)
-        #expect(settings.modifierIntensity == HapticSettings.defaultModifierIntensity)
         #expect(settings.dragIntensity == HapticSettings.defaultDragIntensity)
     }
 
@@ -34,14 +33,12 @@ struct HapticSettingsTests {
         // Pre-populate UserDefaults
         defaults.set(false, forKey: SettingsKey.hapticEnabled.rawValue)
         defaults.set(0.3, forKey: SettingsKey.hapticIntensityTap.rawValue)
-        defaults.set(0.6, forKey: SettingsKey.hapticIntensityModifier.rawValue)
         defaults.set(0.9, forKey: SettingsKey.hapticIntensityDrag.rawValue)
 
         let settings = HapticSettings(defaults: defaults, shouldPersist: false)
 
         #expect(settings.enabled == false)
         #expect(abs(settings.tapIntensity - 0.3) < 0.01)
-        #expect(abs(settings.modifierIntensity - 0.6) < 0.01)
         #expect(abs(settings.dragIntensity - 0.9) < 0.01)
     }
 
@@ -110,14 +107,11 @@ struct HapticSettingsTests {
 
         // Store non-numeric values that could corrupt settings
         defaults.set("not_a_number", forKey: SettingsKey.hapticIntensityTap.rawValue)
-        defaults.set(true, forKey: SettingsKey.hapticIntensityModifier.rawValue)
 
         let settings = HapticSettings(defaults: defaults, shouldPersist: false)
 
         // Should fall back to defaults, not use 0.0
         #expect(settings.tapIntensity == HapticSettings.defaultTapIntensity)
-        // Boolean stored as NSNumber: true -> 1.0, clamped to 1.0
-        #expect(settings.modifierIntensity == 1.0)
     }
 
     @Test func missingDefaultsFallBackCorrectly() {
@@ -126,7 +120,6 @@ struct HapticSettingsTests {
         let settings = HapticSettings(defaults: defaults, shouldPersist: false)
 
         #expect(settings.tapIntensity == HapticSettings.defaultTapIntensity)
-        #expect(settings.modifierIntensity == HapticSettings.defaultModifierIntensity)
         #expect(settings.dragIntensity == HapticSettings.defaultDragIntensity)
         #expect(settings.enabled == true)
     }
@@ -138,11 +131,9 @@ struct HapticSettingsTests {
         let settings = HapticSettings(defaults: defaults, shouldPersist: false)
 
         settings.tapIntensity = 0.3
-        settings.modifierIntensity = 0.6
         settings.dragIntensity = 0.9
 
         #expect(settings.intensity(for: .tap) == 0.3)
-        #expect(settings.intensity(for: .modifier) == 0.6)
         #expect(settings.intensity(for: .drag) == 0.9)
     }
 }

--- a/wurstfingerTests/wurstfingerTests.swift
+++ b/wurstfingerTests/wurstfingerTests.swift
@@ -160,14 +160,12 @@ struct wurstfingerTests {
 
         let viewModel = KeyboardViewModel(userDefaults: defaults)
         viewModel.hapticIntensityTap = 0.8
-        viewModel.hapticIntensityModifier = 0.2
         viewModel.hapticIntensityDrag = 1.1
 
         // Ensure UserDefaults are flushed (can be delayed in CI environments)
         defaults.synchronize()
 
         #expect(defaults.double(forKey: KeyboardViewModel.hapticTapIntensityKey) == 0.8)
-        #expect(defaults.double(forKey: KeyboardViewModel.hapticModifierIntensityKey) == 0.2)
         let dragDefault = defaults.double(forKey: KeyboardViewModel.hapticDragIntensityKey)
         #expect(abs(dragDefault - 1.0) < 0.0001)
     }

--- a/wurstfingerUITests/wurstfingerUITests.swift
+++ b/wurstfingerUITests/wurstfingerUITests.swift
@@ -114,8 +114,10 @@ final class wurstfingerUITests: XCTestCase {
         // Should navigate to haptic settings (title is "Haptics")
         XCTAssertTrue(app.navigationBars["Haptics"].waitForExistence(timeout: 2))
 
-        // Check that sliders exist
-        XCTAssertTrue(app.sliders.count >= 1, "Should have haptic intensity sliders")
+        // Without Full Access: shows a disabled toggle and warning text
+        // With Full Access: shows sliders for intensity control
+        // Either way, the Haptic Feedback toggle should be visible
+        XCTAssertTrue(app.switches["Haptic Feedback"].exists, "Should show the haptic feedback toggle")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- **Haptic feedback now fires immediately on touch-down** (first finger contact), matching Thumb-Key's approach. Previously, feedback only fired after gesture classification on finger release, causing a noticeable delay.
- **Removed the modifier haptic event type** — with touch-down feedback, there's no distinction between tap and modifier keys anymore. Settings simplified from 3 sliders (tap/modifier/drag) to 2 (tap/drag).
- **Haptics require Full Access** — `UIImpactFeedbackGenerator` needs `CHHapticEngine`, which is blocked by the keyboard extension sandbox without Full Access. Settings UI now shows a warning with instructions when Full Access is not granted.

## Changes

### Touch-down feedback
- `KeyboardButtonCallbacks` gains `onTouchDown` closure
- `KeyboardButton.onChanged` fires `onTouchDown` on first contact point
- `SpaceKeyButton` and `DeleteKeyButton` call `feedbackTap()` on drag start
- All `feedbackTap()`/`feedbackModifier()` calls removed from action handlers in `KeyboardViewModel`

### Simplified haptic model
- `KeyboardHapticEvent.modifier` removed (only `.tap` and `.drag` remain)
- `HapticSettings.modifierIntensity` and related defaults/persistence removed
- `HapticFeedbackManager.modifier()` removed
- Settings UI shows 2 sliders instead of 3

### Full Access gating
- `KeyboardViewController.viewWillAppear` persists `hasFullAccess` to `SharedDefaults`
- `HapticSettingsView` checks `keyboardFullAccess` and shows disabled toggle + warning when not granted
- New `SettingsKey.keyboardFullAccess`

## Test plan
- [x] Build succeeds (simulator)
- [x] 287/288 tests pass (1 pre-existing UI test failure)
- [ ] Verify haptic feedback fires on touch-down on physical device
- [ ] Verify no haptic on finger release
- [ ] Verify drag feedback still works during space/delete sliding
- [ ] Verify haptic settings show warning without Full Access
- [ ] Verify haptic settings show sliders with Full Access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist keyboard Full Access state; UI shows contextual messaging and a prompt to open the keyboard to sync access.
  * Full Access gating: when denied, Haptic Feedback is forced off and controls are disabled.
  * Added touch-down haptic feedback for delete, space and other keys.

* **Bug Fixes & Improvements**
  * Removed modifier feedback intensity; haptics settings now only control Tap and Drag.
  * Reset restores Tap, Drag and global haptics only and respects Full Access state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->