### PR TITLE
Add KeyboardRegistry with Lazy Loading and Caching

### DIFF
--- a/wurstfingerKeyboard/KeyboardInfo.swift
+++ b/wurstfingerKeyboard/KeyboardInfo.swift
@@ -1,0 +1,28 @@
+//
+//  KeyboardInfo.swift
+//  Wurstfinger
+//
+//  Lightweight keyboard metadata for UI and selection.
+//
+
+import Foundation
+
+/// Lightweight metadata for a keyboard layout.
+/// Used by the language selection UI without loading the full definition.
+struct KeyboardInfo: Codable, Identifiable, Equatable {
+    let id: String
+    let title: String
+    let localeIdentifier: String
+
+    init(id: String, title: String, localeIdentifier: String) {
+        self.id = id
+        self.title = title
+        self.localeIdentifier = localeIdentifier
+    }
+
+    init(from definition: KeyboardDefinition) {
+        id = definition.id
+        title = definition.title
+        localeIdentifier = definition.localeIdentifier
+    }
+}

--- a/wurstfingerKeyboard/KeyboardRegistry.swift
+++ b/wurstfingerKeyboard/KeyboardRegistry.swift
@@ -13,13 +13,19 @@ enum KeyboardRegistry {
     /// All available keyboard layouts (lightweight metadata only).
     static let available: [KeyboardInfo] = LanguageDefinitions.all.map { KeyboardInfo(from: $0) }
 
+    /// Precomputed index for O(1) definition lookup by id.
+    private static let definitionsByID: [String: KeyboardDefinition] =
+        LanguageDefinitions.all.reduce(into: [:]) { dict, def in
+            dict[def.id] = def
+        }
+
     /// Cache for loaded definitions.
     private static var cache: [String: KeyboardDefinition] = [:]
 
     /// Loads the full definition for a keyboard ID, caching the result.
     static func load(id: String) -> KeyboardDefinition? {
         if let cached = cache[id] { return cached }
-        guard let definition = LanguageDefinitions.all.first(where: { $0.id == id }) else {
+        guard let definition = definitionsByID[id] else {
             return nil
         }
         cache[id] = definition

--- a/wurstfingerKeyboard/KeyboardRegistry.swift
+++ b/wurstfingerKeyboard/KeyboardRegistry.swift
@@ -35,4 +35,9 @@ final class KeyboardRegistry {
     static func evictAll() {
         cache.removeAll()
     }
+
+    /// Whether a definition is currently cached (for testing).
+    static func isCached(id: String) -> Bool {
+        cache[id] != nil
+    }
 }

--- a/wurstfingerKeyboard/KeyboardRegistry.swift
+++ b/wurstfingerKeyboard/KeyboardRegistry.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Registry for keyboard layouts.
 /// Exposes lightweight metadata via `available` and loads full definitions on demand.
-final class KeyboardRegistry {
+enum KeyboardRegistry {
     /// All available keyboard layouts (lightweight metadata only).
     static let available: [KeyboardInfo] = LanguageDefinitions.all.map { KeyboardInfo(from: $0) }
 

--- a/wurstfingerKeyboard/KeyboardRegistry.swift
+++ b/wurstfingerKeyboard/KeyboardRegistry.swift
@@ -1,0 +1,38 @@
+//
+//  KeyboardRegistry.swift
+//  Wurstfinger
+//
+//  Registry for keyboard layouts with lazy loading and caching.
+//
+
+import Foundation
+
+/// Registry for keyboard layouts.
+/// Exposes lightweight metadata via `available` and loads full definitions on demand.
+final class KeyboardRegistry {
+    /// All available keyboard layouts (lightweight metadata only).
+    static let available: [KeyboardInfo] = LanguageDefinitions.all.map { KeyboardInfo(from: $0) }
+
+    /// Cache for loaded definitions.
+    private static var cache: [String: KeyboardDefinition] = [:]
+
+    /// Loads the full definition for a keyboard ID, caching the result.
+    static func load(id: String) -> KeyboardDefinition? {
+        if let cached = cache[id] { return cached }
+        guard let definition = LanguageDefinitions.all.first(where: { $0.id == id }) else {
+            return nil
+        }
+        cache[id] = definition
+        return definition
+    }
+
+    /// Removes a cached definition (e.g. on memory warning).
+    static func evict(id: String) {
+        cache.removeValue(forKey: id)
+    }
+
+    /// Clears the entire cache.
+    static func evictAll() {
+        cache.removeAll()
+    }
+}

--- a/wurstfingerTests/KeyboardRegistryTests.swift
+++ b/wurstfingerTests/KeyboardRegistryTests.swift
@@ -28,6 +28,7 @@ struct KeyboardInfoTests {
 
 // MARK: - KeyboardRegistry
 
+@Suite(.serialized)
 struct KeyboardRegistryTests {
     @Test func availableContainsAllLanguages() {
         #expect(KeyboardRegistry.available.count == LanguageDefinitions.all.count)
@@ -50,9 +51,11 @@ struct KeyboardRegistryTests {
 
     @Test func loadCachesResult() {
         KeyboardRegistry.evictAll()
+        #expect(!KeyboardRegistry.isCached(id: LanguageDefinitions.german.id))
         let first = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
-        let second = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
         #expect(first != nil)
+        #expect(KeyboardRegistry.isCached(id: LanguageDefinitions.german.id))
+        let second = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
         #expect(first == second)
     }
 
@@ -63,7 +66,9 @@ struct KeyboardRegistryTests {
     @Test func evictRemovesFromCache() {
         KeyboardRegistry.evictAll()
         _ = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
+        #expect(KeyboardRegistry.isCached(id: LanguageDefinitions.german.id))
         KeyboardRegistry.evict(id: LanguageDefinitions.german.id)
+        #expect(!KeyboardRegistry.isCached(id: LanguageDefinitions.german.id))
         // After evict, load should still work (rebuilds from LanguageDefinitions)
         let reloaded = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
         #expect(reloaded != nil)
@@ -73,11 +78,10 @@ struct KeyboardRegistryTests {
         // Load a few definitions
         _ = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
         _ = KeyboardRegistry.load(id: LanguageDefinitions.english.id)
+        #expect(KeyboardRegistry.isCached(id: LanguageDefinitions.german.id))
+        #expect(KeyboardRegistry.isCached(id: LanguageDefinitions.english.id))
         KeyboardRegistry.evictAll()
-        // All should still be loadable after evict
-        let german = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
-        let english = KeyboardRegistry.load(id: LanguageDefinitions.english.id)
-        #expect(german != nil)
-        #expect(english != nil)
+        #expect(!KeyboardRegistry.isCached(id: LanguageDefinitions.german.id))
+        #expect(!KeyboardRegistry.isCached(id: LanguageDefinitions.english.id))
     }
 }

--- a/wurstfingerTests/KeyboardRegistryTests.swift
+++ b/wurstfingerTests/KeyboardRegistryTests.swift
@@ -31,7 +31,9 @@ struct KeyboardInfoTests {
 @Suite(.serialized)
 struct KeyboardRegistryTests {
     @Test func availableContainsAllLanguages() {
-        #expect(KeyboardRegistry.available.count == LanguageDefinitions.all.count)
+        let expectedIDs = Set(LanguageDefinitions.all.map(\.id))
+        let actualIDs = Set(KeyboardRegistry.available.map(\.id))
+        #expect(actualIDs == expectedIDs)
     }
 
     @Test func availableContainsGerman() {

--- a/wurstfingerTests/KeyboardRegistryTests.swift
+++ b/wurstfingerTests/KeyboardRegistryTests.swift
@@ -1,0 +1,83 @@
+//
+//  KeyboardRegistryTests.swift
+//  WurstfingerTests
+//
+//  Tests for KeyboardInfo and KeyboardRegistry.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+// MARK: - KeyboardInfo
+
+struct KeyboardInfoTests {
+    @Test func initFromDefinition() {
+        let definition = LanguageDefinitions.german
+        let info = KeyboardInfo(from: definition)
+        #expect(info.id == definition.id)
+        #expect(info.title == definition.title)
+        #expect(info.localeIdentifier == definition.localeIdentifier)
+    }
+
+    @Test func identifiable() {
+        let info = KeyboardInfo(id: "test", title: "Test", localeIdentifier: "en_US")
+        #expect(info.id == "test")
+    }
+}
+
+// MARK: - KeyboardRegistry
+
+struct KeyboardRegistryTests {
+    @Test func availableContainsAllLanguages() {
+        #expect(KeyboardRegistry.available.count == LanguageDefinitions.all.count)
+    }
+
+    @Test func availableContainsGerman() {
+        let german = KeyboardRegistry.available.first { $0.id == LanguageDefinitions.german.id }
+        #expect(german != nil)
+        #expect(german?.title == LanguageDefinitions.german.title)
+        #expect(german?.localeIdentifier == LanguageDefinitions.german.localeIdentifier)
+    }
+
+    @Test func loadReturnsCorrectDefinition() {
+        KeyboardRegistry.evictAll()
+        let definition = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
+        #expect(definition != nil)
+        #expect(definition?.id == LanguageDefinitions.german.id)
+        #expect(definition?.title == LanguageDefinitions.german.title)
+    }
+
+    @Test func loadCachesResult() {
+        KeyboardRegistry.evictAll()
+        let first = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
+        let second = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
+        #expect(first != nil)
+        #expect(first == second)
+    }
+
+    @Test func loadNonexistentReturnsNil() {
+        #expect(KeyboardRegistry.load(id: "nonexistent_layout") == nil)
+    }
+
+    @Test func evictRemovesFromCache() {
+        KeyboardRegistry.evictAll()
+        _ = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
+        KeyboardRegistry.evict(id: LanguageDefinitions.german.id)
+        // After evict, load should still work (rebuilds from LanguageDefinitions)
+        let reloaded = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
+        #expect(reloaded != nil)
+    }
+
+    @Test func evictAllClearsCache() {
+        // Load a few definitions
+        _ = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
+        _ = KeyboardRegistry.load(id: LanguageDefinitions.english.id)
+        KeyboardRegistry.evictAll()
+        // All should still be loadable after evict
+        let german = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
+        let english = KeyboardRegistry.load(id: LanguageDefinitions.english.id)
+        #expect(german != nil)
+        #expect(english != nil)
+    }
+}


### PR DESCRIPTION
## Summary
- `KeyboardInfo` — lightweight metadata struct (id, title, locale) for UI without loading full definitions
- `KeyboardRegistry` — exposes `available: [KeyboardInfo]` and loads full `KeyboardDefinition` on demand via `load(id:)` with caching
- `evict(id:)` / `evictAll()` for memory pressure scenarios

## Test plan
- [x] All 502 tests pass (9 new)
- [x] `available` contains all 14 language layouts
- [x] `load(id:)` returns correct definition and caches result
- [x] `load(id: "nonexistent")` returns nil
- [x] `evict` / `evictAll` clear cache; layouts remain reloadable
- [x] `KeyboardInfo(from:)` extracts metadata from full definition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard registry system with intelligent caching mechanism to optimize keyboard loading performance
  * Implemented keyboard metadata management for better organization and accessibility of available keyboard layouts
  * Enhanced backend infrastructure to support improved keyboard management and configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->