### PR TITLE
Add Core Value Types for Data-Driven Architecture

### DIFF
--- a/wurstfingerKeyboard/GestureType.swift
+++ b/wurstfingerKeyboard/GestureType.swift
@@ -1,0 +1,35 @@
+//
+//  GestureType.swift
+//  Wurstfinger
+//
+//  All gestures that can be recognized on a key.
+//
+
+import Foundation
+
+/// All gestures that can be recognized on a key.
+enum GestureType: String, Codable, CaseIterable {
+    // Tap
+    case tap
+
+    // 8 directions
+    case swipeUp, swipeDown, swipeLeft, swipeRight
+    case swipeUpLeft, swipeUpRight, swipeDownLeft, swipeDownRight
+
+    // Circular gestures
+    case circularClockwise, circularCounterclockwise
+
+    // Long press
+    case longPress
+
+    /// Whether this gesture is a directional swipe.
+    var isSwipe: Bool {
+        switch self {
+        case .swipeUp, .swipeDown, .swipeLeft, .swipeRight,
+             .swipeUpLeft, .swipeUpRight, .swipeDownLeft, .swipeDownRight:
+            true
+        default:
+            false
+        }
+    }
+}

--- a/wurstfingerKeyboard/KeyAction.swift
+++ b/wurstfingerKeyboard/KeyAction.swift
@@ -1,0 +1,55 @@
+//
+//  KeyAction.swift
+//  Wurstfinger
+//
+//  All possible actions a key binding can trigger.
+//
+
+import Foundation
+
+/// All possible actions a key binding can trigger.
+enum KeyAction: Codable, Equatable {
+    /// Insert text
+    case commitText(String)
+
+    /// Compose trigger (accent composition with previous character)
+    case compose(trigger: String)
+
+    /// Cycle through accents (ä → â → à → ...)
+    case cycleAccents
+
+    /// Switch to another mode by name.
+    /// Replaces the old toggleShift/toggleSymbols — arbitrary modes possible.
+    /// e.g. "shifted", "numeric", "emoji", "symbols", "main"
+    case switchMode(String)
+
+    /// Capitalize/uncapitalize last word
+    case capitalizeWord(uppercased: Bool)
+
+    /// Next input method (Globe key)
+    case advanceToNextInputMode
+
+    /// Dismiss keyboard
+    case dismissKeyboard
+
+    /// Delete backward
+    case deleteBackward
+
+    /// Delete forward
+    case deleteForward
+
+    /// Space
+    case space
+
+    /// Newline
+    case newline
+
+    /// Move cursor
+    case moveCursor(offset: Int)
+
+    /// Clipboard
+    case copy, paste, cut
+
+    /// No action (empty slot)
+    case none
+}

--- a/wurstfingerKeyboard/KeyBinding.swift
+++ b/wurstfingerKeyboard/KeyBinding.swift
@@ -1,0 +1,32 @@
+//
+//  KeyBinding.swift
+//  Wurstfinger
+//
+//  What a single gesture on a key produces.
+//
+
+import Foundation
+
+/// What a single gesture on a key produces.
+struct KeyBinding: Codable, Equatable {
+    /// Displayed text on the key (can differ from output, e.g. "⇧" for shift)
+    let label: String
+
+    /// What happens when triggered
+    let action: KeyAction
+
+    /// Semantic category — controls behavior like auto-shift, haptics, hint styling.
+    /// nil = automatically derived from action (see resolvedCategory).
+    let category: KeyCategory?
+
+    /// Optional alternative action for return swipe (swipe out and back)
+    let returnAction: KeyAction?
+
+    /// VoiceOver label, only set when different from label (e.g. "Löschen" for "⌫")
+    let accessibilityLabel: String?
+
+    /// Category: explicit or automatically derived from the action.
+    var resolvedCategory: KeyCategory {
+        category ?? action.inferredCategory
+    }
+}

