### PR TITLE
Add KeyboardMode, KeyboardDefinition, and Validation

### DIFF
--- a/wurstfingerKeyboard/KeyboardDefinition.swift
+++ b/wurstfingerKeyboard/KeyboardDefinition.swift
@@ -1,0 +1,80 @@
+//
+//  KeyboardDefinition.swift
+//  Wurstfinger
+//
+//  Complete definition of a keyboard with all modes and settings.
+//
+
+import Foundation
+
+/// Complete definition of a keyboard with all modes and settings.
+struct KeyboardDefinition: Codable, Equatable {
+    /// Display name (e.g. "Deutsch MessagEase")
+    let title: String
+
+    /// Unique ID (e.g. "de_messagease")
+    let id: String
+
+    /// Locale identifier as String for Codable (e.g. "de_DE")
+    let localeIdentifier: String
+
+    /// Computed: Locale for uppercase logic, auto-capitalization, etc.
+    var locale: Locale {
+        Locale(identifier: localeIdentifier)
+    }
+
+    /// All available modes, accessible by name.
+    /// Arbitrarily many modes possible: "main", "shifted", "numeric", "emoji", ...
+    let modes: [String: KeyboardMode]
+
+    /// Which mode is active at start (normally "main")
+    let defaultMode: String
+
+    /// Keyboard-specific settings
+    let settings: KeyboardDefinitionSettings
+
+    /// Convenience: Mode lookup
+    func mode(_ name: String) -> KeyboardMode? {
+        modes[name]
+    }
+}
+
+/// Well-known mode names as constants (extensible without code change)
+enum ModeNames {
+    static let main = "main"
+    static let shifted = "shifted"
+    static let capsLock = "capsLock"
+    static let numeric = "numeric"
+    static let symbols = "symbols"
+    static let emoji = "emoji"
+}
+
+/// Keyboard-specific settings for a KeyboardDefinition.
+struct KeyboardDefinitionSettings: Codable, Equatable {
+    /// Auto-capitalization enabled
+    let autoCapitalize: Bool
+
+    /// Language-specific auto-capitalizer rules (e.g. "i" → "I" in English)
+    let autoCapitalizers: [AutoCapitalizerRule]
+
+    /// Language-specific compose rule overrides.
+    /// Merged with global base rules at runtime.
+    /// nil = only use global rules (sufficient for most languages).
+    let composeRuleOverrides: ComposeRuleSet?
+}
+
+/// A complete set of compose rules, loadable from JSON.
+struct ComposeRuleSet: Codable, Equatable {
+    /// trigger → (baseChar → result)
+    /// e.g. "¨" → ["a": "ä", "o": "ö", ...]
+    let rules: [String: [String: String]]
+}
+
+/// A rule for automatic capitalization.
+struct AutoCapitalizerRule: Codable, Equatable {
+    /// Pattern recognized in text before cursor
+    let pattern: String
+
+    /// Replacement
+    let replacement: String
+}

--- a/wurstfingerKeyboard/KeyboardMode.swift
+++ b/wurstfingerKeyboard/KeyboardMode.swift
@@ -1,0 +1,66 @@
+//
+//  KeyboardMode.swift
+//  Wurstfinger
+//
+//  A complete keyboard mode (e.g. lowercase, uppercase, numbers).
+//
+
+import Foundation
+
+/// A complete keyboard mode (e.g. lowercase, uppercase, numbers).
+/// Separates key definitions (WHAT the keys do) from arrangements (WHERE they are).
+/// Contains state machine rules for automatic mode transitions.
+struct KeyboardMode: Codable, Equatable {
+    /// Unique name of the mode
+    let name: String
+
+    /// Pool of all keys in this mode, accessible by ID
+    let keys: [String: KeyConfig]
+
+    /// Different grid arrangements for different contexts.
+    /// At least `.portrait` must be present.
+    let arrangements: [ArrangementContext: GridArrangement]
+
+    // MARK: - State Machine
+
+    /// Automatic mode transitions after input of a certain category.
+    /// e.g. in "shifted" mode: [.letter: "main"] → after letter back to main.
+    /// Empty dictionary = mode stays active (like caps lock or numeric).
+    let autoTransitions: [KeyCategory: String]
+
+    /// Double-tap on the switchMode key that leads to this mode → switch here.
+    /// e.g. shifted.doubleTapMode = "capsLock" → double-tap shift → caps lock.
+    /// nil = no double-tap behavior.
+    let doubleTapMode: String?
+
+    // MARK: - Convenience
+
+    func key(for id: String) -> KeyConfig? {
+        keys[id]
+    }
+
+    func arrangement(for context: ArrangementContext) -> GridArrangement {
+        arrangements[context] ?? arrangements[.portrait]!
+    }
+
+    /// Determines the next mode after an action with the given category.
+    /// Returns nil if the current mode should be kept.
+    func nextMode(after category: KeyCategory) -> String? {
+        autoTransitions[category]
+    }
+
+    /// Creates a copy with changed state machine properties.
+    func with(
+        name: String? = nil,
+        autoTransitions: [KeyCategory: String]? = nil,
+        doubleTapMode: String?? = nil
+    ) -> KeyboardMode {
+        KeyboardMode(
+            name: name ?? self.name,
+            keys: keys,
+            arrangements: arrangements,
+            autoTransitions: autoTransitions ?? self.autoTransitions,
+            doubleTapMode: doubleTapMode ?? self.doubleTapMode
+        )
+    }
+}

