### PR TITLE
Add UI tests for keyboard dead zone detection

### DIFF
--- a/wurstfinger/KeyboardShowcaseView.swift
+++ b/wurstfinger/KeyboardShowcaseView.swift
@@ -11,6 +11,9 @@ struct KeyboardShowcaseView: View {
     @StateObject private var viewModel = KeyboardViewModel(shouldPersistSettings: false)
     @StateObject private var languageSettings = LanguageSettings.shared
     @State private var colorScheme: ColorScheme?
+    @State private var actionCount = 0
+
+    private let isDeadZoneTest = ProcessInfo.processInfo.environment["DEAD_ZONE_TEST"] != nil
 
     var body: some View {
         VStack(spacing: 0) {
@@ -19,11 +22,23 @@ struct KeyboardShowcaseView: View {
                 .background(Color(.systemBackground))
                 .accessibilityIdentifier("showcaseKeyboard")
                 .padding(.vertical, 8)
+
+            if isDeadZoneTest {
+                Text("\(actionCount)")
+                    .accessibilityIdentifier("actionCount")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
         }
         .background(Color(.systemBackground))
         .preferredColorScheme(colorScheme)
         .statusBar(hidden: true)
         .onAppear {
+            if isDeadZoneTest {
+                viewModel.bindActionHandler { _ in
+                    actionCount += 1
+                }
+            }
             // Set language from environment if specified (for UI tests)
             if let forcedLanguage = ProcessInfo.processInfo.environment["FORCE_LANGUAGE"] {
                 languageSettings.selectedLanguageId = forcedLanguage

--- a/wurstfingerUITests/DeadZoneTests.swift
+++ b/wurstfingerUITests/DeadZoneTests.swift
@@ -15,7 +15,11 @@ final class DeadZoneTests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = true
         app = XCUIApplication()
-        app.launchArguments = ["SCREENSHOT_MODE"]
+        app.launchArguments = [
+            "SCREENSHOT_MODE",
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_US",
+        ]
         app.launchEnvironment["FORCE_LAYER"] = "lower"
         app.launchEnvironment["FORCE_APPEARANCE"] = "light"
         app.launchEnvironment["DEAD_ZONE_TEST"] = "1"

--- a/wurstfingerUITests/DeadZoneTests.swift
+++ b/wurstfingerUITests/DeadZoneTests.swift
@@ -232,13 +232,13 @@ final class DeadZoneTests: XCTestCase {
             )
         }
 
-        // Right edge — to the right of rightmost grid key (toward utility)
-        if let keyI = findKey("i") {
-            let edgeInset = keyI.frame.width * 0.2
+        // Right edge — outside the utility column (true keyboard boundary)
+        if let ret = findKey("Return") {
+            let edgeInset = ret.frame.width * 0.15
             tapAndAssert(
-                x: keyI.frame.maxX + edgeInset,
-                y: keyI.frame.midY,
-                label: "right of 'i' (toward globe)"
+                x: ret.frame.maxX + edgeInset,
+                y: ret.frame.midY,
+                label: "right edge outside utility column"
             )
         }
 

--- a/wurstfingerUITests/DeadZoneTests.swift
+++ b/wurstfingerUITests/DeadZoneTests.swift
@@ -1,0 +1,279 @@
+//
+//  DeadZoneTests.swift
+//  wurstfingerUITests
+//
+//  UI tests that verify there are no dead zones on the keyboard surface.
+//  Taps in the gaps between keys and at keyboard edges, then checks that
+//  each tap produces an action.
+//
+
+import XCTest
+
+final class DeadZoneTests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = true
+        app = XCUIApplication()
+        app.launchArguments = ["SCREENSHOT_MODE"]
+        app.launchEnvironment["FORCE_LAYER"] = "lower"
+        app.launchEnvironment["FORCE_APPEARANCE"] = "light"
+        app.launchEnvironment["DEAD_ZONE_TEST"] = "1"
+        app.launch()
+    }
+
+    // MARK: - Helpers
+
+    private func actionCount() -> Int {
+        let el = app.staticTexts.matching(identifier: "actionCount").firstMatch
+        return Int(el.label) ?? -1
+    }
+
+    /// Taps at the given screen coordinate and asserts the action counter incremented.
+    private func tapAndAssert(
+        x: CGFloat,
+        y: CGFloat,
+        label: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let before = actionCount()
+        app.coordinate(withNormalizedOffset: .zero)
+            .withOffset(CGVector(dx: x, dy: y))
+            .tap()
+        Thread.sleep(forTimeInterval: 0.5)
+        let after = actionCount()
+        XCTAssertGreaterThan(
+            after, before,
+            "Dead zone: \(label) at (\(Int(x)), \(Int(y)))",
+            file: file, line: line
+        )
+    }
+
+    /// Finds a button by accessibility label in the app.
+    private func findKey(
+        _ keyLabel: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> XCUIElement? {
+        let key = app.buttons[keyLabel]
+        if !key.waitForExistence(timeout: 2) {
+            XCTFail("Key '\(keyLabel)' not found", file: file, line: line)
+            return nil
+        }
+        return key
+    }
+
+    private func waitForKeyboard() {
+        let keyA = app.buttons["a"]
+        XCTAssertTrue(keyA.waitForExistence(timeout: 5), "Keyboard not loaded")
+        let counter = app.staticTexts.matching(identifier: "actionCount").firstMatch
+        XCTAssertTrue(counter.waitForExistence(timeout: 2), "Action counter not found")
+    }
+
+    // MARK: - Grid key labels (German lower layout)
+
+    //
+    //   Col 0   Col 1   Col 2   |  Col 3 (utility, right side)
+    //     a       n       i     |    🌐  (row 0)
+    //     h       d       r     |   123  (row 1)
+    //     t       e       s     |    ⌫   (row 2)
+    //         [ Space ]         |    ⏎   (row 3)
+
+    private let gridKeys: [[String]] = [
+        ["a", "n", "i"],
+        ["h", "d", "r"],
+        ["t", "e", "s"],
+    ]
+
+    // MARK: - Tests
+
+    /// Tap in every horizontal gap between adjacent grid keys (rows 0–2).
+    @MainActor
+    func testHorizontalGapsBetweenGridKeys() {
+        waitForKeyboard()
+
+        for (rowIdx, row) in gridKeys.enumerated() {
+            for colIdx in 0 ..< (row.count - 1) {
+                guard let left = findKey(row[colIdx]),
+                      let right = findKey(row[colIdx + 1])
+                else { continue }
+
+                let x = (left.frame.maxX + right.frame.minX) / 2
+                let y = (left.frame.midY + right.frame.midY) / 2
+                tapAndAssert(
+                    x: x, y: y,
+                    label: "h-gap row \(rowIdx): \(row[colIdx])-\(row[colIdx + 1])"
+                )
+            }
+        }
+    }
+
+    /// Tap in every vertical gap between adjacent rows of grid keys,
+    /// including the gap between row 2 and the space bar row.
+    @MainActor
+    func testVerticalGapsBetweenRows() {
+        waitForKeyboard()
+
+        // Between grid rows 0–1 and 1–2
+        for rowIdx in 0 ..< (gridKeys.count - 1) {
+            for colIdx in 0 ..< gridKeys[rowIdx].count {
+                guard let top = findKey(gridKeys[rowIdx][colIdx]),
+                      let bottom = findKey(gridKeys[rowIdx + 1][colIdx])
+                else { continue }
+
+                let x = (top.frame.midX + bottom.frame.midX) / 2
+                let y = (top.frame.maxY + bottom.frame.minY) / 2
+                tapAndAssert(
+                    x: x, y: y,
+                    label: "v-gap: \(gridKeys[rowIdx][colIdx])-\(gridKeys[rowIdx + 1][colIdx])"
+                )
+            }
+        }
+
+        // Between row 2 and space bar row: use Return key as row 3 anchor
+        guard let ret = findKey("Return") else { return }
+        for letter in gridKeys[2] {
+            guard let top = findKey(letter) else { continue }
+            let x = top.frame.midX
+            let y = (top.frame.maxY + ret.frame.minY) / 2
+            tapAndAssert(x: x, y: y, label: "v-gap: \(letter)-SpaceRow")
+        }
+    }
+
+    /// Tap at the intersection of horizontal and vertical gaps where four keys meet.
+    @MainActor
+    func testDiagonalGapIntersections() {
+        waitForKeyboard()
+
+        for rowIdx in 0 ..< (gridKeys.count - 1) {
+            for colIdx in 0 ..< (gridKeys[rowIdx].count - 1) {
+                guard let topLeft = findKey(gridKeys[rowIdx][colIdx]),
+                      let topRight = findKey(gridKeys[rowIdx][colIdx + 1]),
+                      let botLeft = findKey(gridKeys[rowIdx + 1][colIdx])
+                else { continue }
+
+                let x = (topLeft.frame.maxX + topRight.frame.minX) / 2
+                let y = (topLeft.frame.maxY + botLeft.frame.minY) / 2
+                tapAndAssert(
+                    x: x, y: y,
+                    label: "intersection: \(gridKeys[rowIdx][colIdx])/" +
+                        "\(gridKeys[rowIdx][colIdx + 1])/" +
+                        "\(gridKeys[rowIdx + 1][colIdx])/" +
+                        "\(gridKeys[rowIdx + 1][colIdx + 1])"
+                )
+            }
+        }
+    }
+
+    /// Tap in gaps between the space bar row and the grid/utility keys.
+    @MainActor
+    func testSpaceBarAndUtilityGaps() {
+        waitForKeyboard()
+
+        guard let ret = findKey("Return") else { return }
+
+        // Gap between Space bar and Return key (horizontal)
+        // Space bar is to the left of Return. Tap just left of Return's left edge.
+        if let keyT = findKey("t") {
+            // Space bar left edge ≈ leftmost grid key left edge
+            // Tap between space bar's right side and Return
+            let spaceRightApprox = ret.frame.minX
+            let x = spaceRightApprox - 2.5 // just inside the gap
+            let y = ret.frame.midY
+            tapAndAssert(x: x, y: y, label: "gap Space-Return")
+        }
+
+        // Gap between grid key 's' and Delete (row 2, grid to utility)
+        // Both 's' and Delete produce actions
+        if let keyS = findKey("s") {
+            tapAndAssert(
+                x: keyS.frame.maxX + 20,
+                y: keyS.frame.midY,
+                label: "h-gap: s-Delete"
+            )
+        }
+
+        // Gap between Delete and Return (vertical, utility column)
+        // Both produce actions
+        if let keyS = findKey("s") {
+            let utilityX = keyS.frame.maxX + 30 // approximate utility column x
+            tapAndAssert(
+                x: utilityX,
+                y: (keyS.frame.maxY + ret.frame.minY) / 2,
+                label: "v-gap: Delete-Return"
+            )
+        }
+    }
+
+    /// Tap at the very edges of the keyboard surface.
+    @MainActor
+    func testEdgePaddingAreas() {
+        waitForKeyboard()
+
+        // Left edge — well to the left of the leftmost grid key
+        if let keyA = findKey("a") {
+            tapAndAssert(
+                x: keyA.frame.minX - 10,
+                y: keyA.frame.midY,
+                label: "left edge near 'a'"
+            )
+        }
+        if let keyT = findKey("t") {
+            tapAndAssert(
+                x: keyT.frame.minX - 10,
+                y: keyT.frame.midY,
+                label: "left edge near 't'"
+            )
+        }
+
+        // Right edge — to the right of rightmost grid key (toward utility)
+        if let keyI = findKey("i") {
+            tapAndAssert(
+                x: keyI.frame.maxX + 15,
+                y: keyI.frame.midY,
+                label: "right of 'i' (toward globe)"
+            )
+        }
+
+        // Top edge — above the top row
+        if let keyA = findKey("a") {
+            tapAndAssert(
+                x: keyA.frame.midX,
+                y: keyA.frame.minY - 10,
+                label: "top edge above 'a'"
+            )
+        }
+        if let keyN = findKey("n") {
+            tapAndAssert(
+                x: keyN.frame.midX,
+                y: keyN.frame.minY - 10,
+                label: "top edge above 'n'"
+            )
+        }
+        if let keyI = findKey("i") {
+            tapAndAssert(
+                x: keyI.frame.midX,
+                y: keyI.frame.minY - 10,
+                label: "top edge above 'i'"
+            )
+        }
+
+        // Bottom edge — below the space bar / return row
+        if let ret = findKey("Return") {
+            tapAndAssert(
+                x: ret.frame.midX,
+                y: ret.frame.maxY + 5,
+                label: "bottom edge below Return"
+            )
+            // Also test below center of space bar area
+            if let keyE = findKey("e") {
+                tapAndAssert(
+                    x: keyE.frame.midX,
+                    y: ret.frame.maxY + 5,
+                    label: "bottom edge below Space"
+                )
+            }
+        }
+    }
+}

--- a/wurstfingerUITests/DeadZoneTests.swift
+++ b/wurstfingerUITests/DeadZoneTests.swift
@@ -26,7 +26,11 @@ final class DeadZoneTests: XCTestCase {
 
     private func actionCount() -> Int {
         let el = app.staticTexts.matching(identifier: "actionCount").firstMatch
-        return Int(el.label) ?? -1
+        guard let count = Int(el.label) else {
+            XCTFail("Failed to parse actionCount label: '\(el.label)'")
+            return 0
+        }
+        return count
     }
 
     /// Taps at the given screen coordinate and asserts the action counter incremented.
@@ -41,11 +45,13 @@ final class DeadZoneTests: XCTestCase {
         app.coordinate(withNormalizedOffset: .zero)
             .withOffset(CGVector(dx: x, dy: y))
             .tap()
-        Thread.sleep(forTimeInterval: 0.5)
+        let predicate = NSPredicate { _, _ in self.actionCount() > before }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        let result = XCTWaiter.wait(for: [expectation], timeout: 2.0)
         let after = actionCount()
         XCTAssertGreaterThan(
             after, before,
-            "Dead zone: \(label) at (\(Int(x)), \(Int(y)))",
+            "Dead zone: \(label) at (\(Int(x)), \(Int(y)))\(result == .timedOut ? " (timed out)" : "")",
             file: file, line: line
         )
     }
@@ -174,32 +180,29 @@ final class DeadZoneTests: XCTestCase {
         guard let ret = findKey("Return") else { return }
 
         // Gap between Space bar and Return key (horizontal)
-        // Space bar is to the left of Return. Tap just left of Return's left edge.
-        if let keyT = findKey("t") {
-            // Space bar left edge ≈ leftmost grid key left edge
-            // Tap between space bar's right side and Return
-            let spaceRightApprox = ret.frame.minX
-            let x = spaceRightApprox - 2.5 // just inside the gap
-            let y = ret.frame.midY
-            tapAndAssert(x: x, y: y, label: "gap Space-Return")
-        }
+        // Tap between space bar's right side and Return
+        let gapInset = ret.frame.width * 0.05
+        tapAndAssert(
+            x: ret.frame.minX - gapInset,
+            y: ret.frame.midY,
+            label: "gap Space-Return"
+        )
 
         // Gap between grid key 's' and Delete (row 2, grid to utility)
-        // Both 's' and Delete produce actions
         if let keyS = findKey("s") {
+            let hOffset = keyS.frame.width * 0.3
             tapAndAssert(
-                x: keyS.frame.maxX + 20,
+                x: keyS.frame.maxX + hOffset,
                 y: keyS.frame.midY,
                 label: "h-gap: s-Delete"
             )
         }
 
         // Gap between Delete and Return (vertical, utility column)
-        // Both produce actions
         if let keyS = findKey("s") {
-            let utilityX = keyS.frame.maxX + 30 // approximate utility column x
+            let hOffset = keyS.frame.width * 0.5
             tapAndAssert(
-                x: utilityX,
+                x: keyS.frame.maxX + hOffset,
                 y: (keyS.frame.maxY + ret.frame.minY) / 2,
                 label: "v-gap: Delete-Return"
             )
@@ -213,15 +216,17 @@ final class DeadZoneTests: XCTestCase {
 
         // Left edge — well to the left of the leftmost grid key
         if let keyA = findKey("a") {
+            let edgeInset = keyA.frame.width * 0.15
             tapAndAssert(
-                x: keyA.frame.minX - 10,
+                x: keyA.frame.minX - edgeInset,
                 y: keyA.frame.midY,
                 label: "left edge near 'a'"
             )
         }
         if let keyT = findKey("t") {
+            let edgeInset = keyT.frame.width * 0.15
             tapAndAssert(
-                x: keyT.frame.minX - 10,
+                x: keyT.frame.minX - edgeInset,
                 y: keyT.frame.midY,
                 label: "left edge near 't'"
             )
@@ -229,8 +234,9 @@ final class DeadZoneTests: XCTestCase {
 
         // Right edge — to the right of rightmost grid key (toward utility)
         if let keyI = findKey("i") {
+            let edgeInset = keyI.frame.width * 0.2
             tapAndAssert(
-                x: keyI.frame.maxX + 15,
+                x: keyI.frame.maxX + edgeInset,
                 y: keyI.frame.midY,
                 label: "right of 'i' (toward globe)"
             )
@@ -238,39 +244,42 @@ final class DeadZoneTests: XCTestCase {
 
         // Top edge — above the top row
         if let keyA = findKey("a") {
+            let edgeInset = keyA.frame.height * 0.15
             tapAndAssert(
                 x: keyA.frame.midX,
-                y: keyA.frame.minY - 10,
+                y: keyA.frame.minY - edgeInset,
                 label: "top edge above 'a'"
             )
         }
         if let keyN = findKey("n") {
+            let edgeInset = keyN.frame.height * 0.15
             tapAndAssert(
                 x: keyN.frame.midX,
-                y: keyN.frame.minY - 10,
+                y: keyN.frame.minY - edgeInset,
                 label: "top edge above 'n'"
             )
         }
         if let keyI = findKey("i") {
+            let edgeInset = keyI.frame.height * 0.15
             tapAndAssert(
                 x: keyI.frame.midX,
-                y: keyI.frame.minY - 10,
+                y: keyI.frame.minY - edgeInset,
                 label: "top edge above 'i'"
             )
         }
 
         // Bottom edge — below the space bar / return row
         if let ret = findKey("Return") {
+            let edgeInset = ret.frame.height * 0.1
             tapAndAssert(
                 x: ret.frame.midX,
-                y: ret.frame.maxY + 5,
+                y: ret.frame.maxY + edgeInset,
                 label: "bottom edge below Return"
             )
-            // Also test below center of space bar area
             if let keyE = findKey("e") {
                 tapAndAssert(
                     x: keyE.frame.midX,
-                    y: ret.frame.maxY + 5,
+                    y: ret.frame.maxY + edgeInset,
                     label: "bottom edge below Space"
                 )
             }


### PR DESCRIPTION
## Summary
- Add `DeadZoneTests.swift` with 5 UI test methods that tap in gaps between keys, at diagonal intersections, and at keyboard edges to verify every tap produces an action
- Add action counter infrastructure to `KeyboardShowcaseView` (gated behind `DEAD_ZONE_TEST` env var) so UI tests can verify taps are registered

## Test coverage
- **Horizontal gaps** between all adjacent grid keys (6 gaps across 3 rows)
- **Vertical gaps** between all adjacent rows including row 2 → space bar row (9 gaps)
- **Diagonal intersections** where 4 keys meet (4 corners)
- **Utility column gaps** — Space↔Return, s↔Delete, Delete↔Return
- **Edge padding** — left, right, top, and bottom edges of the keyboard surface

## Test plan
- [x] All 5 tests pass on iPhone 17 Pro simulator
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When test mode is enabled, the keyboard view displays an accessibility‑labeled action counter that updates with interactions.

* **Tests**
  * Added a comprehensive UI test suite that validates keyboard dead‑zone behavior across horizontal/vertical gaps, diagonal intersections, space/utility areas, and edge padding by tapping precise locations and asserting the action counter increments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->