--- a/wurstfingerKeyboard/KeyCategory.swift
+++ b/wurstfingerKeyboard/KeyCategory.swift
@@ -1,0 +1,44 @@
+//
+//  KeyCategory.swift
+//  Wurstfinger
+//
+//  Semantic classification of key bindings.
+//
+
+import Foundation
+
+/// Categorizes a binding for context-dependent behavior.
+enum KeyCategory: String, Codable {
+    case letter // Letter — reacts to shift, triggers auto-capitalization
+    case digit // Digit
+    case symbol // Punctuation, special character
+    case compose // Accent/compose trigger
+    case modifier // Shift, symbols toggle, caps lock
+    case utility // Globe, delete, return
+    case whitespace // Space, newline
+}
+
+extension KeyAction {
+    /// Derives the category automatically from the action.
+    /// Sufficient for ~90% of cases. Explicit category only needed for edge cases
+    /// (e.g. commitText("ß") should be .letter, not .symbol).
+    var inferredCategory: KeyCategory {
+        switch self {
+        case let .commitText(text):
+            guard let char = text.first else { return .symbol }
+            if char.isLetter { return .letter }
+            if char.isNumber { return .digit }
+            return .symbol
+        case .compose: return .compose
+        case .cycleAccents: return .compose
+        case .switchMode: return .modifier
+        case .capitalizeWord: return .modifier
+        case .space, .newline: return .whitespace
+        case .deleteBackward, .deleteForward, .moveCursor,
+             .advanceToNextInputMode, .dismissKeyboard:
+            return .utility
+        case .copy, .paste, .cut: return .utility
+        case .none: return .utility
+        }
+    }
+}

--- a/wurstfingerKeyboard/KeyConfig.swift
+++ b/wurstfingerKeyboard/KeyConfig.swift
@@ -1,0 +1,30 @@
+//
+//  KeyConfig.swift
+//  Wurstfinger
+//
+//  Complete definition of a single key (behavior, not layout).
+//
+
+import Foundation
+
+/// Complete definition of a single key (behavior, not layout).
+struct KeyConfig: Codable, Equatable, Identifiable {
+    /// Semantic slot name (e.g. "topLeft", "center", "globe")
+    let id: String
+
+    /// Binding for each gesture. Only set entries are active.
+    let bindings: [GestureType: KeyBinding]
+
+    /// Allowed swipe directions (default: .eightWay)
+    let swipeMode: SwipeMode
+
+    /// Special drag behavior
+    let slideType: SlideType
+
+    /// Visual role — affects styling, not logic
+    let style: KeyStyle
+
+    /// Optional multi-tap actions (e.g. space → comma → period → ?)
+    /// Inspired by Thumb-Key's nextTapActions
+    let tapCycleActions: [KeyAction]?
+}

--- a/wurstfingerKeyboard/KeyStyle.swift
+++ b/wurstfingerKeyboard/KeyStyle.swift
@@ -1,0 +1,17 @@
+//
+//  KeyStyle.swift
+//  Wurstfinger
+//
+//  Visual appearance of a key.
+//
+
+import Foundation
+
+/// Visual appearance of a key.
+enum KeyStyle: String, Codable {
+    case primary // Main keys (letters) — large font, full background
+    case secondary // Helper keys (swipe symbols) — smaller font
+    case utility // Function keys (delete, return, globe) — icon instead of text
+    case spacebar // Space bar — special rendering
+    case accent // Accent/compose — visually highlighted
+}

--- a/wurstfingerKeyboard/SlideType.swift
+++ b/wurstfingerKeyboard/SlideType.swift
@@ -1,0 +1,15 @@
+//
+//  SlideType.swift
+//  Wurstfinger
+//
+//  Special drag behavior for held keys.
+//
+
+import Foundation
+
+/// Special behavior when dragging over a key.
+enum SlideType: String, Codable {
+    case none // No slide behavior (default)
+    case moveCursor // Move cursor (space key)
+    case delete // Progressive deletion (delete key)
+}

--- a/wurstfingerKeyboard/SwipeMode.swift
+++ b/wurstfingerKeyboard/SwipeMode.swift
@@ -1,0 +1,36 @@
+//
+//  SwipeMode.swift
+//  Wurstfinger
+//
+//  Allowed swipe directions per key.
+//
+
+import Foundation
+
+/// Restriction of allowed swipe directions per key.
+enum SwipeMode: String, Codable {
+    case eightWay // All 8 directions (default for letter keys)
+    case fourWayCross // Cross only (↑↓←→)
+    case fourWayDiagonal // Diagonals only
+    case twoWayHorizontal // Only ←→ (e.g. delete key)
+    case twoWayVertical // Only ↑↓
+    case none // No swipes (e.g. globe key)
+
+    /// Checks whether a given gesture is allowed in this mode.
+    func allows(_ gesture: GestureType) -> Bool {
+        switch self {
+        case .eightWay:
+            gesture.isSwipe
+        case .fourWayCross:
+            [.swipeUp, .swipeDown, .swipeLeft, .swipeRight].contains(gesture)
+        case .fourWayDiagonal:
+            [.swipeUpLeft, .swipeUpRight, .swipeDownLeft, .swipeDownRight].contains(gesture)
+        case .twoWayHorizontal:
+            [.swipeLeft, .swipeRight].contains(gesture)
+        case .twoWayVertical:
+            [.swipeUp, .swipeDown].contains(gesture)
+        case .none:
+            false
+        }
+    }
+}

