### PR TITLE
Refactor PR 4: Slot Names, Key Factories & Shifted Generator

### DIFF
--- a/wurstfingerKeyboard/GridSlot.swift
+++ b/wurstfingerKeyboard/GridSlot.swift
@@ -1,16 +1,15 @@
 //
-//  MessagEaseSlot.swift
+//  GridSlot.swift
 //  Wurstfinger
 //
-//  Semantic slot names for MessagEase 3x3 layouts.
+//  Semantic slot names for 3x3 grid layouts.
 //
 
 import Foundation
 
-/// Slot names for MessagEase 3x3 layouts.
-/// Stable across all languages — DE and FR both have a "topLeft" slot,
-/// but with different characters.
-enum MessagEaseSlot {
+/// Semantic slot names for a 3x3 key grid.
+/// Stable across all languages and layout families.
+enum GridSlot {
     static let topLeft = "topLeft"
     static let topCenter = "topCenter"
     static let topRight = "topRight"

--- a/wurstfingerKeyboard/KeyConfig+Factories.swift
+++ b/wurstfingerKeyboard/KeyConfig+Factories.swift
@@ -1,0 +1,64 @@
+//
+//  KeyConfig+Factories.swift
+//  Wurstfinger
+//
+//  Convenience factory methods for creating KeyConfig instances.
+//
+
+import Foundation
+
+extension KeyConfig {
+    /// Creates a letter key. Category is automatically derived from the action.
+    static func letter(
+        _ id: String,
+        tap: String,
+        swipes: [GestureType: String] = [:],
+        returnSwipes: [GestureType: String] = [:],
+        composeSwipes: [GestureType: (trigger: String, label: String)] = [:]
+    ) -> KeyConfig {
+        var bindings: [GestureType: KeyBinding] = [:]
+        bindings[.tap] = KeyBinding(
+            label: tap, action: .commitText(tap),
+            category: nil, returnAction: nil, accessibilityLabel: nil
+        )
+        for (gesture, char) in swipes {
+            bindings[gesture] = KeyBinding(
+                label: char, action: .commitText(char), category: nil,
+                returnAction: returnSwipes[gesture].map { .commitText($0) },
+                accessibilityLabel: nil
+            )
+        }
+        for (gesture, compose) in composeSwipes {
+            bindings[gesture] = KeyBinding(
+                label: compose.label, action: .compose(trigger: compose.trigger),
+                category: .compose, returnAction: nil, accessibilityLabel: nil
+            )
+        }
+        return KeyConfig(
+            id: id, bindings: bindings, swipeMode: .eightWay,
+            slideType: .none, style: .primary, tapCycleActions: nil
+        )
+    }
+
+    /// Creates a utility key (Globe, Delete, Return, etc.)
+    static func utility(
+        _ id: String,
+        label: String,
+        action: KeyAction,
+        swipeMode: SwipeMode = .none,
+        slideType: SlideType = .none,
+        swipes: [GestureType: KeyBinding] = [:],
+        accessibilityLabel: String? = nil
+    ) -> KeyConfig {
+        var bindings = swipes
+        bindings[.tap] = KeyBinding(
+            label: label, action: action,
+            category: .utility, returnAction: nil,
+            accessibilityLabel: accessibilityLabel
+        )
+        return KeyConfig(
+            id: id, bindings: bindings, swipeMode: swipeMode,
+            slideType: slideType, style: .utility, tapCycleActions: nil
+        )
+    }
+}

--- a/wurstfingerKeyboard/KeyboardMode+Shifted.swift
+++ b/wurstfingerKeyboard/KeyboardMode+Shifted.swift
@@ -35,10 +35,12 @@ extension KeyConfig {
     func autoShifted(locale: Locale) -> KeyConfig {
         let shiftedBindings = bindings.mapValues { binding -> KeyBinding in
             guard binding.resolvedCategory == .letter else { return binding }
-            let upper = binding.label.uppercased(with: locale)
+            guard case let .commitText(text) = binding.action else { return binding }
+            let upperLabel = binding.label.uppercased(with: locale)
+            let upperText = text.uppercased(with: locale)
             return KeyBinding(
-                label: upper,
-                action: .commitText(upper),
+                label: upperLabel,
+                action: .commitText(upperText),
                 category: binding.category,
                 returnAction: binding.returnAction,
                 accessibilityLabel: binding.accessibilityLabel

--- a/wurstfingerKeyboard/KeyboardMode+Shifted.swift
+++ b/wurstfingerKeyboard/KeyboardMode+Shifted.swift
@@ -1,0 +1,52 @@
+//
+//  KeyboardMode+Shifted.swift
+//  Wurstfinger
+//
+//  Automatic shifted layer generation from a main mode.
+//
+
+import Foundation
+
+extension KeyboardMode {
+    /// Generates the shifted layer from this mode.
+    /// - Letter bindings are uppercased using the given locale
+    /// - Arrangements are reused as-is (same key IDs)
+    /// - Overrides allow manual corrections (e.g. ß → ẞ)
+    func generateShifted(
+        locale: Locale,
+        overrides: [String: KeyConfig] = [:]
+    ) -> KeyboardMode {
+        let shiftedKeys = keys.mapValues { key in
+            overrides[key.id] ?? key.autoShifted(locale: locale)
+        }
+        return KeyboardMode(
+            name: ModeNames.shifted,
+            keys: shiftedKeys,
+            arrangements: arrangements,
+            autoTransitions: [:],
+            doubleTapMode: nil
+        )
+    }
+}
+
+extension KeyConfig {
+    /// Creates an uppercase variant of this key.
+    /// Only bindings with resolvedCategory == .letter are uppercased.
+    func autoShifted(locale: Locale) -> KeyConfig {
+        let shiftedBindings = bindings.mapValues { binding -> KeyBinding in
+            guard binding.resolvedCategory == .letter else { return binding }
+            let upper = binding.label.uppercased(with: locale)
+            return KeyBinding(
+                label: upper,
+                action: .commitText(upper),
+                category: binding.category,
+                returnAction: binding.returnAction,
+                accessibilityLabel: binding.accessibilityLabel
+            )
+        }
+        return KeyConfig(
+            id: id, bindings: shiftedBindings, swipeMode: swipeMode,
+            slideType: slideType, style: style, tapCycleActions: tapCycleActions
+        )
+    }
+}

--- a/wurstfingerKeyboard/MessagEaseSlot.swift
+++ b/wurstfingerKeyboard/MessagEaseSlot.swift
@@ -1,0 +1,30 @@
+//
+//  MessagEaseSlot.swift
+//  Wurstfinger
+//
+//  Semantic slot names for MessagEase 3x3 layouts.
+//
+
+import Foundation
+
+/// Slot names for MessagEase 3x3 layouts.
+/// Stable across all languages — DE and FR both have a "topLeft" slot,
+/// but with different characters.
+enum MessagEaseSlot {
+    static let topLeft = "topLeft"
+    static let topCenter = "topCenter"
+    static let topRight = "topRight"
+    static let midLeft = "midLeft"
+    static let center = "center"
+    static let midRight = "midRight"
+    static let bottomLeft = "bottomLeft"
+    static let bottomCenter = "bottomCenter"
+    static let bottomRight = "bottomRight"
+
+    /// Ordered list of all slots (for mapping from centerCharacters arrays)
+    static let allSlots: [[String]] = [
+        [topLeft, topCenter, topRight],
+        [midLeft, center, midRight],
+        [bottomLeft, bottomCenter, bottomRight],
+    ]
+}

--- a/wurstfingerKeyboard/UtilitySlot.swift
+++ b/wurstfingerKeyboard/UtilitySlot.swift
@@ -1,0 +1,17 @@
+//
+//  UtilitySlot.swift
+//  Wurstfinger
+//
+//  Utility key slot names (independent of layout family).
+//
+
+import Foundation
+
+/// Utility keys have functional names (independent of layout family).
+enum UtilitySlot {
+    static let globe = "globe"
+    static let delete = "delete"
+    static let `return` = "return"
+    static let space = "space"
+    static let symbols = "symbols"
+}

--- a/wurstfingerTests/SlotFactoryShiftedTests.swift
+++ b/wurstfingerTests/SlotFactoryShiftedTests.swift
@@ -1,0 +1,314 @@
+//
+//  SlotFactoryShiftedTests.swift
+//  WurstfingerTests
+//
+//  Tests for MessagEaseSlot, UtilitySlot, KeyConfig factories,
+//  and shifted layer generation.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+// MARK: - MessagEaseSlot Tests
+
+struct MessagEaseSlotTests {
+    @Test func allSlotsContainsNineSlots() {
+        let flat = MessagEaseSlot.allSlots.flatMap(\.self)
+        #expect(flat.count == 9)
+    }
+
+    @Test func allSlotsHasThreeRows() {
+        #expect(MessagEaseSlot.allSlots.count == 3)
+        for row in MessagEaseSlot.allSlots {
+            #expect(row.count == 3)
+        }
+    }
+
+    @Test func allSlotsAreUnique() {
+        let flat = MessagEaseSlot.allSlots.flatMap(\.self)
+        #expect(Set(flat).count == 9)
+    }
+
+    @Test func slotNamesMatchAllSlots() {
+        let expected: [[String]] = [
+            [MessagEaseSlot.topLeft, MessagEaseSlot.topCenter, MessagEaseSlot.topRight],
+            [MessagEaseSlot.midLeft, MessagEaseSlot.center, MessagEaseSlot.midRight],
+            [MessagEaseSlot.bottomLeft, MessagEaseSlot.bottomCenter, MessagEaseSlot.bottomRight],
+        ]
+        #expect(MessagEaseSlot.allSlots == expected)
+    }
+}
+
+// MARK: - UtilitySlot Tests
+
+struct UtilitySlotTests {
+    @Test func utilitySlotConstants() {
+        #expect(UtilitySlot.globe == "globe")
+        #expect(UtilitySlot.delete == "delete")
+        #expect(UtilitySlot.return == "return")
+        #expect(UtilitySlot.space == "space")
+        #expect(UtilitySlot.symbols == "symbols")
+    }
+
+    @Test func utilitySlotNamesAreDistinct() {
+        let names = [UtilitySlot.globe, UtilitySlot.delete, UtilitySlot.return, UtilitySlot.space, UtilitySlot.symbols]
+        #expect(Set(names).count == 5)
+    }
+}
+
+// MARK: - KeyConfig.letter() Tests
+
+struct KeyConfigLetterFactoryTests {
+    @Test func basicLetterKey() {
+        let key = KeyConfig.letter("center", tap: "d", swipes: [.swipeUp: "g"])
+        #expect(key.id == "center")
+        #expect(key.style == .primary)
+        #expect(key.swipeMode == .eightWay)
+        #expect(key.slideType == .none)
+        #expect(key.tapCycleActions == nil)
+
+        // Tap binding
+        let tap = key.bindings[.tap]
+        #expect(tap?.label == "d")
+        #expect(tap?.action == .commitText("d"))
+        #expect(tap?.resolvedCategory == .letter)
+        #expect(tap?.returnAction == nil)
+
+        // Swipe binding
+        let swipeUp = key.bindings[.swipeUp]
+        #expect(swipeUp?.label == "g")
+        #expect(swipeUp?.action == .commitText("g"))
+        #expect(swipeUp?.returnAction == nil)
+    }
+
+    @Test func letterKeyWithReturnSwipes() {
+        let key = KeyConfig.letter(
+            "topLeft", tap: "a",
+            swipes: [.swipeUp: "v", .swipeRight: "x"],
+            returnSwipes: [.swipeUp: "1"]
+        )
+        // .tap has no returnAction
+        #expect(key.bindings[.tap]?.returnAction == nil)
+        // .swipeUp has returnAction "1"
+        #expect(key.bindings[.swipeUp]?.returnAction == .commitText("1"))
+        // .swipeRight has no returnAction (not in returnSwipes)
+        #expect(key.bindings[.swipeRight]?.returnAction == nil)
+    }
+
+    @Test func letterKeyWithComposeSwipes() {
+        let key = KeyConfig.letter(
+            "center", tap: "d",
+            composeSwipes: [.swipeDownLeft: (trigger: "¨", label: "¨")]
+        )
+        let compose = key.bindings[.swipeDownLeft]
+        #expect(compose?.action == .compose(trigger: "¨"))
+        #expect(compose?.label == "¨")
+        #expect(compose?.resolvedCategory == .compose)
+    }
+
+    @Test func letterKeyOnlyContainsRequestedBindings() {
+        let key = KeyConfig.letter("topLeft", tap: "a", swipes: [.swipeUp: "v"])
+        #expect(key.bindings.count == 2) // tap + swipeUp
+    }
+}
+
+// MARK: - KeyConfig.utility() Tests
+
+struct KeyConfigUtilityFactoryTests {
+    @Test func basicUtilityKey() {
+        let key = KeyConfig.utility(
+            "delete",
+            label: "⌫",
+            action: .deleteBackward,
+            swipeMode: .twoWayHorizontal,
+            slideType: .delete,
+            accessibilityLabel: "Delete"
+        )
+        #expect(key.id == "delete")
+        #expect(key.style == .utility)
+        #expect(key.swipeMode == .twoWayHorizontal)
+        #expect(key.slideType == .delete)
+
+        let tap = key.bindings[.tap]
+        #expect(tap?.label == "⌫")
+        #expect(tap?.action == .deleteBackward)
+        #expect(tap?.resolvedCategory == .utility)
+        #expect(tap?.accessibilityLabel == "Delete")
+    }
+
+    @Test func utilityKeyDefaults() {
+        let key = KeyConfig.utility("globe", label: "🌐", action: .advanceToNextInputMode)
+        #expect(key.swipeMode == .none)
+        #expect(key.slideType == .none)
+        #expect(key.bindings.count == 1)
+    }
+
+    @Test func utilityKeyWithSwipes() {
+        let swipeBinding = KeyBinding(
+            label: "→", action: .moveCursor(offset: 1),
+            category: .utility, returnAction: nil, accessibilityLabel: nil
+        )
+        let key = KeyConfig.utility(
+            "delete",
+            label: "⌫",
+            action: .deleteBackward,
+            swipes: [.swipeRight: swipeBinding]
+        )
+        #expect(key.bindings.count == 2)
+        #expect(key.bindings[.swipeRight]?.action == .moveCursor(offset: 1))
+    }
+}
+
+// MARK: - KeyConfig.autoShifted() Tests
+
+struct AutoShiftedTests {
+    @Test func autoShiftedGermanBasic() {
+        let key = KeyConfig.letter("center", tap: "d", swipes: [.swipeUp: "g"])
+        let shifted = key.autoShifted(locale: Locale(identifier: "de_DE"))
+
+        #expect(shifted.id == "center")
+        #expect(shifted.bindings[.tap]?.label == "D")
+        #expect(shifted.bindings[.tap]?.action == .commitText("D"))
+        #expect(shifted.bindings[.swipeUp]?.label == "G")
+        #expect(shifted.bindings[.swipeUp]?.action == .commitText("G"))
+    }
+
+    @Test func autoShiftedGermanEszett() {
+        let key = KeyConfig.letter("bottomLeft", tap: "ß")
+        let shifted = key.autoShifted(locale: Locale(identifier: "de_DE"))
+
+        // German ß uppercases to SS (or ẞ depending on locale data, but SS is the standard)
+        let upper = "ß".uppercased(with: Locale(identifier: "de_DE"))
+        #expect(shifted.bindings[.tap]?.label == upper)
+        #expect(shifted.bindings[.tap]?.action == .commitText(upper))
+    }
+
+    @Test func autoShiftedTurkishI() {
+        let key = KeyConfig.letter("center", tap: "i")
+        let shifted = key.autoShifted(locale: Locale(identifier: "tr_TR"))
+
+        #expect(shifted.bindings[.tap]?.label == "İ")
+        #expect(shifted.bindings[.tap]?.action == .commitText("İ"))
+    }
+
+    @Test func autoShiftedPreservesNonLetterBindings() {
+        let key = KeyConfig.letter(
+            "center", tap: "d",
+            composeSwipes: [.swipeDownLeft: (trigger: "¨", label: "¨")]
+        )
+        let shifted = key.autoShifted(locale: Locale(identifier: "de_DE"))
+
+        // Letter binding is shifted
+        #expect(shifted.bindings[.tap]?.label == "D")
+        // Compose binding is unchanged
+        #expect(shifted.bindings[.swipeDownLeft]?.action == .compose(trigger: "¨"))
+        #expect(shifted.bindings[.swipeDownLeft]?.label == "¨")
+    }
+
+    @Test func autoShiftedPreservesReturnAction() {
+        let key = KeyConfig.letter(
+            "topLeft", tap: "a",
+            swipes: [.swipeUp: "v"],
+            returnSwipes: [.swipeUp: "1"]
+        )
+        let shifted = key.autoShifted(locale: Locale(identifier: "de_DE"))
+
+        #expect(shifted.bindings[.swipeUp]?.returnAction == .commitText("1"))
+    }
+
+    @Test func autoShiftedPreservesKeyProperties() {
+        let key = KeyConfig.letter("center", tap: "d")
+        let shifted = key.autoShifted(locale: Locale(identifier: "de_DE"))
+
+        #expect(shifted.swipeMode == key.swipeMode)
+        #expect(shifted.slideType == key.slideType)
+        #expect(shifted.style == key.style)
+        #expect(shifted.tapCycleActions == key.tapCycleActions)
+    }
+
+    @Test func autoShiftedUtilityKeyUnchanged() {
+        let key = KeyConfig.utility("delete", label: "⌫", action: .deleteBackward)
+        let shifted = key.autoShifted(locale: Locale(identifier: "de_DE"))
+
+        #expect(shifted.bindings[.tap]?.label == "⌫")
+        #expect(shifted.bindings[.tap]?.action == .deleteBackward)
+    }
+}
+
+// MARK: - KeyboardMode.generateShifted() Tests
+
+struct GenerateShiftedTests {
+    private static func sampleMode() -> KeyboardMode {
+        let keys: [String: KeyConfig] = [
+            "a": KeyConfig.letter("a", tap: "a", swipes: [.swipeUp: "v"]),
+            "b": KeyConfig.letter("b", tap: "b"),
+            "shift": KeyConfig.utility("shift", label: "⇧", action: .switchMode(ModeNames.shifted)),
+        ]
+        let arrangement = GridArrangement(columns: 3, rows: [
+            [KeyPlacement(keyId: "a"), KeyPlacement(keyId: "b"), KeyPlacement(keyId: "shift")],
+        ])
+        return KeyboardMode(
+            name: ModeNames.main, keys: keys,
+            arrangements: [.portrait: arrangement],
+            autoTransitions: [:], doubleTapMode: nil
+        )
+    }
+
+    @Test func generateShiftedBasic() {
+        let main = Self.sampleMode()
+        let shifted = main.generateShifted(locale: Locale(identifier: "de_DE"))
+
+        #expect(shifted.name == ModeNames.shifted)
+        #expect(shifted.keys["a"]?.bindings[.tap]?.label == "A")
+        #expect(shifted.keys["a"]?.bindings[.swipeUp]?.label == "V")
+        #expect(shifted.keys["b"]?.bindings[.tap]?.label == "B")
+    }
+
+    @Test func generateShiftedReusesArrangements() {
+        let main = Self.sampleMode()
+        let shifted = main.generateShifted(locale: Locale(identifier: "de_DE"))
+
+        #expect(shifted.arrangements == main.arrangements)
+    }
+
+    @Test func generateShiftedWithOverrides() {
+        let main = Self.sampleMode()
+        let overrideKey = KeyConfig.letter("a", tap: "Ä")
+        let shifted = main.generateShifted(
+            locale: Locale(identifier: "de_DE"),
+            overrides: ["a": overrideKey]
+        )
+
+        // Override takes effect
+        #expect(shifted.keys["a"]?.bindings[.tap]?.label == "Ä")
+        // Non-overridden key is auto-shifted
+        #expect(shifted.keys["b"]?.bindings[.tap]?.label == "B")
+    }
+
+    @Test func generateShiftedUtilityKeysUnchanged() {
+        let main = Self.sampleMode()
+        let shifted = main.generateShifted(locale: Locale(identifier: "de_DE"))
+
+        #expect(shifted.keys["shift"]?.bindings[.tap]?.label == "⇧")
+        #expect(shifted.keys["shift"]?.bindings[.tap]?.action == .switchMode(ModeNames.shifted))
+    }
+
+    @Test func generateShiftedDefaultTransitions() {
+        let main = Self.sampleMode()
+        let shifted = main.generateShifted(locale: Locale(identifier: "de_DE"))
+
+        // Default: empty autoTransitions (stays active like caps lock)
+        #expect(shifted.autoTransitions.isEmpty)
+        #expect(shifted.doubleTapMode == nil)
+    }
+
+    @Test func generateShiftedWithPostConfiguration() {
+        let main = Self.sampleMode()
+        let shifted = main.generateShifted(locale: Locale(identifier: "de_DE"))
+            .with(autoTransitions: [.letter: ModeNames.main], doubleTapMode: ModeNames.capsLock)
+
+        #expect(shifted.autoTransitions[.letter] == ModeNames.main)
+        #expect(shifted.doubleTapMode == ModeNames.capsLock)
+    }
+}

--- a/wurstfingerTests/SlotFactoryShiftedTests.swift
+++ b/wurstfingerTests/SlotFactoryShiftedTests.swift
@@ -2,7 +2,7 @@
 //  SlotFactoryShiftedTests.swift
 //  WurstfingerTests
 //
-//  Tests for MessagEaseSlot, UtilitySlot, KeyConfig factories,
+//  Tests for GridSlot, UtilitySlot, KeyConfig factories,
 //  and shifted layer generation.
 //
 
@@ -10,33 +10,33 @@ import Foundation
 import Testing
 @testable import WurstfingerApp
 
-// MARK: - MessagEaseSlot Tests
+// MARK: - GridSlot Tests
 
-struct MessagEaseSlotTests {
+struct GridSlotTests {
     @Test func allSlotsContainsNineSlots() {
-        let flat = MessagEaseSlot.allSlots.flatMap(\.self)
+        let flat = GridSlot.allSlots.flatMap(\.self)
         #expect(flat.count == 9)
     }
 
     @Test func allSlotsHasThreeRows() {
-        #expect(MessagEaseSlot.allSlots.count == 3)
-        for row in MessagEaseSlot.allSlots {
+        #expect(GridSlot.allSlots.count == 3)
+        for row in GridSlot.allSlots {
             #expect(row.count == 3)
         }
     }
 
     @Test func allSlotsAreUnique() {
-        let flat = MessagEaseSlot.allSlots.flatMap(\.self)
+        let flat = GridSlot.allSlots.flatMap(\.self)
         #expect(Set(flat).count == 9)
     }
 
     @Test func slotNamesMatchAllSlots() {
         let expected: [[String]] = [
-            [MessagEaseSlot.topLeft, MessagEaseSlot.topCenter, MessagEaseSlot.topRight],
-            [MessagEaseSlot.midLeft, MessagEaseSlot.center, MessagEaseSlot.midRight],
-            [MessagEaseSlot.bottomLeft, MessagEaseSlot.bottomCenter, MessagEaseSlot.bottomRight],
+            [GridSlot.topLeft, GridSlot.topCenter, GridSlot.topRight],
+            [GridSlot.midLeft, GridSlot.center, GridSlot.midRight],
+            [GridSlot.bottomLeft, GridSlot.bottomCenter, GridSlot.bottomRight],
         ]
-        #expect(MessagEaseSlot.allSlots == expected)
+        #expect(GridSlot.allSlots == expected)
     }
 }
 

--- a/wurstfingerTests/SlotFactoryShiftedTests.swift
+++ b/wurstfingerTests/SlotFactoryShiftedTests.swift
@@ -163,6 +163,29 @@ struct KeyConfigUtilityFactoryTests {
 // MARK: - KeyConfig.autoShifted() Tests
 
 struct AutoShiftedTests {
+    @Test func autoShiftedUsesCommittedTextNotLabel() {
+        // Label and committed text differ — shifted must uppercase each independently
+        let key = KeyConfig(
+            id: "test",
+            bindings: [
+                .tap: KeyBinding(
+                    label: "display",
+                    action: .commitText("payload"),
+                    category: .letter,
+                    returnAction: nil,
+                    accessibilityLabel: nil
+                ),
+            ],
+            swipeMode: .eightWay,
+            slideType: .none,
+            style: .primary,
+            tapCycleActions: nil
+        )
+        let shifted = key.autoShifted(locale: Locale(identifier: "en_US"))
+        #expect(shifted.bindings[.tap]?.label == "DISPLAY")
+        #expect(shifted.bindings[.tap]?.action == .commitText("PAYLOAD"))
+    }
+
     @Test func autoShiftedGermanBasic() {
         let key = KeyConfig.letter("center", tap: "d", swipes: [.swipeUp: "g"])
         let shifted = key.autoShifted(locale: Locale(identifier: "de_DE"))


### PR DESCRIPTION
## Summary
- **MessagEaseSlot**: Semantic slot names for 3x3 grid positions (topLeft, center, bottomRight, etc.), stable across languages
- **UtilitySlot**: Functional names for utility keys (globe, delete, return, space, symbols)
- **KeyConfig.letter()**: Factory for creating letter keys with swipes, return swipes, and compose swipes
- **KeyConfig.utility()**: Factory for creating utility keys with optional swipes
- **KeyConfig.autoShifted(locale:)**: Locale-aware uppercase transformation (preserves non-letter bindings)
- **KeyboardMode.generateShifted(locale:overrides:)**: Automatic shifted layer generation with manual override support

Part of the data-driven architecture refactoring. Depends on PR #146.

## Test plan
- [x] MessagEaseSlot: 9 unique slots in 3x3 grid, names match constants
- [x] UtilitySlot: 5 distinct constants with correct values
- [x] KeyConfig.letter(): tap/swipe bindings, return swipes, compose swipes, binding count
- [x] KeyConfig.utility(): style, swipeMode, slideType, additional swipes
- [x] autoShifted: German basic (d→D), German ß, Turkish i→İ, preserves non-letter/compose/returnAction/key properties
- [x] generateShifted: basic uppercase, reuses arrangements, overrides, utility keys unchanged, default transitions, post-configuration with .with()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced keyboard configuration with factory methods for creating customizable letter and utility key configurations supporting multiple gesture types and swipe mappings
  * Introduced automatic shifted keyboard layer generation with locale-aware text transformation

* **Tests**
  * Added comprehensive test coverage for keyboard configuration factories, slot definitions, and shifted mode behavior validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->