### PR TITLE
Fix Supported Language List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ Initial public release of Wurstfinger — a MessagEase-inspired keyboard for iOS
 ### Features
 
 - Gesture-based typing: tap center for primary letters, swipe in 8 directions for additional characters
-- 14 keyboard languages: German, English, Spanish, French, Italian, Portuguese, Dutch, Polish, Swedish, Norwegian, Danish, Finnish, Turkish, Vietnamese
+- 14 keyboard languages: Catalan, Croatian, English, Estonian-Finnish, Finnish, French, German, Hebrew, Italian, Polish, Russian, Spanish, Swedish, Tagalog
 - Compose rules: create accented characters by combining keys (e.g., ' + a → á)
 - Circular gestures: draw a circle on a letter for uppercase
 - Cursor control: drag on space bar to move cursor, long-press for text selection

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Want to try the latest features before they hit the App Store? Join our public T
 
 ## Features
 
-- **Multi-language support**: 14 languages including English, German, Spanish, French, Portuguese, Italian, Dutch, Swedish, Norwegian, Danish, Finnish, Polish, Czech, and Vietnamese
+- **Multi-language support**: 14 languages including Catalan, Croatian, English, Estonian-Finnish, Finnish, French, German, Hebrew, Italian, Polish, Russian, Spanish, Swedish, and Tagalog
 - **MessagEase layout** with symbol and numeric layers
 - **Compose engine** that reproduces Thumb-Key's combination triggers (e.g. `' + a → á`)
 - **Return swipes** for punctuation and math symbols (`?`→`¿`, `*`→`†`, `/`→`÷`, ...)

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -8,7 +8,7 @@ FEATURES:
 
 • Large 3x3 Key Grid - Optimized for thumbs, not precision pointers
 • Swipe Gestures - Access 8 additional characters per key by swiping
-• 14 Languages - German, English, Spanish, French, Portuguese, Italian, Dutch, Swedish, Norwegian, Danish, Finnish, Polish, Czech, and Vietnamese
+• 14 Languages - Catalan, Croatian, English, Estonian-Finnish, Finnish, French, German, Hebrew, Italian, Polish, Russian, Spanish, Swedish, and Tagalog
 • Compose Rules - Create accents through combinations (e.g. ' + a = á)
 • Circular Gestures - Draw a circle for uppercase letters
 • Cursor Control - Drag on space bar to move cursor, long-press for text selection


### PR DESCRIPTION
## Summary

- Fix incorrect language lists in README, CHANGELOG (v1.0.0), and App Store metadata
- Listed languages (Portuguese, Dutch, Norwegian, Danish, Czech, Turkish, Vietnamese) were never implemented
- Replace with the actual 14 languages: Catalan, Croatian, English, Estonian-Finnish, Finnish, French, German, Hebrew, Italian, Polish, Russian, Spanish, Swedish, Tagalog

Ref: discovered during review of #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated language support documentation across CHANGELOG, README, and app store metadata to maintain accuracy and currency. The supported languages list has been refreshed to include newly added languages such as Catalan, Croatian, Estonian-Finnish, Hebrew, Russian, and Tagalog, ensuring accurate reflection of the app's comprehensive multi-language capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->