### PR TITLE
Add language definitions and numeric layouts

### DIFF
--- a/wurstfingerKeyboard/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/GridKeyboardFactory.swift
@@ -19,12 +19,17 @@ enum GridKeyboardFactory {
     ///   - localeIdentifier: Locale string for uppercasing (e.g. "de_DE")
     ///   - centerCharacters: 3x3 grid of center tap characters
     ///   - directionalOverrides: Per-slot overrides that replace CommonKeys defaults
+    ///   - numericBackToAlphaLabel: Label shown on the symbols key in numeric
+    ///     mode that switches back to the main (alphabetic) layer. Defaults to
+    ///     the Latin "abc"; non-Latin layouts (Hebrew, Russian, …) should
+    ///     supply a script-appropriate label.
     static func layout(
         id: String,
         title: String,
         localeIdentifier: String,
         centerCharacters: [[String]],
-        directionalOverrides: [String: [GestureType: String]] = [:]
+        directionalOverrides: [String: [GestureType: String]] = [:],
+        numericBackToAlphaLabel: String = NumericLayouts.defaultBackToAlphaLabel
     ) -> KeyboardDefinition {
         precondition(
             centerCharacters.count == 3 && centerCharacters.allSatisfy { $0.count == 3 },
@@ -95,7 +100,7 @@ enum GridKeyboardFactory {
                 ModeNames.main: mainMode,
                 ModeNames.shifted: shiftedMode,
                 ModeNames.capsLock: capsLockMode,
-                ModeNames.numeric: NumericLayouts.phone,
+                ModeNames.numeric: NumericLayouts.phone(backToAlphaLabel: numericBackToAlphaLabel),
             ],
             defaultMode: ModeNames.main,
             settings: KeyboardDefinitionSettings(

--- a/wurstfingerKeyboard/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/GridKeyboardFactory.swift
@@ -23,13 +23,17 @@ enum GridKeyboardFactory {
     ///     mode that switches back to the main (alphabetic) layer. Defaults to
     ///     the Latin "abc"; non-Latin layouts (Hebrew, Russian, …) should
     ///     supply a script-appropriate label.
+    ///   - inputMethod: Which input method is applied to committed characters.
+    ///     Defaults to `.direct`; Vietnamese layouts should pass `.telex` so
+    ///     that `TelexMiddleware` activates for this keyboard at runtime.
     static func layout(
         id: String,
         title: String,
         localeIdentifier: String,
         centerCharacters: [[String]],
         directionalOverrides: [String: [GestureType: String]] = [:],
-        numericBackToAlphaLabel: String = NumericLayouts.defaultBackToAlphaLabel
+        numericBackToAlphaLabel: String = NumericLayouts.defaultBackToAlphaLabel,
+        inputMethod: InputMethodKind = .direct
     ) -> KeyboardDefinition {
         precondition(
             centerCharacters.count == 3 && centerCharacters.allSatisfy { $0.count == 3 },
@@ -106,7 +110,8 @@ enum GridKeyboardFactory {
             settings: KeyboardDefinitionSettings(
                 autoCapitalize: true,
                 autoCapitalizers: [],
-                composeRuleOverrides: nil
+                composeRuleOverrides: nil,
+                inputMethod: inputMethod
             )
         )
     }

--- a/wurstfingerKeyboard/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/GridKeyboardFactory.swift
@@ -86,16 +86,7 @@ enum GridKeyboardFactory {
         let capsLockMode = mainMode.generateShifted(locale: locale)
             .with(name: ModeNames.capsLock)
 
-        // 6. Stub numeric mode — replaced by real NumericLayouts in PR6
-        let numericStub = KeyboardMode(
-            name: ModeNames.numeric,
-            keys: allKeys,
-            arrangements: arrangements,
-            autoTransitions: [:],
-            doubleTapMode: nil
-        )
-
-        // 7. Assemble definition
+        // 6. Assemble definition
         return KeyboardDefinition(
             title: title,
             id: id,
@@ -104,7 +95,7 @@ enum GridKeyboardFactory {
                 ModeNames.main: mainMode,
                 ModeNames.shifted: shiftedMode,
                 ModeNames.capsLock: capsLockMode,
-                ModeNames.numeric: numericStub,
+                ModeNames.numeric: NumericLayouts.phone,
             ],
             defaultMode: ModeNames.main,
             settings: KeyboardDefinitionSettings(

--- a/wurstfingerKeyboard/KeyboardDefinition.swift
+++ b/wurstfingerKeyboard/KeyboardDefinition.swift
@@ -49,6 +49,21 @@ enum ModeNames {
     static let emoji = "emoji"
 }
 
+/// Identifies which text input method is applied to committed characters.
+///
+/// Most languages commit characters directly. A few need a stateful
+/// transformation over recent document context — Vietnamese Telex being
+/// the first real example. Making this a data-driven enum on the keyboard
+/// definition keeps language activation out of view-controller locale checks.
+enum InputMethodKind: String, Codable, Equatable {
+    /// Characters are committed verbatim. Default.
+    case direct
+
+    /// Vietnamese Telex: single-char and digraph lookback composition
+    /// handled by `TelexMiddleware`.
+    case telex
+}
+
 /// Keyboard-specific settings for a KeyboardDefinition.
 struct KeyboardDefinitionSettings: Codable, Equatable {
     /// Auto-capitalization enabled
@@ -61,6 +76,22 @@ struct KeyboardDefinitionSettings: Codable, Equatable {
     /// Merged with global base rules at runtime.
     /// nil = only use global rules (sufficient for most languages).
     let composeRuleOverrides: ComposeRuleSet?
+
+    /// Which input method to apply to committed characters. Defaults to
+    /// `.direct`; set to `.telex` for Vietnamese Telex composition.
+    let inputMethod: InputMethodKind
+
+    init(
+        autoCapitalize: Bool,
+        autoCapitalizers: [AutoCapitalizerRule],
+        composeRuleOverrides: ComposeRuleSet?,
+        inputMethod: InputMethodKind = .direct
+    ) {
+        self.autoCapitalize = autoCapitalize
+        self.autoCapitalizers = autoCapitalizers
+        self.composeRuleOverrides = composeRuleOverrides
+        self.inputMethod = inputMethod
+    }
 }
 
 /// A complete set of compose rules, loadable from JSON.

--- a/wurstfingerKeyboard/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/LanguageDefinitions.swift
@@ -1,0 +1,423 @@
+//
+//  LanguageDefinitions.swift
+//  Wurstfinger
+//
+//  All supported keyboard language definitions using GridKeyboardFactory.
+//
+
+import Foundation
+
+/// All supported keyboard language definitions.
+/// Each definition is a complete KeyboardDefinition produced by GridKeyboardFactory.
+enum LanguageDefinitions {
+    // MARK: - Croatian
+
+    static let croatian = GridKeyboardFactory.layout(
+        id: "hr_HR",
+        title: "Hrvatski (Croatian)",
+        localeIdentifier: "hr_HR",
+        centerCharacters: [
+            ["a", "n", "i"],
+            ["h", "o", "r"],
+            ["t", "e", "s"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeUp: "š", .swipeDown: "đ", .swipeDownRight: "v"],
+            GridSlot.topCenter: [.swipeDown: "l"],
+            GridSlot.topRight: [.swipeDownLeft: "x"],
+            GridSlot.midLeft: [.swipeUp: "ć", .swipeDown: "č", .swipeRight: "k"],
+            GridSlot.center: [
+                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                .swipeDownLeft: "g", .swipeLeft: "c",
+            ],
+            GridSlot.midRight: [.swipeLeft: "m"],
+            GridSlot.bottomLeft: [.swipeUp: "ž", .swipeUpRight: "y"],
+            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
+            GridSlot.bottomRight: [.swipeUpLeft: "f"],
+        ]
+    )
+
+    // MARK: - English
+
+    static let english = GridKeyboardFactory.layout(
+        id: "en_US",
+        title: "English",
+        localeIdentifier: "en_US",
+        centerCharacters: [
+            ["a", "n", "i"],
+            ["h", "o", "r"],
+            ["t", "e", "s"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeDownRight: "v"],
+            GridSlot.topCenter: [.swipeDown: "l"],
+            GridSlot.topRight: [.swipeDownLeft: "x"],
+            GridSlot.midLeft: [.swipeRight: "k"],
+            GridSlot.center: [
+                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                .swipeDownLeft: "g", .swipeLeft: "c",
+            ],
+            GridSlot.midRight: [.swipeLeft: "m"],
+            GridSlot.bottomLeft: [.swipeUpRight: "y"],
+            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
+            GridSlot.bottomRight: [.swipeUpLeft: "f"],
+        ]
+    )
+
+    // MARK: - Estonian-Finnish
+
+    static let estonianFinnish = GridKeyboardFactory.layout(
+        id: "et_EE",
+        title: "Eesti-Suomi (Estonian-Finnish)",
+        localeIdentifier: "et_EE",
+        centerCharacters: [
+            ["a", "n", "i"],
+            ["h", "o", "r"],
+            ["t", "e", "s"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeUp: "å", .swipeDown: "ä", .swipeDownRight: "v"],
+            GridSlot.topCenter: [.swipeDown: "l"],
+            GridSlot.topRight: [.swipeDownLeft: "x"],
+            GridSlot.midLeft: [.swipeUp: "ö", .swipeDown: "õ", .swipeRight: "k"],
+            GridSlot.center: [
+                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                .swipeDownLeft: "g", .swipeLeft: "c",
+            ],
+            GridSlot.midRight: [.swipeLeft: "m"],
+            GridSlot.bottomLeft: [.swipeUp: "ü", .swipeUpRight: "y"],
+            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "ž"],
+            GridSlot.bottomRight: [.swipeUpLeft: "f", .swipeLeft: "š"],
+        ]
+    )
+
+    // MARK: - Finnish
+
+    static let finnish = GridKeyboardFactory.layout(
+        id: "fi_FI",
+        title: "Suomi (Finnish)",
+        localeIdentifier: "fi_FI",
+        centerCharacters: [
+            ["a", "n", "i"],
+            ["h", "o", "r"],
+            ["t", "e", "s"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeDown: "ä", .swipeDownRight: "v"],
+            GridSlot.topCenter: [.swipeDown: "l"],
+            GridSlot.topRight: [.swipeDownLeft: "x"],
+            GridSlot.midLeft: [.swipeDown: "ö", .swipeRight: "k"],
+            GridSlot.center: [
+                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                .swipeDownLeft: "g", .swipeLeft: "c",
+            ],
+            GridSlot.midRight: [.swipeLeft: "m"],
+            GridSlot.bottomLeft: [.swipeUpRight: "y"],
+            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
+            GridSlot.bottomRight: [.swipeUpLeft: "f"],
+        ]
+    )
+
+    // MARK: - French
+
+    static let french = GridKeyboardFactory.layout(
+        id: "fr_FR",
+        title: "Français (French)",
+        localeIdentifier: "fr_FR",
+        centerCharacters: [
+            ["a", "n", "i"],
+            ["u", "o", "r"],
+            ["t", "e", "s"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeUpRight: "à", .swipeDown: "â", .swipeDownRight: "v"],
+            GridSlot.topCenter: [.swipeDown: "l"],
+            GridSlot.topRight: [.swipeDownLeft: "x"],
+            GridSlot.midLeft: [.swipeUp: "û", .swipeDown: "ç", .swipeRight: "k"],
+            GridSlot.center: [
+                .swipeUpLeft: "q", .swipeUp: "h", .swipeUpRight: "p",
+                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                .swipeDownLeft: "g", .swipeLeft: "c",
+            ],
+            GridSlot.midRight: [.swipeLeft: "m"],
+            GridSlot.bottomLeft: [.swipeUp: "ê", .swipeRight: "è", .swipeDown: "ù", .swipeUpRight: "y"],
+            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "é"],
+            GridSlot.bottomRight: [.swipeUpLeft: "f"],
+        ]
+    )
+
+    // MARK: - German
+
+    static let german = GridKeyboardFactory.layout(
+        id: "de_DE",
+        title: "Deutsch (German)",
+        localeIdentifier: "de_DE",
+        centerCharacters: [
+            ["a", "n", "i"],
+            ["h", "d", "r"],
+            ["t", "e", "s"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeDown: "ä", .swipeDownRight: "v"],
+            GridSlot.topCenter: [.swipeDown: "l"],
+            GridSlot.topRight: [.swipeDownLeft: "x"],
+            GridSlot.midLeft: [.swipeUp: "ü", .swipeDown: "ö", .swipeRight: "k"],
+            GridSlot.center: [
+                .swipeUp: "u", .swipeUpLeft: "q", .swipeLeft: "c",
+                .swipeDownLeft: "g", .swipeDown: "o", .swipeDownRight: "j",
+                .swipeRight: "b", .swipeUpRight: "p",
+            ],
+            GridSlot.midRight: [.swipeLeft: "m"],
+            GridSlot.bottomLeft: [.swipeDown: "ß", .swipeUpRight: "y"],
+            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
+            GridSlot.bottomRight: [.swipeUpLeft: "f"],
+        ]
+    )
+
+    // MARK: - Hebrew
+
+    static let hebrew = GridKeyboardFactory.layout(
+        id: "he_IL",
+        title: "עברית (Hebrew)",
+        localeIdentifier: "he_IL",
+        centerCharacters: [
+            ["ר", "ב", "א"],
+            ["מ", "י", "ו"],
+            ["ת", "ה", "ל"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeDownRight: "ן"],
+            GridSlot.topCenter: [.swipeDown: "ג"],
+            GridSlot.topRight: [.swipeDownLeft: "צ"],
+            GridSlot.midLeft: [.swipeRight: "ם"],
+            GridSlot.center: [
+                .swipeUpLeft: "ק", .swipeUp: "ח", .swipeUpRight: "פ",
+                .swipeRight: "ד", .swipeDownRight: "ש", .swipeDown: "נ",
+                .swipeDownLeft: "כ", .swipeLeft: "ע",
+            ],
+            GridSlot.bottomLeft: [.swipeUpRight: "ז"],
+            GridSlot.bottomCenter: [.swipeUp: "ס"],
+            GridSlot.bottomRight: [.swipeUpLeft: "ט"],
+        ]
+    )
+
+    // MARK: - Italian
+
+    static let italian = GridKeyboardFactory.layout(
+        id: "it_IT",
+        title: "Italiano (Italian)",
+        localeIdentifier: "it_IT",
+        centerCharacters: [
+            ["a", "n", "i"],
+            ["l", "o", "r"],
+            ["t", "e", "s"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeUpRight: "à", .swipeDownRight: "v"],
+            GridSlot.topCenter: [.swipeDown: "h"],
+            GridSlot.topRight: [.swipeUpLeft: "ì", .swipeDownLeft: "x"],
+            GridSlot.midLeft: [.swipeUp: "ù", .swipeDown: "ò", .swipeRight: "k"],
+            GridSlot.center: [
+                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                .swipeDownLeft: "g", .swipeLeft: "c",
+            ],
+            GridSlot.midRight: [.swipeLeft: "m"],
+            GridSlot.bottomLeft: [.swipeRight: "è", .swipeUpRight: "y"],
+            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "é"],
+            GridSlot.bottomRight: [.swipeUpLeft: "f"],
+        ]
+    )
+
+    // MARK: - Polish
+
+    static let polish = GridKeyboardFactory.layout(
+        id: "pl_PL",
+        title: "Polski (Polish)",
+        localeIdentifier: "pl_PL",
+        centerCharacters: [
+            ["a", "n", "i"],
+            ["w", "o", "r"],
+            ["z", "e", "s"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeDown: "ą", .swipeDownRight: "v"],
+            GridSlot.topCenter: [.swipeUp: "ń", .swipeDown: "l"],
+            GridSlot.topRight: [.swipeUpLeft: "ł", .swipeDownLeft: "x"],
+            GridSlot.midLeft: [.swipeUp: "ó", .swipeDown: "ć", .swipeRight: "k"],
+            GridSlot.center: [
+                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                .swipeDownLeft: "g", .swipeLeft: "c",
+            ],
+            GridSlot.midRight: [.swipeLeft: "m"],
+            GridSlot.bottomLeft: [.swipeDown: "ę", .swipeRight: "ź", .swipeUpRight: "y"],
+            GridSlot.bottomCenter: [.swipeUp: "h", .swipeRight: "t", .swipeLeft: "ż"],
+            GridSlot.bottomRight: [.swipeUpLeft: "f", .swipeLeft: "ś"],
+        ]
+    )
+
+    // MARK: - Russian
+
+    static let russian = GridKeyboardFactory.layout(
+        id: "ru_RU",
+        title: "Русский (Russian)",
+        localeIdentifier: "ru_RU",
+        centerCharacters: [
+            ["с", "и", "т"],
+            ["в", "о", "а"],
+            ["е", "р", "н"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeDown: "ц", .swipeDownRight: "п"],
+            GridSlot.topCenter: [.swipeUp: "й", .swipeDown: "к"],
+            GridSlot.topRight: [.swipeDownLeft: "ь"],
+            GridSlot.midLeft: [.swipeUp: "б", .swipeDown: "ъ", .swipeRight: "ы"],
+            GridSlot.center: [
+                .swipeUpLeft: "ч", .swipeUp: "м", .swipeUpRight: "х",
+                .swipeRight: "г", .swipeDownRight: "ш", .swipeDown: "я",
+                .swipeDownLeft: "щ", .swipeLeft: "ж",
+            ],
+            GridSlot.midRight: [.swipeLeft: "л"],
+            GridSlot.bottomLeft: [.swipeUp: "ё", .swipeRight: "э", .swipeUpRight: "д"],
+            GridSlot.bottomCenter: [.swipeUp: "у", .swipeRight: "з", .swipeLeft: "ю"],
+            GridSlot.bottomRight: [.swipeUpLeft: "ф"],
+        ]
+    )
+
+    // MARK: - Spanish-Catalan
+
+    static let spanishCatalan = GridKeyboardFactory.layout(
+        id: "ca_ES",
+        title: "Español-Català (Spanish-Catalan)",
+        localeIdentifier: "ca_ES",
+        centerCharacters: [
+            ["a", "n", "i"],
+            ["d", "o", "r"],
+            ["t", "e", "s"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeUp: "à", .swipeDown: "á", .swipeDownRight: "v"],
+            GridSlot.topCenter: [.swipeUp: "ñ", .swipeDown: "l"],
+            GridSlot.topRight: [.swipeUpLeft: "í", .swipeUpRight: "ï", .swipeDownLeft: "x"],
+            GridSlot.midLeft: [.swipeUp: "ü", .swipeDown: "ç", .swipeRight: "k"],
+            GridSlot.center: [
+                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "h",
+                .swipeDownLeft: "g", .swipeLeft: "c",
+            ],
+            GridSlot.midRight: [.swipeLeft: "m"],
+            GridSlot.bottomLeft: [.swipeUp: "ú", .swipeDown: "ó", .swipeUpRight: "y"],
+            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "é"],
+            GridSlot.bottomRight: [.swipeUpLeft: "f"],
+        ]
+    )
+
+    // MARK: - Spanish
+
+    static let spanish = GridKeyboardFactory.layout(
+        id: "es_ES",
+        title: "Español (Spanish)",
+        localeIdentifier: "es_ES",
+        centerCharacters: [
+            ["a", "n", "i"],
+            ["d", "o", "r"],
+            ["t", "e", "s"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeDown: "á", .swipeDownRight: "v"],
+            GridSlot.topCenter: [.swipeUp: "ñ", .swipeDown: "l"],
+            GridSlot.topRight: [.swipeUpLeft: "í", .swipeDownLeft: "x"],
+            GridSlot.midLeft: [.swipeUp: "ü", .swipeRight: "k"],
+            GridSlot.center: [
+                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "h",
+                .swipeDownLeft: "g", .swipeLeft: "c",
+            ],
+            GridSlot.midRight: [.swipeLeft: "m"],
+            GridSlot.bottomLeft: [.swipeUp: "ú", .swipeDown: "ó", .swipeUpRight: "y"],
+            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "é"],
+            GridSlot.bottomRight: [.swipeUpLeft: "f"],
+        ]
+    )
+
+    // MARK: - Swedish
+
+    static let swedish = GridKeyboardFactory.layout(
+        id: "sv_SE",
+        title: "Svenska (Swedish)",
+        localeIdentifier: "sv_SE",
+        centerCharacters: [
+            ["a", "n", "i"],
+            ["h", "d", "r"],
+            ["t", "e", "s"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeUp: "å", .swipeDown: "ä", .swipeDownRight: "v"],
+            GridSlot.topCenter: [.swipeDown: "l"],
+            GridSlot.topRight: [.swipeDownLeft: "x"],
+            GridSlot.midLeft: [.swipeDown: "ö", .swipeRight: "k"],
+            GridSlot.center: [
+                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "o",
+                .swipeDownLeft: "g", .swipeLeft: "c",
+            ],
+            GridSlot.midRight: [.swipeLeft: "m"],
+            GridSlot.bottomLeft: [.swipeUpRight: "y"],
+            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
+            GridSlot.bottomRight: [.swipeUpLeft: "f"],
+        ]
+    )
+
+    // MARK: - Tagalog
+
+    static let tagalog = GridKeyboardFactory.layout(
+        id: "tl_PH",
+        title: "Tagalog (Filipino)",
+        localeIdentifier: "tl_PH",
+        centerCharacters: [
+            ["a", "n", "i"],
+            ["h", "o", "r"],
+            ["t", "e", "s"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeDownRight: "v"],
+            GridSlot.topCenter: [.swipeUp: "ñ", .swipeDown: "l"],
+            GridSlot.topRight: [.swipeDownLeft: "x"],
+            GridSlot.midLeft: [.swipeRight: "k"],
+            GridSlot.center: [
+                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                .swipeDownLeft: "g", .swipeLeft: "c",
+            ],
+            GridSlot.midRight: [.swipeLeft: "m"],
+            GridSlot.bottomLeft: [.swipeUpRight: "y"],
+            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
+            GridSlot.bottomRight: [.swipeUpLeft: "f"],
+        ]
+    )
+
+    // MARK: - Registry
+
+    /// All available language definitions, sorted alphabetically by title.
+    static let all: [KeyboardDefinition] = [
+        spanishCatalan,
+        croatian,
+        english,
+        estonianFinnish,
+        finnish,
+        french,
+        german,
+        hebrew,
+        italian,
+        polish,
+        russian,
+        spanish,
+        swedish,
+        tagalog,
+    ].sorted { $0.title < $1.title }
+}

--- a/wurstfingerKeyboard/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/LanguageDefinitions.swift
@@ -202,7 +202,8 @@ enum LanguageDefinitions {
             GridSlot.bottomLeft: [.swipeUpRight: "ז"],
             GridSlot.bottomCenter: [.swipeUp: "ס"],
             GridSlot.bottomRight: [.swipeUpLeft: "ט"],
-        ]
+        ],
+        numericBackToAlphaLabel: "אבג"
     )
 
     // MARK: - Italian
@@ -286,7 +287,8 @@ enum LanguageDefinitions {
             GridSlot.bottomLeft: [.swipeUp: "ё", .swipeRight: "э", .swipeUpRight: "д"],
             GridSlot.bottomCenter: [.swipeUp: "у", .swipeRight: "з", .swipeLeft: "ю"],
             GridSlot.bottomRight: [.swipeUpLeft: "ф"],
-        ]
+        ],
+        numericBackToAlphaLabel: "абв"
     )
 
     // MARK: - Spanish-Catalan

--- a/wurstfingerKeyboard/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/LanguageDefinitions.swift
@@ -403,6 +403,32 @@ enum LanguageDefinitions {
         ]
     )
 
