### PR TITLE
Use Visual Diff for Screenshot Change Detection

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -74,9 +74,16 @@ jobs:
           THRESHOLD = 1.0
 
           changed = False
-          new_files = [f for f in os.listdir(NEW_DIR) if f.endswith(".webp")]
+          old_files = {f for f in os.listdir(OLD_DIR) if f.endswith(".webp")} if os.path.isdir(OLD_DIR) else set()
+          new_files = {f for f in os.listdir(NEW_DIR) if f.endswith(".webp")}
 
-          for filename in new_files:
+          # Detect removed/renamed screenshots
+          removed = old_files - new_files
+          for filename in sorted(removed):
+              print(f"  🗑️  Removed screenshot: {filename}")
+              changed = True
+
+          for filename in sorted(new_files):
               old_path = os.path.join(OLD_DIR, filename)
               new_path = os.path.join(NEW_DIR, filename)
 
@@ -85,15 +92,20 @@ jobs:
                   changed = True
                   continue
 
-              old_img = np.array(Image.open(old_path).convert("RGB"))
-              new_img = np.array(Image.open(new_path).convert("RGB"))
+              old_img = Image.open(old_path).convert("RGB")
+              new_img = Image.open(new_path).convert("RGB")
 
-              if old_img.shape != new_img.shape:
-                  print(f"  📐 Size changed: {filename} ({old_img.shape} → {new_img.shape})")
-                  changed = True
-                  continue
+              # Normalize to common dimensions to handle crop jitter
+              if old_img.size != new_img.size:
+                  w = min(old_img.width, new_img.width)
+                  h = min(old_img.height, new_img.height)
+                  old_img = old_img.resize((w, h), Image.LANCZOS)
+                  new_img = new_img.resize((w, h), Image.LANCZOS)
 
-              diff = np.mean(np.abs(old_img.astype(float) - new_img.astype(float)))
+              old_arr = np.array(old_img)
+              new_arr = np.array(new_img)
+
+              diff = np.mean(np.abs(old_arr.astype(float) - new_arr.astype(float)))
               if diff > THRESHOLD:
                   print(f"  🔄 Visual change: {filename} (diff={diff:.2f})")
                   changed = True
@@ -121,7 +133,7 @@ jobs:
           BRANCH_NAME="automated/update-screenshots-$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH_NAME"
 