--- a/wurstfingerKeyboard/KeyboardMode.swift
+++ b/wurstfingerKeyboard/KeyboardMode.swift
@@ -39,8 +39,8 @@ struct KeyboardMode: Codable, Equatable {
         keys[id]
     }
 
-    func arrangement(for context: ArrangementContext) -> GridArrangement {
-        arrangements[context] ?? arrangements[.portrait]!
+    func arrangement(for context: ArrangementContext) -> GridArrangement? {
+        arrangements[context] ?? arrangements[.portrait]
     }
 
     /// Determines the next mode after an action with the given category.

--- a/wurstfingerKeyboard/ValidationError.swift
+++ b/wurstfingerKeyboard/ValidationError.swift
@@ -15,6 +15,7 @@ enum ValidationError: Error, Equatable, CustomStringConvertible {
     case emptyKeyPool
     case noPortraitArrangement
     case duplicateKeyId(String)
+    case modeNameMismatch(key: String, modeName: String)
 
     var description: String {
         switch self {
@@ -30,6 +31,8 @@ enum ValidationError: Error, Equatable, CustomStringConvertible {
             "No portrait arrangement defined"
         case let .duplicateKeyId(id):
             "Duplicate key ID '\(id)' in arrangement"
+        case let .modeNameMismatch(key, modeName):
+            "Mode dictionary key '\(key)' does not match mode name '\(modeName)'"
         }
     }
 }
@@ -98,6 +101,11 @@ extension KeyboardDefinition {
         // defaultMode must exist
         if modes[defaultMode] == nil {
             errors.append(.missingMode(defaultMode))
+        }
+
+        // Mode dictionary keys must match mode names
+        for (key, mode) in modes where key != mode.name {
+            errors.append(.modeNameMismatch(key: key, modeName: mode.name))
         }
 
         // All switchMode targets must exist

--- a/wurstfingerKeyboard/ValidationError.swift
+++ b/wurstfingerKeyboard/ValidationError.swift
@@ -1,0 +1,132 @@
+//
+//  ValidationError.swift
+//  Wurstfinger
+//
+//  Validation for data-driven keyboard definitions.
+//
+
+import Foundation
+
+/// Validation errors for keyboard definitions.
+enum ValidationError: Error, Equatable, CustomStringConvertible {
+    case missingKey(keyId: String, context: ArrangementContext)
+    case missingMode(String)
+    case columnMismatch(row: Int, context: ArrangementContext, expected: Int, got: Int)
+    case emptyKeyPool
+    case noPortraitArrangement
+    case duplicateKeyId(String)
+
+    var description: String {
+        switch self {
+        case let .missingKey(keyId, context):
+            "Key '\(keyId)' referenced in arrangement '\(context)' but not found in key pool"
+        case let .missingMode(name):
+            "Mode '\(name)' referenced but not found in definition"
+        case let .columnMismatch(row, context, expected, got):
+            "Row \(row) in '\(context)' has \(got) columns (expected \(expected))"
+        case .emptyKeyPool:
+            "Key pool is empty"
+        case .noPortraitArrangement:
+            "No portrait arrangement defined"
+        case let .duplicateKeyId(id):
+            "Duplicate key ID '\(id)' in arrangement"
+        }
+    }
+}
+
+// MARK: - KeyboardMode Validation
+
+extension KeyboardMode {
+    func validate() -> [ValidationError] {
+        var errors: [ValidationError] = []
+
+        if keys.isEmpty {
+            errors.append(.emptyKeyPool)
+        }
+
+        if arrangements[.portrait] == nil {
+            errors.append(.noPortraitArrangement)
+        }
+
+        for (context, arrangement) in arrangements {
+            // All keyIds must exist in the key pool
+            for row in arrangement.rows {
+                for placement in row where keys[placement.keyId] == nil {
+                    errors.append(.missingKey(keyId: placement.keyId, context: context))
+                }
+            }
+
+            // Detect duplicate keyIds within an arrangement
+            let allIds = arrangement.rows.flatMap { $0.map(\.keyId) }
+            var seen = Set<String>()
+            for id in allIds where !seen.insert(id).inserted {
+                errors.append(.duplicateKeyId(id))
+            }
+
+            // Column validation: widthMultiplier sum + columns spanned from above == columns.
+            // Keys with heightMultiplier > 1 occupy their columns in subsequent rows.
+            var spannedColumns: [Int: Int] = [:]
+            for (i, row) in arrangement.rows.enumerated() {
+                let spanning = spannedColumns[i, default: 0]
+                let sum = row.reduce(0) { $0 + $1.widthMultiplier } + spanning
+                if sum != arrangement.columns {
+                    errors.append(.columnMismatch(
+                        row: i, context: context,
+                        expected: arrangement.columns, got: sum
+                    ))
+                }
+                // Register keys that span into subsequent rows
+                for placement in row where placement.heightMultiplier > 1 {
+                    for extraRow in 1 ..< placement.heightMultiplier {
+                        spannedColumns[i + extraRow, default: 0] += placement.widthMultiplier
+                    }
+                }
+            }
+        }
+
+        return errors
+    }
+}
+
+// MARK: - KeyboardDefinition Validation
+
+extension KeyboardDefinition {
+    /// Validates all modes and the overall structure.
+    func validate() -> [ValidationError] {
+        var errors: [ValidationError] = []
+
+        // defaultMode must exist
+        if modes[defaultMode] == nil {
+            errors.append(.missingMode(defaultMode))
+        }
+
+        // All switchMode targets must exist
+        for (_, mode) in modes {
+            for (_, key) in mode.keys {
+                for (_, binding) in key.bindings {
+                    if case let .switchMode(target) = binding.action,
+                       modes[target] == nil {
+                        errors.append(.missingMode(target))
+                    }
+                }
+            }
+
+            // All autoTransition targets must exist
+            for (_, targetMode) in mode.autoTransitions where modes[targetMode] == nil {
+                errors.append(.missingMode(targetMode))
+            }
+
+            // All doubleTapMode targets must exist
+            if let doubleTap = mode.doubleTapMode, modes[doubleTap] == nil {
+                errors.append(.missingMode(doubleTap))
+            }
+        }
+
+        // Validate each mode individually
+        for (_, mode) in modes {
+            errors += mode.validate()
+        }
+
+        return errors
+    }
+}

--- a/wurstfingerKeyboard/ValidationError.swift
+++ b/wurstfingerKeyboard/ValidationError.swift
@@ -16,6 +16,7 @@ enum ValidationError: Error, Equatable, CustomStringConvertible {
     case noPortraitArrangement
     case duplicateKeyId(String)
     case modeNameMismatch(key: String, modeName: String)
+    case rowSpanOutOfBounds(keyId: String, context: ArrangementContext)
 
     var description: String {
         switch self {
@@ -33,6 +34,8 @@ enum ValidationError: Error, Equatable, CustomStringConvertible {
             "Duplicate key ID '\(id)' in arrangement"
         case let .modeNameMismatch(key, modeName):
             "Mode dictionary key '\(key)' does not match mode name '\(modeName)'"
+        case let .rowSpanOutOfBounds(keyId, context):
+            "Key '\(keyId)' in '\(context)' spans past the last row"
         }
     }
 }
@@ -80,6 +83,10 @@ extension KeyboardMode {
                 }
                 // Register keys that span into subsequent rows
                 for placement in row where placement.heightMultiplier > 1 {
+                    guard i + placement.heightMultiplier <= arrangement.rows.count else {
+                        errors.append(.rowSpanOutOfBounds(keyId: placement.keyId, context: context))
+                        continue
+                    }
                     for extraRow in 1 ..< placement.heightMultiplier {
                         spannedColumns[i + extraRow, default: 0] += placement.widthMultiplier
                     }

--- a/wurstfingerTests/ModeDefinitionValidationTests.swift
+++ b/wurstfingerTests/ModeDefinitionValidationTests.swift
@@ -311,6 +311,21 @@ struct ValidationTests {
         #expect(errors.contains(.columnMismatch(row: 1, context: .portrait, expected: 2, got: 3)))
     }
 
+    @Test func heightMultiplierSpansPastLastRow() {
+        // Single row, but key "a" has height 2 — spans into non-existent row 1
+        let arrangement = GridArrangement(columns: 2, rows: [
+            [KeyPlacement(keyId: "a", widthMultiplier: 1, heightMultiplier: 2), KeyPlacement(keyId: "b")],
+        ])
+        let mode = KeyboardMode(
+            name: "test",
+            keys: ["a": letterKey("a", "a"), "b": letterKey("b", "b")],
+            arrangements: [.portrait: arrangement],
+            autoTransitions: [:], doubleTapMode: nil
+        )
+        let errors = mode.validate()
+        #expect(errors.contains(.rowSpanOutOfBounds(keyId: "a", context: .portrait)))
+    }
+
     // MARK: Duplicate Key ID
 
     @Test func duplicateKeyId() {

--- a/wurstfingerTests/ModeDefinitionValidationTests.swift
+++ b/wurstfingerTests/ModeDefinitionValidationTests.swift
@@ -355,6 +355,24 @@ struct ValidationTests {
         let errors = mode.validate()
         #expect(errors.contains(.noPortraitArrangement))
     }
+
+    // MARK: Mode Name Mismatch
+
+    @Test func modeNameMismatchDetected() {
+        let mode = minimalMode()
+        let definition = KeyboardDefinition(
+            title: "Test", id: "test", localeIdentifier: "en_US",
+            modes: ["wrong_key": mode], // key "wrong_key" != mode.name "main"
+            defaultMode: "wrong_key",
+            settings: KeyboardDefinitionSettings(
+                autoCapitalize: false,
+                autoCapitalizers: [],
+                composeRuleOverrides: nil
+            )
+        )
+        let errors = definition.validate()
+        #expect(errors.contains(.modeNameMismatch(key: "wrong_key", modeName: "main")))
+    }
 }
 
 // MARK: - Supporting Type Tests

--- a/wurstfingerTests/ModeDefinitionValidationTests.swift
+++ b/wurstfingerTests/ModeDefinitionValidationTests.swift
@@ -1,0 +1,388 @@
+//
+//  ModeDefinitionValidationTests.swift
+//  WurstfingerTests
+//
+//  Tests for KeyboardMode, KeyboardDefinition, and Validation.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+// MARK: - Test Helpers
+
+private func letterBinding(_ char: String) -> KeyBinding {
+    KeyBinding(label: char, action: .commitText(char), category: nil, returnAction: nil, accessibilityLabel: nil)
+}
+
+private func letterKey(_ id: String, _ char: String) -> KeyConfig {
+    KeyConfig(id: id, bindings: [.tap: letterBinding(char)], swipeMode: .eightWay, slideType: .none, style: .primary, tapCycleActions: nil)
+}
+
+private func utilityKey(_ id: String, action: KeyAction) -> KeyConfig {
+    KeyConfig(
+        id: id,
+        bindings: [.tap: KeyBinding(label: id, action: action, category: .utility, returnAction: nil, accessibilityLabel: nil)],
+        swipeMode: .none, slideType: .none, style: .utility, tapCycleActions: nil
+    )
+}
+
+/// Minimal valid mode with 4 keys and a portrait arrangement
+private func minimalMode(
+    name: String = "main",
+    autoTransitions: [KeyCategory: String] = [:],
+    doubleTapMode: String? = nil
+) -> KeyboardMode {
+    let keys: [String: KeyConfig] = [
+        "a": letterKey("a", "a"),
+        "b": letterKey("b", "b"),
+        "c": letterKey("c", "c"),
+        "shift": utilityKey("shift", action: .switchMode(ModeNames.shifted)),
+    ]
+    let arrangement = GridArrangement(columns: 2, rows: [
+        [KeyPlacement(keyId: "a"), KeyPlacement(keyId: "b")],
+        [KeyPlacement(keyId: "c"), KeyPlacement(keyId: "shift")],
+    ])
+    return KeyboardMode(
+        name: name, keys: keys,
+        arrangements: [.portrait: arrangement],
+        autoTransitions: autoTransitions,
+        doubleTapMode: doubleTapMode
+    )
+}
+
+/// Minimal valid definition with main + shifted modes
+private func minimalDefinition(
+    modes: [String: KeyboardMode]? = nil,
+    defaultMode: String = ModeNames.main
+) -> KeyboardDefinition {
+    let defaultModes: [String: KeyboardMode] = [
+        ModeNames.main: minimalMode(name: ModeNames.main),
+        ModeNames.shifted: minimalMode(name: ModeNames.shifted, autoTransitions: [.letter: ModeNames.main]),
+    ]
+    return KeyboardDefinition(
+        title: "Test", id: "test", localeIdentifier: "en_US",
+        modes: modes ?? defaultModes,
+        defaultMode: defaultMode,
+        settings: KeyboardDefinitionSettings(autoCapitalize: true, autoCapitalizers: [], composeRuleOverrides: nil)
+    )
+}
+
+// MARK: - KeyboardMode Tests
+
+struct KeyboardModeTests {
+    @Test func keyLookup() {
+        let mode = minimalMode()
+        #expect(mode.key(for: "a") != nil)
+        #expect(mode.key(for: "nonexistent") == nil)
+    }
+
+    @Test func arrangementFallbackToPortrait() {
+        let mode = minimalMode()
+        // Landscape not defined — should fall back to portrait
+        let landscape = mode.arrangement(for: .landscape)
+        let portrait = mode.arrangement(for: .portrait)
+        #expect(landscape == portrait)
+    }
+
+    @Test func arrangementReturnsSpecificContext() throws {
+        let landscapeArrangement = GridArrangement(columns: 4, rows: [
+            [KeyPlacement(keyId: "a"), KeyPlacement(keyId: "b"), KeyPlacement(keyId: "c"), KeyPlacement(keyId: "shift")],
+        ])
+        let mode = try KeyboardMode(
+            name: "main",
+            keys: minimalMode().keys,
+            arrangements: [
+                .portrait: #require(minimalMode().arrangements[.portrait]),
+                .landscape: landscapeArrangement,
+            ],
+            autoTransitions: [:],
+            doubleTapMode: nil
+        )
+        let result = mode.arrangement(for: .landscape)
+        #expect(result == landscapeArrangement)
+        #expect(result != mode.arrangement(for: .portrait))
+    }
+
+    @Test func nextModeStateMachineShifted() {
+        let shifted = minimalMode(autoTransitions: [.letter: ModeNames.main])
+        #expect(shifted.nextMode(after: .letter) == ModeNames.main)
+        #expect(shifted.nextMode(after: .symbol) == nil)
+        #expect(shifted.nextMode(after: .utility) == nil)
+    }
+
+    @Test func nextModeStateMachineCapsLock() {
+        let capsLock = minimalMode(autoTransitions: [:])
+        // Empty autoTransitions — mode stays active
+        #expect(capsLock.nextMode(after: .letter) == nil)
+        #expect(capsLock.nextMode(after: .symbol) == nil)
+    }
+
+    @Test func nextModeStateMachineEmoji() {
+        let emoji = minimalMode(autoTransitions: [.symbol: ModeNames.main])
+        #expect(emoji.nextMode(after: .symbol) == ModeNames.main)
+        #expect(emoji.nextMode(after: .letter) == nil)
+    }
+
+    @Test func withChangesAutoTransitions() {
+        let mode = minimalMode()
+        let modified = mode.with(autoTransitions: [.letter: ModeNames.main])
+        #expect(modified.autoTransitions[.letter] == ModeNames.main)
+        #expect(modified.name == mode.name)
+        #expect(modified.keys == mode.keys)
+    }
+
+    @Test func withChangesName() {
+        let mode = minimalMode()
+        let modified = mode.with(name: "capsLock")
+        #expect(modified.name == "capsLock")
+        #expect(modified.keys == mode.keys)
+    }
+
+    @Test func withChangesDoubleTapMode() {
+        let mode = minimalMode()
+        let modified = mode.with(doubleTapMode: "capsLock")
+        #expect(modified.doubleTapMode == "capsLock")
+    }
+
+    @Test func withClearsDoubleTapMode() {
+        let mode = minimalMode(doubleTapMode: "capsLock")
+        let modified = mode.with(doubleTapMode: .some(nil))
+        #expect(modified.doubleTapMode == nil)
+    }
+
+    @Test func codableRoundtrip() throws {
+        let mode = minimalMode(autoTransitions: [.letter: "main"], doubleTapMode: "capsLock")
+        let data = try JSONEncoder().encode(mode)
+        let decoded = try JSONDecoder().decode(KeyboardMode.self, from: data)
+        #expect(decoded == mode)
+    }
+}
+
+// MARK: - KeyboardDefinition Tests
+
+struct KeyboardDefinitionTests {
+    @Test func modeLookup() {
+        let def = minimalDefinition()
+        #expect(def.mode(ModeNames.main) != nil)
+        #expect(def.mode(ModeNames.shifted) != nil)
+        #expect(def.mode("nonexistent") == nil)
+    }
+
+    @Test func locale() {
+        let def = minimalDefinition()
+        #expect(def.locale.identifier == "en_US")
+    }
+
+    @Test func codableRoundtrip() throws {
+        let def = minimalDefinition()
+        let data = try JSONEncoder().encode(def)
+        let decoded = try JSONDecoder().decode(KeyboardDefinition.self, from: data)
+        #expect(decoded == def)
+    }
+}
+
+// MARK: - Validation Tests
+
+struct ValidationTests {
+    // MARK: Happy Path
+
+    @Test func validDefinitionHasNoErrors() {
+        let def = minimalDefinition()
+        #expect(def.validate().isEmpty)
+    }
+
+    @Test func validModeHasNoErrors() {
+        let mode = minimalMode()
+        #expect(mode.validate().isEmpty)
+    }
+
+    // MARK: Missing Key
+
+    @Test func missingKeyInArrangement() {
+        let arrangement = GridArrangement(columns: 2, rows: [
+            [KeyPlacement(keyId: "a"), KeyPlacement(keyId: "nonexistent")],
+        ])
+        let mode = KeyboardMode(
+            name: "test",
+            keys: ["a": letterKey("a", "a")],
+            arrangements: [.portrait: arrangement],
+            autoTransitions: [:], doubleTapMode: nil
+        )
+        let errors = mode.validate()
+        #expect(errors.contains(.missingKey(keyId: "nonexistent", context: .portrait)))
+    }
+
+    // MARK: Missing Mode
+
+    @Test func missingDefaultMode() {
+        let def = minimalDefinition(defaultMode: "nonexistent")
+        let errors = def.validate()
+        #expect(errors.contains(.missingMode("nonexistent")))
+    }
+
+    @Test func missingSwitchModeTarget() {
+        let shiftKey = KeyConfig(
+            id: "shift",
+            bindings: [.tap: KeyBinding(
+                label: "⇧",
+                action: .switchMode("nonexistent"),
+                category: .modifier,
+                returnAction: nil,
+                accessibilityLabel: nil
+            )],
+            swipeMode: .none, slideType: .none, style: .utility, tapCycleActions: nil
+        )
+        let keys: [String: KeyConfig] = ["a": letterKey("a", "a"), "shift": shiftKey]
+        let arrangement = GridArrangement(columns: 2, rows: [
+            [KeyPlacement(keyId: "a"), KeyPlacement(keyId: "shift")],
+        ])
+        let mode = KeyboardMode(name: "main", keys: keys, arrangements: [.portrait: arrangement], autoTransitions: [:], doubleTapMode: nil)
+        let def = minimalDefinition(modes: [ModeNames.main: mode])
+        let errors = def.validate()
+        #expect(errors.contains(.missingMode("nonexistent")))
+    }
+
+    @Test func missingAutoTransitionTarget() {
+        let mode = minimalMode(autoTransitions: [.letter: "nonexistent"])
+        let def = minimalDefinition(modes: [ModeNames.main: mode])
+        let errors = def.validate()
+        #expect(errors.contains(.missingMode("nonexistent")))
+    }
+
+    @Test func missingDoubleTapModeTarget() {
+        let mode = minimalMode(doubleTapMode: "nonexistent")
+        let def = minimalDefinition(modes: [ModeNames.main: mode])
+        let errors = def.validate()
+        #expect(errors.contains(.missingMode("nonexistent")))
+    }
+
+    // MARK: Column Mismatch
+
+    @Test func columnMismatch() {
+        let arrangement = GridArrangement(columns: 3, rows: [
+            [KeyPlacement(keyId: "a"), KeyPlacement(keyId: "b")], // sum = 2, expected 3
+        ])
+        let mode = KeyboardMode(
+            name: "test",
+            keys: ["a": letterKey("a", "a"), "b": letterKey("b", "b")],
+            arrangements: [.portrait: arrangement],
+            autoTransitions: [:], doubleTapMode: nil
+        )
+        let errors = mode.validate()
+        #expect(errors.contains(.columnMismatch(row: 0, context: .portrait, expected: 3, got: 2)))
+    }
+
+    // MARK: Height Multiplier Spanning
+
+    @Test func heightMultiplierSpanningValid() {
+        // Row 0: a(1) + b(1, height:2) = 2 columns
+        // Row 1: c(1) + [b spans] = 1 + 1 = 2 columns ✓
+        let arrangement = GridArrangement(columns: 2, rows: [
+            [KeyPlacement(keyId: "a"), KeyPlacement(keyId: "b", widthMultiplier: 1, heightMultiplier: 2)],
+            [KeyPlacement(keyId: "c")],
+        ])
+        let mode = KeyboardMode(
+            name: "test",
+            keys: ["a": letterKey("a", "a"), "b": letterKey("b", "b"), "c": letterKey("c", "c")],
+            arrangements: [.portrait: arrangement],
+            autoTransitions: [:], doubleTapMode: nil
+        )
+        #expect(mode.validate().filter { if case .columnMismatch = $0 { true } else { false } }.isEmpty)
+    }
+
+    @Test func heightMultiplierSpanningInvalid() {
+        // Row 0: a(1) + b(1, height:2) = 2 columns
+        // Row 1: c(1) + d(1) + [b spans] = 2 + 1 = 3 ≠ 2
+        let arrangement = GridArrangement(columns: 2, rows: [
+            [KeyPlacement(keyId: "a"), KeyPlacement(keyId: "b", widthMultiplier: 1, heightMultiplier: 2)],
+            [KeyPlacement(keyId: "c"), KeyPlacement(keyId: "d")],
+        ])
+        let mode = KeyboardMode(
+            name: "test",
+            keys: [
+                "a": letterKey("a", "a"), "b": letterKey("b", "b"),
+                "c": letterKey("c", "c"), "d": letterKey("d", "d"),
+            ],
+            arrangements: [.portrait: arrangement],
+            autoTransitions: [:], doubleTapMode: nil
+        )
+        let errors = mode.validate()
+        #expect(errors.contains(.columnMismatch(row: 1, context: .portrait, expected: 2, got: 3)))
+    }
+
+    // MARK: Duplicate Key ID
+
+    @Test func duplicateKeyId() {
+        let arrangement = GridArrangement(columns: 2, rows: [
+            [KeyPlacement(keyId: "a"), KeyPlacement(keyId: "a")],
+        ])
+        let mode = KeyboardMode(
+            name: "test",
+            keys: ["a": letterKey("a", "a")],
+            arrangements: [.portrait: arrangement],
+            autoTransitions: [:], doubleTapMode: nil
+        )
+        let errors = mode.validate()
+        #expect(errors.contains(.duplicateKeyId("a")))
+    }
+
+    // MARK: Empty Key Pool
+
+    @Test func emptyKeyPool() {
+        let arrangement = GridArrangement(columns: 0, rows: [])
+        let mode = KeyboardMode(
+            name: "test", keys: [:],
+            arrangements: [.portrait: arrangement],
+            autoTransitions: [:], doubleTapMode: nil
+        )
+        let errors = mode.validate()
+        #expect(errors.contains(.emptyKeyPool))
+    }
+
+    // MARK: No Portrait Arrangement
+
+    @Test func noPortraitArrangement() {
+        let arrangement = GridArrangement(columns: 2, rows: [
+            [KeyPlacement(keyId: "a"), KeyPlacement(keyId: "b")],
+        ])
+        let mode = KeyboardMode(
+            name: "test",
+            keys: ["a": letterKey("a", "a"), "b": letterKey("b", "b")],
+            arrangements: [.landscape: arrangement], // No portrait!
+            autoTransitions: [:], doubleTapMode: nil
+        )
+        let errors = mode.validate()
+        #expect(errors.contains(.noPortraitArrangement))
+    }
+}
+
+// MARK: - Supporting Type Tests
+
+struct SupportingTypeTests {
+    @Test func composeRuleSetCodable() throws {
+        let rules = ComposeRuleSet(rules: [
+            "¨": ["a": "ä", "o": "ö", "u": "ü"],
+            "´": ["a": "á", "e": "é"],
+        ])
+        let data = try JSONEncoder().encode(rules)
+        let decoded = try JSONDecoder().decode(ComposeRuleSet.self, from: data)
+        #expect(decoded == rules)
+    }
+
+    @Test func autoCapitalizerRuleCodable() throws {
+        let rule = AutoCapitalizerRule(pattern: " i ", replacement: " I ")
+        let data = try JSONEncoder().encode(rule)
+        let decoded = try JSONDecoder().decode(AutoCapitalizerRule.self, from: data)
+        #expect(decoded == rule)
+    }
+
+    @Test func modeNamesConstants() {
+        #expect(ModeNames.main == "main")
+        #expect(ModeNames.shifted == "shifted")
+        #expect(ModeNames.capsLock == "capsLock")
+        #expect(ModeNames.numeric == "numeric")
+        #expect(ModeNames.symbols == "symbols")
+        #expect(ModeNames.emoji == "emoji")
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces the top-level types that compose a complete keyboard definition (Phase 1.13–1.16, 1.20)
- `KeyboardMode` includes a state machine (`autoTransitions`, `doubleTapMode`) for configurable mode behavior — replaces hardcoded shift/capsLock logic
- `ValidationError` with `validate()` on both `KeyboardMode` and `KeyboardDefinition`, including heightMultiplier spanning validation
- Depends on PR #145 (Grid Types)

## New Types
| Type | Purpose |
|------|---------|
| `KeyboardMode` | Key pool + arrangements + state machine + `.with()` |
| `KeyboardDefinition` | Complete keyboard: modes dict, locale, settings |
| `KeyboardDefinitionSettings` | autoCapitalize, autoCapitalizers, composeRuleOverrides |
| `ComposeRuleSet` | Compose rules as `[String: [String: String]]` |
| `AutoCapitalizerRule` | Pattern → replacement rule |
| `ModeNames` | Well-known mode name constants |
| `ValidationError` | 6 error cases + `validate()` on Mode and Definition |

## Test plan
- [x] 33 new unit tests in `ModeDefinitionValidationTests.swift`
- [x] State machine: shifted (one-shot), capsLock (sticky), emoji transitions
- [x] Arrangement fallback: landscape falls back to portrait
- [x] `.with()`: changes name, autoTransitions, doubleTapMode independently
- [x] Validation: missingKey, missingMode (defaultMode, switchMode target, autoTransition target, doubleTapMode target), columnMismatch, heightMultiplier spanning (valid + invalid), duplicateKeyId, emptyKeyPool, noPortraitArrangement
- [x] Happy path: valid definition has no errors
- [x] Codable roundtrips for all new types
- [x] Full test suite passes (408 tests, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable keyboard configuration system with multiple modes (main, shifted, caps lock, numeric, symbols, emoji), per-mode key layouts, and mode transitions.
  * Added auto-capitalization rules and customizable compose (dead-key) rule sets.
* **Quality**
  * Added validation to detect configuration issues (missing keys/modes, layout mismatches, duplicate IDs, row/span errors).
* **Tests**
  * Added comprehensive unit tests covering layout behavior, validation, serialization, and equality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->