### PR TITLE
Add Grid Types and Arrangement Transformations

### DIFF
--- a/wurstfingerKeyboard/ArrangementContext.swift
+++ b/wurstfingerKeyboard/ArrangementContext.swift
@@ -1,0 +1,17 @@
+//
+//  ArrangementContext.swift
+//  Wurstfinger
+//
+//  Determines which arrangement to use for which context.
+//
+
+import Foundation
+
+/// Determines which arrangement to use for which context.
+enum ArrangementContext: String, Codable, CaseIterable {
+    case portrait // Portrait, utility right (default)
+    case portraitUtilityLeft // Portrait, utility left
+    case landscape // Landscape
+    case landscapeUtilityLeft // Landscape, utility left
+    // Extensible: .tablet, .oneHanded, .split, ...
+}

--- a/wurstfingerKeyboard/GridArrangement.swift
+++ b/wurstfingerKeyboard/GridArrangement.swift
@@ -32,6 +32,8 @@ extension GridArrangement {
 
     /// Changes the column count and adjusts a specific key's width.
     func resized(columns newColumns: Int, adjusting keyId: String, toWidth newWidth: Int) -> GridArrangement {
+        precondition(newColumns > 0, "newColumns must be positive")
+        precondition(newWidth > 0, "newWidth must be positive")
         GridArrangement(
             columns: newColumns,
             rows: rows.map { row in

--- a/wurstfingerKeyboard/GridArrangement.swift
+++ b/wurstfingerKeyboard/GridArrangement.swift
@@ -34,7 +34,7 @@ extension GridArrangement {
     func resized(columns newColumns: Int, adjusting keyId: String, toWidth newWidth: Int) -> GridArrangement {
         precondition(newColumns > 0, "newColumns must be positive")
         precondition(newWidth > 0, "newWidth must be positive")
-        GridArrangement(
+        return GridArrangement(
             columns: newColumns,
             rows: rows.map { row in
                 row.map { placement in

--- a/wurstfingerKeyboard/GridArrangement.swift
+++ b/wurstfingerKeyboard/GridArrangement.swift
@@ -1,0 +1,54 @@
+//
+//  GridArrangement.swift
+//  Wurstfinger
+//
+//  A concrete spatial arrangement of keys in a grid.
+//
+
+import Foundation
+
+/// A concrete spatial arrangement of keys.
+/// Multiple arrangements can lay out the same key pool differently.
+struct GridArrangement: Codable, Equatable {
+    /// Number of logical columns.
+    /// The sum of widthMultipliers in each row (plus columns spanned by keys from
+    /// previous rows via heightMultiplier) must equal this value.
+    let columns: Int
+
+    /// The placements, organized by row.
+    let rows: [[KeyPlacement]]
+}
+
+// MARK: - Transformations
+
+extension GridArrangement {
+    /// Mirrors each row horizontally (utility left ↔ right).
+    func mirroredHorizontally() -> GridArrangement {
+        GridArrangement(
+            columns: columns,
+            rows: rows.map { $0.reversed() }
+        )
+    }
+
+    /// Changes the column count and adjusts a specific key's width.
+    func resized(columns newColumns: Int, adjusting keyId: String, toWidth newWidth: Int) -> GridArrangement {
+        GridArrangement(
+            columns: newColumns,
+            rows: rows.map { row in
+                row.map { placement in
+                    placement.keyId == keyId
+                        ? KeyPlacement(keyId: keyId, widthMultiplier: newWidth, heightMultiplier: placement.heightMultiplier)
+                        : placement
+                }
+            }
+        )
+    }
+
+    /// Removes a key from all rows (e.g. for more compact layouts).
+    func removing(keyId: String) -> GridArrangement {
+        GridArrangement(
+            columns: columns,
+            rows: rows.map { $0.filter { $0.keyId != keyId } }
+        )
+    }
+}

--- a/wurstfingerKeyboard/KeyPlacement.swift
+++ b/wurstfingerKeyboard/KeyPlacement.swift
@@ -27,4 +27,26 @@ struct KeyPlacement: Codable, Equatable {
         self.widthMultiplier = widthMultiplier
         self.heightMultiplier = heightMultiplier
     }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let keyId = try container.decode(String.self, forKey: .keyId)
+        let width = try container.decode(Int.self, forKey: .widthMultiplier)
+        let height = try container.decode(Int.self, forKey: .heightMultiplier)
+
+        guard width > 0 else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .widthMultiplier, in: container,
+                debugDescription: "widthMultiplier must be positive"
+            )
+        }
+        guard height > 0 else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .heightMultiplier, in: container,
+                debugDescription: "heightMultiplier must be positive"
+            )
+        }
+
+        self.init(keyId: keyId, widthMultiplier: width, heightMultiplier: height)
+    }
 }

--- a/wurstfingerKeyboard/KeyPlacement.swift
+++ b/wurstfingerKeyboard/KeyPlacement.swift
@@ -1,0 +1,28 @@
+//
+//  KeyPlacement.swift
+//  Wurstfinger
+//
+//  References a key by ID and determines its size in the grid.
+//
+
+import Foundation
+
+/// References a key by ID and determines its size in the grid.
+/// The same key can be placed differently in different arrangements.
+struct KeyPlacement: Codable, Equatable {
+    /// Reference to a KeyConfig.id
+    let keyId: String
+
+    /// Width as multiple of standard column width (1 = normal, 2 = double, 3 = triple)
+    let widthMultiplier: Int
+
+    /// Height as multiple of standard row height (1 = normal, 2 = double)
+    /// Enables e.g. a tall return key spanning 2 rows.
+    let heightMultiplier: Int
+
+    init(keyId: String, widthMultiplier: Int = 1, heightMultiplier: Int = 1) {
+        self.keyId = keyId
+        self.widthMultiplier = widthMultiplier
+        self.heightMultiplier = heightMultiplier
+    }
+}

--- a/wurstfingerKeyboard/KeyPlacement.swift
+++ b/wurstfingerKeyboard/KeyPlacement.swift
@@ -21,6 +21,8 @@ struct KeyPlacement: Codable, Equatable {
     let heightMultiplier: Int
 
     init(keyId: String, widthMultiplier: Int = 1, heightMultiplier: Int = 1) {
+        precondition(widthMultiplier > 0, "widthMultiplier must be positive")
+        precondition(heightMultiplier > 0, "heightMultiplier must be positive")
         self.keyId = keyId
         self.widthMultiplier = widthMultiplier
         self.heightMultiplier = heightMultiplier

--- a/wurstfingerTests/GridTypeTests.swift
+++ b/wurstfingerTests/GridTypeTests.swift
@@ -43,6 +43,20 @@ struct KeyPlacementTests {
         #expect(a == b)
         #expect(a != c)
     }
+
+    @Test func decodingRejectsZeroWidthMultiplier() {
+        let json = #"{"keyId":"a","widthMultiplier":0,"heightMultiplier":1}"#
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(KeyPlacement.self, from: Data(json.utf8))
+        }
+    }
+
+    @Test func decodingRejectsNegativeHeightMultiplier() {
+        let json = #"{"keyId":"a","widthMultiplier":1,"heightMultiplier":-1}"#
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(KeyPlacement.self, from: Data(json.utf8))
+        }
+    }
 }
 
 // MARK: - GridArrangement Tests

--- a/wurstfingerTests/GridTypeTests.swift
+++ b/wurstfingerTests/GridTypeTests.swift
@@ -1,0 +1,188 @@
+//
+//  GridTypeTests.swift
+//  WurstfingerTests
+//
+//  Tests for KeyPlacement, GridArrangement, and ArrangementContext.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+// MARK: - KeyPlacement Tests
+
+struct KeyPlacementTests {
+    @Test func defaultMultipliers() {
+        let placement = KeyPlacement(keyId: "topLeft")
+        #expect(placement.widthMultiplier == 1)
+        #expect(placement.heightMultiplier == 1)
+    }
+
+    @Test func customMultipliers() {
+        let placement = KeyPlacement(keyId: "space", widthMultiplier: 3, heightMultiplier: 1)
+        #expect(placement.widthMultiplier == 3)
+        #expect(placement.heightMultiplier == 1)
+    }
+
+    @Test func heightMultiplier() {
+        let placement = KeyPlacement(keyId: "return", widthMultiplier: 1, heightMultiplier: 2)
+        #expect(placement.heightMultiplier == 2)
+    }
+
+    @Test func codableRoundtrip() throws {
+        let placement = KeyPlacement(keyId: "center", widthMultiplier: 2, heightMultiplier: 3)
+        let data = try JSONEncoder().encode(placement)
+        let decoded = try JSONDecoder().decode(KeyPlacement.self, from: data)
+        #expect(decoded == placement)
+    }
+
+    @Test func equatable() {
+        let a = KeyPlacement(keyId: "topLeft")
+        let b = KeyPlacement(keyId: "topLeft")
+        let c = KeyPlacement(keyId: "topRight")
+        #expect(a == b)
+        #expect(a != c)
+    }
+}
+
+// MARK: - GridArrangement Tests
+
+struct GridArrangementTests {
+    // A standard 4-column portrait arrangement for testing
+    static let portrait = GridArrangement(
+        columns: 4,
+        rows: [
+            [.init(keyId: "topLeft"), .init(keyId: "topCenter"), .init(keyId: "topRight"), .init(keyId: "globe")],
+            [.init(keyId: "midLeft"), .init(keyId: "center"), .init(keyId: "midRight"), .init(keyId: "symbols")],
+            [.init(keyId: "bottomLeft"), .init(keyId: "bottomCenter"), .init(keyId: "bottomRight"), .init(keyId: "delete")],
+            [.init(keyId: "space", widthMultiplier: 3), .init(keyId: "return")],
+        ]
+    )
+
+    @Test func mirroredHorizontallyReversesEachRow() {
+        let mirrored = Self.portrait.mirroredHorizontally()
+
+        #expect(mirrored.columns == 4)
+        #expect(mirrored.rows.count == 4)
+
+        // First row: globe should now be first
+        #expect(mirrored.rows[0][0].keyId == "globe")
+        #expect(mirrored.rows[0][1].keyId == "topRight")
+        #expect(mirrored.rows[0][2].keyId == "topCenter")
+        #expect(mirrored.rows[0][3].keyId == "topLeft")
+
+        // Last row: return first, space second
+        #expect(mirrored.rows[3][0].keyId == "return")
+        #expect(mirrored.rows[3][1].keyId == "space")
+    }
+
+    @Test func mirroredHorizontallyPreservesMultipliers() throws {
+        let mirrored = Self.portrait.mirroredHorizontally()
+        // Space should keep its widthMultiplier
+        let spacePlacement = try #require(mirrored.rows[3].first { $0.keyId == "space" })
+        #expect(spacePlacement.widthMultiplier == 3)
+    }
+
+    @Test func doubleMirrorIsIdentity() {
+        let doubleMirrored = Self.portrait.mirroredHorizontally().mirroredHorizontally()
+        #expect(doubleMirrored == Self.portrait)
+    }
+
+    @Test func resizedAdjustsTargetKey() throws {
+        // Resize space from width 3 to width 4, total columns 4 → 5
+        let resized = Self.portrait.resized(columns: 5, adjusting: "space", toWidth: 4)
+
+        #expect(resized.columns == 5)
+        let spacePlacement = try #require(resized.rows[3].first { $0.keyId == "space" })
+        #expect(spacePlacement.widthMultiplier == 4)
+    }
+
+    @Test func resizedLeavesOtherKeysUntouched() throws {
+        let resized = Self.portrait.resized(columns: 5, adjusting: "space", toWidth: 4)
+
+        // topLeft should still have width 1
+        let topLeft = try #require(resized.rows[0].first { $0.keyId == "topLeft" })
+        #expect(topLeft.widthMultiplier == 1)
+    }
+
+    @Test func resizedPreservesHeightMultiplier() throws {
+        let withHeight = GridArrangement(
+            columns: 4,
+            rows: [
+                [.init(keyId: "a"), .init(keyId: "b", widthMultiplier: 2, heightMultiplier: 2), .init(keyId: "c")],
+            ]
+        )
+        let resized = withHeight.resized(columns: 5, adjusting: "b", toWidth: 3)
+        let b = try #require(resized.rows[0].first { $0.keyId == "b" })
+        #expect(b.widthMultiplier == 3)
+        #expect(b.heightMultiplier == 2)
+    }
+
+    @Test func removingDeletesFromAllRows() {
+        let removed = Self.portrait.removing(keyId: "globe")
+
+        // Globe was in row 0 — should be gone
+        let row0Ids = removed.rows[0].map(\.keyId)
+        #expect(!row0Ids.contains("globe"))
+        #expect(row0Ids == ["topLeft", "topCenter", "topRight"])
+
+        // Other rows should be untouched
+        #expect(removed.rows[1].count == 4)
+        #expect(removed.rows[3].count == 2)
+    }
+
+    @Test func removingKeyNotPresentIsNoOp() {
+        let removed = Self.portrait.removing(keyId: "nonexistent")
+        #expect(removed == Self.portrait)
+    }
+
+    @Test func removingPreservesColumns() {
+        let removed = Self.portrait.removing(keyId: "globe")
+        #expect(removed.columns == 4)
+    }
+
+    @Test func codableRoundtrip() throws {
+        let data = try JSONEncoder().encode(Self.portrait)
+        let decoded = try JSONDecoder().decode(GridArrangement.self, from: data)
+        #expect(decoded == Self.portrait)
+    }
+
+    @Test func emptyGrid() {
+        let empty = GridArrangement(columns: 0, rows: [])
+        #expect(empty.rows.isEmpty)
+        #expect(empty.columns == 0)
+    }
+
+    @Test func singleCellGrid() {
+        let single = GridArrangement(
+            columns: 1,
+            rows: [[KeyPlacement(keyId: "only")]]
+        )
+        #expect(single.rows.count == 1)
+        #expect(single.rows[0].count == 1)
+        #expect(single.rows[0][0].keyId == "only")
+    }
+}
+
+// MARK: - ArrangementContext Tests
+
+struct ArrangementContextTests {
+    @Test func caseIterable() {
+        #expect(ArrangementContext.allCases.count == 4)
+    }
+
+    @Test func codableRoundtrip() throws {
+        for context in ArrangementContext.allCases {
+            let data = try JSONEncoder().encode(context)
+            let decoded = try JSONDecoder().decode(ArrangementContext.self, from: data)
+            #expect(decoded == context)
+        }
+    }
+
+    @Test func rawValues() {
+        #expect(ArrangementContext.portrait.rawValue == "portrait")
+        #expect(ArrangementContext.portraitUtilityLeft.rawValue == "portraitUtilityLeft")
+        #expect(ArrangementContext.landscape.rawValue == "landscape")
+        #expect(ArrangementContext.landscapeUtilityLeft.rawValue == "landscapeUtilityLeft")
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces layout/placement types that separate key behavior from key position (Phase 1.9–1.12)
- `GridArrangement` transformations enable deriving utility-left/landscape layouts from a single base definition
- Depends on PR #144 (Core Value Types)

## New Types
| Type | Purpose |
|------|---------|
| `KeyPlacement` | References a key by ID with width/height multipliers |
| `GridArrangement` | Spatial arrangement of keys + `mirroredHorizontally()`, `resized()`, `removing()` |
| `ArrangementContext` | Portrait/landscape × utility left/right (4 contexts) |

## Test plan
- [x] 20 new unit tests in `GridTypeTests.swift`
- [x] `KeyPlacement`: default multipliers, Codable, Equatable
- [x] `mirroredHorizontally()`: row reversal, multiplier preservation, double-mirror = identity
- [x] `resized()`: target key adjusted, others untouched, heightMultiplier preserved
- [x] `removing()`: key removed from all rows, no-op for missing key, columns unchanged
- [x] Edge cases: empty grid, single-cell grid
- [x] Full test suite passes (375 tests, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Introduced configurable keyboard arrangement contexts supporting portrait and landscape orientations with utility panel placement options
* Added grid-based layout system enabling key placement configuration with resizable and repositionable keys

## Tests
* Added comprehensive test coverage for arrangement contexts, grid layouts, and key placement configurations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->