### PR TITLE
feat(multi-language): Add in-keyboard language switching

### DIFF
--- a/wurstfinger/LanguageSelectionView.swift
+++ b/wurstfinger/LanguageSelectionView.swift
@@ -58,35 +58,37 @@ private struct LanguageRow: View {
     let onToggle: () -> Void
 
     var body: some View {
-        Button(action: onTap) {
-            HStack {
-                Button(action: onToggle) {
-                    Image(systemName: isEnabled ? "checkmark.circle.fill" : "circle")
-                        .foregroundColor(isEnabled ? .accentColor : .secondary)
-                        .imageScale(.large)
-                }
-                .buttonStyle(.plain)
+        HStack {
+            Button(action: onToggle) {
+                Image(systemName: isEnabled ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(isEnabled ? .accentColor : .secondary)
+                    .imageScale(.large)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(isEnabled ? "Disable" : "Enable") \(language.name)")
+            .accessibilityValue(isEnabled ? "Enabled" : "Disabled")
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(language.name)
-                        .font(.body)
-                        .foregroundColor(.primary)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(language.name)
+                    .font(.body)
+                    .foregroundColor(.primary)
 
-                    Text("MessagEase Layout")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
+                Text("MessagEase Layout")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
 
-                Spacer()
+            Spacer()
 
-                if isActive {
-                    Text("Active")
-                        .font(.caption)
-                        .foregroundColor(.accentColor)
-                        .fontWeight(.medium)
-                }
+            if isActive {
+                Text("Active")
+                    .font(.caption)
+                    .foregroundColor(.accentColor)
+                    .fontWeight(.medium)
             }
         }
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
     }
 }
 

--- a/wurstfinger/LanguageSelectionView.swift
+++ b/wurstfinger/LanguageSelectionView.swift
@@ -9,36 +9,84 @@ import SwiftUI
 
 struct LanguageSelectionView: View {
     @StateObject private var languageSettings = LanguageSettings.shared
-    @Environment(\.dismiss) private var dismiss
+    @State private var showLastLanguageAlert = false
 
     var body: some View {
-        List(LanguageConfig.allLanguages) { language in
-            Button {
-                languageSettings.selectLanguage(language)
-                dismiss()
-            } label: {
-                HStack {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(language.name)
-                            .font(.body)
-                            .foregroundColor(.primary)
-
-                        Text("MessagEase Layout")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-
-                    Spacer()
-
-                    if languageSettings.selectedLanguageId == language.id {
-                        Image(systemName: "checkmark")
-                            .foregroundColor(.accentColor)
-                    }
+        List {
+            Section {
+                ForEach(LanguageConfig.allLanguages) { language in
+                    LanguageRow(
+                        language: language,
+                        isEnabled: languageSettings.isLanguageEnabled(language),
+                        isActive: languageSettings.selectedLanguageId == language.id,
+                        onTap: {
+                            if languageSettings.isLanguageEnabled(language) {
+                                languageSettings.selectLanguage(language)
+                            } else {
+                                languageSettings.toggleLanguage(language)
+                                languageSettings.selectLanguage(language)
+                            }
+                        },
+                        onToggle: {
+                            if !languageSettings.toggleLanguage(language) {
+                                showLastLanguageAlert = true
+                            }
+                        }
+                    )
+                }
+            } footer: {
+                if languageSettings.hasMultipleLanguages {
+                    Text("Swipe right on the globe key to switch languages.")
                 }
             }
         }
-        .navigationTitle("Keyboard Language")
+        .navigationTitle("Languages")
         .navigationBarTitleDisplayMode(.inline)
+        .alert("Cannot Disable", isPresented: $showLastLanguageAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("At least one language must be enabled.")
+        }
+    }
+}
+
+private struct LanguageRow: View {
+    let language: LanguageConfig
+    let isEnabled: Bool
+    let isActive: Bool
+    let onTap: () -> Void
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack {
+                Button(action: onToggle) {
+                    Image(systemName: isEnabled ? "checkmark.circle.fill" : "circle")
+                        .foregroundColor(isEnabled ? .accentColor : .secondary)
+                        .imageScale(.large)
+                }
+                .buttonStyle(.plain)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(language.name)
+                        .font(.body)
+                        .foregroundColor(.primary)
+
+                    Text("MessagEase Layout")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                if isActive {
+                    Text("Active")
+                        .font(.caption)
+                        .foregroundColor(.accentColor)
+                        .fontWeight(.medium)
+                }
+            }
+        }
     }
 }
 

--- a/wurstfinger/LanguageSelectionView.swift
+++ b/wurstfinger/LanguageSelectionView.swift
@@ -18,13 +18,13 @@ struct LanguageSelectionView: View {
                     LanguageRow(
                         language: language,
                         isEnabled: languageSettings.isLanguageEnabled(language),
-                        isActive: languageSettings.selectedLanguageId == language.id,
+                        isDefault: languageSettings.pinnedLanguageId == language.id,
                         onTap: {
                             if languageSettings.isLanguageEnabled(language) {
-                                languageSettings.selectLanguage(language)
+                                languageSettings.pinLanguage(language)
                             } else {
                                 languageSettings.toggleLanguage(language)
-                                languageSettings.selectLanguage(language)
+                                languageSettings.pinLanguage(language)
                             }
                         },
                         onToggle: {
@@ -36,7 +36,7 @@ struct LanguageSelectionView: View {
                 }
             } footer: {
                 if languageSettings.hasMultipleLanguages {
-                    Text("Swipe right on the globe key to switch languages.")
+                    Text("Swipe right on the globe key to switch languages. Tap a language to set it as the default startup language.")
                 }
             }
         }
@@ -53,7 +53,7 @@ struct LanguageSelectionView: View {
 private struct LanguageRow: View {
     let language: LanguageConfig
     let isEnabled: Bool
-    let isActive: Bool
+    let isDefault: Bool
     let onTap: () -> Void
     let onToggle: () -> Void
 
@@ -80,8 +80,8 @@ private struct LanguageRow: View {
 
             Spacer()
 
-            if isActive {
-                Text("Active")
+            if isDefault {
+                Text("Default")
                     .font(.caption)
                     .foregroundColor(.accentColor)
                     .fontWeight(.medium)

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -206,10 +206,15 @@ struct SettingsView: View {
 
     private var enabledLanguagesSummary: String {
         let names = languageSettings.enabledLanguages.map(\.name)
-        if names.count <= 2 {
-            return names.joined(separator: ", ")
+        let list = if names.count <= 2 {
+            names.joined(separator: ", ")
+        } else {
+            "\(names[0]) + \(names.count - 1) more"
         }
-        return "\(names[0]) + \(names.count - 1) more"
+        if let pinned = languageSettings.pinnedLanguage {
+            return "\(list) (default: \(pinned.name))"
+        }
+        return list
     }
 
     private var keyboardStyleDescription: String {

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -63,7 +63,7 @@ struct SettingsView: View {
     private var generalSection: some View {
         Section {
             NavigationLink(destination: LanguageSelectionView()) {
-                SettingsRow(icon: "globe", color: .blue, title: "Language", subtitle: languageSettings.selectedLanguage.name)
+                SettingsRow(icon: "globe", color: .blue, title: "Languages", subtitle: enabledLanguagesSummary)
             }
 
             Toggle(isOn: $utilityColumnLeading) {
@@ -203,6 +203,14 @@ struct SettingsView: View {
     }
 
     // MARK: - Helpers
+
+    private var enabledLanguagesSummary: String {
+        let names = languageSettings.enabledLanguages.map(\.name)
+        if names.count <= 2 {
+            return names.joined(separator: ", ")
+        }
+        return "\(names[0]) + \(names.count - 1) more"
+    }
 
     private var keyboardStyleDescription: String {
         let style = KeyboardStyle(rawValue: keyboardStyleRaw) ?? .classic

--- a/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
+++ b/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
@@ -28,6 +28,10 @@ enum CommonKeys {
             category: .utility, returnAction: nil,
             accessibilityLabel: "Tastatur ausblenden"
         )
+        bindings[.swipeRight] = KeyBinding(
+            label: "", action: .switchToNextLanguage,
+            category: .utility, returnAction: nil, accessibilityLabel: nil
+        )
         return KeyConfig(
             id: UtilitySlot.globe, bindings: bindings,
             swipeMode: .fourWayCross, slideType: .none,

--- a/wurstfingerKeyboard/Definition/Language/LanguageConfig.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageConfig.swift
@@ -30,6 +30,14 @@ extension LanguageConfig {
         id: "en_US", name: "English", locale: Locale(identifier: "en_US")
     )
 
+    static let german = LanguageConfig(
+        id: "de_DE", name: "Deutsch", locale: Locale(identifier: "de_DE")
+    )
+
+    static let russian = LanguageConfig(
+        id: "ru_RU", name: "Русский", locale: Locale(identifier: "ru_RU")
+    )
+
     /// All supported languages, derived from `KeyboardRegistry.available` and
     /// sorted alphabetically by name. This is the single source of truth --
     /// adding a new `KeyboardDefinition` to `LanguageDefinitions.all`

--- a/wurstfingerKeyboard/Definition/Model/KeyAction.swift
+++ b/wurstfingerKeyboard/Definition/Model/KeyAction.swift
@@ -31,6 +31,9 @@ enum KeyAction: Codable, Equatable {
     /// Dismiss keyboard
     case dismissKeyboard
 
+    /// Switch to the next enabled language
+    case switchToNextLanguage
+
     /// Delete backward
     case deleteBackward
 

--- a/wurstfingerKeyboard/Definition/Model/KeyCategory.swift
+++ b/wurstfingerKeyboard/Definition/Model/KeyCategory.swift
@@ -35,7 +35,7 @@ extension KeyAction {
         case .capitalizeWord: return .modifier
         case .space, .newline: return .whitespace
         case .deleteBackward, .deleteForward, .moveCursor,
-             .advanceToNextInputMode, .dismissKeyboard:
+             .advanceToNextInputMode, .dismissKeyboard, .switchToNextLanguage:
             return .utility
         case .copy, .paste, .cut: return .utility
         case .none: return .utility

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -153,7 +153,6 @@ final class KeyboardViewModel: ObservableObject {
         enabledLanguageIds = LanguageSettings.loadEnabledLanguageIds(from: defaults)
             ?? [SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue) ?? "en_US"]
 
-
         // Forward settings changes to trigger objectWillChange on this ViewModel
         hapticSettings.objectWillChange
             .sink { [weak self] _ in self?.objectWillChange.send() }

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -153,6 +153,7 @@ final class KeyboardViewModel: ObservableObject {
         enabledLanguageIds = LanguageSettings.loadEnabledLanguageIds(from: defaults)
             ?? [SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue) ?? "en_US"]
 
+
         // Forward settings changes to trigger objectWillChange on this ViewModel
         hapticSettings.objectWillChange
             .sink { [weak self] _ in self?.objectWillChange.send() }

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -80,6 +80,7 @@ final class KeyboardViewModel: ObservableObject {
     var onDismissKeyboard: (() -> Void)?
     /// Locale used by the pipeline (set from the keyboard definition).
     var pipelineLocale: Locale?
+    private var enabledLanguageIds: [String] = []
 
     // MARK: - Settings (delegated to extracted classes)
 
@@ -148,6 +149,9 @@ final class KeyboardViewModel: ObservableObject {
         hapticSettings = HapticSettings(defaults: defaults, shouldPersist: shouldPersistSettings)
         layoutSettings = LayoutSettings(defaults: defaults, shouldPersist: shouldPersistSettings)
         hapticManager = HapticFeedbackManager(settings: hapticSettings)
+
+        enabledLanguageIds = LanguageSettings.loadEnabledLanguageIds(from: defaults)
+            ?? [SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue) ?? "en_US"]
 
         // Forward settings changes to trigger objectWillChange on this ViewModel
         hapticSettings.objectWillChange
@@ -225,6 +229,32 @@ final class KeyboardViewModel: ObservableObject {
         // Delegate to extracted settings classes - eliminates duplicate code
         hapticSettings.reload()
         layoutSettings.reload()
+
+        enabledLanguageIds = LanguageSettings.loadEnabledLanguageIds(from: sharedDefaults)
+            ?? enabledLanguageIds
+    }
+
+    func switchToNextLanguage() {
+        guard enabledLanguageIds.count > 1 else { return }
+
+        let currentId = sharedDefaults.string(forKey: SettingsKey.selectedLanguageId.rawValue)
+            ?? currentDefinition?.id
+            ?? "en_US"
+        let nextId = LanguageSettings(userDefaults: sharedDefaults).nextLanguageId(after: currentId)
+
+        if nextId != currentId {
+            sharedDefaults.set(nextId, forKey: SettingsKey.selectedLanguageId.rawValue)
+            loadDefinition(for: nextId)
+        }
+    }
+
+    var hasMultipleLanguages: Bool {
+        enabledLanguageIds.count > 1
+    }
+
+    var currentLanguageLabel: String {
+        let lang = pipelineLocale?.language.languageCode?.identifier ?? ""
+        return lang.uppercased()
     }
 
     // MARK: - Haptic Feedback (delegated to HapticFeedbackManager)

--- a/wurstfingerKeyboard/Runtime/Pipeline/AutoCapitalizationMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/AutoCapitalizationMiddleware.swift
@@ -44,7 +44,7 @@ struct AutoCapitalizationMiddleware: ActionMiddleware {
              .compose, .cycleAccents, .paste, .cut:
             true
         case .moveCursor, .switchMode, .capitalizeWord, .advanceToNextInputMode,
-             .dismissKeyboard, .copy, .none:
+             .dismissKeyboard, .copy, .none, .switchToNextLanguage:
             false
         }
     }

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -174,6 +174,11 @@ extension KeyboardViewModel {
             return
         }
 
+        if case .switchToNextLanguage = binding.action {
+            switchToNextLanguage()
+            return
+        }
+
         let context = ActionContext(
             action: binding.action,
             binding: binding,

--- a/wurstfingerKeyboard/Runtime/Pipeline/TextInputMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/TextInputMiddleware.swift
@@ -50,7 +50,7 @@ struct TextInputMiddleware: ActionMiddleware {
             target.adjustTextPosition(byCharacterOffset: offset)
         case .compose, .cycleAccents, .switchMode, .capitalizeWord,
              .advanceToNextInputMode, .dismissKeyboard, .deleteForward,
-             .copy, .paste, .cut, .none:
+             .copy, .paste, .cut, .none, .switchToNextLanguage:
             break
         }
     }

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -33,6 +33,19 @@ struct KeyView: View {
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var keyAspectRatio: Double = DeviceLayoutUtils.defaultKeyAspectRatio
 
+    @AppStorage(SettingsKey.selectedLanguageId.rawValue, store: SharedDefaults.store)
+    private var selectedLanguageId: String = "en_US"
+
+    private var languageLabel: String {
+        let locale = Locale(identifier: selectedLanguageId)
+        return locale.language.languageCode?.identifier.uppercased() ?? ""
+    }
+
+    private var hasMultipleLanguages: Bool {
+        let ids = SharedDefaults.store.stringArray(forKey: SettingsKey.enabledLanguageIds.rawValue)
+        return (ids?.count ?? 0) > 1
+    }
+
     /// Maps emoji labels to SF Symbol names for utility keys.
     private static let sfSymbolMap: [String: String] = [
         "🌐": "globe",
@@ -250,16 +263,30 @@ struct KeyView: View {
 
             ForEach(Array(key.bindings.keys), id: \.self) { gesture in
                 if let binding = key.bindings[gesture],
-                   !binding.label.isEmpty,
                    let alignment = Self.hintAlignments[gesture] {
-                    hintContent(for: binding)
-                        .fixedSize()
-                        .padding(Self.hintEdgePadding(for: gesture, horizontal: hPad, vertical: vPad))
-                        .frame(
-                            width: size.width,
-                            height: size.height,
-                            alignment: alignment
-                        )
+                    if binding.action == .switchToNextLanguage {
+                        if hasMultipleLanguages {
+                            Text(languageLabel)
+                                .font(.system(size: scaledHintFontSize * 0.75, weight: .semibold, design: .rounded))
+                                .foregroundStyle(Color.primary.opacity(0.5))
+                                .fixedSize()
+                                .padding(Self.hintEdgePadding(for: gesture, horizontal: hPad, vertical: vPad))
+                                .frame(
+                                    width: size.width,
+                                    height: size.height,
+                                    alignment: alignment
+                                )
+                        }
+                    } else if !binding.label.isEmpty {
+                        hintContent(for: binding)
+                            .fixedSize()
+                            .padding(Self.hintEdgePadding(for: gesture, horizontal: hPad, vertical: vPad))
+                            .frame(
+                                width: size.width,
+                                height: size.height,
+                                alignment: alignment
+                            )
+                    }
                 }
             }
         }

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -24,6 +24,7 @@ enum SettingsKey: String {
     case keyboardHorizontalPosition
     case numpadStyle
     case selectedLanguageId
+    case enabledLanguageIds
     case autoCapitalizeEnabled
     case expertModeEnabled
     case keyboardStyle

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -25,6 +25,7 @@ enum SettingsKey: String {
     case numpadStyle
     case selectedLanguageId
     case enabledLanguageIds
+    case pinnedLanguageId
     case autoCapitalizeEnabled
     case expertModeEnabled
     case keyboardStyle

--- a/wurstfingerKeyboard/Settings/LanguageSettings.swift
+++ b/wurstfingerKeyboard/Settings/LanguageSettings.swift
@@ -22,6 +22,17 @@ class LanguageSettings: ObservableObject {
     @Published private(set) var enabledLanguageIds: [String] {
         didSet {
             saveEnabledLanguages()
+            if let pinned = pinnedLanguageId, !enabledLanguageIds.contains(pinned) {
+                pinnedLanguageId = nil
+            }
+        }
+    }
+
+    /// Optional pinned default language. When set, the keyboard always opens
+    /// with this language. When nil, it opens with the last-used language.
+    @Published var pinnedLanguageId: String? {
+        didSet {
+            userDefaults.set(pinnedLanguageId, forKey: SettingsKey.pinnedLanguageId.rawValue)
         }
     }
 
@@ -51,12 +62,23 @@ class LanguageSettings: ObservableObject {
             resolvedEnabled = [resolvedLanguageId]
         }
 
+        // Load pinned language (before enabledLanguageIds didSet can fire)
+        let storedPinned = defaults.string(forKey: SettingsKey.pinnedLanguageId.rawValue)
+
         selectedLanguageId = resolvedLanguageId
         enabledLanguageIds = resolvedEnabled
+        pinnedLanguageId = storedPinned
 
         // Ensure selected language is in the enabled list
         if !resolvedEnabled.contains(resolvedLanguageId) {
             enabledLanguageIds.insert(resolvedLanguageId, at: 0)
+        }
+
+        // Clear stale pinned ID
+        if let pinned = pinnedLanguageId {
+            if !enabledLanguageIds.contains(pinned) || LanguageConfig.language(withId: pinned) == nil {
+                pinnedLanguageId = nil
+            }
         }
 
         // Persist normalized values
@@ -109,6 +131,32 @@ class LanguageSettings: ObservableObject {
     var currentLanguageLabel: String {
         let lang = selectedLanguage.locale.language.languageCode?.identifier ?? selectedLanguageId
         return lang.uppercased(with: selectedLanguage.locale)
+    }
+
+    var pinnedLanguage: LanguageConfig? {
+        pinnedLanguageId.flatMap { LanguageConfig.language(withId: $0) }
+    }
+
+    /// Returns the language the keyboard should open with: pinned if set and
+    /// valid, otherwise the last-used selected language.
+    var startupLanguageId: String {
+        if let pinned = pinnedLanguageId, enabledLanguageIds.contains(pinned),
+           LanguageConfig.language(withId: pinned) != nil {
+            return pinned
+        }
+        return selectedLanguageId
+    }
+
+    /// Pin a language as the default startup language. If already pinned, unpin it.
+    func pinLanguage(_ language: LanguageConfig) {
+        if pinnedLanguageId == language.id {
+            pinnedLanguageId = nil
+        } else {
+            if !enabledLanguageIds.contains(language.id) {
+                enabledLanguageIds.append(language.id)
+            }
+            pinnedLanguageId = language.id
+        }
     }
 
     func selectLanguage(_ language: LanguageConfig) {

--- a/wurstfingerKeyboard/Settings/LanguageSettings.swift
+++ b/wurstfingerKeyboard/Settings/LanguageSettings.swift
@@ -5,6 +5,7 @@
 //  Created by Claas Flint on 06.11.25.
 //
 
+import Combine
 import Foundation
 
 /// Manages keyboard language settings shared between host app and keyboard extension.
@@ -107,14 +108,14 @@ class LanguageSettings: ObservableObject {
     /// Short uppercase label for the current language, e.g. "EN", "RU", "DE"
     var currentLanguageLabel: String {
         let lang = selectedLanguage.locale.language.languageCode?.identifier ?? selectedLanguageId
-        return lang.uppercased()
+        return lang.uppercased(with: selectedLanguage.locale)
     }
 
     func selectLanguage(_ language: LanguageConfig) {
-        selectedLanguageId = language.id
         if !enabledLanguageIds.contains(language.id) {
             enabledLanguageIds.append(language.id)
         }
+        selectedLanguageId = language.id
     }
 
     /// Toggle a language on/off in the enabled list. Returns false if trying to
@@ -123,11 +124,11 @@ class LanguageSettings: ObservableObject {
     func toggleLanguage(_ language: LanguageConfig) -> Bool {
         if let index = enabledLanguageIds.firstIndex(of: language.id) {
             guard enabledLanguageIds.count > 1 else { return false }
-            enabledLanguageIds.remove(at: index)
-            // If the removed language was selected, switch to the first enabled
             if selectedLanguageId == language.id {
-                selectedLanguageId = enabledLanguageIds[0]
+                let fallbackId = enabledLanguageIds[index == 0 ? 1 : 0]
+                selectedLanguageId = fallbackId
             }
+            enabledLanguageIds.remove(at: index)
         } else {
             enabledLanguageIds.append(language.id)
         }

--- a/wurstfingerKeyboard/Settings/LanguageSettings.swift
+++ b/wurstfingerKeyboard/Settings/LanguageSettings.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-/// Manages keyboard language settings shared between host app and keyboard extension
+/// Manages keyboard language settings shared between host app and keyboard extension.
+/// Supports multiple enabled languages with in-keyboard cycling.
 class LanguageSettings: ObservableObject {
     static let shared = LanguageSettings()
 
@@ -17,42 +18,69 @@ class LanguageSettings: ObservableObject {
         }
     }
 
-    private let userDefaults: UserDefaults
-    private let languageKey = SettingsKey.selectedLanguageId.rawValue
-
-    private init() {
-        userDefaults = SharedDefaults.store
-
-        // Load saved language or detect from system, then normalize
-        let storedLanguageId = userDefaults.string(forKey: languageKey) ?? Self.detectSystemLanguage()
-        let resolvedLanguageId = LanguageConfig.language(withId: storedLanguageId)?.id ?? LanguageConfig.english.id
-        selectedLanguageId = resolvedLanguageId
-
-        // Persist the resolved ID so other readers (e.g. KeyboardViewModel.reloadLanguage)
-        // see the same normalized value
-        if resolvedLanguageId != storedLanguageId {
-            userDefaults.set(resolvedLanguageId, forKey: languageKey)
+    @Published var enabledLanguageIds: [String] {
+        didSet {
+            saveEnabledLanguages()
         }
     }
+
+    private let userDefaults: UserDefaults
+    private let languageKey = SettingsKey.selectedLanguageId.rawValue
+    private let enabledKey = SettingsKey.enabledLanguageIds.rawValue
+
+    init(userDefaults: UserDefaults? = nil) {
+        let defaults = userDefaults ?? SharedDefaults.store
+        self.userDefaults = defaults
+
+        // Load saved language or detect from system, then normalize
+        let storedLanguageId = defaults.string(forKey: SettingsKey.selectedLanguageId.rawValue)
+            ?? Self.detectSystemLanguage()
+        let resolvedLanguageId = LanguageConfig.language(withId: storedLanguageId)?.id
+            ?? LanguageConfig.english.id
+
+        // Load enabled languages, migrating from single-language if needed
+        let storedEnabled = Self.loadEnabledLanguageIds(from: defaults)
+        let resolvedEnabled: [String]
+        if let stored = storedEnabled, !stored.isEmpty {
+            // Filter out any stale/unknown IDs
+            let valid = stored.filter { LanguageConfig.language(withId: $0) != nil }
+            resolvedEnabled = valid.isEmpty ? [resolvedLanguageId] : valid
+        } else {
+            // Migration: no enabled list stored yet, seed with current selection
+            resolvedEnabled = [resolvedLanguageId]
+        }
+
+        selectedLanguageId = resolvedLanguageId
+        enabledLanguageIds = resolvedEnabled
+
+        // Ensure selected language is in the enabled list
+        if !resolvedEnabled.contains(resolvedLanguageId) {
+            enabledLanguageIds.insert(resolvedLanguageId, at: 0)
+        }
+
+        // Persist normalized values
+        if resolvedLanguageId != storedLanguageId {
+            defaults.set(resolvedLanguageId, forKey: SettingsKey.selectedLanguageId.rawValue)
+        }
+        Self.saveEnabledLanguageIds(enabledLanguageIds, to: defaults)
+    }
+
+    // MARK: - Public API
 
     /// Detects the system language and returns matching language ID, or English as fallback
     static func detectSystemLanguage(preferredLanguages: [String]? = nil) -> String {
         let preferredLanguages = preferredLanguages ?? Locale.preferredLanguages
 
-        // Try to find a matching language config for the user's preferred languages
         for languageCode in preferredLanguages {
-            // Extract language and region (e.g., "de-DE", "en-US", "fr")
             let locale = Locale(identifier: languageCode)
             let language = locale.language.languageCode?.identifier ?? ""
             let region = locale.region?.identifier ?? ""
 
-            // Try exact match first (e.g., "de_DE")
             let exactId = "\(language)_\(region)"
             if let match = LanguageConfig.allLanguages.first(where: { $0.id == exactId }) {
                 return match.id
             }
 
-            // Try language-only match (e.g., any German variant for "de")
             if let match = LanguageConfig.allLanguages.first(where: {
                 $0.locale.language.languageCode?.identifier == language
             }) {
@@ -60,7 +88,6 @@ class LanguageSettings: ObservableObject {
             }
         }
 
-        // Fallback to English
         return LanguageConfig.english.id
     }
 
@@ -68,11 +95,87 @@ class LanguageSettings: ObservableObject {
         LanguageConfig.language(withId: selectedLanguageId) ?? .english
     }
 
+    /// Resolved LanguageConfig objects for enabled IDs, preserving order
+    var enabledLanguages: [LanguageConfig] {
+        enabledLanguageIds.compactMap { LanguageConfig.language(withId: $0) }
+    }
+
+    var hasMultipleLanguages: Bool {
+        enabledLanguageIds.count > 1
+    }
+
+    /// Short uppercase label for the current language, e.g. "EN", "RU", "DE"
+    var currentLanguageLabel: String {
+        let lang = selectedLanguage.locale.language.languageCode?.identifier ?? selectedLanguageId
+        return lang.uppercased()
+    }
+
     func selectLanguage(_ language: LanguageConfig) {
         selectedLanguageId = language.id
+        if !enabledLanguageIds.contains(language.id) {
+            enabledLanguageIds.append(language.id)
+        }
     }
+
+    /// Toggle a language on/off in the enabled list. Returns false if trying to
+    /// disable the last remaining language (operation is rejected).
+    @discardableResult
+    func toggleLanguage(_ language: LanguageConfig) -> Bool {
+        if let index = enabledLanguageIds.firstIndex(of: language.id) {
+            guard enabledLanguageIds.count > 1 else { return false }
+            enabledLanguageIds.remove(at: index)
+            // If the removed language was selected, switch to the first enabled
+            if selectedLanguageId == language.id {
+                selectedLanguageId = enabledLanguageIds[0]
+            }
+        } else {
+            enabledLanguageIds.append(language.id)
+        }
+        return true
+    }
+
+    func isLanguageEnabled(_ language: LanguageConfig) -> Bool {
+        enabledLanguageIds.contains(language.id)
+    }
+
+    /// Returns the next language ID after the current one, wrapping around.
+    /// If only one language is enabled, returns that same language.
+    func nextLanguageId(after currentId: String) -> String {
+        guard enabledLanguageIds.count > 1 else {
+            return enabledLanguageIds.first ?? currentId
+        }
+        guard let currentIndex = enabledLanguageIds.firstIndex(of: currentId) else {
+            return enabledLanguageIds[0]
+        }
+        let nextIndex = (currentIndex + 1) % enabledLanguageIds.count
+        return enabledLanguageIds[nextIndex]
+    }
+
+    // MARK: - Persistence
 
     private func save() {
         userDefaults.set(selectedLanguageId, forKey: languageKey)
+    }
+
+    private func saveEnabledLanguages() {
+        Self.saveEnabledLanguageIds(enabledLanguageIds, to: userDefaults)
+    }
+
+    /// Encodes the enabled language IDs as a JSON array string for UserDefaults storage.
+    /// Using JSON rather than NSArray ensures clean cross-process serialization.
+    static func saveEnabledLanguageIds(_ ids: [String], to defaults: UserDefaults) {
+        guard let data = try? JSONEncoder().encode(ids),
+              let json = String(data: data, encoding: .utf8) else { return }
+        defaults.set(json, forKey: SettingsKey.enabledLanguageIds.rawValue)
+    }
+
+    static func loadEnabledLanguageIds(from defaults: UserDefaults) -> [String]? {
+        guard let json = defaults.string(forKey: SettingsKey.enabledLanguageIds.rawValue),
+              let data = json.data(using: .utf8),
+              let ids = try? JSONDecoder().decode([String].self, from: data)
+        else {
+            return nil
+        }
+        return ids
     }
 }

--- a/wurstfingerKeyboard/Settings/LanguageSettings.swift
+++ b/wurstfingerKeyboard/Settings/LanguageSettings.swift
@@ -18,7 +18,7 @@ class LanguageSettings: ObservableObject {
         }
     }
 
-    @Published var enabledLanguageIds: [String] {
+    @Published private(set) var enabledLanguageIds: [String] {
         didSet {
             saveEnabledLanguages()
         }
@@ -141,14 +141,18 @@ class LanguageSettings: ObservableObject {
     /// Returns the next language ID after the current one, wrapping around.
     /// If only one language is enabled, returns that same language.
     func nextLanguageId(after currentId: String) -> String {
-        guard enabledLanguageIds.count > 1 else {
-            return enabledLanguageIds.first ?? currentId
+        Self.nextLanguageId(after: currentId, in: enabledLanguageIds)
+    }
+
+    static func nextLanguageId(after currentId: String, in enabledIds: [String]) -> String {
+        guard enabledIds.count > 1 else {
+            return enabledIds.first ?? currentId
         }
-        guard let currentIndex = enabledLanguageIds.firstIndex(of: currentId) else {
-            return enabledLanguageIds[0]
+        guard let currentIndex = enabledIds.firstIndex(of: currentId) else {
+            return enabledIds[0]
         }
-        let nextIndex = (currentIndex + 1) % enabledLanguageIds.count
-        return enabledLanguageIds[nextIndex]
+        let nextIndex = (currentIndex + 1) % enabledIds.count
+        return enabledIds[nextIndex]
     }
 
     // MARK: - Persistence
@@ -161,21 +165,11 @@ class LanguageSettings: ObservableObject {
         Self.saveEnabledLanguageIds(enabledLanguageIds, to: userDefaults)
     }
 
-    /// Encodes the enabled language IDs as a JSON array string for UserDefaults storage.
-    /// Using JSON rather than NSArray ensures clean cross-process serialization.
     static func saveEnabledLanguageIds(_ ids: [String], to defaults: UserDefaults) {
-        guard let data = try? JSONEncoder().encode(ids),
-              let json = String(data: data, encoding: .utf8) else { return }
-        defaults.set(json, forKey: SettingsKey.enabledLanguageIds.rawValue)
+        defaults.set(ids, forKey: SettingsKey.enabledLanguageIds.rawValue)
     }
 
     static func loadEnabledLanguageIds(from defaults: UserDefaults) -> [String]? {
-        guard let json = defaults.string(forKey: SettingsKey.enabledLanguageIds.rawValue),
-              let data = json.data(using: .utf8),
-              let ids = try? JSONDecoder().decode([String].self, from: data)
-        else {
-            return nil
-        }
-        return ids
+        defaults.stringArray(forKey: SettingsKey.enabledLanguageIds.rawValue)
     }
 }

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -264,6 +264,232 @@ struct PrimaryLanguageResolutionTests {
     }
 }
 
+// MARK: - Multi-Language Settings Tests
+
+struct MultiLanguageSettingsTests {
+    private func createTestDefaults() -> (UserDefaults, String) {
+        let suiteName = "test.multiLang.\(UUID().uuidString)"
+        return (UserDefaults(suiteName: suiteName)!, suiteName)
+    }
+
+    private func createSettings(defaults: UserDefaults, selectedId: String = "en_US", enabledIds: [String]? = nil) -> LanguageSettings {
+        defaults.set(selectedId, forKey: SettingsKey.selectedLanguageId.rawValue)
+        if let enabledIds {
+            LanguageSettings.saveEnabledLanguageIds(enabledIds, to: defaults)
+        }
+        return LanguageSettings(userDefaults: defaults)
+    }
+
+    @Test("Migration: no enabled list seeds from selected language")
+    func migrationSeedsFromSelected() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "de_DE")
+        #expect(settings.enabledLanguageIds == ["de_DE"])
+        #expect(settings.selectedLanguageId == "de_DE")
+    }
+
+    @Test("Loads existing enabled list from UserDefaults")
+    func loadsEnabledList() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU", "de_DE"])
+        #expect(settings.enabledLanguageIds == ["en_US", "ru_RU", "de_DE"])
+    }
+
+    @Test("Toggle enables a language")
+    func toggleEnablesLanguage() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
+        settings.toggleLanguage(.russian)
+        #expect(settings.enabledLanguageIds.contains("ru_RU"))
+        #expect(settings.enabledLanguageIds.count == 2)
+    }
+
+    @Test("Toggle disables an enabled language")
+    func toggleDisablesLanguage() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU", "de_DE"])
+        let result = settings.toggleLanguage(.russian)
+        #expect(result == true)
+        #expect(!settings.enabledLanguageIds.contains("ru_RU"))
+        #expect(settings.enabledLanguageIds.count == 2)
+    }
+
+    @Test("Cannot disable last remaining language")
+    func cannotDisableLastLanguage() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
+        let result = settings.toggleLanguage(.english)
+        #expect(result == false)
+        #expect(settings.enabledLanguageIds == ["en_US"])
+    }
+
+    @Test("Disabling selected language switches to first enabled")
+    func disablingSelectedSwitchesToFirst() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "ru_RU", enabledIds: ["en_US", "ru_RU", "de_DE"])
+        settings.toggleLanguage(.russian)
+        #expect(settings.selectedLanguageId == "en_US")
+    }
+
+    @Test("Selecting a language adds it to enabled if not present")
+    func selectAddsToEnabled() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
+        settings.selectLanguage(.russian)
+        #expect(settings.selectedLanguageId == "ru_RU")
+        #expect(settings.enabledLanguageIds.contains("ru_RU"))
+    }
+
+    @Test("Next language cycles through enabled list with 2 languages")
+    func nextLanguageCyclesTwoLanguages() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
+        #expect(settings.nextLanguageId(after: "en_US") == "ru_RU")
+        #expect(settings.nextLanguageId(after: "ru_RU") == "en_US")
+    }
+
+    @Test("Next language cycles through enabled list with 3 languages")
+    func nextLanguageCyclesThreeLanguages() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU", "de_DE"])
+        #expect(settings.nextLanguageId(after: "en_US") == "ru_RU")
+        #expect(settings.nextLanguageId(after: "ru_RU") == "de_DE")
+        #expect(settings.nextLanguageId(after: "de_DE") == "en_US")
+    }
+
+    @Test("Next language cycles through many enabled languages")
+    func nextLanguageCyclesManyLanguages() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let ids = ["en_US", "ru_RU", "de_DE", "fr_FR", "es_ES"]
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ids)
+        for i in 0 ..< ids.count {
+            let next = settings.nextLanguageId(after: ids[i])
+            let expectedIndex = (i + 1) % ids.count
+            #expect(next == ids[expectedIndex], "After \(ids[i]) expected \(ids[expectedIndex]), got \(next)")
+        }
+    }
+
+    @Test("Next language returns same when only one enabled")
+    func nextLanguageSingleLanguage() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
+        #expect(settings.nextLanguageId(after: "en_US") == "en_US")
+    }
+
+    @Test("Next language falls back to first when current not in list")
+    func nextLanguageFallsBackWhenNotInList() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
+        #expect(settings.nextLanguageId(after: "de_DE") == "en_US")
+    }
+
+    @Test("hasMultipleLanguages reflects enabled count")
+    func hasMultipleLanguagesFlag() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let single = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
+        #expect(single.hasMultipleLanguages == false)
+
+        let multi = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
+        #expect(multi.hasMultipleLanguages == true)
+    }
+
+    @Test("currentLanguageLabel returns uppercase language code")
+    func languageLabelUppercase() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let enSettings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
+        #expect(enSettings.currentLanguageLabel == "EN")
+
+        let ruSettings = createSettings(defaults: defaults, selectedId: "ru_RU", enabledIds: ["ru_RU"])
+        #expect(ruSettings.currentLanguageLabel == "RU")
+
+        let deSettings = createSettings(defaults: defaults, selectedId: "de_DE", enabledIds: ["de_DE"])
+        #expect(deSettings.currentLanguageLabel == "DE")
+    }
+
+    @Test("enabledLanguages returns resolved LanguageConfig objects")
+    func enabledLanguagesResolved() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU", "de_DE"])
+        let configs = settings.enabledLanguages
+        #expect(configs.count == 3)
+        #expect(configs[0].id == "en_US")
+        #expect(configs[1].id == "ru_RU")
+        #expect(configs[2].id == "de_DE")
+    }
+
+    @Test("Stale IDs in enabled list are filtered out on load")
+    func staleIdsFiltered() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "zz_ZZ", "ru_RU"])
+        #expect(settings.enabledLanguageIds == ["en_US", "ru_RU"])
+    }
+
+    @Test("Selected language always in enabled list after init")
+    func selectedAlwaysInEnabled() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        // Selected is ru_RU but enabled list only has en_US
+        let settings = createSettings(defaults: defaults, selectedId: "ru_RU", enabledIds: ["en_US"])
+        #expect(settings.enabledLanguageIds.contains("ru_RU"))
+        #expect(settings.enabledLanguageIds.contains("en_US"))
+    }
+
+    @Test("Enabled list persistence round-trips through JSON")
+    func enabledListPersistence() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let ids = ["en_US", "ru_RU", "de_DE", "fr_FR"]
+        LanguageSettings.saveEnabledLanguageIds(ids, to: defaults)
+        let loaded = LanguageSettings.loadEnabledLanguageIds(from: defaults)
+        #expect(loaded == ids)
+    }
+
+    @Test("isLanguageEnabled reflects enabled state")
+    func isLanguageEnabledCheck() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
+        #expect(settings.isLanguageEnabled(.english) == true)
+        #expect(settings.isLanguageEnabled(.russian) == true)
+        #expect(settings.isLanguageEnabled(.german) == false)
+    }
+}
+
 // MARK: - Info.plist PrimaryLanguage Tests
 
 struct InfoPlistLanguageTests {

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -636,6 +636,24 @@ struct PinnedLanguageTests {
         let stored = defaults.string(forKey: SettingsKey.pinnedLanguageId.rawValue)
         #expect(stored == nil)
     }
+
+    @Test("KeyboardViewModel boots with pinned language, not selected")
+    func viewModelBootsWithPinnedLanguage() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set("en_US", forKey: SettingsKey.selectedLanguageId.rawValue)
+        LanguageSettings.saveEnabledLanguageIds(["en_US", "ru_RU"], to: defaults)
+        defaults.set("ru_RU", forKey: SettingsKey.pinnedLanguageId.rawValue)
+
+        let viewModel = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
+        viewModel.bindActionHandler { _ in }
+
+        #expect(
+            viewModel.currentLocale().identifier == "ru_RU",
+            "ViewModel should boot with pinned language ru_RU, not selected en_US"
+        )
+    }
 }
 
 // MARK: - Info.plist PrimaryLanguage Tests

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -647,10 +647,15 @@ struct PinnedLanguageTests {
         defaults.set("ru_RU", forKey: SettingsKey.pinnedLanguageId.rawValue)
 
         let viewModel = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
-        viewModel.bindActionHandler { _ in }
+        let target = MockTextTarget()
+        viewModel.bindTextInputTarget(target)
+        viewModel.bindViewControllerActions(advanceToNextInputMode: {}, dismissKeyboard: {})
+
+        let startupId = LanguageSettings(userDefaults: defaults).startupLanguageId
+        viewModel.loadDefinition(for: startupId)
 
         #expect(
-            viewModel.currentLocale().identifier == "ru_RU",
+            viewModel.pipelineLocale?.identifier == "ru_RU",
             "ViewModel should boot with pinned language ru_RU, not selected en_US"
         )
     }

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -490,6 +490,154 @@ struct MultiLanguageSettingsTests {
     }
 }
 
+// MARK: - Pinned Default Language Tests
+
+struct PinnedLanguageTests {
+    private func createTestDefaults() -> (UserDefaults, String) {
+        let suiteName = "test.pinned.\(UUID().uuidString)"
+        return (UserDefaults(suiteName: suiteName)!, suiteName)
+    }
+
+    private func createSettings(
+        defaults: UserDefaults,
+        selectedId: String = "en_US",
+        enabledIds: [String],
+        pinnedId: String? = nil
+    ) -> LanguageSettings {
+        defaults.set(selectedId, forKey: SettingsKey.selectedLanguageId.rawValue)
+        LanguageSettings.saveEnabledLanguageIds(enabledIds, to: defaults)
+        defaults.set(pinnedId, forKey: SettingsKey.pinnedLanguageId.rawValue)
+        return LanguageSettings(userDefaults: defaults)
+    }
+
+    @Test("Pin a language sets pinnedLanguageId")
+    func pinSetsId() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"])
+        settings.pinLanguage(.russian)
+        #expect(settings.pinnedLanguageId == "ru_RU")
+    }
+
+    @Test("Unpin by tapping the same language")
+    func unpinSameLanguage() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
+        settings.pinLanguage(.russian)
+        #expect(settings.pinnedLanguageId == nil)
+    }
+
+    @Test("Pin a different language replaces the previous pin")
+    func pinDifferentLanguage() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "en_US")
+        settings.pinLanguage(.russian)
+        #expect(settings.pinnedLanguageId == "ru_RU")
+    }
+
+    @Test("Pinning a disabled language enables it first")
+    func pinDisabledLanguageEnablesIt() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US"])
+        settings.pinLanguage(.russian)
+        #expect(settings.pinnedLanguageId == "ru_RU")
+        #expect(settings.enabledLanguageIds.contains("ru_RU"))
+    }
+
+    @Test("Disabling the pinned language clears the pin")
+    func disablingPinnedLanguageClearsPin() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
+        settings.toggleLanguage(.russian)
+        #expect(settings.pinnedLanguageId == nil)
+    }
+
+    @Test("startupLanguageId returns pinned when set")
+    func startupReturnsPinned() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
+        #expect(settings.startupLanguageId == "ru_RU")
+    }
+
+    @Test("startupLanguageId returns selectedLanguageId when no pin")
+    func startupReturnsSelectedWhenNoPin() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
+        #expect(settings.startupLanguageId == "en_US")
+    }
+
+    @Test("Stale pinned ID is cleared on load")
+    func stalePinnedIdCleared() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "zz_ZZ")
+        #expect(settings.pinnedLanguageId == nil)
+    }
+
+    @Test("Pinned ID not in enabled list is cleared on load")
+    func pinnedNotInEnabledCleared() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US"], pinnedId: "ru_RU")
+        #expect(settings.pinnedLanguageId == nil)
+    }
+
+    @Test("pinnedLanguage returns resolved LanguageConfig")
+    func pinnedLanguageResolved() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
+        #expect(settings.pinnedLanguage?.id == "ru_RU")
+    }
+
+    @Test("pinnedLanguage is nil when no pin")
+    func pinnedLanguageNilWhenNoPin() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"])
+        #expect(settings.pinnedLanguage == nil)
+    }
+
+    @Test("Pin persists to UserDefaults")
+    func pinPersists() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"])
+        settings.pinLanguage(.russian)
+        let stored = defaults.string(forKey: SettingsKey.pinnedLanguageId.rawValue)
+        #expect(stored == "ru_RU")
+    }
+
+    @Test("Unpin persists nil to UserDefaults")
+    func unpinPersistsNil() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
+        settings.pinLanguage(.russian)
+        let stored = defaults.string(forKey: SettingsKey.pinnedLanguageId.rawValue)
+        #expect(stored == nil)
+    }
+}
+
 // MARK: - Info.plist PrimaryLanguage Tests
 
 struct InfoPlistLanguageTests {


### PR DESCRIPTION
Closes #91

## Summary

Enable users to select multiple keyboard languages in settings and cycle through them by swiping right on the globe key, without leaving the keyboard.

- Add `enabledLanguageIds` to shared UserDefaults for multi-language persistence
- Rewrite `LanguageSettings` with enabled list, toggle, cycling, and migration from single-language
- Rewrite `LanguageSelectionView` as multi-select UI with active/enabled distinction
- Add `switchToNextLanguage()` to `KeyboardViewModel`, triggered by globe swipe-right
- Show current language abbreviation (e.g. "EN", "RU") on the globe key when multiple languages are enabled
- Fully data-driven: adding a new `LanguageConfig` requires zero changes elsewhere
- Seamless migration for existing single-language users

## Test plan

- [x] 19 new unit tests covering: enable/disable, cycling (2, 3, N languages), cannot-disable-last, migration, stale ID filtering, persistence round-trip, label generation, edge cases
- [x] All existing tests pass (full suite on iPhone 16 Plus simulator)
- [x] swiftformat --lint passes
- [x] swiftlint --strict passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-language support: enable/disable multiple keyboard languages, persist enabled list and default (pinned) language, and cycle to the next enabled language via globe swipe (right).

* **UI/UX Improvements**
  * Languages list redesigned into per-language rows with toggle and tap actions, shows “Default” status, no longer auto-dismisses on selection, and prevents disabling the last language with an alert.
  * Settings subtitle now summarizes enabled languages and indicates the default; globe key overlay can show the current language label.

* **Tests**
  * Added comprehensive tests for multi-language behavior, pinning, persistence, toggling, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->