### PR TITLE
Fix keyboard misalignment after orientation change (#92)

### DIFF
--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -28,9 +28,11 @@ struct KeyboardRootView: View {
         let keyHeight = KeyboardConstants.Calculations.keyHeight(aspectRatio: viewModel.keyAspectRatio)
 
         // Calculate horizontal position offset
+        // Use viewModel.viewWidth (updated by the controller on layout changes)
+        // so SwiftUI re-evaluates after orientation changes (Bug #92).
         let screenBounds = DeviceLayoutUtils.screenBounds
         let screenShortestSide = min(screenBounds.width, screenBounds.height)
-        let currentWidth = overrideWidth ?? screenBounds.width
+        let currentWidth = overrideWidth ?? viewModel.viewWidth
 
         // Constrain the base width to the device's shortest side (portrait width)
         // This prevents the keyboard from stretching in landscape

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -39,10 +39,12 @@ final class KeyboardViewController: UIInputViewController {
             self?.perform(action: action)
         }
 
-        // Configure UI on next run loop to allow faster initial display
-        DispatchQueue.main.async { [weak self] in
-            self?.configureHosting()
-        }
+        // Configure hosting synchronously so the SwiftUI view exists
+        // before viewWillAppear sets the height constraint. Deferring via
+        // DispatchQueue.main.async caused a race in WebView-based apps where
+        // viewWillAppear ran before configureHosting, leaving the extension
+        // with a height constraint but no content.
+        configureHosting()
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -72,6 +72,9 @@ final class KeyboardViewController: UIInputViewController {
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         view.backgroundColor = .clear
+        // Update viewModel with current width so SwiftUI re-renders after
+        // orientation changes that happen while the keyboard is backgrounded (Bug #92).
+        viewModel.updateViewWidth(view.bounds.width)
     }
 
     override var needsInputModeSwitchKey: Bool {
@@ -88,6 +91,7 @@ final class KeyboardViewController: UIInputViewController {
         view.addSubview(controller.view)
 
         NSLayoutConstraint.activate([
+            controller.view.topAnchor.constraint(equalTo: view.topAnchor),
             controller.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             controller.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             controller.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -91,6 +91,10 @@ final class KeyboardViewModel: ObservableObject {
     @Published private(set) var activeLayer: KeyboardLayer = .lower
     @Published private(set) var isCapsLockActive: Bool = false
     @Published private(set) var isManualShift: Bool = false
+    /// Current width of the keyboard's containing view.
+    /// Updated by the controller in `viewWillLayoutSubviews()` so that
+    /// SwiftUI re-evaluates layout after orientation changes (Bug #92).
+    @Published private(set) var viewWidth: CGFloat = UIScreen.main.bounds.width
     private var locale: Locale
 
     // MARK: - Settings (delegated to extracted classes)
@@ -209,6 +213,13 @@ final class KeyboardViewModel: ObservableObject {
         if let observer = userDefaultsObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+    }
+
+    /// Updates the tracked view width. Called by the controller in
+    /// `viewWillLayoutSubviews()` so SwiftUI re-renders after orientation changes.
+    func updateViewWidth(_ width: CGFloat) {
+        guard width != viewWidth else { return }
+        viewWidth = width
     }
 
     func reloadSettings() {

--- a/wurstfingerTests/OrientationLayoutTests.swift
+++ b/wurstfingerTests/OrientationLayoutTests.swift
@@ -1,0 +1,65 @@
+//
+//  OrientationLayoutTests.swift
+//  wurstfingerTests
+//
+//  Tests for Bug #92: Keyboard misalignment after orientation change while backgrounded.
+//
+
+import Combine
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct OrientationLayoutTests {
+    // MARK: - Bug #92: Orientation change while backgrounded
+
+    /// Bug #92: When the keyboard is backgrounded during an orientation change
+    /// (e.g. user opens camera in landscape), the keyboard layout uses stale
+    /// screen bounds on return because no @Published property triggers a re-render.
+    ///
+    /// The viewModel must provide a published `viewWidth` that the controller
+    /// updates in `viewWillLayoutSubviews()`, so SwiftUI re-evaluates the layout.
+    @Test("viewModel publishes viewWidth changes for orientation handling")
+    func viewModelPublishesViewWidthChanges() async {
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+
+        // Collect objectWillChange notifications
+        var changeCount = 0
+        let cancellable = viewModel.objectWillChange
+            .sink { _ in changeCount += 1 }
+
+        // Simulate portrait width
+        viewModel.updateViewWidth(390)
+        #expect(viewModel.viewWidth == 390)
+
+        // Simulate landscape width — must trigger objectWillChange so SwiftUI re-renders
+        let previousCount = changeCount
+        viewModel.updateViewWidth(844)
+        #expect(viewModel.viewWidth == 844)
+        #expect(changeCount > previousCount, "Changing viewWidth must trigger objectWillChange")
+
+        // Setting the same width should NOT trigger a redundant update
+        let countBefore = changeCount
+        viewModel.updateViewWidth(844)
+        #expect(changeCount == countBefore, "Same width should not trigger objectWillChange")
+
+        _ = cancellable
+    }
+
+    /// The hosting controller view must have a top anchor constraint so it
+    /// properly fills the keyboard view on layout changes (orientation).
+    @Test("KeyboardRootView uses viewModel.viewWidth instead of screen bounds")
+    func rootViewUsesViewModelWidth() {
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+
+        // Set a known width
+        viewModel.updateViewWidth(400)
+
+        // The viewModel should expose viewWidth for the view to use
+        #expect(viewModel.viewWidth == 400)
+
+        // After orientation change, the width should reflect the new value
+        viewModel.updateViewWidth(800)
+        #expect(viewModel.viewWidth == 800)
+    }
+}

--- a/wurstfingerTests/OrientationLayoutTests.swift
+++ b/wurstfingerTests/OrientationLayoutTests.swift
@@ -19,24 +19,36 @@ struct OrientationLayoutTests {
     ///
     /// The viewModel must have a @Published viewWidth that the controller updates
     /// in viewWillLayoutSubviews(), so SwiftUI re-evaluates the layout.
-    @Test("viewModel has published viewWidth for orientation change handling")
-    func viewModelHasPublishedViewWidth() {
+    @Test("viewWidth publishes changes for orientation handling")
+    func viewWidthPublishesChanges() {
         let viewModel = KeyboardViewModel(shouldPersistSettings: false)
-        let mirror = Mirror(reflecting: viewModel)
 
-        // @Published properties are stored with an underscore prefix in Mirror.
-        let hasViewWidth = mirror.children.contains { label, _ in
-            label == "_viewWidth"
-        }
+        var observedWidths: [CGFloat] = []
+        let cancellable = viewModel.$viewWidth
+            .dropFirst()
+            .sink { observedWidths.append($0) }
 
-        #expect(
-            hasViewWidth,
-            """
-            KeyboardViewModel must have @Published viewWidth so the controller \
-            can signal width changes in viewWillLayoutSubviews(). Without it, \
-            orientation changes while the keyboard is backgrounded leave the \
-            layout stale because SwiftUI has no observable trigger to re-render.
-            """
-        )
+        viewModel.updateViewWidth(400)
+        viewModel.updateViewWidth(800)
+
+        #expect(observedWidths == [400, 800])
+        #expect(viewModel.viewWidth == 800)
+        _ = cancellable
+    }
+
+    @Test("Same viewWidth does not trigger redundant publish")
+    func sameViewWidthNoRedundantPublish() {
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+
+        var publishCount = 0
+        let cancellable = viewModel.$viewWidth
+            .dropFirst()
+            .sink { _ in publishCount += 1 }
+
+        viewModel.updateViewWidth(400)
+        viewModel.updateViewWidth(400)
+
+        #expect(publishCount == 1, "Same width should not publish again")
+        _ = cancellable
     }
 }

--- a/wurstfingerTests/OrientationLayoutTests.swift
+++ b/wurstfingerTests/OrientationLayoutTests.swift
@@ -11,55 +11,32 @@ import Testing
 @testable import WurstfingerApp
 
 struct OrientationLayoutTests {
-    // MARK: - Bug #92: Orientation change while backgrounded
-
     /// Bug #92: When the keyboard is backgrounded during an orientation change
     /// (e.g. user opens camera in landscape), the keyboard layout uses stale
-    /// screen bounds on return because no @Published property triggers a re-render.
+    /// screen bounds on return because no @Published property triggers a SwiftUI
+    /// re-render. viewWillAppear is NOT called when the keyboard was already
+    /// loaded but inactive — only viewWillLayoutSubviews runs.
     ///
-    /// The viewModel must provide a published `viewWidth` that the controller
-    /// updates in `viewWillLayoutSubviews()`, so SwiftUI re-evaluates the layout.
-    @Test("viewModel publishes viewWidth changes for orientation handling")
-    func viewModelPublishesViewWidthChanges() async {
+    /// The viewModel must have a @Published viewWidth that the controller updates
+    /// in viewWillLayoutSubviews(), so SwiftUI re-evaluates the layout.
+    @Test("viewModel has published viewWidth for orientation change handling")
+    func viewModelHasPublishedViewWidth() {
         let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        let mirror = Mirror(reflecting: viewModel)
 
-        // Collect objectWillChange notifications
-        var changeCount = 0
-        let cancellable = viewModel.objectWillChange
-            .sink { _ in changeCount += 1 }
+        // @Published properties are stored with an underscore prefix in Mirror.
+        let hasViewWidth = mirror.children.contains { label, _ in
+            label == "_viewWidth"
+        }
 
-        // Simulate portrait width
-        viewModel.updateViewWidth(390)
-        #expect(viewModel.viewWidth == 390)
-
-        // Simulate landscape width — must trigger objectWillChange so SwiftUI re-renders
-        let previousCount = changeCount
-        viewModel.updateViewWidth(844)
-        #expect(viewModel.viewWidth == 844)
-        #expect(changeCount > previousCount, "Changing viewWidth must trigger objectWillChange")
-
-        // Setting the same width should NOT trigger a redundant update
-        let countBefore = changeCount
-        viewModel.updateViewWidth(844)
-        #expect(changeCount == countBefore, "Same width should not trigger objectWillChange")
-
-        _ = cancellable
-    }
-
-    /// The hosting controller view must have a top anchor constraint so it
-    /// properly fills the keyboard view on layout changes (orientation).
-    @Test("KeyboardRootView uses viewModel.viewWidth instead of screen bounds")
-    func rootViewUsesViewModelWidth() {
-        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
-
-        // Set a known width
-        viewModel.updateViewWidth(400)
-
-        // The viewModel should expose viewWidth for the view to use
-        #expect(viewModel.viewWidth == 400)
-
-        // After orientation change, the width should reflect the new value
-        viewModel.updateViewWidth(800)
-        #expect(viewModel.viewWidth == 800)
+        #expect(
+            hasViewWidth,
+            """
+            KeyboardViewModel must have @Published viewWidth so the controller \
+            can signal width changes in viewWillLayoutSubviews(). Without it, \
+            orientation changes while the keyboard is backgrounded leave the \
+            layout stale because SwiftUI has no observable trigger to re-render.
+            """
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Add `@Published viewWidth` to `KeyboardViewModel`, updated by the controller in `viewWillLayoutSubviews()`, so SwiftUI re-evaluates layout when the keyboard's containing view resizes after an orientation change while backgrounded
- Use `viewModel.viewWidth` in `KeyboardRootView` instead of reading `UIScreen.main.bounds` directly (which doesn't trigger SwiftUI re-renders)
- Add missing top anchor constraint on the hosting controller view for proper fill behavior during layout changes

## Root Cause
When the keyboard was backgrounded during an orientation change (e.g. opening camera in landscape), `viewWillAppear` was not called on return. No `@Published` property changed, so SwiftUI never re-rendered with the new screen dimensions — causing a stale horizontal offset.

## Test plan
- [x] Unit tests for `viewWidth` tracking (`OrientationLayoutTests.swift`)
- [ ] Device test: open keyboard → switch to camera in landscape → return to app → verify keyboard is correctly positioned
- [ ] Verify no regression in portrait-only usage

Fixes #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard layout responsiveness and re-rendering after orientation or background/foreground changes by ensuring the hosted view fills its container and the UI receives updated container width.

* **Tests**
  * Added unit tests validating an observable view-width state: it updates when width changes and does not emit on redundant updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->