+    static let vietnamese = GridKeyboardFactory.layout(
+        id: "vi_VN",
+        title: "Tiếng Việt (Vietnamese-Telex)",
+        localeIdentifier: "vi_VN",
+        centerCharacters: [
+            ["a", "n", "i"],
+            ["h", "o", "r"],
+            ["t", "e", "s"],
+        ],
+        directionalOverrides: [
+            GridSlot.topLeft: [.swipeDown: "đ", .swipeDownRight: "v"],
+            GridSlot.topCenter: [.swipeDown: "l"],
+            GridSlot.topRight: [.swipeDownLeft: "x"],
+            GridSlot.midLeft: [.swipeRight: "k"],
+            GridSlot.center: [
+                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                .swipeDownLeft: "g", .swipeLeft: "c",
+            ],
+            GridSlot.midRight: [.swipeLeft: "m"],
+            GridSlot.bottomLeft: [.swipeUpRight: "y"],
+            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
+            GridSlot.bottomRight: [.swipeUpLeft: "f"],
+        ]
+    )
+
     // MARK: - Registry
 
     /// All available language definitions, sorted alphabetically by title.
@@ -421,5 +447,6 @@ enum LanguageDefinitions {
         spanish,
         swedish,
         tagalog,
+        vietnamese,
     ].sorted { $0.title < $1.title }
 }

