### PR TITLE
Add Optional MessagEase-Style Discrete Cursor Movement

### DIFF
--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -31,6 +31,9 @@ struct SettingsView: View {
     @AppStorage(SettingsKey.numpadStyle.rawValue, store: SharedDefaults.store)
     private var numpadStyleRaw = NumpadStyle.phone.rawValue
 
+    @AppStorage(SettingsKey.cursorMovementStyle.rawValue, store: SharedDefaults.store)
+    private var cursorMovementStyleRaw = CursorMovementStyle.continuous.rawValue
+
     @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
     private var keyboardStyleRaw = KeyboardStyle.classic.rawValue
 
@@ -76,6 +79,17 @@ struct SettingsView: View {
                     icon: "textformat.size.larger", color: .teal,
                     title: "Auto-Capitalize",
                     subtitle: "Capitalize after sentence-ending punctuation"
+                )
+            }
+
+            Picker(selection: $cursorMovementStyleRaw) {
+                Text("Continuous").tag(CursorMovementStyle.continuous.rawValue)
+                Text("Step-by-step").tag(CursorMovementStyle.discrete.rawValue)
+            } label: {
+                SettingsRow(
+                    icon: "cursor.rays", color: .green,
+                    title: "Cursor Movement",
+                    subtitle: cursorMovementStyleDescription
                 )
             }
         } header: {
@@ -193,6 +207,16 @@ struct SettingsView: View {
     private var keyboardStyleDescription: String {
         let style = KeyboardStyle(rawValue: keyboardStyleRaw) ?? .classic
         return style.displayName
+    }
+
+    private var cursorMovementStyleDescription: String {
+        let style = CursorMovementStyle(rawValue: cursorMovementStyleRaw) ?? .continuous
+        switch style {
+        case .continuous:
+            return "Drag to move cursor"
+        case .discrete:
+            return "Swipe per character, return-swipe per word"
+        }
     }
 
     private var numpadStyleDescription: String {

--- a/wurstfingerKeyboard/KeyboardLayout.swift
+++ b/wurstfingerKeyboard/KeyboardLayout.swift
@@ -21,6 +21,12 @@ enum NumpadStyle: String, CaseIterable {
     case classic // 7-8-9 / 4-5-6 / 1-2-3 (like calculator)
 }
 
+/// Space bar cursor movement style
+enum CursorMovementStyle: String, CaseIterable {
+    case continuous // Joystick-style: drag distance controls cursor position
+    case discrete // MessagEase-style: one swipe = one character, return-swipe = one word
+}
+
 /// Visual style for the keyboard appearance
 enum KeyboardStyle: String, CaseIterable {
     case classic // Traditional opaque key backgrounds
@@ -1018,6 +1024,10 @@ enum KeyboardConstants {
         /// Distance per cursor movement step (one character).
         /// Provides smooth, controlled cursor navigation.
         static let dragStep: CGFloat = 14
+
+        /// Maximum ratio of final displacement to peak displacement for a return swipe.
+        /// Below this threshold, the gesture is classified as a return swipe (word movement).
+        static let returnSwipeThreshold: CGFloat = 0.3
     }
 
     // MARK: - Delete Key Gestures

--- a/wurstfingerKeyboard/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/KeyboardSettings.swift
@@ -28,6 +28,7 @@ enum SettingsKey: String {
     case expertModeEnabled
     case keyboardStyle
     case keyboardFullAccess
+    case cursorMovementStyle
 }
 
 // MARK: - Haptic Settings

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -128,18 +128,38 @@ final class KeyboardViewController: UIInputViewController {
             dismissKeyboard()
         case let .capitalizeWord(style):
             capitalizeCurrentWord(style: style)
-        case let .moveCursor(offset):
-            textDocumentProxy.adjustTextPosition(byCharacterOffset: offset)
+        case .moveCursor, .moveCursorByWord:
+            performCursorAction(action)
         case let .compose(trigger):
             handleCompose(trigger: trigger)
         case .cycleAccents:
             handleCycleAccents()
+        case .copy, .paste, .cut:
+            performClipboardAction(action)
+        }
+    }
+
+    private func performCursorAction(_ action: KeyboardAction) {
+        switch action {
+        case let .moveCursor(offset):
+            textDocumentProxy.adjustTextPosition(byCharacterOffset: offset)
+        case let .moveCursorByWord(forward):
+            moveCursorByWord(forward: forward)
+        default:
+            break
+        }
+    }
+
+    private func performClipboardAction(_ action: KeyboardAction) {
+        switch action {
         case .copy:
             handleCopy()
         case .paste:
             handlePaste()
         case .cut:
             handleCut()
+        default:
+            break
         }
     }
 
@@ -150,6 +170,52 @@ final class KeyboardViewController: UIInputViewController {
            SharedDefaults.store.bool(forKey: SettingsKey.autoCapitalizeEnabled.rawValue) {
             viewModel.setLayer(.upper)
         }
+    }
+
+    /// Move cursor forward or backward by one word.
+    private func moveCursorByWord(forward: Bool) {
+        if forward {
+            guard let after = textDocumentProxy.documentContextAfterInput, !after.isEmpty else { return }
+            let offset = Self.nextWordBoundaryOffset(in: after)
+            textDocumentProxy.adjustTextPosition(byCharacterOffset: offset)
+        } else {
+            guard let before = textDocumentProxy.documentContextBeforeInput, !before.isEmpty else { return }
+            let offset = Self.previousWordBoundaryOffset(in: before)
+            textDocumentProxy.adjustTextPosition(byCharacterOffset: -offset)
+        }
+    }
+
+    /// Returns the character offset to the next word boundary from the start of the string.
+    static func nextWordBoundaryOffset(in text: String) -> Int {
+        // Skip leading whitespace, then skip word characters
+        var index = text.startIndex
+        // Skip whitespace
+        while index < text.endIndex, text[index].isWhitespace {
+            index = text.index(after: index)
+        }
+        // Skip word characters (non-whitespace)
+        while index < text.endIndex, !text[index].isWhitespace {
+            index = text.index(after: index)
+        }
+        return text.distance(from: text.startIndex, to: index)
+    }
+
+    /// Returns the character offset from the end of the string to the previous word boundary.
+    static func previousWordBoundaryOffset(in text: String) -> Int {
+        var index = text.endIndex
+        // Skip trailing whitespace
+        while index > text.startIndex {
+            let prev = text.index(before: index)
+            guard text[prev].isWhitespace else { break }
+            index = prev
+        }
+        // Skip word characters (non-whitespace)
+        while index > text.startIndex {
+            let prev = text.index(before: index)
+            guard !text[prev].isWhitespace else { break }
+            index = prev
+        }
+        return text.distance(from: index, to: text.endIndex)
     }
 
     /// Delete one character after cursor. Returns `true` if a character was deleted.

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -20,6 +20,7 @@ enum KeyboardAction {
     case dismissKeyboard
     case capitalizeWord(CapitalizationStyle)
     case moveCursor(offset: Int)
+    case moveCursorByWord(forward: Bool)
     case compose(trigger: String)
     case cycleAccents
     // Text editing actions (clipboard)
@@ -529,6 +530,24 @@ final class KeyboardViewModel: ObservableObject {
     func endSpaceDrag() {
         isSpaceDragging = false
         spaceDragResidual = 0
+    }
+
+    // MARK: - Discrete Cursor Movement
+
+    func handleDiscreteSpaceSwipe(forward: Bool) {
+        actionHandler?(.moveCursor(offset: forward ? 1 : -1))
+        feedbackDrag()
+    }
+
+    func handleDiscreteSpaceReturnSwipe(forward: Bool) {
+        actionHandler?(.moveCursorByWord(forward: forward))
+        feedbackDrag()
+    }
+
+    var cursorMovementStyle: CursorMovementStyle {
+        let raw = sharedDefaults.string(forKey: SettingsKey.cursorMovementStyle.rawValue)
+            ?? CursorMovementStyle.continuous.rawValue
+        return CursorMovementStyle(rawValue: raw) ?? .continuous
     }
 
     func beginDeleteDrag() {

--- a/wurstfingerKeyboard/SpaceKeyButton.swift
+++ b/wurstfingerKeyboard/SpaceKeyButton.swift
@@ -16,6 +16,9 @@ struct SpaceKeyButton: View {
     @State private var dragStarted = false
     @State private var hasDragged = false
     @State private var lastTranslation: CGSize = .zero
+    // Discrete mode: track peak displacement and final position
+    @State private var maxDisplacementX: CGFloat = 0
+    @State private var maxDisplacementSign: Int = 0
 
     var body: some View {
         KeyCap(
@@ -39,24 +42,36 @@ struct SpaceKeyButton: View {
                         viewModel.beginSpaceDrag()
                     }
 
-                    let deltaX = value.translation.width - lastTranslation.width
-                    viewModel.updateSpaceDrag(deltaX: deltaX)
+                    let currentX = value.translation.width
+
+                    if viewModel.cursorMovementStyle == .continuous {
+                        let deltaX = currentX - lastTranslation.width
+                        viewModel.updateSpaceDrag(deltaX: deltaX)
+                    }
+
+                    // Track peak displacement for discrete mode
+                    if abs(currentX) > abs(maxDisplacementX) {
+                        maxDisplacementX = currentX
+                        maxDisplacementSign = currentX > 0 ? 1 : -1
+                    }
 
                     lastTranslation = value.translation
 
-                    if !hasDragged, abs(value.translation.width) >= KeyboardConstants.SpaceGestures.dragActivationThreshold {
+                    if !hasDragged, abs(currentX) >= KeyboardConstants.SpaceGestures.dragActivationThreshold {
                         hasDragged = true
                     }
 
                     isActive = true
                 }
-                .onEnded { _ in
+                .onEnded { value in
                     if dragStarted {
                         viewModel.endSpaceDrag()
                     }
 
                     if !hasDragged {
                         viewModel.handleSpace()
+                    } else if viewModel.cursorMovementStyle == .discrete {
+                        classifyDiscreteGesture(finalX: value.translation.width)
                     }
 
                     resetGestureState()
@@ -64,10 +79,27 @@ struct SpaceKeyButton: View {
         )
     }
 
+    private func classifyDiscreteGesture(finalX: CGFloat) {
+        let forward = maxDisplacementSign > 0
+        let returnRatio = abs(maxDisplacementX) > 0
+            ? abs(finalX) / abs(maxDisplacementX)
+            : 1.0
+
+        if returnRatio < KeyboardConstants.SpaceGestures.returnSwipeThreshold {
+            // Finger returned near start → word movement
+            viewModel.handleDiscreteSpaceReturnSwipe(forward: forward)
+        } else {
+            // Finger stayed away → character movement
+            viewModel.handleDiscreteSpaceSwipe(forward: forward)
+        }
+    }
+
     private func resetGestureState() {
         isActive = false
         dragStarted = false
         hasDragged = false
         lastTranslation = .zero
+        maxDisplacementX = 0
+        maxDisplacementSign = 0
     }
 }

--- a/wurstfingerTests/CursorMovementTests.swift
+++ b/wurstfingerTests/CursorMovementTests.swift
@@ -1,0 +1,97 @@
+//
+//  CursorMovementTests.swift
+//  WurstfingerTests
+//
+//  Tests for word boundary calculation used by discrete cursor movement.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct WordBoundaryTests {
+    // MARK: - Forward (nextWordBoundaryOffset)
+
+    @Test func forwardSkipsToEndOfFirstWord() {
+        #expect(KeyboardViewController.nextWordBoundaryOffset(in: "hello world") == 5)
+    }
+
+    @Test func forwardSkipsLeadingWhitespace() {
+        #expect(KeyboardViewController.nextWordBoundaryOffset(in: "  hello") == 7)
+    }
+
+    @Test func forwardHandlesSingleCharacter() {
+        #expect(KeyboardViewController.nextWordBoundaryOffset(in: "a") == 1)
+    }
+
+    @Test func forwardHandlesOnlyWhitespace() {
+        #expect(KeyboardViewController.nextWordBoundaryOffset(in: "   ") == 3)
+    }
+
+    @Test func forwardHandlesEmptyString() {
+        #expect(KeyboardViewController.nextWordBoundaryOffset(in: "") == 0)
+    }
+
+    @Test func forwardHandlesPunctuation() {
+        // Punctuation is non-whitespace, so it's treated as part of a word
+        #expect(KeyboardViewController.nextWordBoundaryOffset(in: "hello, world") == 6)
+    }
+
+    @Test func forwardHandlesMultipleSpaces() {
+        #expect(KeyboardViewController.nextWordBoundaryOffset(in: "   word") == 7)
+    }
+
+    // MARK: - Backward (previousWordBoundaryOffset)
+
+    @Test func backwardSkipsToStartOfLastWord() {
+        #expect(KeyboardViewController.previousWordBoundaryOffset(in: "hello world") == 5)
+    }
+
+    @Test func backwardSkipsTrailingWhitespace() {
+        #expect(KeyboardViewController.previousWordBoundaryOffset(in: "hello  ") == 7)
+    }
+
+    @Test func backwardHandlesSingleCharacter() {
+        #expect(KeyboardViewController.previousWordBoundaryOffset(in: "a") == 1)
+    }
+
+    @Test func backwardHandlesOnlyWhitespace() {
+        #expect(KeyboardViewController.previousWordBoundaryOffset(in: "   ") == 3)
+    }
+
+    @Test func backwardHandlesEmptyString() {
+        #expect(KeyboardViewController.previousWordBoundaryOffset(in: "") == 0)
+    }
+
+    @Test func backwardHandlesPunctuation() {
+        #expect(KeyboardViewController.previousWordBoundaryOffset(in: "hello, world") == 5)
+    }
+
+    @Test func backwardHandlesMultipleWords() {
+        #expect(KeyboardViewController.previousWordBoundaryOffset(in: "one two three") == 5)
+    }
+}
+
+struct DiscreteGestureClassificationTests {
+    @Test func returnRatioBelowThresholdIsReturnSwipe() {
+        // finalX near zero, maxDisplacement large → return swipe
+        let maxDisplacement: CGFloat = 50
+        let finalX: CGFloat = 5
+        let ratio = abs(finalX) / abs(maxDisplacement)
+        #expect(ratio < KeyboardConstants.SpaceGestures.returnSwipeThreshold)
+    }
+
+    @Test func returnRatioAboveThresholdIsRegularSwipe() {
+        // finalX close to maxDisplacement → regular swipe
+        let maxDisplacement: CGFloat = 50
+        let finalX: CGFloat = 45
+        let ratio = abs(finalX) / abs(maxDisplacement)
+        #expect(ratio >= KeyboardConstants.SpaceGestures.returnSwipeThreshold)
+    }
+
+    @Test func returnSwipeThresholdIsReasonable() {
+        let threshold = KeyboardConstants.SpaceGestures.returnSwipeThreshold
+        #expect(threshold > 0)
+        #expect(threshold < 1)
+    }
+}


### PR DESCRIPTION
## Summary

- Add step-by-step cursor movement on the space bar as an alternative to the current continuous joystick behavior
- In discrete mode: swipe right/left moves cursor one character, return-swipe moves one word
- Configurable via Settings > General > Cursor Movement picker
- Word boundary calculation handles whitespace, punctuation, and edge cases

Closes #78

## Changes

| File | Change |
|------|--------|
| `KeyboardLayout.swift` | `CursorMovementStyle` enum, `returnSwipeThreshold` constant |
| `KeyboardSettings.swift` | `cursorMovementStyle` settings key |
| `KeyboardViewModel.swift` | `.moveCursorByWord` action, discrete handlers |
| `KeyboardViewController.swift` | Word-level cursor movement, refactored action dispatch |
| `SpaceKeyButton.swift` | Discrete mode gesture tracking + classification |
| `SettingsView.swift` | Cursor Movement style picker |
| `CursorMovementTests.swift` | 14 new tests for word boundaries + gesture classification |

## Test plan

- [x] All 300 tests pass
- [x] SwiftFormat + SwiftLint pass
- [ ] Manual: Setting → "Step-by-step" → swipe right on space → cursor moves 1 character
- [ ] Manual: Return-swipe right → cursor jumps 1 word
- [ ] Manual: Setting → "Continuous" → original joystick behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Cursor Movement" setting in General section with two modes: Continuous for smooth character-by-character movement, and Discrete for gesture-based control where short space-bar swipes move the cursor by one character and longer swipes jump by word.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->