### PR TITLE
Eliminate dead zones on keyboard surface

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -46,11 +46,17 @@ jobs:
 
       - name: Boot Simulator
         id: sim
+        timeout-minutes: 5
         run: |
           SIMULATOR_ID=$(xcrun simctl list devices available | grep "iPhone 16" | grep -v "Plus\|Pro" | head -1 | grep -oE '\([A-F0-9-]+\)' | tr -d '()')
           if [ -z "$SIMULATOR_ID" ]; then
             echo "iPhone 16 simulator not found, using iPhone 15"
             SIMULATOR_ID=$(xcrun simctl list devices available | grep "iPhone 15" | grep -v "Plus\|Pro" | head -1 | grep -oE '\([A-F0-9-]+\)' | tr -d '()')
+          fi
+          if [ -z "$SIMULATOR_ID" ]; then
+            echo "::error::No compatible iPhone simulator found (iPhone 16 or iPhone 15)"
+            xcrun simctl list devices available
+            exit 1
           fi
           echo "Using simulator: $SIMULATOR_ID"
           echo "simulator_id=$SIMULATOR_ID" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -45,6 +45,7 @@ jobs:
         run: gem install xcpretty
 
       - name: Boot Simulator
+        id: sim
         run: |
           SIMULATOR_ID=$(xcrun simctl list devices available | grep "iPhone 16" | grep -v "Plus\|Pro" | head -1 | grep -oE '\([A-F0-9-]+\)' | tr -d '()')
           if [ -z "$SIMULATOR_ID" ]; then
@@ -52,6 +53,7 @@ jobs:
             SIMULATOR_ID=$(xcrun simctl list devices available | grep "iPhone 15" | grep -v "Plus\|Pro" | head -1 | grep -oE '\([A-F0-9-]+\)' | tr -d '()')
           fi
           echo "Using simulator: $SIMULATOR_ID"
+          echo "simulator_id=$SIMULATOR_ID" >> "$GITHUB_OUTPUT"
           xcrun simctl boot "$SIMULATOR_ID" || true
           xcrun simctl bootstatus "$SIMULATOR_ID"
 
@@ -61,7 +63,7 @@ jobs:
           set -o pipefail && xcodebuild test \
             -scheme Wurstfinger \
             -project Wurstfinger.xcodeproj \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.simulator_id }}' \
             -only-testing:WurstfingerTests \
             -resultBundlePath TestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO \

--- a/wurstfingerKeyboard/DeleteKeyButton.swift
+++ b/wurstfingerKeyboard/DeleteKeyButton.swift
@@ -49,6 +49,7 @@ struct DeleteKeyButton: View {
             Image(systemName: "delete.left")
         }
         .accessibilityLabel(Text("Delete"))
