### PR TITLE
Fix flaky UI test and add AGENTS.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ Gemfile.lock
 
 # Claude Code
 .claude/
+AGENTS.md

--- a/wurstfingerTests/wurstfingerTests.swift
+++ b/wurstfingerTests/wurstfingerTests.swift
@@ -11,7 +11,7 @@ import Testing
 
 struct wurstfingerTests {
     @Test func circularGestureInsertsUppercaseForBothDirections() throws {
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         var inserted: [String] = []
 
         viewModel.bindActionHandler { action in
@@ -29,7 +29,7 @@ struct wurstfingerTests {
     }
 
     @Test func toggleSymbolsShowsNumericLayout() throws {
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         viewModel.toggleSymbols()
 
         #expect(viewModel.activeLayer == .numbers)
@@ -44,7 +44,7 @@ struct wurstfingerTests {
     }
 
     @Test func symbolsLayerFollowsNumericLayer() throws {
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
 
         // First toggle: lower → numbers
         viewModel.toggleSymbols()
@@ -60,7 +60,7 @@ struct wurstfingerTests {
     }
 
     @Test func circularGestureOnGlobeTogglesUtilityColumn() {
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
 
         #expect(!viewModel.utilityColumnLeading)
 
@@ -72,7 +72,7 @@ struct wurstfingerTests {
     }
 
     @Test func numericLayerInsertsDigits() throws {
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         var inserted: [String] = []
 
         viewModel.bindActionHandler { action in
@@ -95,7 +95,7 @@ struct wurstfingerTests {
     }
 
     @Test func letterLayerProvidesAdditionalSymbols() throws {
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         let firstRow = try #require(viewModel.rows.first)
         let aKey = try #require(firstRow.first)
         let nKey = try #require(firstRow.dropFirst().first)
@@ -116,7 +116,7 @@ struct wurstfingerTests {
     }
 
     @Test func spaceDragEmitsCursorMovements() {
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         var moves: [Int] = []
 
         viewModel.bindActionHandler { action in
@@ -135,7 +135,7 @@ struct wurstfingerTests {
     }
 
     @Test func deleteDragEmitsRepeatedDeletes() {
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         var deletes = 0
 
         viewModel.bindActionHandler { action in
@@ -204,7 +204,7 @@ struct wurstfingerTests {
     }
 
     @Test func composeSwipeEmitsComposeAction() throws {
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         var captured: String?
 
         viewModel.bindActionHandler { action in
@@ -226,7 +226,7 @@ struct wurstfingerTests {
     }
 
     @Test func composeSwipeWorksInUpperLayer() throws {
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         var captured: String?
 
         viewModel.bindActionHandler { action in
@@ -253,7 +253,7 @@ struct wurstfingerTests {
     }
 
     @Test func returnSwipeOnPlusProducesTimes() throws {
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         var inserted: [String] = []
 
         viewModel.bindActionHandler { action in
@@ -271,7 +271,7 @@ struct wurstfingerTests {
     }
 
     @Test func returnSwipesProduceTypographicVariants() throws {
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         var inserted: [String] = []
 
         viewModel.bindActionHandler { action in
@@ -304,7 +304,7 @@ struct wurstfingerTests {
     }
 
     @Test func directPunctuationSwipeDoesNotCompose() throws {
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         var inserts: [String] = []
         var composed: [String] = []
 
@@ -405,7 +405,7 @@ struct wurstfingerTests {
     @Test func apostropheIsNeverAComposeTrigger() {
         // Verify no key in the layout uses apostrophe (') as a compose trigger.
         // Composition uses ´ (U+00B4 acute accent), not ' (U+0027 apostrophe).
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
 
         for (rowIndex, row) in viewModel.rows.enumerated() {
             for (colIndex, key) in row.enumerated() {
@@ -425,7 +425,7 @@ struct wurstfingerTests {
     @Test func apostropheReturnSwipeInsertsPlainText() throws {
         // Return swipe on N-key upRight should insert plain apostrophe,
         // not trigger compose mode (returnOverride with .text("'"))
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         var inserts: [String] = []
         var composed: [String] = []
 
@@ -485,7 +485,7 @@ struct wurstfingerTests {
     @Test func backtickIsNeverAComposeTrigger() {
         // Verify no key in the layout uses backtick (`) as a compose trigger.
         // Composition uses ˋ (U+02CB modifier letter grave accent), not ` (U+0060).
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
 
         for (rowIndex, row) in viewModel.rows.enumerated() {
             for (colIndex, key) in row.enumerated() {
@@ -505,7 +505,7 @@ struct wurstfingerTests {
     @Test func dollarSignRemainsAutoComposeTrigger() throws {
         // $ is in composeTriggers and appears in textMap for key (0,0) downLeft.
         // Swiping there should emit .compose, confirming auto-detection still works.
-        let viewModel = KeyboardViewModel()
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
         var composed: [String] = []
 
         viewModel.bindActionHandler { action in

--- a/wurstfingerUITests/wurstfingerUITests.swift
+++ b/wurstfingerUITests/wurstfingerUITests.swift
@@ -83,10 +83,13 @@ final class wurstfingerUITests: XCTestCase {
         app.tabBars.buttons["Settings"].tap()
 
         // Check main settings rows exist
-        XCTAssertTrue(app.staticTexts["Language"].waitForExistence(timeout: 2))
-        XCTAssertTrue(app.staticTexts["Key Aspect Ratio"].exists)
-        XCTAssertTrue(app.staticTexts["Haptic Feedback"].exists)
-        XCTAssertTrue(app.staticTexts["Version"].exists)
+        XCTAssertTrue(app.staticTexts["Language"].waitForExistence(timeout: 2), "Language row missing")
+        XCTAssertTrue(app.staticTexts["Key Aspect Ratio"].exists, "Key Aspect Ratio row missing")
+        XCTAssertTrue(app.staticTexts["Haptic Feedback"].exists, "Haptic Feedback row missing")
+
+        // Version is in the About section at the bottom — scroll to reveal it
+        app.swipeUp()
+        XCTAssertTrue(app.staticTexts["Version"].waitForExistence(timeout: 2), "Version row missing")
     }
 
     @MainActor

--- a/wurstfingerUITests/wurstfingerUITests.swift
+++ b/wurstfingerUITests/wurstfingerUITests.swift
@@ -87,8 +87,11 @@ final class wurstfingerUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Key Aspect Ratio"].exists, "Key Aspect Ratio row missing")
         XCTAssertTrue(app.staticTexts["Haptic Feedback"].exists, "Haptic Feedback row missing")
 
-        // Version is in the About section at the bottom — scroll to reveal it
-        app.swipeUp()
+        // Version is in the About section at the bottom — scroll until visible
+        for _ in 0 ..< 5 {
+            if app.staticTexts["Version"].exists { break }
+            app.swipeUp()
+        }
         XCTAssertTrue(app.staticTexts["Version"].waitForExistence(timeout: 2), "Version row missing")
     }
 


### PR DESCRIPTION
## Summary

- **Fix `testSettingsViewShowsMainOptions`** — the "Version" row in the About section sits below the visible area on iPhone simulators. Added `swipeUp()` before asserting its existence.
- **Add `AGENTS.md` to `.gitignore`** — this is a local agent configuration file that shouldn't be tracked.

## Test plan
- [x] `testSettingsViewShowsMainOptions` now passes
- [x] All 288 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened Settings UI test with explicit failure messages for main options and improved Version detection via a scroll-and-wait flow.
  * Updated unit tests to instantiate components with non-persistent settings by default for isolated test behavior.

* **Chores**
  * Added a rule to ignore a specific local file from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->