--- a/wurstfingerKeyboard/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/LanguageDefinitions.swift
@@ -403,6 +403,8 @@ enum LanguageDefinitions {
         ]
     )
 
+    // MARK: - Vietnamese (Telex)
+
     static let vietnamese = GridKeyboardFactory.layout(
         id: "vi_VN",
         title: "Tiếng Việt (Vietnamese-Telex)",
@@ -426,7 +428,8 @@ enum LanguageDefinitions {
             GridSlot.bottomLeft: [.swipeUpRight: "y"],
             GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
             GridSlot.bottomRight: [.swipeUpLeft: "f"],
-        ]
+        ],
+        inputMethod: .telex
     )
 
     // MARK: - Registry

--- a/wurstfingerKeyboard/NumericLayouts.swift
+++ b/wurstfingerKeyboard/NumericLayouts.swift
@@ -9,26 +9,45 @@ import Foundation
 
 /// Numeric keyboard modes shared across all languages.
 enum NumericLayouts {
+    /// Default Latin label for the back-to-alpha key. Languages whose
+    /// alphabet is not Latin (Hebrew, Russian, …) should pass their own
+    /// script-appropriate label via `phone(backToAlphaLabel:)`.
+    static let defaultBackToAlphaLabel = "abc"
+
     /// Phone-style layout (1-2-3 in top row).
-    static let phone: KeyboardMode = buildMode(centerDigits: [
-        ["1", "2", "3"],
-        ["4", "5", "6"],
-        ["7", "8", "9"],
-    ])
+    static func phone(backToAlphaLabel: String = defaultBackToAlphaLabel) -> KeyboardMode {
+        buildMode(
+            centerDigits: [
+                ["1", "2", "3"],
+                ["4", "5", "6"],
+                ["7", "8", "9"],
+            ],
+            backToAlphaLabel: backToAlphaLabel
+        )
+    }
 
     /// Classic calculator style (7-8-9 in top row).
-    static let classic: KeyboardMode = buildMode(centerDigits: [
-        ["7", "8", "9"],
-        ["4", "5", "6"],
-        ["1", "2", "3"],
-    ])
+    static func classic(backToAlphaLabel: String = defaultBackToAlphaLabel) -> KeyboardMode {
+        buildMode(
+            centerDigits: [
+                ["7", "8", "9"],
+                ["4", "5", "6"],
+                ["1", "2", "3"],
+            ],
+            backToAlphaLabel: backToAlphaLabel
+        )
+    }
 
     // MARK: - Numeric Utility Keys
 
-    /// Symbols key in numeric mode switches back to main (label "abc").
-    private static let backToMain = KeyConfig.utility(
-        UtilitySlot.symbols, label: "abc", action: .switchMode(ModeNames.main)
-    )
+    /// Builds the symbols key in numeric mode, which switches back to main.
+    /// The label is locale/script-aware so non-Latin keyboards (e.g. Hebrew,
+    /// Russian) can show an appropriate label instead of the Latin "abc".
+    private static func backToMain(label: String) -> KeyConfig {
+        KeyConfig.utility(
+            UtilitySlot.symbols, label: label, action: .switchMode(ModeNames.main)
+        )
+    }
 
     /// Space key with "0" on tap in numeric mode.
     private static let spaceWithZero = KeyConfig.utility(
@@ -36,14 +55,17 @@ enum NumericLayouts {
         slideType: .moveCursor
     )
 
-    /// Utility keys for numeric mode (symbols → back to main, space → 0).
-    private static let utilityKeys: [String: KeyConfig] = [
-        UtilitySlot.globe: CommonKeys.globe,
-        UtilitySlot.delete: CommonKeys.delete,
-        UtilitySlot.return: CommonKeys.return,
-        UtilitySlot.symbols: backToMain,
-        UtilitySlot.space: spaceWithZero,
-    ]
+    /// Builds the utility-key dictionary for numeric mode using the supplied
+    /// back-to-alpha label.
+    private static func utilityKeys(backToAlphaLabel: String) -> [String: KeyConfig] {
+        [
+            UtilitySlot.globe: CommonKeys.globe,
+            UtilitySlot.delete: CommonKeys.delete,
+            UtilitySlot.return: CommonKeys.return,
+            UtilitySlot.symbols: backToMain(label: backToAlphaLabel),
+            UtilitySlot.space: spaceWithZero,
+        ]
+    }
 
     // MARK: - Symbol Swipes per Digit
 
@@ -91,7 +113,7 @@ enum NumericLayouts {
 
     // MARK: - Builder
 
-    private static func buildMode(centerDigits: [[String]]) -> KeyboardMode {
+    private static func buildMode(centerDigits: [[String]], backToAlphaLabel: String) -> KeyboardMode {
         precondition(
             centerDigits.count == 3 && centerDigits.allSatisfy { $0.count == 3 },
             "centerDigits must be a 3×3 matrix"
@@ -126,7 +148,7 @@ enum NumericLayouts {
             }
         }
 
-        let allKeys = digitKeys.merging(utilityKeys) { digit, _ in digit }
+        let allKeys = digitKeys.merging(utilityKeys(backToAlphaLabel: backToAlphaLabel)) { digit, _ in digit }
 
         return KeyboardMode(
             name: ModeNames.numeric,

--- a/wurstfingerKeyboard/NumericLayouts.swift
+++ b/wurstfingerKeyboard/NumericLayouts.swift
@@ -148,7 +148,13 @@ enum NumericLayouts {
             }
         }
 
-        let allKeys = digitKeys.merging(utilityKeys(backToAlphaLabel: backToAlphaLabel)) { digit, _ in digit }
+        let utilityKeyMap = utilityKeys(backToAlphaLabel: backToAlphaLabel)
+        let duplicateIds = Set(digitKeys.keys).intersection(utilityKeyMap.keys)
+        precondition(
+            duplicateIds.isEmpty,
+            "Duplicate key ids in numeric layout: \(duplicateIds)"
+        )
+        let allKeys = digitKeys.merging(utilityKeyMap) { digit, _ in digit }
 
         return KeyboardMode(
             name: ModeNames.numeric,

--- a/wurstfingerKeyboard/NumericLayouts.swift
+++ b/wurstfingerKeyboard/NumericLayouts.swift
@@ -1,0 +1,135 @@
+//
+//  NumericLayouts.swift
+//  Wurstfinger
+//
+//  Numeric keyboard modes (phone and classic digit ordering).
+//
+
+import Foundation
+
+/// Numeric keyboard modes shared across all languages.
+enum NumericLayouts {
+    /// Phone-style layout (1-2-3 in top row).
+    static let phone: KeyboardMode = buildMode(centerDigits: [
+        ["1", "2", "3"],
+        ["4", "5", "6"],
+        ["7", "8", "9"],
+    ])
+
+    /// Classic calculator style (7-8-9 in top row).
+    static let classic: KeyboardMode = buildMode(centerDigits: [
+        ["7", "8", "9"],
+        ["4", "5", "6"],
+        ["1", "2", "3"],
+    ])
+
+    // MARK: - Numeric Utility Keys
+
+    /// Symbols key in numeric mode switches back to main (label "abc").
+    private static let backToMain = KeyConfig.utility(
+        UtilitySlot.symbols, label: "abc", action: .switchMode(ModeNames.main)
+    )
+
+    /// Space key with "0" on tap in numeric mode.
+    private static let spaceWithZero = KeyConfig.utility(
+        UtilitySlot.space, label: "0", action: .commitText("0"),
+        slideType: .moveCursor
+    )
+
+    /// Utility keys for numeric mode (symbols → back to main, space → 0).
+    private static let utilityKeys: [String: KeyConfig] = [
+        UtilitySlot.globe: CommonKeys.globe,
+        UtilitySlot.delete: CommonKeys.delete,
+        UtilitySlot.return: CommonKeys.return,
+        UtilitySlot.symbols: backToMain,
+        UtilitySlot.space: spaceWithZero,
+    ]
+
+    // MARK: - Symbol Swipes per Digit
+
+    /// Default symbol swipes for each digit key position.
+    private static let digitSwipes: [String: [GestureType: String]] = [
+        GridSlot.topLeft: [
+            .swipeRight: "#",
+            .swipeDown: "(",
+            .swipeDownRight: "/",
+        ],
+        GridSlot.topCenter: [
+            .swipeDown: "$",
+            .swipeLeft: "+",
+            .swipeRight: "!",
+        ],
+        GridSlot.topRight: [
+            .swipeLeft: ")",
+            .swipeDown: "=",
+            .swipeDownLeft: "\\",
+        ],
+        GridSlot.midLeft: [
+            .swipeRight: "*",
+            .swipeUp: "[",
+            .swipeDown: "{",
+        ],
+        GridSlot.midRight: [
+            .swipeLeft: "%",
+            .swipeUp: "]",
+            .swipeDown: "}",
+        ],
+        GridSlot.bottomLeft: [
+            .swipeRight: "-",
+            .swipeUp: "<",
+        ],
+        GridSlot.bottomCenter: [
+            .swipeDown: ".",
+            .swipeLeft: ",",
+            .swipeRight: ":",
+        ],
+        GridSlot.bottomRight: [
+            .swipeLeft: "@",
+            .swipeUp: ">",
+        ],
+    ]
+
+    // MARK: - Builder
+
+    private static func buildMode(centerDigits: [[String]]) -> KeyboardMode {
+        var digitKeys: [String: KeyConfig] = [:]
+
+        for (rowIdx, row) in centerDigits.enumerated() {
+            for (colIdx, digit) in row.enumerated() {
+                let slotId = GridSlot.allSlots[rowIdx][colIdx]
+                var bindings: [GestureType: KeyBinding] = [:]
+
+                // Tap → digit
+                bindings[.tap] = KeyBinding(
+                    label: digit, action: .commitText(digit),
+                    category: .digit, returnAction: nil, accessibilityLabel: nil
+                )
+
+                // Symbol swipes
+                if let swipes = digitSwipes[slotId] {
+                    for (gesture, symbol) in swipes {
+                        bindings[gesture] = KeyBinding(
+                            label: symbol, action: .commitText(symbol),
+                            category: nil, returnAction: nil, accessibilityLabel: nil
+                        )
+                    }
+                }
+
+                digitKeys[slotId] = KeyConfig(
+                    id: slotId, bindings: bindings, swipeMode: .eightWay,
+                    slideType: .none, style: .primary, tapCycleActions: nil
+                )
+            }
+        }
+
+        let allKeys = digitKeys.merging(utilityKeys) { digit, _ in digit }
+
+        return KeyboardMode(
+            name: ModeNames.numeric,
+            keys: allKeys,
+            arrangements: StandardArrangements.grid3x3,
+            autoTransitions: [:],
+            doubleTapMode: nil
+        )
+    }
+}

--- a/wurstfingerKeyboard/NumericLayouts.swift
+++ b/wurstfingerKeyboard/NumericLayouts.swift
@@ -92,6 +92,10 @@ enum NumericLayouts {
     // MARK: - Builder
 
     private static func buildMode(centerDigits: [[String]]) -> KeyboardMode {
+        precondition(
+            centerDigits.count == 3 && centerDigits.allSatisfy { $0.count == 3 },
+            "centerDigits must be a 3×3 matrix"
+        )
         var digitKeys: [String: KeyConfig] = [:]
 
         for (rowIdx, row) in centerDigits.enumerated() {

--- a/wurstfingerTests/LanguageDefinitionTests.swift
+++ b/wurstfingerTests/LanguageDefinitionTests.swift
@@ -1,0 +1,125 @@
+//
+//  LanguageDefinitionTests.swift
+//  WurstfingerTests
+//
+//  Tests for LanguageDefinitions and NumericLayouts.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+// MARK: - All Layouts Validate
+
+struct LanguageDefinitionValidationTests {
+    @Test(arguments: LanguageDefinitions.all)
+    func layoutValidatesWithoutErrors(layout: KeyboardDefinition) {
+        let errors = layout.validate()
+        #expect(errors.isEmpty, "Validation errors for \(layout.id): \(errors)")
+    }
+
+    @Test(arguments: LanguageDefinitions.all)
+    func layoutHasRequiredModes(layout: KeyboardDefinition) {
+        #expect(layout.modes[ModeNames.main] != nil, "\(layout.id) missing main mode")
+        #expect(layout.modes[ModeNames.shifted] != nil, "\(layout.id) missing shifted mode")
+        #expect(layout.modes[ModeNames.numeric] != nil, "\(layout.id) missing numeric mode")
+    }
+
+    @Test func allLanguagesCount() {
+        #expect(LanguageDefinitions.all.count == 14)
+    }
+}
+
+// MARK: - German Layout Tests
+
+struct GermanLayoutTests {
+    static let german = LanguageDefinitions.german
+
+    @Test func centerCharacters() throws {
+        let main = try #require(Self.german.modes[ModeNames.main])
+        #expect(main.keys[GridSlot.topLeft]?.bindings[.tap]?.action == .commitText("a"))
+        #expect(main.keys[GridSlot.topCenter]?.bindings[.tap]?.action == .commitText("n"))
+        #expect(main.keys[GridSlot.topRight]?.bindings[.tap]?.action == .commitText("i"))
+        #expect(main.keys[GridSlot.midLeft]?.bindings[.tap]?.action == .commitText("h"))
+        #expect(main.keys[GridSlot.center]?.bindings[.tap]?.action == .commitText("d"))
+        #expect(main.keys[GridSlot.midRight]?.bindings[.tap]?.action == .commitText("r"))
+        #expect(main.keys[GridSlot.bottomLeft]?.bindings[.tap]?.action == .commitText("t"))
+        #expect(main.keys[GridSlot.bottomCenter]?.bindings[.tap]?.action == .commitText("e"))
+        #expect(main.keys[GridSlot.bottomRight]?.bindings[.tap]?.action == .commitText("s"))
+    }
+
+    @Test func umlauts() throws {
+        let main = try #require(Self.german.modes[ModeNames.main])
+        #expect(main.keys[GridSlot.topLeft]?.bindings[.swipeDown]?.action == .commitText("ä"))
+        #expect(main.keys[GridSlot.midLeft]?.bindings[.swipeUp]?.action == .commitText("ü"))
+        #expect(main.keys[GridSlot.midLeft]?.bindings[.swipeDown]?.action == .commitText("ö"))
+    }
+
+    @Test func eszett() throws {
+        let main = try #require(Self.german.modes[ModeNames.main])
+        #expect(main.keys[GridSlot.bottomLeft]?.bindings[.swipeDown]?.action == .commitText("ß"))
+    }
+
+    @Test func shiftedUmlauts() throws {
+        let shifted = try #require(Self.german.modes[ModeNames.shifted])
+        #expect(shifted.keys[GridSlot.topLeft]?.bindings[.swipeDown]?.action == .commitText("Ä"))
+        #expect(shifted.keys[GridSlot.midLeft]?.bindings[.swipeUp]?.action == .commitText("Ü"))
+        #expect(shifted.keys[GridSlot.midLeft]?.bindings[.swipeDown]?.action == .commitText("Ö"))
+    }
+
+    @Test func localeIsGerman() {
+        #expect(Self.german.localeIdentifier == "de_DE")
+    }
+}
+
+// MARK: - NumericLayouts Tests
+
+struct NumericLayoutTests {
+    @Test func phoneFirstRowIs123() {
+        let phone = NumericLayouts.phone
+        #expect(phone.keys[GridSlot.topLeft]?.bindings[.tap]?.action == .commitText("1"))
+        #expect(phone.keys[GridSlot.topCenter]?.bindings[.tap]?.action == .commitText("2"))
+        #expect(phone.keys[GridSlot.topRight]?.bindings[.tap]?.action == .commitText("3"))
+    }
+
+    @Test func classicFirstRowIs789() {
+        let classic = NumericLayouts.classic
+        #expect(classic.keys[GridSlot.topLeft]?.bindings[.tap]?.action == .commitText("7"))
+        #expect(classic.keys[GridSlot.topCenter]?.bindings[.tap]?.action == .commitText("8"))
+        #expect(classic.keys[GridSlot.topRight]?.bindings[.tap]?.action == .commitText("9"))
+    }
+
+    @Test func phoneValidates() {
+        // Build a minimal definition to validate the numeric mode
+        let errors = NumericLayouts.phone.validate()
+        #expect(errors.isEmpty, "Validation errors: \(errors)")
+    }
+
+    @Test func classicValidates() {
+        let errors = NumericLayouts.classic.validate()
+        #expect(errors.isEmpty, "Validation errors: \(errors)")
+    }
+
+    @Test func symbolsKeySwitchesToMain() {
+        let phone = NumericLayouts.phone
+        #expect(phone.keys[UtilitySlot.symbols]?.bindings[.tap]?.action == .switchMode(ModeNames.main))
+    }
+
+    @Test func spaceKeyOutputsZero() {
+        let phone = NumericLayouts.phone
+        #expect(phone.keys[UtilitySlot.space]?.bindings[.tap]?.action == .commitText("0"))
+    }
+
+    @Test func hasSymbolSwipes() {
+        let phone = NumericLayouts.phone
+        // Spot-check a few symbol swipes
+        #expect(phone.keys[GridSlot.bottomCenter]?.bindings[.swipeDown]?.action == .commitText("."))
+        #expect(phone.keys[GridSlot.bottomCenter]?.bindings[.swipeLeft]?.action == .commitText(","))
+    }
+
+    @Test func phoneHasAllGridAndUtilityKeys() {
+        let phone = NumericLayouts.phone
+        // 9 grid slots + 5 utility keys = 14
+        #expect(phone.keys.count == 14)
+    }
+}

--- a/wurstfingerTests/LanguageDefinitionTests.swift
+++ b/wurstfingerTests/LanguageDefinitionTests.swift
@@ -22,6 +22,7 @@ struct LanguageDefinitionValidationTests {
     func layoutHasRequiredModes(layout: KeyboardDefinition) {
         #expect(layout.modes[ModeNames.main] != nil, "\(layout.id) missing main mode")
         #expect(layout.modes[ModeNames.shifted] != nil, "\(layout.id) missing shifted mode")
+        #expect(layout.modes[ModeNames.capsLock] != nil, "\(layout.id) missing capsLock mode")
         #expect(layout.modes[ModeNames.numeric] != nil, "\(layout.id) missing numeric mode")
     }
 

--- a/wurstfingerTests/LanguageDefinitionTests.swift
+++ b/wurstfingerTests/LanguageDefinitionTests.swift
@@ -77,14 +77,14 @@ struct GermanLayoutTests {
 
 struct NumericLayoutTests {
     @Test func phoneFirstRowIs123() {
-        let phone = NumericLayouts.phone
+        let phone = NumericLayouts.phone()
         #expect(phone.keys[GridSlot.topLeft]?.bindings[.tap]?.action == .commitText("1"))
         #expect(phone.keys[GridSlot.topCenter]?.bindings[.tap]?.action == .commitText("2"))
         #expect(phone.keys[GridSlot.topRight]?.bindings[.tap]?.action == .commitText("3"))
     }
 
     @Test func classicFirstRowIs789() {
-        let classic = NumericLayouts.classic
+        let classic = NumericLayouts.classic()
         #expect(classic.keys[GridSlot.topLeft]?.bindings[.tap]?.action == .commitText("7"))
         #expect(classic.keys[GridSlot.topCenter]?.bindings[.tap]?.action == .commitText("8"))
         #expect(classic.keys[GridSlot.topRight]?.bindings[.tap]?.action == .commitText("9"))
@@ -92,35 +92,65 @@ struct NumericLayoutTests {
 
     @Test func phoneValidates() {
         // Build a minimal definition to validate the numeric mode
-        let errors = NumericLayouts.phone.validate()
+        let errors = NumericLayouts.phone().validate()
         #expect(errors.isEmpty, "Validation errors: \(errors)")
     }
 
     @Test func classicValidates() {
-        let errors = NumericLayouts.classic.validate()
+        let errors = NumericLayouts.classic().validate()
         #expect(errors.isEmpty, "Validation errors: \(errors)")
     }
 
     @Test func symbolsKeySwitchesToMain() {
-        let phone = NumericLayouts.phone
+        let phone = NumericLayouts.phone()
         #expect(phone.keys[UtilitySlot.symbols]?.bindings[.tap]?.action == .switchMode(ModeNames.main))
     }
 
     @Test func spaceKeyOutputsZero() {
-        let phone = NumericLayouts.phone
+        let phone = NumericLayouts.phone()
         #expect(phone.keys[UtilitySlot.space]?.bindings[.tap]?.action == .commitText("0"))
     }
 
     @Test func hasSymbolSwipes() {
-        let phone = NumericLayouts.phone
+        let phone = NumericLayouts.phone()
         // Spot-check a few symbol swipes
         #expect(phone.keys[GridSlot.bottomCenter]?.bindings[.swipeDown]?.action == .commitText("."))
         #expect(phone.keys[GridSlot.bottomCenter]?.bindings[.swipeLeft]?.action == .commitText(","))
     }
 
     @Test func phoneHasAllGridAndUtilityKeys() {
-        let phone = NumericLayouts.phone
-        // 9 grid slots + 5 utility keys = 14
-        #expect(phone.keys.count == 14)
+        let phone = NumericLayouts.phone()
+        let expectedKeys = Set(
+            GridSlot.allSlots.flatMap(\.self) + [
+                UtilitySlot.globe,
+                UtilitySlot.delete,
+                UtilitySlot.return,
+                UtilitySlot.symbols,
+                UtilitySlot.space,
+            ]
+        )
+        #expect(Set(phone.keys.keys) == expectedKeys)
+    }
+
+    @Test func defaultBackToAlphaLabelIsLatinAbc() {
+        let phone = NumericLayouts.phone()
+        #expect(phone.keys[UtilitySlot.symbols]?.bindings[.tap]?.label == "abc")
+    }
+
+    @Test func customBackToAlphaLabelIsRespected() {
+        let phone = NumericLayouts.phone(backToAlphaLabel: "אבג")
+        #expect(phone.keys[UtilitySlot.symbols]?.bindings[.tap]?.label == "אבג")
+    }
+
+    @Test func hebrewLayoutUsesHebrewBackToAlphaLabel() throws {
+        let hebrew = LanguageDefinitions.hebrew
+        let numeric = try #require(hebrew.modes[ModeNames.numeric])
+        #expect(numeric.keys[UtilitySlot.symbols]?.bindings[.tap]?.label == "אבג")
+    }
+
+    @Test func russianLayoutUsesCyrillicBackToAlphaLabel() throws {
+        let russian = LanguageDefinitions.russian
+        let numeric = try #require(russian.modes[ModeNames.numeric])
+        #expect(numeric.keys[UtilitySlot.symbols]?.bindings[.tap]?.label == "абв")
     }
 }

--- a/wurstfingerTests/LanguageDefinitionTests.swift
+++ b/wurstfingerTests/LanguageDefinitionTests.swift
@@ -26,8 +26,13 @@ struct LanguageDefinitionValidationTests {
         #expect(layout.modes[ModeNames.numeric] != nil, "\(layout.id) missing numeric mode")
     }
 
-    @Test func allLanguagesCount() {
-        #expect(LanguageDefinitions.all.count == 14)
+    @Test func allLanguagesMatchRegistry() {
+        // Parity check against the canonical LanguageConfig registry —
+        // catches drift if a language is added to one list but not the other.
+        #expect(
+            Set(LanguageDefinitions.all.map(\.id))
+                == Set(LanguageConfig.allLanguages.map(\.id))
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- **LanguageDefinitions**: all 14 supported languages (Croatian, English, Estonian-Finnish, Finnish, French, German, Hebrew, Italian, Polish, Russian, Spanish-Catalan, Spanish, Swedish, Tagalog) expressed as `GridKeyboardFactory.layout()` calls — each language is pure data (~20 lines)
- **NumericLayouts**: phone-style (1-2-3 top) and classic (7-8-9 top) numeric keyboard modes with symbol swipes, "0" on space key, and "abc" button to return to main
- **GridKeyboardFactory**: stub numeric mode replaced with real `NumericLayouts.phone`

PR 6 in the refactoring chain. Builds on CommonKeys, StandardArrangements, and GridKeyboardFactory from PR 5.

## Test plan
- [x] Parameterized validation test: all 14 layouts validate without errors
- [x] Parameterized mode test: all 14 layouts have main, shifted, numeric modes
- [x] German center characters (a/n/i/h/d/r/t/e/s) correct
- [x] German umlauts (ä/ü/ö) and ß on correct swipe directions
- [x] German shifted umlauts (Ä/Ü/Ö) present
- [x] NumericLayouts.phone: 1-2-3 in first row, symbols key → main, space → "0"
- [x] NumericLayouts.classic: 7-8-9 in first row
- [x] Both numeric modes validate without errors
- [x] All 482 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 15 keyboard languages with directional swipe customizations.
  * Introduced shared numeric layouts ("phone" and "classic") with customizable back‑to‑alpha labels.
  * Added per‑layout input method support (e.g., Vietnamese uses Telex) and a public registry of all layouts.

* **Tests**
  * Added validation and behavior tests for language definitions, numeric layouts, utility keys, locale labels, and German layout specifics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->