### PR TITLE
Remove redundant #require warnings in ReturnSwipeLanguageTests

### DIFF
--- a/wurstfingerTests/ReturnSwipeLanguageTests.swift
+++ b/wurstfingerTests/ReturnSwipeLanguageTests.swift
@@ -13,7 +13,7 @@ import Testing
 struct ReturnSwipeLanguageTests {
     /// Bug #94: French layout return swipe up on center key (O) should produce "H",
     /// because the French up-swipe character is "h" — not "U" (the English default).
-    @Test func frenchReturnSwipeUpOnCenterKeyProducesH() throws {
+    @Test func frenchReturnSwipeUpOnCenterKeyProducesH() {
         let frenchLayout = KeyboardLayout.layout(for: .french)
         let viewModel = KeyboardViewModel(layout: frenchLayout, shouldPersistSettings: false)
         var inserted: [String] = []
@@ -24,7 +24,7 @@ struct ReturnSwipeLanguageTests {
             }
         }
 
-        let centerKey = try #require(viewModel.rows[1][1])
+        let centerKey = viewModel.rows[1][1]
         viewModel.handleKeySwipeReturn(centerKey, direction: .up)
 
         #expect(
@@ -35,13 +35,13 @@ struct ReturnSwipeLanguageTests {
 
     /// Regression guard: for every language, the center key's return swipe overrides
     /// should match the uppercased version of the regular swipe output.
-    @Test func centerKeyReturnSwipeMatchesUppercasedSwipeForAllLanguages() throws {
+    @Test func centerKeyReturnSwipeMatchesUppercasedSwipeForAllLanguages() {
         for config in LanguageConfig.allLanguages {
             let layout = KeyboardLayout.layout(for: config)
             let viewModel = KeyboardViewModel(layout: layout, shouldPersistSettings: false)
             viewModel.bindActionHandler { _ in }
 
-            let centerKey = try #require(viewModel.rows[1][1])
+            let centerKey = viewModel.rows[1][1]
 
             for direction in KeyboardDirection.allCases where direction != .center {
                 // Get the regular swipe output


### PR DESCRIPTION
## Summary

- Removes two redundant `try #require(viewModel.rows[1][1])` calls in `ReturnSwipeLanguageTests.swift`, replacing them with direct access `viewModel.rows[1][1]` since the subscript never returns an optional
- Removes `throws` from both test function signatures as they no longer contain any throwing expressions

## Test plan

- [ ] Verify the compiler warnings about redundant `#require` are gone
- [ ] Confirm both tests still pass: `frenchReturnSwipeUpOnCenterKeyProducesH` and `centerKeyReturnSwipeMatchesUppercasedSwipeForAllLanguages`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test execution by removing unnecessary error handling mechanisms from language-related tests, improving test clarity and maintainability without changing test coverage or expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->