-          git add docs/images/*.webp
+          git add -A docs/images/
           git commit -m "Update screenshots"
           git push -u origin "$BRANCH_NAME"
 

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -70,8 +70,10 @@ jobs:
 
           OLD_DIR = "/tmp/old-screenshots"
           NEW_DIR = "docs/images"
-          # Maximum average pixel difference (0-255) to consider identical
-          THRESHOLD = 1.0
+          # Per-pixel noise threshold: channel differences below this are compression noise
+          PIXEL_THRESHOLD = 10
+          # Fraction of pixels that must exceed PIXEL_THRESHOLD to count as a real change
+          CHANGE_RATIO = 0.001  # 0.1% of pixels
 
           changed = False
           old_files = {f for f in os.listdir(OLD_DIR) if f.endswith(".webp")} if os.path.isdir(OLD_DIR) else set()
@@ -105,12 +107,16 @@ jobs:
               old_arr = np.array(old_img)
               new_arr = np.array(new_img)
 
-              diff = np.mean(np.abs(old_arr.astype(float) - new_arr.astype(float)))
-              if diff > THRESHOLD:
-                  print(f"  🔄 Visual change: {filename} (diff={diff:.2f})")
+              # Count pixels where any channel differs beyond noise threshold
+              pixel_diff = np.max(np.abs(old_arr.astype(float) - new_arr.astype(float)), axis=2)
+              changed_pixels = np.sum(pixel_diff > PIXEL_THRESHOLD)
+              total_pixels = pixel_diff.size
+              ratio = changed_pixels / total_pixels
+              if ratio > CHANGE_RATIO:
+                  print(f"  🔄 Visual change: {filename} ({changed_pixels}/{total_pixels} pixels changed, {ratio:.4%})")
                   changed = True
               else:
-                  print(f"  ✅ Unchanged: {filename} (diff={diff:.2f})")
+                  print(f"  ✅ Unchanged: {filename} ({changed_pixels}/{total_pixels} pixels changed, {ratio:.4%})")
                   # Restore old file so git sees no diff
                   os.replace(old_path, new_path)
 

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -47,31 +47,69 @@ jobs:
           xcrun simctl bootstatus "$DEVICE_UDID" -b
           echo "Simulator ready"
 
+      - name: Save existing screenshots for comparison
+        run: |
+          mkdir -p /tmp/old-screenshots
+          cp docs/images/*.webp /tmp/old-screenshots/ 2>/dev/null || true
+
       - name: Generate screenshots
         run: |
           source venv/bin/activate
           ./scripts/generate-screenshots.sh
         timeout-minutes: 25
 
-      - name: Check for screenshot changes
+      - name: Check for visual screenshot changes
         id: check_changes
         run: |
-          echo "📁 Files in docs/images/:"
-          ls -la docs/images/ || echo "Directory does not exist"
-          echo ""
-          echo "📊 Git status:"
-          git status docs/images/ || true
-          echo ""
-          echo "🔍 Git diff:"
-          git diff --stat docs/images/*.webp || true
-          echo ""
-          if git diff --quiet docs/images/*.webp 2>/dev/null; then
-            echo "Result: No changes detected"
-            echo "changed=false" >> $GITHUB_OUTPUT
-          else
-            echo "Result: Changes detected!"
-            echo "changed=true" >> $GITHUB_OUTPUT
-          fi
+          source venv/bin/activate
+          python3 << 'PYEOF'
+          import os
+          import sys
+          from PIL import Image
+          import numpy as np
+
+          OLD_DIR = "/tmp/old-screenshots"
+          NEW_DIR = "docs/images"
+          # Maximum average pixel difference (0-255) to consider identical
+          THRESHOLD = 1.0
+
+          changed = False
+          new_files = [f for f in os.listdir(NEW_DIR) if f.endswith(".webp")]
+
+          for filename in new_files:
+              old_path = os.path.join(OLD_DIR, filename)
+              new_path = os.path.join(NEW_DIR, filename)
+
+              if not os.path.exists(old_path):
+                  print(f"  ✨ New screenshot: {filename}")
+                  changed = True
+                  continue
+
+              old_img = np.array(Image.open(old_path).convert("RGB"))
+              new_img = np.array(Image.open(new_path).convert("RGB"))
+
+              if old_img.shape != new_img.shape:
+                  print(f"  📐 Size changed: {filename} ({old_img.shape} → {new_img.shape})")
+                  changed = True
+                  continue
+
+              diff = np.mean(np.abs(old_img.astype(float) - new_img.astype(float)))
+              if diff > THRESHOLD:
+                  print(f"  🔄 Visual change: {filename} (diff={diff:.2f})")
+                  changed = True
+              else:
+                  print(f"  ✅ Unchanged: {filename} (diff={diff:.2f})")
+                  # Restore old file so git sees no diff
+                  os.replace(old_path, new_path)
+
+          if changed:
+              print("\nResult: Visual changes detected!")
+          else:
+              print("\nResult: No visual changes")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"changed={'true' if changed else 'false'}\n")
+          PYEOF
 
       - name: Create PR with screenshots
         if: steps.check_changes.outputs.changed == 'true'

--- a/scripts/generate-appstore-screenshots.sh
+++ b/scripts/generate-appstore-screenshots.sh
@@ -97,6 +97,21 @@ echo "  Booting simulator..."
 xcrun simctl boot "$UDID" 2>/dev/null || true
 xcrun simctl bootstatus "$UDID" -b 2>/dev/null || true
 
+# Override status bar to get consistent screenshots (Apple's standard 9:41)
+echo "  Setting consistent status bar..."
+xcrun simctl status_bar "$UDID" override --time "9:41" --batteryState charged --batteryLevel 100
+
+# Ensure cleanup runs on any exit (normal, error, or signal)
+cleanup() {
+    echo ""
+    echo -e "${BLUE}🧹 Cleaning up...${NC}"
+    xcrun simctl status_bar "$UDID" clear 2>/dev/null || true
+    xcrun simctl shutdown "$UDID" 2>/dev/null || true
+    rm -rf "$DERIVED_DATA"
+    rm -rf "$TEMP_SCREENSHOTS"
+}
+trap cleanup EXIT
+
 # Run screenshot tests
 echo "  Running screenshot tests..."
 rm -rf "$DERIVED_DATA"
@@ -111,9 +126,6 @@ xcodebuild test \
     2>&1 | if command -v xcpretty >/dev/null; then xcpretty --color; else cat; fi
 TEST_RESULT=$?
 set -e
-
-# Shutdown simulator
-xcrun simctl shutdown "$UDID" 2>/dev/null || true
 
 if [ $TEST_RESULT -ne 0 ]; then
     echo -e "${YELLOW}⚠️  Tests may have issues, checking for screenshots...${NC}"
@@ -187,12 +199,6 @@ for src in "$FASTLANE_SCREENSHOTS/APP_IPHONE_67"/*.png; do
         COUNTER=$((COUNTER + 1))
     fi
 done
-
-# Cleanup
-echo ""
-echo -e "${BLUE}🧹 Cleaning up...${NC}"
-rm -rf "$DERIVED_DATA"
-rm -rf "$TEMP_SCREENSHOTS"
 
 # Summary
 echo ""

--- a/scripts/generate-appstore-screenshots.sh
+++ b/scripts/generate-appstore-screenshots.sh
@@ -97,10 +97,6 @@ echo "  Booting simulator..."
 xcrun simctl boot "$UDID" 2>/dev/null || true
 xcrun simctl bootstatus "$UDID" -b 2>/dev/null || true
 
-# Override status bar to get consistent screenshots (Apple's standard 9:41)
-echo "  Setting consistent status bar..."
-xcrun simctl status_bar "$UDID" override --time "9:41" --batteryState charged --batteryLevel 100
-
 # Ensure cleanup runs on any exit (normal, error, or signal)
 cleanup() {
     echo ""
@@ -111,6 +107,10 @@ cleanup() {
     rm -rf "$TEMP_SCREENSHOTS"
 }
 trap cleanup EXIT
+
+# Override status bar to get consistent screenshots (Apple's standard 9:41)
+echo "  Setting consistent status bar..."
+xcrun simctl status_bar "$UDID" override --time "9:41" --batteryState charged --batteryLevel 100
 
 # Run screenshot tests
 echo "  Running screenshot tests..."

--- a/scripts/generate-screenshots.sh
+++ b/scripts/generate-screenshots.sh
@@ -49,14 +49,35 @@ echo ""
 
 # Override status bar to get consistent screenshots (Apple's standard 9:41)
 echo -e "${BLUE}⏰ Setting consistent status bar...${NC}"
-BOOTED_UDID=$(xcrun simctl list devices booted -j | python3 -c "import sys,json; devs=json.load(sys.stdin)['devices']; print(next(d['udid'] for ds in devs.values() for d in ds if d['state']=='Booted'))" 2>/dev/null || true)
-if [ -n "$BOOTED_UDID" ]; then
-    xcrun simctl status_bar "$BOOTED_UDID" override --time "9:41" --batteryState charged --batteryLevel 100
-    echo "  Set status bar to 9:41 on $BOOTED_UDID"
+TARGET_UDID=$(xcrun simctl list devices available -j | python3 -c "
+import json, sys
+name = '$DEVICE_NAME'
+devices = json.load(sys.stdin)['devices']
+for runtime_devices in devices.values():
+    for d in runtime_devices:
+        if d.get('name') == name and d.get('isAvailable', True):
+            print(d['udid'])
+            raise SystemExit(0)
+raise SystemExit(1)
+" 2>/dev/null || true)
+if [ -n "$TARGET_UDID" ]; then
+    xcrun simctl status_bar "$TARGET_UDID" override --time "9:41" --batteryState charged --batteryLevel 100
+    echo "  Set status bar to 9:41 on $TARGET_UDID ($DEVICE_NAME)"
 else
-    echo "  ⚠️  No booted simulator found, skipping status bar override"
+    echo "  ⚠️  Could not find simulator '$DEVICE_NAME', skipping status bar override"
 fi
 echo ""
+
+# Ensure cleanup runs on any exit (normal, error, or signal)
+cleanup() {
+    echo ""
+    echo -e "${BLUE}🧹 Cleaning up...${NC}"
+    if [ -n "$TARGET_UDID" ]; then
+        xcrun simctl status_bar "$TARGET_UDID" clear
+    fi
+    rm -rf "$DERIVED_DATA"
+}
+trap cleanup EXIT
 
 # Run UI tests to generate screenshots
 echo -e "${BLUE}🧪 Running UI tests to generate screenshots...${NC}"
@@ -203,13 +224,5 @@ else
   echo "  - Verify Pillow is installed: pip3 install Pillow"
   echo "  - Run tests manually: xcodebuild test -scheme $SCHEME -destination '$DESTINATION' -only-testing:$TEST_TARGET"
 fi
-
-echo ""
-echo -e "${BLUE}🧹 Cleaning up...${NC}"
-# Clear status bar override
-if [ -n "$BOOTED_UDID" ]; then
-    xcrun simctl status_bar "$BOOTED_UDID" clear
-fi
-rm -rf "$DERIVED_DATA"
 
 echo -e "${GREEN}✨ Done!${NC}"

--- a/scripts/generate-screenshots.sh
+++ b/scripts/generate-screenshots.sh
@@ -47,8 +47,7 @@ echo "  Destination: $DESTINATION"
 echo "  Output: $DOCS_DIR"
 echo ""
 
-# Override status bar to get consistent screenshots (Apple's standard 9:41)
-echo -e "${BLUE}⏰ Setting consistent status bar...${NC}"
+# Find target simulator UDID by name
 TARGET_UDID=$(xcrun simctl list devices available -j | python3 -c "
 import json, sys
 name = '$DEVICE_NAME'
@@ -60,6 +59,20 @@ for runtime_devices in devices.values():
             raise SystemExit(0)
 raise SystemExit(1)
 " 2>/dev/null || true)
+
+# Ensure cleanup runs on any exit (normal, error, or signal)
+cleanup() {
+    echo ""
+    echo -e "${BLUE}🧹 Cleaning up...${NC}"
+    if [ -n "$TARGET_UDID" ]; then
+        xcrun simctl status_bar "$TARGET_UDID" clear 2>/dev/null || true
+    fi
+    rm -rf "$DERIVED_DATA"
+}
+trap cleanup EXIT
+
+# Override status bar to get consistent screenshots (Apple's standard 9:41)
+echo -e "${BLUE}⏰ Setting consistent status bar...${NC}"
 if [ -n "$TARGET_UDID" ]; then
     xcrun simctl status_bar "$TARGET_UDID" override --time "9:41" --batteryState charged --batteryLevel 100
     echo "  Set status bar to 9:41 on $TARGET_UDID ($DEVICE_NAME)"
@@ -67,17 +80,6 @@ else
     echo "  ⚠️  Could not find simulator '$DEVICE_NAME', skipping status bar override"
 fi
 echo ""
-
-# Ensure cleanup runs on any exit (normal, error, or signal)
-cleanup() {
-    echo ""
-    echo -e "${BLUE}🧹 Cleaning up...${NC}"
-    if [ -n "$TARGET_UDID" ]; then
-        xcrun simctl status_bar "$TARGET_UDID" clear
-    fi
-    rm -rf "$DERIVED_DATA"
-}
-trap cleanup EXIT
 
 # Run UI tests to generate screenshots
 echo -e "${BLUE}🧪 Running UI tests to generate screenshots...${NC}"

--- a/scripts/generate-screenshots.sh
+++ b/scripts/generate-screenshots.sh
@@ -47,6 +47,17 @@ echo "  Destination: $DESTINATION"
 echo "  Output: $DOCS_DIR"
 echo ""
 
+# Override status bar to get consistent screenshots (Apple's standard 9:41)
+echo -e "${BLUE}⏰ Setting consistent status bar...${NC}"
+BOOTED_UDID=$(xcrun simctl list devices booted -j | python3 -c "import sys,json; devs=json.load(sys.stdin)['devices']; print(next(d['udid'] for ds in devs.values() for d in ds if d['state']=='Booted'))" 2>/dev/null || true)
+if [ -n "$BOOTED_UDID" ]; then
+    xcrun simctl status_bar "$BOOTED_UDID" override --time "9:41" --batteryState charged --batteryLevel 100
+    echo "  Set status bar to 9:41 on $BOOTED_UDID"
+else
+    echo "  ⚠️  No booted simulator found, skipping status bar override"
+fi
+echo ""
+
 # Run UI tests to generate screenshots
 echo -e "${BLUE}🧪 Running UI tests to generate screenshots...${NC}"
 
@@ -195,6 +206,10 @@ fi
 
 echo ""
 echo -e "${BLUE}🧹 Cleaning up...${NC}"
+# Clear status bar override
+if [ -n "$BOOTED_UDID" ]; then
+    xcrun simctl status_bar "$BOOTED_UDID" clear
+fi
 rm -rf "$DERIVED_DATA"
 
 echo -e "${GREEN}✨ Done!${NC}"


### PR DESCRIPTION
## Summary

- Replace byte-level `git diff --quiet` with pixel-based comparison for screenshot change detection
- Screenshots are non-deterministic (WebP compression artifacts, render timing, crop variance), so byte-identical checks created spurious PRs on every code change
- Uses Pillow/numpy (already installed in the workflow) to compare old vs new screenshots
- Only creates a PR when the average pixel difference exceeds a threshold of 1.0 (on a 0-255 scale)
- Visually unchanged screenshots are restored from backup so `git add` ignores them

## Test plan

- [ ] Trigger workflow manually (`workflow_dispatch`) — should report "No visual changes" and skip PR creation
- [ ] Push a visual change (e.g. modify key label) — should detect the difference and create a PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI screenshot workflow: preserves previous screenshots, performs pixel- and dimension-based visual comparisons with thresholds to detect real changes, restores unchanged images to prevent spurious diffs, emits a CI "changed" flag, and stages directory-wide image additions/deletions/renames for commit.
  * Ensures screenshots are captured with a deterministic simulated status bar, and guarantees cleanup (status-bar reset, simulator shutdown, and temp data removal) on script exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->