--- a/wurstfingerKeyboard/SwipeMode.swift
+++ b/wurstfingerKeyboard/SwipeMode.swift
@@ -16,19 +16,24 @@ enum SwipeMode: String, Codable {
     case twoWayVertical // Only ↑↓
     case none // No swipes (e.g. globe key)
 
+    private static let fourWayCrossGestures: Set<GestureType> = [.swipeUp, .swipeDown, .swipeLeft, .swipeRight]
+    private static let fourWayDiagonalGestures: Set<GestureType> = [.swipeUpLeft, .swipeUpRight, .swipeDownLeft, .swipeDownRight]
+    private static let twoWayHorizontalGestures: Set<GestureType> = [.swipeLeft, .swipeRight]
+    private static let twoWayVerticalGestures: Set<GestureType> = [.swipeUp, .swipeDown]
+
     /// Checks whether a given gesture is allowed in this mode.
     func allows(_ gesture: GestureType) -> Bool {
         switch self {
         case .eightWay:
             gesture.isSwipe
         case .fourWayCross:
-            [.swipeUp, .swipeDown, .swipeLeft, .swipeRight].contains(gesture)
+            Self.fourWayCrossGestures.contains(gesture)
         case .fourWayDiagonal:
-            [.swipeUpLeft, .swipeUpRight, .swipeDownLeft, .swipeDownRight].contains(gesture)
+            Self.fourWayDiagonalGestures.contains(gesture)
         case .twoWayHorizontal:
-            [.swipeLeft, .swipeRight].contains(gesture)
+            Self.twoWayHorizontalGestures.contains(gesture)
         case .twoWayVertical:
-            [.swipeUp, .swipeDown].contains(gesture)
+            Self.twoWayVerticalGestures.contains(gesture)
         case .none:
             false
         }

--- a/wurstfingerTests/CoreValueTypeTests.swift
+++ b/wurstfingerTests/CoreValueTypeTests.swift
@@ -43,7 +43,7 @@ struct KeyActionTests {
 
     @Test func codableRoundtripSimpleCases() throws {
         let cases: [KeyAction] = [
-            .cycleAccents, .capitalizeWord(uppercased: true),
+            .cycleAccents, .capitalizeWord(uppercased: true), .capitalizeWord(uppercased: false),
             .advanceToNextInputMode, .dismissKeyboard,
             .deleteBackward, .deleteForward,
             .space, .newline,

--- a/wurstfingerTests/CoreValueTypeTests.swift
+++ b/wurstfingerTests/CoreValueTypeTests.swift
@@ -259,7 +259,7 @@ struct KeyBindingTests {
         #expect(decoded == binding)
     }
 
-    @Test func codableRoundtripWithAllNils() throws {
+    @Test func codableRoundtripWithNilOptionalFields() throws {
         let binding = KeyBinding(
             label: "⌫", action: .deleteBackward,
             category: .utility, returnAction: nil,
@@ -376,5 +376,33 @@ struct KeyConfigTests {
         )
         #expect(config1 == config2)
         #expect(config1 != config3)
+    }
+}
+
+// MARK: - Exhaustive Enum Codable Roundtrips
+
+struct EnumCodableTests {
+    @Test func swipeModeAllCases() throws {
+        for mode in [SwipeMode.eightWay, .fourWayCross, .fourWayDiagonal, .twoWayHorizontal, .twoWayVertical, .none] {
+            let data = try JSONEncoder().encode(mode)
+            let decoded = try JSONDecoder().decode(SwipeMode.self, from: data)
+            #expect(decoded == mode)
+        }
+    }
+
+    @Test func slideTypeAllCases() throws {
+        for slide in [SlideType.none, .moveCursor, .delete] {
+            let data = try JSONEncoder().encode(slide)
+            let decoded = try JSONDecoder().decode(SlideType.self, from: data)
+            #expect(decoded == slide)
+        }
+    }
+
+    @Test func keyStyleAllCases() throws {
+        for style in [KeyStyle.primary, .secondary, .utility, .spacebar, .accent] {
+            let data = try JSONEncoder().encode(style)
+            let decoded = try JSONDecoder().decode(KeyStyle.self, from: data)
+            #expect(decoded == style)
+        }
     }
 }

--- a/wurstfingerTests/CoreValueTypeTests.swift
+++ b/wurstfingerTests/CoreValueTypeTests.swift
@@ -1,0 +1,380 @@
+//
+//  CoreValueTypeTests.swift
+//  WurstfingerTests
+//
+//  Tests for the core value types: KeyAction, KeyCategory, GestureType,
+//  SwipeMode, SlideType, KeyStyle, KeyBinding, KeyConfig.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+// MARK: - KeyAction Tests
+
+struct KeyActionTests {
+    @Test func codableRoundtripCommitText() throws {
+        let action = KeyAction.commitText("a")
+        let data = try JSONEncoder().encode(action)
+        let decoded = try JSONDecoder().decode(KeyAction.self, from: data)
+        #expect(decoded == action)
+    }
+
+    @Test func codableRoundtripCompose() throws {
+        let action = KeyAction.compose(trigger: "¨")
+        let data = try JSONEncoder().encode(action)
+        let decoded = try JSONDecoder().decode(KeyAction.self, from: data)
+        #expect(decoded == action)
+    }
+
+    @Test func codableRoundtripSwitchMode() throws {
+        let action = KeyAction.switchMode("shifted")
+        let data = try JSONEncoder().encode(action)
+        let decoded = try JSONDecoder().decode(KeyAction.self, from: data)
+        #expect(decoded == action)
+    }
+
+    @Test func codableRoundtripMoveCursor() throws {
+        let action = KeyAction.moveCursor(offset: -3)
+        let data = try JSONEncoder().encode(action)
+        let decoded = try JSONDecoder().decode(KeyAction.self, from: data)
+        #expect(decoded == action)
+    }
+
+    @Test func codableRoundtripSimpleCases() throws {
+        let cases: [KeyAction] = [
+            .cycleAccents, .capitalizeWord(uppercased: true),
+            .advanceToNextInputMode, .dismissKeyboard,
+            .deleteBackward, .deleteForward,
+            .space, .newline,
+            .copy, .paste, .cut, .none,
+        ]
+        for action in cases {
+            let data = try JSONEncoder().encode(action)
+            let decoded = try JSONDecoder().decode(KeyAction.self, from: data)
+            #expect(decoded == action)
+        }
+    }
+
+    @Test func equatable() {
+        #expect(KeyAction.commitText("a") == KeyAction.commitText("a"))
+        #expect(KeyAction.commitText("a") != KeyAction.commitText("b"))
+        #expect(KeyAction.space == KeyAction.space)
+        #expect(KeyAction.space != KeyAction.newline)
+        #expect(KeyAction.switchMode("shifted") == KeyAction.switchMode("shifted"))
+        #expect(KeyAction.switchMode("shifted") != KeyAction.switchMode("numeric"))
+    }
+}
+
+// MARK: - KeyCategory / inferredCategory Tests
+
+struct KeyCategoryTests {
+    @Test func letterInference() {
+        #expect(KeyAction.commitText("a").inferredCategory == .letter)
+        #expect(KeyAction.commitText("Z").inferredCategory == .letter)
+        #expect(KeyAction.commitText("ß").inferredCategory == .letter)
+        #expect(KeyAction.commitText("é").inferredCategory == .letter)
+        #expect(KeyAction.commitText("ñ").inferredCategory == .letter)
+    }
+
+    @Test func digitInference() {
+        #expect(KeyAction.commitText("0").inferredCategory == .digit)
+        #expect(KeyAction.commitText("9").inferredCategory == .digit)
+    }
+
+    @Test func symbolInference() {
+        #expect(KeyAction.commitText(".").inferredCategory == .symbol)
+        #expect(KeyAction.commitText(",").inferredCategory == .symbol)
+        #expect(KeyAction.commitText("!").inferredCategory == .symbol)
+        #expect(KeyAction.commitText("@").inferredCategory == .symbol)
+    }
+
+    @Test func emptyTextInference() {
+        #expect(KeyAction.commitText("").inferredCategory == .symbol)
+    }
+
+    @Test func composeInference() {
+        #expect(KeyAction.compose(trigger: "¨").inferredCategory == .compose)
+        #expect(KeyAction.cycleAccents.inferredCategory == .compose)
+    }
+
+    @Test func modifierInference() {
+        #expect(KeyAction.switchMode("shifted").inferredCategory == .modifier)
+        #expect(KeyAction.capitalizeWord(uppercased: true).inferredCategory == .modifier)
+    }
+
+    @Test func whitespaceInference() {
+        #expect(KeyAction.space.inferredCategory == .whitespace)
+        #expect(KeyAction.newline.inferredCategory == .whitespace)
+    }
+
+    @Test func utilityInference() {
+        #expect(KeyAction.deleteBackward.inferredCategory == .utility)
+        #expect(KeyAction.deleteForward.inferredCategory == .utility)
+        #expect(KeyAction.moveCursor(offset: 1).inferredCategory == .utility)
+        #expect(KeyAction.advanceToNextInputMode.inferredCategory == .utility)
+        #expect(KeyAction.dismissKeyboard.inferredCategory == .utility)
+        #expect(KeyAction.copy.inferredCategory == .utility)
+        #expect(KeyAction.paste.inferredCategory == .utility)
+        #expect(KeyAction.cut.inferredCategory == .utility)
+        #expect(KeyAction.none.inferredCategory == .utility)
+    }
+
+    @Test func keyCategoryCodable() throws {
+        for category in [KeyCategory.letter, .digit, .symbol, .compose, .modifier, .utility, .whitespace] {
+            let data = try JSONEncoder().encode(category)
+            let decoded = try JSONDecoder().decode(KeyCategory.self, from: data)
+            #expect(decoded == category)
+        }
+    }
+}
+
+// MARK: - GestureType Tests
+
+struct GestureTypeTests {
+    @Test func isSwipe() {
+        let swipes: [GestureType] = [
+            .swipeUp, .swipeDown, .swipeLeft, .swipeRight,
+            .swipeUpLeft, .swipeUpRight, .swipeDownLeft, .swipeDownRight,
+        ]
+        for gesture in swipes {
+            #expect(gesture.isSwipe, "Expected \(gesture) to be a swipe")
+        }
+
+        let nonSwipes: [GestureType] = [.tap, .circularClockwise, .circularCounterclockwise, .longPress]
+        for gesture in nonSwipes {
+            #expect(!gesture.isSwipe, "Expected \(gesture) not to be a swipe")
+        }
+    }
+
+    @Test func caseIterable() {
+        #expect(GestureType.allCases.count == 12)
+    }
+
+    @Test func codableRoundtrip() throws {
+        for gesture in GestureType.allCases {
+            let data = try JSONEncoder().encode(gesture)
+            let decoded = try JSONDecoder().decode(GestureType.self, from: data)
+            #expect(decoded == gesture)
+        }
+    }
+}
+
+// MARK: - SwipeMode Tests
+
+struct SwipeModeTests {
+    @Test func eightWayAllowsAllSwipes() {
+        let swipes: [GestureType] = [
+            .swipeUp, .swipeDown, .swipeLeft, .swipeRight,
+            .swipeUpLeft, .swipeUpRight, .swipeDownLeft, .swipeDownRight,
+        ]
+        for gesture in swipes {
+            #expect(SwipeMode.eightWay.allows(gesture), "eightWay should allow \(gesture)")
+        }
+    }
+
+    @Test func eightWayRejectsNonSwipes() {
+        #expect(!SwipeMode.eightWay.allows(.tap))
+        #expect(!SwipeMode.eightWay.allows(.circularClockwise))
+        #expect(!SwipeMode.eightWay.allows(.longPress))
+    }
+
+    @Test func fourWayCrossAllowsOnlyCardinals() {
+        #expect(SwipeMode.fourWayCross.allows(.swipeUp))
+        #expect(SwipeMode.fourWayCross.allows(.swipeDown))
+        #expect(SwipeMode.fourWayCross.allows(.swipeLeft))
+        #expect(SwipeMode.fourWayCross.allows(.swipeRight))
+        #expect(!SwipeMode.fourWayCross.allows(.swipeUpLeft))
+        #expect(!SwipeMode.fourWayCross.allows(.swipeDownRight))
+    }
+
+    @Test func fourWayDiagonalAllowsOnlyDiagonals() {
+        #expect(SwipeMode.fourWayDiagonal.allows(.swipeUpLeft))
+        #expect(SwipeMode.fourWayDiagonal.allows(.swipeUpRight))
+        #expect(SwipeMode.fourWayDiagonal.allows(.swipeDownLeft))
+        #expect(SwipeMode.fourWayDiagonal.allows(.swipeDownRight))
+        #expect(!SwipeMode.fourWayDiagonal.allows(.swipeUp))
+        #expect(!SwipeMode.fourWayDiagonal.allows(.swipeLeft))
+    }
+
+    @Test func twoWayHorizontal() {
+        #expect(SwipeMode.twoWayHorizontal.allows(.swipeLeft))
+        #expect(SwipeMode.twoWayHorizontal.allows(.swipeRight))
+        #expect(!SwipeMode.twoWayHorizontal.allows(.swipeUp))
+        #expect(!SwipeMode.twoWayHorizontal.allows(.swipeDown))
+        #expect(!SwipeMode.twoWayHorizontal.allows(.swipeUpLeft))
+    }
+
+    @Test func twoWayVertical() {
+        #expect(SwipeMode.twoWayVertical.allows(.swipeUp))
+        #expect(SwipeMode.twoWayVertical.allows(.swipeDown))
+        #expect(!SwipeMode.twoWayVertical.allows(.swipeLeft))
+        #expect(!SwipeMode.twoWayVertical.allows(.swipeRight))
+    }
+
+    @Test func noneRejectsEverything() {
+        for gesture in GestureType.allCases {
+            #expect(!SwipeMode.none.allows(gesture), "none should reject \(gesture)")
+        }
+    }
+}
+
+// MARK: - KeyBinding Tests
+
+struct KeyBindingTests {
+    @Test func resolvedCategoryAutoDerivesFromAction() {
+        let binding = KeyBinding(
+            label: "a", action: .commitText("a"),
+            category: nil, returnAction: nil, accessibilityLabel: nil
+        )
+        #expect(binding.resolvedCategory == .letter)
+    }
+
+    @Test func resolvedCategoryPrefersExplicitCategory() {
+        // "ß" would infer .letter, but we can override to .symbol for testing
+        let binding = KeyBinding(
+            label: "ß", action: .commitText("ß"),
+            category: .symbol, returnAction: nil, accessibilityLabel: nil
+        )
+        #expect(binding.resolvedCategory == .symbol)
+    }
+
+    @Test func resolvedCategoryExplicitLetterForEdgeCase() {
+        // Explicit .letter for a character that might be ambiguous
+        let binding = KeyBinding(
+            label: "ℝ", action: .commitText("ℝ"),
+            category: .letter, returnAction: nil, accessibilityLabel: nil
+        )
+        #expect(binding.resolvedCategory == .letter)
+    }
+
+    @Test func codableRoundtrip() throws {
+        let binding = KeyBinding(
+            label: "a", action: .commitText("a"),
+            category: nil, returnAction: .commitText("1"),
+            accessibilityLabel: "Letter A"
+        )
+        let data = try JSONEncoder().encode(binding)
+        let decoded = try JSONDecoder().decode(KeyBinding.self, from: data)
+        #expect(decoded == binding)
+    }
+
+    @Test func codableRoundtripWithAllNils() throws {
+        let binding = KeyBinding(
+            label: "⌫", action: .deleteBackward,
+            category: .utility, returnAction: nil,
+            accessibilityLabel: nil
+        )
+        let data = try JSONEncoder().encode(binding)
+        let decoded = try JSONDecoder().decode(KeyBinding.self, from: data)
+        #expect(decoded == binding)
+    }
+}
+
+// MARK: - KeyConfig Tests
+
+struct KeyConfigTests {
+    @Test func identifiable() {
+        let config = KeyConfig(
+            id: "topLeft",
+            bindings: [
+                .tap: KeyBinding(
+                    label: "a", action: .commitText("a"),
+                    category: nil, returnAction: nil, accessibilityLabel: nil
+                ),
+            ],
+            swipeMode: .eightWay,
+            slideType: .none,
+            style: .primary,
+            tapCycleActions: nil
+        )
+        #expect(config.id == "topLeft")
+    }
+
+    @Test func codableRoundtrip() throws {
+        let config = KeyConfig(
+            id: "center",
+            bindings: [
+                .tap: KeyBinding(
+                    label: "d", action: .commitText("d"),
+                    category: nil, returnAction: nil, accessibilityLabel: nil
+                ),
+                .swipeUp: KeyBinding(
+                    label: "g", action: .commitText("g"),
+                    category: nil, returnAction: .commitText("5"),
+                    accessibilityLabel: nil
+                ),
+            ],
+            swipeMode: .eightWay,
+            slideType: .none,
+            style: .primary,
+            tapCycleActions: nil
+        )
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(KeyConfig.self, from: data)
+        #expect(decoded == config)
+    }
+
+    @Test func codableRoundtripWithTapCycleActions() throws {
+        let config = KeyConfig(
+            id: "space",
+            bindings: [
+                .tap: KeyBinding(
+                    label: "␣", action: .space,
+                    category: nil, returnAction: nil, accessibilityLabel: nil
+                ),
+            ],
+            swipeMode: .none,
+            slideType: .moveCursor,
+            style: .spacebar,
+            tapCycleActions: [.space, .commitText(","), .commitText(".")]
+        )
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(KeyConfig.self, from: data)
+        #expect(decoded == config)
+    }
+
+    @Test func codableRoundtripUtilityKey() throws {
+        let config = KeyConfig(
+            id: "delete",
+            bindings: [
+                .tap: KeyBinding(
+                    label: "⌫", action: .deleteBackward,
+                    category: .utility, returnAction: nil,
+                    accessibilityLabel: "Löschen"
+                ),
+            ],
+            swipeMode: .twoWayHorizontal,
+            slideType: .delete,
+            style: .utility,
+            tapCycleActions: nil
+        )
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(KeyConfig.self, from: data)
+        #expect(decoded == config)
+    }
+
+    @Test func equatable() {
+        let binding = KeyBinding(
+            label: "a", action: .commitText("a"),
+            category: nil, returnAction: nil, accessibilityLabel: nil
+        )
+        let config1 = KeyConfig(
+            id: "topLeft", bindings: [.tap: binding],
+            swipeMode: .eightWay, slideType: .none,
+            style: .primary, tapCycleActions: nil
+        )
+        let config2 = KeyConfig(
+            id: "topLeft", bindings: [.tap: binding],
+            swipeMode: .eightWay, slideType: .none,
+            style: .primary, tapCycleActions: nil
+        )
+        let config3 = KeyConfig(
+            id: "topRight", bindings: [.tap: binding],
+            swipeMode: .eightWay, slideType: .none,
+            style: .primary, tapCycleActions: nil
+        )
+        #expect(config1 == config2)
+        #expect(config1 != config3)
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces the foundational data types for the refactoring toward a generic, data-driven keyboard architecture (Phase 1 of the refactoring plan)
- All types are `Codable`, `Equatable`, and exist parallel to the current implementation — no existing code is changed
- First of 13 planned PRs (see `REFACTORING_PLAN.md`)

## New Types
| Type | Purpose |
|------|---------|
| `KeyAction` | All possible key actions (17 cases) |
| `KeyCategory` | Semantic classification + `inferredCategory` auto-derivation |
| `GestureType` | 12 gesture types (tap, 8 swipes, circular, long press) |
| `SwipeMode` | Per-key swipe direction restrictions with `allows()` |
| `SlideType` | Special drag behaviors (cursor, progressive delete) |
| `KeyStyle` | Visual key appearance roles |
| `KeyBinding` | Gesture-to-action mapping with `resolvedCategory` |
| `KeyConfig` | Complete key definition (bindings, swipeMode, slideType, style) |

## Test plan
- [x] 27 new unit tests in `CoreValueTypeTests.swift`
- [x] Codable roundtrip tests for all types
- [x] `inferredCategory` coverage: letters, digits, symbols, ß, compose, modifiers, whitespace, utility
- [x] `SwipeMode.allows()` for all 6 modes with allowed/rejected gestures
- [x] `resolvedCategory` auto-derivation vs explicit override
- [x] Full test suite passes (355 tests, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full gesture set for keys (tap, 8 swipes, circular gestures, long press)
  * Configurable key bindings and actions with per-key behavior profiles and semantic categories
  * Per-key swipe restriction modes, slide behaviors, visual key styles, and multi-tap cycles

* **Tests**
  * Extensive unit tests covering gestures, category inference, config encoding/decoding, and equality checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->