+        .contentShape(Rectangle().inset(by: -KeyboardConstants.Layout.touchPadding))
         .gesture(
             DragGesture(minimumDistance: 0)
                 .onChanged { value in

--- a/wurstfingerKeyboard/DeleteKeyButton.swift
+++ b/wurstfingerKeyboard/DeleteKeyButton.swift
@@ -49,7 +49,7 @@ struct DeleteKeyButton: View {
             Image(systemName: "delete.left")
         }
         .accessibilityLabel(Text("Delete"))
-        .contentShape(Rectangle().inset(by: -KeyboardConstants.Layout.touchPadding))
+        .contentShape(Rectangle().inset(by: -KeyboardTouchArea.padding))
         .gesture(
             DragGesture(minimumDistance: 0)
                 .onChanged { value in

--- a/wurstfingerKeyboard/KeyboardButton.swift
+++ b/wurstfingerKeyboard/KeyboardButton.swift
@@ -21,7 +21,7 @@ struct KeyboardButton<Label: View, Overlay: View>: View {
 
     /// Extra touch area extension to cover all gaps between and around keys
     private var touchPadding: CGFloat {
-        KeyboardConstants.Layout.touchPadding
+        KeyboardTouchArea.padding
     }
 
     var body: some View {

--- a/wurstfingerKeyboard/KeyboardButton.swift
+++ b/wurstfingerKeyboard/KeyboardButton.swift
@@ -19,11 +19,9 @@ struct KeyboardButton<Label: View, Overlay: View>: View {
     @State private var isActive = false
     @State private var positions = RingBuffer<CGPoint>(capacity: KeyboardConstants.Gesture.positionBufferSize)
 
-    /// Extra touch area extension to cover margins between keys
+    /// Extra touch area extension to cover all gaps between and around keys
     private var touchPadding: CGFloat {
-        // Extend touch area by half the grid spacing on each side
-        // This ensures the entire margin area is covered by adjacent keys
-        KeyboardConstants.Layout.gridHorizontalSpacing / 2 + 2
+        KeyboardConstants.Layout.touchPadding
     }
 
     var body: some View {

--- a/wurstfingerKeyboard/KeyboardButtonComponents.swift
+++ b/wurstfingerKeyboard/KeyboardButtonComponents.swift
@@ -7,6 +7,18 @@
 
 import SwiftUI
 
+/// Touch area extension beyond each key's visual bounds.
+/// Must be at least as large as the biggest padding/spacing gap so that
+/// every pixel on the keyboard surface is covered by at least one key.
+enum KeyboardTouchArea {
+    static let padding: CGFloat = max(
+        KeyboardConstants.Layout.horizontalPadding,
+        KeyboardConstants.Layout.verticalPaddingBottom,
+        KeyboardConstants.Layout.gridHorizontalSpacing / 2 + 1,
+        KeyboardConstants.Layout.gridVerticalSpacing / 2 + 1
+    )
+}
+
 /// Configuration options for keyboard buttons
 struct KeyboardButtonConfig {
     let highlighted: Bool

--- a/wurstfingerKeyboard/KeyboardLayout.swift
+++ b/wurstfingerKeyboard/KeyboardLayout.swift
@@ -1011,16 +1011,6 @@ enum KeyboardConstants {
         static let hintMargin: CGFloat = 10
         /// Larger margin for "returning" hint labels (swipe-and-return gestures).
         static let hintMarginReturning: CGFloat = 22
-
-        /// Touch area extension beyond each key's visual bounds.
-        /// Must be at least as large as the biggest padding/spacing gap so that
-        /// every pixel on the keyboard surface is covered by at least one key.
-        static let touchPadding: CGFloat = max(
-            horizontalPadding,
-            verticalPaddingBottom,
-            gridHorizontalSpacing / 2 + 1,
-            gridVerticalSpacing / 2 + 1
-        )
     }
 
     // MARK: - Gesture Recognition

--- a/wurstfingerKeyboard/KeyboardLayout.swift
+++ b/wurstfingerKeyboard/KeyboardLayout.swift
@@ -1011,6 +1011,16 @@ enum KeyboardConstants {
         static let hintMargin: CGFloat = 10
         /// Larger margin for "returning" hint labels (swipe-and-return gestures).
         static let hintMarginReturning: CGFloat = 22
+
+        /// Touch area extension beyond each key's visual bounds.
+        /// Must be at least as large as the biggest padding/spacing gap so that
+        /// every pixel on the keyboard surface is covered by at least one key.
+        static let touchPadding: CGFloat = max(
+            horizontalPadding,
+            verticalPaddingBottom,
+            gridHorizontalSpacing / 2 + 1,
+            gridVerticalSpacing / 2 + 1
+        )
     }
 
     // MARK: - Gesture Recognition

--- a/wurstfingerKeyboard/SpaceKeyButton.swift
+++ b/wurstfingerKeyboard/SpaceKeyButton.swift
@@ -28,7 +28,7 @@ struct SpaceKeyButton: View {
         ) {
             Color.clear
         }
-        .contentShape(Rectangle())
+        .contentShape(Rectangle().inset(by: -KeyboardConstants.Layout.touchPadding))
         .accessibilityLabel(Text("Space"))
         .gesture(
             DragGesture(minimumDistance: 0)

--- a/wurstfingerKeyboard/SpaceKeyButton.swift
+++ b/wurstfingerKeyboard/SpaceKeyButton.swift
@@ -28,7 +28,7 @@ struct SpaceKeyButton: View {
         ) {
             Color.clear
         }
-        .contentShape(Rectangle().inset(by: -KeyboardConstants.Layout.touchPadding))
+        .contentShape(Rectangle().inset(by: -KeyboardTouchArea.padding))
         .accessibilityLabel(Text("Space"))
         .gesture(
             DragGesture(minimumDistance: 0)

--- a/wurstfingerTests/TouchCoverageTests.swift
+++ b/wurstfingerTests/TouchCoverageTests.swift
@@ -58,7 +58,7 @@ struct TouchCoverageTests {
     /// Verifies that for a standard row (3 grid keys + 1 utility key),
     /// the union of all touch areas covers the entire row width with no gaps.
     @Test("Key touch areas cover full row width")
-    func keyTouchAreasCoverFullRowWidth() {
+    func keyTouchAreasCoverFullRowWidth() throws {
         let aspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
         let keyHeight: CGFloat = 54
         let keyWidth = keyHeight * aspectRatio
@@ -86,8 +86,13 @@ struct TouchCoverageTests {
         let sorted = touchIntervals.sorted { $0.min < $1.min }
 
         // Verify coverage from 0 to totalRowWidth
-        #expect(sorted[0].min <= 0, "First key touch area must reach left edge (got \(sorted[0].min))")
-        #expect(sorted.last!.max >= totalRowWidth, "Last key touch area must reach right edge (got \(sorted.last!.max) vs \(totalRowWidth))")
+        let firstInterval = try #require(sorted.first)
+        let lastInterval = try #require(sorted.last)
+        #expect(firstInterval.min <= 0, "First key touch area must reach left edge")
+        #expect(
+            lastInterval.max >= totalRowWidth,
+            "Last key touch area must reach right edge"
+        )
 
         // Verify no gaps between adjacent intervals
         for i in 1 ..< sorted.count {
@@ -102,7 +107,7 @@ struct TouchCoverageTests {
 
     /// Verifies that 4 rows of keys with touchPadding cover the full keyboard height.
     @Test("Key touch areas cover full keyboard height")
-    func keyTouchAreasCoverFullKeyboardHeight() {
+    func keyTouchAreasCoverFullKeyboardHeight() throws {
         let keyHeight: CGFloat = 54
         let spacing = KeyboardConstants.Layout.gridVerticalSpacing
         let paddingTop = KeyboardConstants.Layout.verticalPaddingTop
@@ -124,8 +129,13 @@ struct TouchCoverageTests {
 
         let sorted = touchIntervals.sorted { $0.min < $1.min }
 
-        #expect(sorted[0].min <= 0, "Top row touch area must reach keyboard top edge")
-        #expect(sorted.last!.max >= totalHeight, "Bottom row touch area must reach keyboard bottom edge")
+        let firstInterval = try #require(sorted.first)
+        let lastInterval = try #require(sorted.last)
+        #expect(firstInterval.min <= 0, "Top row touch area must reach keyboard top edge")
+        #expect(
+            lastInterval.max >= totalHeight,
+            "Bottom row touch area must reach keyboard bottom edge"
+        )
 
         for i in 1 ..< sorted.count {
             #expect(

--- a/wurstfingerTests/TouchCoverageTests.swift
+++ b/wurstfingerTests/TouchCoverageTests.swift
@@ -60,14 +60,15 @@ struct TouchCoverageTests {
     @Test("Key touch areas cover full row width")
     func keyTouchAreasCoverFullRowWidth() throws {
         let aspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
-        let keyHeight: CGFloat = 54
+        let keyHeight = KeyboardConstants.KeyDimensions.height
         let keyWidth = keyHeight * aspectRatio
         let spacing = KeyboardConstants.Layout.gridHorizontalSpacing
         let padding = KeyboardConstants.Layout.horizontalPadding
         let touchPad = KeyboardTouchArea.padding
 
-        // 4 keys per row (3 grid + 1 utility)
-        let keyCount = 4
+        // 3 grid keys + 1 utility key per row
+        let gridColumns = 3
+        let keyCount = gridColumns + 1
         let contentWidth = CGFloat(keyCount) * keyWidth + CGFloat(keyCount - 1) * spacing
         let totalRowWidth = contentWidth + 2 * padding
 
@@ -108,7 +109,7 @@ struct TouchCoverageTests {
     /// Verifies that 4 rows of keys with touchPadding cover the full keyboard height.
     @Test("Key touch areas cover full keyboard height")
     func keyTouchAreasCoverFullKeyboardHeight() throws {
-        let keyHeight: CGFloat = 54
+        let keyHeight = KeyboardConstants.KeyDimensions.height
         let spacing = KeyboardConstants.Layout.gridVerticalSpacing
         let paddingTop = KeyboardConstants.Layout.verticalPaddingTop
         let paddingBottom = KeyboardConstants.Layout.verticalPaddingBottom

--- a/wurstfingerTests/TouchCoverageTests.swift
+++ b/wurstfingerTests/TouchCoverageTests.swift
@@ -1,0 +1,137 @@
+//
+//  TouchCoverageTests.swift
+//  wurstfingerTests
+//
+//  Tests that every pixel on the keyboard surface is covered by at least one
+//  key's touch area, eliminating dead zones.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct TouchCoverageTests {
+    // MARK: - Touch padding constant
+
+    @Test("touchPadding covers horizontal padding")
+    func touchPaddingCoversHorizontalPadding() {
+        #expect(
+            KeyboardConstants.Layout.touchPadding >= KeyboardConstants.Layout.horizontalPadding,
+            "touchPadding must reach the keyboard edge through horizontal padding"
+        )
+    }
+
+    @Test("touchPadding covers bottom padding")
+    func touchPaddingCoversBottomPadding() {
+        #expect(
+            KeyboardConstants.Layout.touchPadding >= KeyboardConstants.Layout.verticalPaddingBottom,
+            "touchPadding must reach the keyboard edge through bottom padding"
+        )
+    }
+
+    @Test("touchPadding covers top padding")
+    func touchPaddingCoversTopPadding() {
+        #expect(
+            KeyboardConstants.Layout.touchPadding >= KeyboardConstants.Layout.verticalPaddingTop,
+            "touchPadding must reach the keyboard edge through top padding"
+        )
+    }
+
+    @Test("touchPadding covers horizontal grid spacing")
+    func touchPaddingCoversHorizontalSpacing() {
+        #expect(
+            KeyboardConstants.Layout.touchPadding >= KeyboardConstants.Layout.gridHorizontalSpacing / 2,
+            "touchPadding must cover at least half the horizontal grid spacing"
+        )
+    }
+
+    @Test("touchPadding covers vertical grid spacing")
+    func touchPaddingCoversVerticalSpacing() {
+        #expect(
+            KeyboardConstants.Layout.touchPadding >= KeyboardConstants.Layout.gridVerticalSpacing / 2,
+            "touchPadding must cover at least half the vertical grid spacing"
+        )
+    }
+
+    // MARK: - Row-level horizontal coverage
+
+    /// Verifies that for a standard row (3 grid keys + 1 utility key),
+    /// the union of all touch areas covers the entire row width with no gaps.
+    @Test("Key touch areas cover full row width")
+    func keyTouchAreasCoverFullRowWidth() {
+        let aspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
+        let keyHeight: CGFloat = 54
+        let keyWidth = keyHeight * aspectRatio
+        let spacing = KeyboardConstants.Layout.gridHorizontalSpacing
+        let padding = KeyboardConstants.Layout.horizontalPadding
+        let touchPad = KeyboardConstants.Layout.touchPadding
+
+        // 4 keys per row (3 grid + 1 utility)
+        let keyCount = 4
+        let contentWidth = CGFloat(keyCount) * keyWidth + CGFloat(keyCount - 1) * spacing
+        let totalRowWidth = contentWidth + 2 * padding
+
+        // Build touch intervals for each key
+        // Keys are positioned: padding + i * (keyWidth + spacing)
+        var touchIntervals: [(min: CGFloat, max: CGFloat)] = []
+        for i in 0 ..< keyCount {
+            let keyLeft = padding + CGFloat(i) * (keyWidth + spacing)
+            let keyRight = keyLeft + keyWidth
+            let touchLeft = keyLeft - touchPad
+            let touchRight = keyRight + touchPad
+            touchIntervals.append((min: touchLeft, max: touchRight))
+        }
+
+        // Sort by min
+        let sorted = touchIntervals.sorted { $0.min < $1.min }
+
+        // Verify coverage from 0 to totalRowWidth
+        #expect(sorted[0].min <= 0, "First key touch area must reach left edge (got \(sorted[0].min))")
+        #expect(sorted.last!.max >= totalRowWidth, "Last key touch area must reach right edge (got \(sorted.last!.max) vs \(totalRowWidth))")
+
+        // Verify no gaps between adjacent intervals
+        for i in 1 ..< sorted.count {
+            #expect(
+                sorted[i].min <= sorted[i - 1].max,
+                "Gap between key \(i - 1) and key \(i): \(sorted[i].min) > \(sorted[i - 1].max)"
+            )
+        }
+    }
+
+    // MARK: - Vertical coverage
+
+    /// Verifies that 4 rows of keys with touchPadding cover the full keyboard height.
+    @Test("Key touch areas cover full keyboard height")
+    func keyTouchAreasCoverFullKeyboardHeight() {
+        let keyHeight: CGFloat = 54
+        let spacing = KeyboardConstants.Layout.gridVerticalSpacing
+        let paddingTop = KeyboardConstants.Layout.verticalPaddingTop
+        let paddingBottom = KeyboardConstants.Layout.verticalPaddingBottom
+        let touchPad = KeyboardConstants.Layout.touchPadding
+
+        let rowCount = KeyboardConstants.KeyDimensions.totalRows
+        let totalHeight = CGFloat(rowCount) * keyHeight +
+            CGFloat(rowCount - 1) * spacing +
+            paddingTop + paddingBottom
+
+        // Build vertical touch intervals for each row
+        var touchIntervals: [(min: CGFloat, max: CGFloat)] = []
+        for i in 0 ..< rowCount {
+            let rowTop = paddingTop + CGFloat(i) * (keyHeight + spacing)
+            let rowBottom = rowTop + keyHeight
+            touchIntervals.append((min: rowTop - touchPad, max: rowBottom + touchPad))
+        }
+
+        let sorted = touchIntervals.sorted { $0.min < $1.min }
+
+        #expect(sorted[0].min <= 0, "Top row touch area must reach keyboard top edge")
+        #expect(sorted.last!.max >= totalHeight, "Bottom row touch area must reach keyboard bottom edge")
+
+        for i in 1 ..< sorted.count {
+            #expect(
+                sorted[i].min <= sorted[i - 1].max,
+                "Vertical gap between row \(i - 1) and row \(i)"
+            )
+        }
+    }
+}

--- a/wurstfingerTests/TouchCoverageTests.swift
+++ b/wurstfingerTests/TouchCoverageTests.swift
@@ -16,7 +16,7 @@ struct TouchCoverageTests {
     @Test("touchPadding covers horizontal padding")
     func touchPaddingCoversHorizontalPadding() {
         #expect(
-            KeyboardConstants.Layout.touchPadding >= KeyboardConstants.Layout.horizontalPadding,
+            KeyboardTouchArea.padding >= KeyboardConstants.Layout.horizontalPadding,
             "touchPadding must reach the keyboard edge through horizontal padding"
         )
     }
@@ -24,7 +24,7 @@ struct TouchCoverageTests {
     @Test("touchPadding covers bottom padding")
     func touchPaddingCoversBottomPadding() {
         #expect(
-            KeyboardConstants.Layout.touchPadding >= KeyboardConstants.Layout.verticalPaddingBottom,
+            KeyboardTouchArea.padding >= KeyboardConstants.Layout.verticalPaddingBottom,
             "touchPadding must reach the keyboard edge through bottom padding"
         )
     }
@@ -32,7 +32,7 @@ struct TouchCoverageTests {
     @Test("touchPadding covers top padding")
     func touchPaddingCoversTopPadding() {
         #expect(
-            KeyboardConstants.Layout.touchPadding >= KeyboardConstants.Layout.verticalPaddingTop,
+            KeyboardTouchArea.padding >= KeyboardConstants.Layout.verticalPaddingTop,
             "touchPadding must reach the keyboard edge through top padding"
         )
     }
@@ -40,7 +40,7 @@ struct TouchCoverageTests {
     @Test("touchPadding covers horizontal grid spacing")
     func touchPaddingCoversHorizontalSpacing() {
         #expect(
-            KeyboardConstants.Layout.touchPadding >= KeyboardConstants.Layout.gridHorizontalSpacing / 2,
+            KeyboardTouchArea.padding >= KeyboardConstants.Layout.gridHorizontalSpacing / 2,
             "touchPadding must cover at least half the horizontal grid spacing"
         )
     }
@@ -48,7 +48,7 @@ struct TouchCoverageTests {
     @Test("touchPadding covers vertical grid spacing")
     func touchPaddingCoversVerticalSpacing() {
         #expect(
-            KeyboardConstants.Layout.touchPadding >= KeyboardConstants.Layout.gridVerticalSpacing / 2,
+            KeyboardTouchArea.padding >= KeyboardConstants.Layout.gridVerticalSpacing / 2,
             "touchPadding must cover at least half the vertical grid spacing"
         )
     }
@@ -64,7 +64,7 @@ struct TouchCoverageTests {
         let keyWidth = keyHeight * aspectRatio
         let spacing = KeyboardConstants.Layout.gridHorizontalSpacing
         let padding = KeyboardConstants.Layout.horizontalPadding
-        let touchPad = KeyboardConstants.Layout.touchPadding
+        let touchPad = KeyboardTouchArea.padding
 
         // 4 keys per row (3 grid + 1 utility)
         let keyCount = 4
@@ -112,7 +112,7 @@ struct TouchCoverageTests {
         let spacing = KeyboardConstants.Layout.gridVerticalSpacing
         let paddingTop = KeyboardConstants.Layout.verticalPaddingTop
         let paddingBottom = KeyboardConstants.Layout.verticalPaddingBottom
-        let touchPad = KeyboardConstants.Layout.touchPadding
+        let touchPad = KeyboardTouchArea.padding
 
         let rowCount = KeyboardConstants.KeyDimensions.totalRows
         let totalHeight = CGFloat(rowCount) * keyHeight +


### PR DESCRIPTION
## Summary
- Increase touch padding on all button types to cover the full keyboard surface (edge padding + inter-key gaps)
- Add `contentShape` with touch extension to `SpaceKeyButton` and `DeleteKeyButton`, which previously had no or minimal touch area beyond their visual bounds
- Centralize `touchPadding` constant in `KeyboardConstants.Layout` (computed as `max(horizontalPadding, verticalPaddingBottom, ...)` = 12pt)

## Details
Previously there were three categories of dead zones:
1. **Edge padding** (12pt horizontal, 10pt bottom) — taps near the keyboard edges were unresponsive
2. **SpaceKeyButton** had `.contentShape(Rectangle())` with no extension beyond visual bounds
3. **DeleteKeyButton** had no `.contentShape()` at all

## Test plan
- [x] 7 new unit tests in `TouchCoverageTests` verify touch areas cover full keyboard width and height
- [x] All 297 tests pass
- [x] Verified keyboard builds and runs correctly in simulator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded and unified touch-sensitive areas for keys (including Delete and Space) to improve responsiveness and reduce missed taps.

* **Tests**
  * Added touch-coverage tests to ensure touch padding reaches edges and prevents gaps between keys and rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->