### PR TITLE
Upgrade GitHub Actions to latest versions (Node.js 24)

### DIFF
--- a/.github/workflows/appstore-release.yml
+++ b/.github/workflows/appstore-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/appstore-release.yml
+++ b/.github/workflows/appstore-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/generate-appstore-screenshots.yml
+++ b/.github/workflows/generate-appstore-screenshots.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: List available simulators
         run: |
@@ -61,7 +61,7 @@ jobs:
           fi
 
       - name: Cache Python venv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: venv
           key: ${{ runner.os }}-venv-appstore-${{ hashFiles('scripts/generate-appstore-screenshots.sh') }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload screenshots artifact
         if: ${{ inputs.upload_artifact }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: appstore-screenshots
           path: appstore-screenshots/

--- a/.github/workflows/generate-appstore-screenshots.yml
+++ b/.github/workflows/generate-appstore-screenshots.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: List available simulators
         run: |
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload screenshots artifact
         if: ${{ inputs.upload_artifact }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: appstore-screenshots
           path: appstore-screenshots/

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -46,11 +46,17 @@ jobs:
 
       - name: Boot Simulator
         id: sim
+        timeout-minutes: 5
         run: |
           SIMULATOR_ID=$(xcrun simctl list devices available | grep "iPhone 16" | grep -v "Plus\|Pro" | head -1 | grep -oE '\([A-F0-9-]+\)' | tr -d '()')
           if [ -z "$SIMULATOR_ID" ]; then
             echo "iPhone 16 simulator not found, using iPhone 15"
             SIMULATOR_ID=$(xcrun simctl list devices available | grep "iPhone 15" | grep -v "Plus\|Pro" | head -1 | grep -oE '\([A-F0-9-]+\)' | tr -d '()')
+          fi
+          if [ -z "$SIMULATOR_ID" ]; then
+            echo "::error::No compatible iPhone simulator found (iPhone 16 or iPhone 15)"
+            xcrun simctl list devices available
+            exit 1
           fi
           echo "Using simulator: $SIMULATOR_ID"
           echo "simulator_id=$SIMULATOR_ID" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -45,6 +45,7 @@ jobs:
         run: gem install xcpretty
 
       - name: Boot Simulator
+        id: sim
         run: |
           SIMULATOR_ID=$(xcrun simctl list devices available | grep "iPhone 16" | grep -v "Plus\|Pro" | head -1 | grep -oE '\([A-F0-9-]+\)' | tr -d '()')
           if [ -z "$SIMULATOR_ID" ]; then
@@ -52,6 +53,7 @@ jobs:
             SIMULATOR_ID=$(xcrun simctl list devices available | grep "iPhone 15" | grep -v "Plus\|Pro" | head -1 | grep -oE '\([A-F0-9-]+\)' | tr -d '()')
           fi
           echo "Using simulator: $SIMULATOR_ID"
+          echo "simulator_id=$SIMULATOR_ID" >> "$GITHUB_OUTPUT"
           xcrun simctl boot "$SIMULATOR_ID" || true
           xcrun simctl bootstatus "$SIMULATOR_ID"
 
@@ -61,7 +63,7 @@ jobs:
           set -o pipefail && xcodebuild test \
             -scheme Wurstfinger \
             -project Wurstfinger.xcodeproj \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.simulator_id }}' \
             -only-testing:WurstfingerTests \
             -resultBundlePath TestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO \

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Tools
         run: brew install swiftlint swiftformat
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Periphery
         run: brew install peripheryapp/periphery/periphery
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install xcpretty
         run: gem install xcpretty
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-results
           path: |

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Tools
         run: brew install swiftlint swiftformat
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Periphery
         run: brew install peripheryapp/periphery/periphery
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install xcpretty
         run: gem install xcpretty
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: |

--- a/.github/workflows/testflight-beta.yml
+++ b/.github/workflows/testflight-beta.yml
@@ -13,7 +13,7 @@ jobs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -37,7 +37,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/testflight-beta.yml
+++ b/.github/workflows/testflight-beta.yml
@@ -13,7 +13,7 @@ jobs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 
@@ -37,7 +37,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Cache Python venv
         uses: actions/cache@v5

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Cache Python venv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: venv
           key: ${{ runner.os }}-venv-${{ hashFiles('scripts/generate-screenshots.sh') }}


### PR DESCRIPTION
## Summary

Upgrades all GitHub Actions action versions to the latest major releases to fix Node.js 20 deprecation warnings.

| Action | Old version | New version |
|--------|-------------|-------------|
| `actions/checkout` | `v5` | `v6` |
| `actions/upload-artifact` | `v5` | `v7` |
| `actions/cache` | `v5` | `v5` (already current) |
| `ruby/setup-ruby` | `v1` | `v1` (already current) |

## Background

GitHub has announced a deprecation timeline for Actions that run on Node.js 20:
- **June 2026**: Forced migration begins — Actions using Node.js 20 will start failing
- **September 2026**: Node.js 20-based Actions are fully removed

`actions/checkout@v5` and `actions/upload-artifact@v5` both still use the Node.js 20 runner, causing deprecation warnings in CI. The new major versions (`v6` and `v7` respectively) have migrated to Node.js 24.

## Affected workflows

- `.github/workflows/appstore-release.yml`
- `.github/workflows/generate-appstore-screenshots.yml`
- `.github/workflows/pr-tests.yml`
- `.github/workflows/testflight-beta.yml`
- `.github/workflows/update-screenshots.yml`

## Test plan

- [ ] Verify CI passes on this PR (pr-tests workflow)
- [ ] Confirm no Node.js 20 deprecation warnings appear in workflow logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped CI/CD workflow action versions across automation pipelines (checkout, cache, artifact steps). This update modernizes our automation toolchain and improves compatibility, security, and reliability of testing, screenshot generation, beta distribution, and app store release processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->