### PR TITLE
Fix keyboard vertical gap above keys

### DIFF
--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -25,7 +25,12 @@ struct KeyboardRootView: View {
     var body: some View {
         // At aspectRatio 1.5 (default), use original height of 54pt
         // Lower ratio = taller keys, higher ratio = shorter keys
-        let keyHeight = KeyboardConstants.Calculations.keyHeight(aspectRatio: viewModel.keyAspectRatio)
+        let unscaledKeyHeight = KeyboardConstants.Calculations.keyHeight(aspectRatio: viewModel.keyAspectRatio)
+
+        // Apply keyboard scale directly to key dimensions instead of using scaleEffect.
+        // This ensures layout height matches visual height, preventing gaps from
+        // iOS allocating more space than the height constraint requests.
+        let keyHeight = unscaledKeyHeight * viewModel.keyboardScale
 
         // Calculate horizontal position offset
         // Use viewModel.viewWidth (updated by the controller on layout changes)
@@ -38,10 +43,11 @@ struct KeyboardRootView: View {
         // This prevents the keyboard from stretching in landscape
         let baseWidth = min(currentWidth, screenShortestSide)
 
-        let availableSpace = currentWidth - (baseWidth * viewModel.keyboardScale)
+        let scaledWidth = baseWidth * viewModel.keyboardScale
+        let availableSpace = currentWidth - scaledWidth
         let horizontalOffset = availableSpace * (viewModel.keyboardHorizontalPosition - 0.5)
 
-        ZStack {
+        ZStack(alignment: .top) {
             // Background layer that always fills the entire space
             keyboardBackground
 
@@ -90,8 +96,7 @@ struct KeyboardRootView: View {
             .padding(.horizontal, KeyboardConstants.Layout.horizontalPadding)
             .padding(.top, KeyboardConstants.Layout.verticalPaddingTop)
             .padding(.bottom, KeyboardConstants.Layout.verticalPaddingBottom)
-            .frame(width: baseWidth, alignment: frameAlignment)
-            .scaleEffect(viewModel.keyboardScale, anchor: scaleAnchor)
+            .frame(width: scaledWidth, alignment: frameAlignment)
             .offset(x: horizontalOffset)
         }
     }


### PR DESCRIPTION
## Summary
- Replace `scaleEffect` with direct key dimension scaling in `KeyboardRootView`
- `scaleEffect` only transforms visual appearance without changing layout size, causing iOS's extra keyboard height allocation (for suggestion bar) to appear as a gap above the keys
- Multiply `keyHeight` and frame width directly by `keyboardScale` so layout height matches visual height
- Align ZStack to `.top` so keyboard content sits at the top of the extension view

## Test plan
- [x] All 275 unit tests pass
- [ ] Verify keyboard has no visible gap above keys on iPhone
- [ ] Verify keyboard renders correctly at different scale settings
- [ ] Verify keyboard preview in Settings still looks correct
- [ ] Test landscape orientation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refined keyboard scaling calculations and layout alignment logic to ensure consistent dimension rendering and proper positioning of keyboard elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->