### PR TITLE
Add CommonKeys, StandardArrangements, and GridKeyboardFactory

### DIFF
--- a/wurstfingerKeyboard/CommonKeys.swift
+++ b/wurstfingerKeyboard/CommonKeys.swift
@@ -1,0 +1,265 @@
+//
+//  CommonKeys.swift
+//  Wurstfinger
+//
+//  Shared key definitions reusable across all MessagEase languages.
+//
+
+import Foundation
+
+/// Shared key definitions reusable across all MessagEase languages.
+/// Utility keys and default punctuation/symbol bindings for the 3x3 grid.
+enum CommonKeys {
+    // MARK: - Utility Keys
+
+    static let globe = KeyConfig.utility(
+        UtilitySlot.globe, label: "🌐", action: .advanceToNextInputMode,
+        accessibilityLabel: "Tastatur wechseln"
+    )
+
+    static let delete = KeyConfig.utility(
+        UtilitySlot.delete, label: "⌫", action: .deleteBackward,
+        swipeMode: .twoWayHorizontal, slideType: .delete,
+        accessibilityLabel: "Löschen"
+    )
+
+    static let `return` = KeyConfig.utility(
+        UtilitySlot.return, label: "↵", action: .newline,
+        accessibilityLabel: "Zeilenumbruch"
+    )
+
+    static let symbols = KeyConfig.utility(
+        UtilitySlot.symbols, label: "123", action: .switchMode(ModeNames.numeric)
+    )
+
+    static let spacebar = KeyConfig.utility(
+        UtilitySlot.space, label: "␣", action: .space,
+        slideType: .moveCursor
+    )
+
+    /// All utility keys as dictionary, mergeable with language keys.
+    static let allUtilityKeys: [String: KeyConfig] = [
+        UtilitySlot.globe: globe,
+        UtilitySlot.delete: delete,
+        UtilitySlot.return: `return`,
+        UtilitySlot.symbols: symbols,
+        UtilitySlot.space: spacebar,
+    ]
+
+    // MARK: - Default Slot Bindings
+
+    /// Shared punctuation, symbol, compose, and action bindings for each grid slot.
+    /// The factory merges these with language-specific center characters.
+    /// Each KeyBinding includes both the primary action and an optional return-swipe action.
+    static let defaultSlotBindings: [String: [GestureType: KeyBinding]] = [
+        // MARK: topLeft
+
+        GridSlot.topLeft: [
+            .swipeUpLeft: KeyBinding(
+                label: "àá", action: .cycleAccents, category: .compose,
+                returnAction: .cycleAccents, accessibilityLabel: nil
+            ),
+            .swipeRight: KeyBinding(
+                label: "-", action: .commitText("-"), category: nil,
+                returnAction: .commitText("÷"), accessibilityLabel: nil
+            ),
+            .swipeDownLeft: KeyBinding(
+                label: "$", action: .commitText("$"), category: nil,
+                returnAction: .commitText("¥"), accessibilityLabel: nil
+            ),
+        ],
+
+        // MARK: topCenter
+
+        GridSlot.topCenter: [
+            .swipeUpLeft: KeyBinding(
+                label: "`", action: .compose(trigger: "ˋ"), category: .compose,
+                returnAction: .commitText("\u{2018}"), accessibilityLabel: nil
+            ),
+            .swipeUp: KeyBinding(
+                label: "^", action: .compose(trigger: "^"), category: .compose,
+                returnAction: .commitText("ˆ"), accessibilityLabel: nil
+            ),
+            .swipeUpRight: KeyBinding(
+                label: "´", action: .compose(trigger: "´"), category: .compose,
+                returnAction: .commitText("\u{2019}"), accessibilityLabel: nil
+            ),
+            .swipeRight: KeyBinding(
+                label: "!", action: .commitText("!"), category: nil,
+                returnAction: .commitText("¡"), accessibilityLabel: nil
+            ),
+            .swipeDownRight: KeyBinding(
+                label: "\\", action: .commitText("\\"), category: nil,
+                returnAction: .commitText("—"), accessibilityLabel: nil
+            ),
+            .swipeDownLeft: KeyBinding(
+                label: "/", action: .commitText("/"), category: nil,
+                returnAction: .commitText("–"), accessibilityLabel: nil
+            ),
+            .swipeLeft: KeyBinding(
+                label: "+", action: .commitText("+"), category: nil,
+                returnAction: .commitText("×"), accessibilityLabel: nil
+            ),
+        ],
+
+        // MARK: topRight
+
+        GridSlot.topRight: [
+            .swipeUpRight: KeyBinding(
+                label: "⏎", action: .commitText("\n"), category: nil,
+                returnAction: .commitText("\n"), accessibilityLabel: nil
+            ),
+            .swipeDownRight: KeyBinding(
+                label: "€", action: .commitText("€"), category: nil,
+                returnAction: .commitText("£"), accessibilityLabel: nil
+            ),
+            .swipeDown: KeyBinding(
+                label: "=", action: .commitText("="), category: nil,
+                returnAction: .commitText("±"), accessibilityLabel: nil
+            ),
+            .swipeLeft: KeyBinding(
+                label: "?", action: .commitText("?"), category: nil,
+                returnAction: .commitText("¿"), accessibilityLabel: nil
+            ),
+        ],
+
+        // MARK: midLeft
+
+        GridSlot.midLeft: [
+            .swipeUpLeft: KeyBinding(
+                label: "{", action: .commitText("{"), category: nil,
+                returnAction: .commitText("}"), accessibilityLabel: nil
+            ),
+            .swipeUpRight: KeyBinding(
+                label: "%", action: .commitText("%"), category: nil,
+                returnAction: .commitText("‰"), accessibilityLabel: nil
+            ),
+            .swipeDownRight: KeyBinding(
+                label: "_", action: .commitText("_"), category: nil,
+                returnAction: .commitText("¬"), accessibilityLabel: nil
+            ),
+            .swipeDownLeft: KeyBinding(
+                label: "[", action: .commitText("["), category: nil,
+                returnAction: .commitText("]"), accessibilityLabel: nil
+            ),
+            .swipeLeft: KeyBinding(
+                label: "(", action: .commitText("("), category: nil,
+                returnAction: .commitText(")"), accessibilityLabel: nil
+            ),
+        ],
+
+        // MARK: center — no defaults (all 8 directions are language-specific)
+
+        // MARK: midRight
+
+        GridSlot.midRight: [
+            .swipeUpLeft: KeyBinding(
+                label: "|", action: .commitText("|"), category: nil,
+                returnAction: .commitText("¶"), accessibilityLabel: nil
+            ),
+            .swipeUp: KeyBinding(
+                label: "⇧", action: .switchMode(ModeNames.shifted), category: .modifier,
+                returnAction: .capitalizeWord(uppercased: true), accessibilityLabel: nil
+            ),
+            .swipeUpRight: KeyBinding(
+                label: "}", action: .commitText("}"), category: nil,
+                returnAction: .commitText("{"), accessibilityLabel: nil
+            ),
+            .swipeRight: KeyBinding(
+                label: ")", action: .commitText(")"), category: nil,
+                returnAction: .commitText("("), accessibilityLabel: nil
+            ),
+            .swipeDown: KeyBinding(
+                label: "⇩", action: .switchMode(ModeNames.main), category: .modifier,
+                returnAction: nil, accessibilityLabel: nil
+            ),
+            .swipeDownRight: KeyBinding(
+                label: "]", action: .commitText("]"), category: nil,
+                returnAction: .commitText("["), accessibilityLabel: nil
+            ),
+            .swipeDownLeft: KeyBinding(
+                label: "@", action: .commitText("@"), category: nil,
+                returnAction: .commitText("ª"), accessibilityLabel: nil
+            ),
+        ],
+
+        // MARK: bottomLeft
+
+        GridSlot.bottomLeft: [
+            .swipeUpLeft: KeyBinding(
+                label: "~", action: .commitText("~"), category: nil,
+                returnAction: .commitText("˜"), accessibilityLabel: nil
+            ),
+            .swipeUp: KeyBinding(
+                label: "¨", action: .compose(trigger: "¨"), category: .compose,
+                returnAction: .commitText("˝"), accessibilityLabel: nil
+            ),
+            .swipeRight: KeyBinding(
+                label: "*", action: .commitText("*"), category: nil,
+                returnAction: .commitText("†"), accessibilityLabel: nil
+            ),
+            .swipeDownRight: KeyBinding(
+                label: "⇥", action: .commitText("\t"), category: nil,
+                returnAction: .commitText("\t"), accessibilityLabel: nil
+            ),
+            .swipeLeft: KeyBinding(
+                label: "<", action: .commitText("<"), category: nil,
+                returnAction: .commitText("‹"), accessibilityLabel: nil
+            ),
+        ],
+
+        // MARK: bottomCenter
+
+        GridSlot.bottomCenter: [
+            .swipeUpLeft: KeyBinding(
+                label: "\"", action: .commitText("\""), category: nil,
+                returnAction: .commitText("\u{201C}"), accessibilityLabel: nil
+            ),
+            .swipeUpRight: KeyBinding(
+                label: "'", action: .commitText("'"), category: nil,
+                returnAction: .commitText("\u{201D}"), accessibilityLabel: nil
+            ),
+            .swipeDownRight: KeyBinding(
+                label: ":", action: .commitText(":"), category: nil,
+                returnAction: .commitText("„"), accessibilityLabel: nil
+            ),
+            .swipeDown: KeyBinding(
+                label: ".", action: .commitText("."), category: nil,
+                returnAction: .commitText("…"), accessibilityLabel: nil
+            ),
+            .swipeDownLeft: KeyBinding(
+                label: ",", action: .commitText(","), category: nil,
+                returnAction: .commitText(","), accessibilityLabel: nil
+            ),
+        ],
+
+        // MARK: bottomRight
+
+        GridSlot.bottomRight: [
+            .swipeUp: KeyBinding(
+                label: "&", action: .commitText("&"), category: nil,
+                returnAction: .commitText("§"), accessibilityLabel: nil
+            ),
+            .swipeUpRight: KeyBinding(
+                label: "°", action: .commitText("°"), category: nil,
+                returnAction: .commitText("º"), accessibilityLabel: nil
+            ),
+            .swipeRight: KeyBinding(
+                label: ">", action: .commitText(">"), category: nil,
+                returnAction: .commitText("›"), accessibilityLabel: nil
+            ),
+            .swipeDownRight: KeyBinding(
+                label: "⎵", action: .commitText(" "), category: nil,
+                returnAction: .commitText(" "), accessibilityLabel: nil
+            ),
+            .swipeDownLeft: KeyBinding(
+                label: ";", action: .commitText(";"), category: nil,
+                returnAction: .commitText(";"), accessibilityLabel: nil
+            ),
+            .swipeLeft: KeyBinding(
+                label: "#", action: .commitText("#"), category: nil,
+                returnAction: .commitText("£"), accessibilityLabel: nil
+            ),
+        ],
+    ]
+}

--- a/wurstfingerKeyboard/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/GridKeyboardFactory.swift
@@ -26,6 +26,11 @@ enum GridKeyboardFactory {
         centerCharacters: [[String]],
         directionalOverrides: [String: [GestureType: String]] = [:]
     ) -> KeyboardDefinition {
+        precondition(
+            centerCharacters.count == 3 && centerCharacters.allSatisfy { $0.count == 3 },
+            "centerCharacters must be a 3×3 matrix"
+        )
+
         let locale = Locale(identifier: localeIdentifier)
         let arrangements = StandardArrangements.grid3x3
 

--- a/wurstfingerKeyboard/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/GridKeyboardFactory.swift
@@ -1,17 +1,17 @@
 //
-//  MessagEaseFactory.swift
+//  GridKeyboardFactory.swift
 //  Wurstfinger
 //
-//  Factory for creating MessagEase-style keyboard definitions.
+//  Factory for creating grid-based keyboard definitions.
 //
 
 import Foundation
 
-/// Factory for creating complete MessagEase-style keyboard definitions.
+/// Factory for creating complete grid-based keyboard definitions.
 /// All shared structure (punctuation, utility keys, arrangements, shifted layer)
 /// is generated automatically — only language-specific parameters are needed.
-enum MessagEaseFactory {
-    /// Creates a complete MessagEase keyboard definition from language-specific parameters.
+enum GridKeyboardFactory {
+    /// Creates a complete keyboard definition from language-specific parameters.
     ///
     /// - Parameters:
     ///   - id: Unique keyboard identifier (e.g. "de_messagease")
@@ -27,7 +27,7 @@ enum MessagEaseFactory {
         directionalOverrides: [String: [GestureType: String]] = [:]
     ) -> KeyboardDefinition {
         let locale = Locale(identifier: localeIdentifier)
-        let arrangements = StandardArrangements.messagEase3x3
+        let arrangements = StandardArrangements.grid3x3
 
         // 1. Build 9 letter keys from center characters + shared defaults + overrides
         var letterKeys: [String: KeyConfig] = [:]

--- a/wurstfingerKeyboard/MessagEaseFactory.swift
+++ b/wurstfingerKeyboard/MessagEaseFactory.swift
@@ -1,0 +1,112 @@
+//
+//  MessagEaseFactory.swift
+//  Wurstfinger
+//
+//  Factory for creating MessagEase-style keyboard definitions.
+//
+
+import Foundation
+
+/// Factory for creating complete MessagEase-style keyboard definitions.
+/// All shared structure (punctuation, utility keys, arrangements, shifted layer)
+/// is generated automatically — only language-specific parameters are needed.
+enum MessagEaseFactory {
+    /// Creates a complete MessagEase keyboard definition from language-specific parameters.
+    ///
+    /// - Parameters:
+    ///   - id: Unique keyboard identifier (e.g. "de_messagease")
+    ///   - title: Display name (e.g. "Deutsch MessagEase")
+    ///   - localeIdentifier: Locale string for uppercasing (e.g. "de_DE")
+    ///   - centerCharacters: 3x3 grid of center tap characters
+    ///   - directionalOverrides: Per-slot overrides that replace CommonKeys defaults
+    static func layout(
+        id: String,
+        title: String,
+        localeIdentifier: String,
+        centerCharacters: [[String]],
+        directionalOverrides: [String: [GestureType: String]] = [:]
+    ) -> KeyboardDefinition {
+        let locale = Locale(identifier: localeIdentifier)
+        let arrangements = StandardArrangements.messagEase3x3
+
+        // 1. Build 9 letter keys from center characters + shared defaults + overrides
+        var letterKeys: [String: KeyConfig] = [:]
+        for (rowIdx, row) in centerCharacters.enumerated() {
+            for (colIdx, char) in row.enumerated() {
+                let slotId = GridSlot.allSlots[rowIdx][colIdx]
+
+                // Start with shared defaults for this slot
+                var bindings = CommonKeys.defaultSlotBindings[slotId] ?? [:]
+
+                // Apply language-specific overrides (replace default binding for that gesture)
+                if let overrides = directionalOverrides[slotId] {
+                    for (gesture, text) in overrides {
+                        bindings[gesture] = KeyBinding(
+                            label: text, action: .commitText(text),
+                            category: nil, returnAction: nil, accessibilityLabel: nil
+                        )
+                    }
+                }
+
+                // Set the tap binding from center character
+                bindings[.tap] = KeyBinding(
+                    label: char, action: .commitText(char),
+                    category: nil, returnAction: nil, accessibilityLabel: nil
+                )
+
+                letterKeys[slotId] = KeyConfig(
+                    id: slotId, bindings: bindings, swipeMode: .eightWay,
+                    slideType: .none, style: .primary, tapCycleActions: nil
+                )
+            }
+        }
+
+        // 2. Merge utility keys
+        let allKeys = letterKeys.merging(CommonKeys.allUtilityKeys) { letter, _ in letter }
+
+        // 3. Main mode — stays active, no auto-transitions
+        let mainMode = KeyboardMode(
+            name: ModeNames.main,
+            keys: allKeys,
+            arrangements: arrangements,
+            autoTransitions: [:],
+            doubleTapMode: nil
+        )
+
+        // 4. Shifted — after typing a letter, returns to main
+        let shiftedMode = mainMode.generateShifted(locale: locale)
+            .with(autoTransitions: [.letter: ModeNames.main], doubleTapMode: ModeNames.capsLock)
+
+        // 5. Caps lock — like shifted but stays active
+        let capsLockMode = mainMode.generateShifted(locale: locale)
+            .with(name: ModeNames.capsLock)
+
+        // 6. Stub numeric mode — replaced by real NumericLayouts in PR6
+        let numericStub = KeyboardMode(
+            name: ModeNames.numeric,
+            keys: allKeys,
+            arrangements: arrangements,
+            autoTransitions: [:],
+            doubleTapMode: nil
+        )
+
+        // 7. Assemble definition
+        return KeyboardDefinition(
+            title: title,
+            id: id,
+            localeIdentifier: localeIdentifier,
+            modes: [
+                ModeNames.main: mainMode,
+                ModeNames.shifted: shiftedMode,
+                ModeNames.capsLock: capsLockMode,
+                ModeNames.numeric: numericStub,
+            ],
+            defaultMode: ModeNames.main,
+            settings: KeyboardDefinitionSettings(
+                autoCapitalize: true,
+                autoCapitalizers: [],
+                composeRuleOverrides: nil
+            )
+        )
+    }
+}

--- a/wurstfingerKeyboard/StandardArrangements.swift
+++ b/wurstfingerKeyboard/StandardArrangements.swift
@@ -2,12 +2,12 @@
 //  StandardArrangements.swift
 //  Wurstfinger
 //
-//  Standard grid arrangements for MessagEase 3x3 layouts.
+//  Standard grid arrangements for 3x3 swipe keyboard layouts.
 //
 
 import Foundation
 
-/// Standard grid arrangements for MessagEase 3x3 layouts.
+/// Standard grid arrangements for 3x3 swipe keyboard layouts.
 /// Shared across all languages using the same 3x3 grid structure.
 enum StandardArrangements {
     // MARK: - Portrait
@@ -57,8 +57,8 @@ enum StandardArrangements {
 
     // MARK: - All 4 Contexts
 
-    /// All 4 arrangement contexts for MessagEase 3x3 layouts.
-    static let messagEase3x3: [ArrangementContext: GridArrangement] = [
+    /// All 4 arrangement contexts for 3x3 grid layouts.
+    static let grid3x3: [ArrangementContext: GridArrangement] = [
         .portrait: portrait,
         .portraitUtilityLeft: portrait.mirroredHorizontally(),
         .landscape: landscape,

--- a/wurstfingerKeyboard/StandardArrangements.swift
+++ b/wurstfingerKeyboard/StandardArrangements.swift
@@ -1,0 +1,67 @@
+//
+//  StandardArrangements.swift
+//  Wurstfinger
+//
+//  Standard grid arrangements for MessagEase 3x3 layouts.
+//
+
+import Foundation
+
+/// Standard grid arrangements for MessagEase 3x3 layouts.
+/// Shared across all languages using the same 3x3 grid structure.
+enum StandardArrangements {
+    // MARK: - Portrait
+
+    private static let portrait = GridArrangement(
+        columns: 4,
+        rows: [
+            [.init(keyId: GridSlot.topLeft), .init(keyId: GridSlot.topCenter), .init(keyId: GridSlot.topRight), .init(keyId: UtilitySlot.globe)],
+            [.init(keyId: GridSlot.midLeft), .init(keyId: GridSlot.center), .init(keyId: GridSlot.midRight), .init(keyId: UtilitySlot.symbols)],
+            [
+                .init(keyId: GridSlot.bottomLeft),
+                .init(keyId: GridSlot.bottomCenter),
+                .init(keyId: GridSlot.bottomRight),
+                .init(keyId: UtilitySlot.delete)
+            ],
+            [.init(keyId: UtilitySlot.space, widthMultiplier: 3), .init(keyId: UtilitySlot.return)],
+        ]
+    )
+
+    // MARK: - Landscape
+
+    private static let landscape = GridArrangement(
+        columns: 5,
+        rows: [
+            [
+                .init(keyId: UtilitySlot.globe),
+                .init(keyId: GridSlot.topLeft),
+                .init(keyId: GridSlot.topCenter),
+                .init(keyId: GridSlot.topRight),
+                .init(keyId: UtilitySlot.delete)
+            ],
+            [
+                .init(keyId: UtilitySlot.symbols),
+                .init(keyId: GridSlot.midLeft),
+                .init(keyId: GridSlot.center),
+                .init(keyId: GridSlot.midRight),
+                .init(keyId: UtilitySlot.return, heightMultiplier: 2)
+            ],
+            [
+                .init(keyId: UtilitySlot.space),
+                .init(keyId: GridSlot.bottomLeft),
+                .init(keyId: GridSlot.bottomCenter),
+                .init(keyId: GridSlot.bottomRight)
+            ],
+        ]
+    )
+
+    // MARK: - All 4 Contexts
+
+    /// All 4 arrangement contexts for MessagEase 3x3 layouts.
+    static let messagEase3x3: [ArrangementContext: GridArrangement] = [
+        .portrait: portrait,
+        .portraitUtilityLeft: portrait.mirroredHorizontally(),
+        .landscape: landscape,
+        .landscapeUtilityLeft: landscape.mirroredHorizontally(),
+    ]
+}

--- a/wurstfingerTests/CommonKeysFactoryTests.swift
+++ b/wurstfingerTests/CommonKeysFactoryTests.swift
@@ -1,0 +1,249 @@
+//
+//  CommonKeysFactoryTests.swift
+//  WurstfingerTests
+//
+//  Tests for CommonKeys, StandardArrangements, and MessagEaseFactory.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+// MARK: - CommonKeys Tests
+
+struct CommonKeysTests {
+    @Test func allUtilityKeysContainsExpectedKeys() {
+        let keys = CommonKeys.allUtilityKeys
+        #expect(keys.count == 5)
+        #expect(keys[UtilitySlot.globe] != nil)
+        #expect(keys[UtilitySlot.delete] != nil)
+        #expect(keys[UtilitySlot.return] != nil)
+        #expect(keys[UtilitySlot.symbols] != nil)
+        #expect(keys[UtilitySlot.space] != nil)
+    }
+
+    @Test func globeKeyAction() {
+        let globe = CommonKeys.globe
+        #expect(globe.id == UtilitySlot.globe)
+        #expect(globe.bindings[.tap]?.action == .advanceToNextInputMode)
+        #expect(globe.style == .utility)
+    }
+
+    @Test func deleteKeyHasSlideType() {
+        let delete = CommonKeys.delete
+        #expect(delete.slideType == .delete)
+        #expect(delete.swipeMode == .twoWayHorizontal)
+    }
+
+    @Test func spacebarHasMoveCursorSlide() {
+        let space = CommonKeys.spacebar
+        #expect(space.slideType == .moveCursor)
+        #expect(space.bindings[.tap]?.action == .space)
+    }
+
+    @Test func symbolsKeySwitchesToNumeric() {
+        let symbols = CommonKeys.symbols
+        #expect(symbols.bindings[.tap]?.action == .switchMode(ModeNames.numeric))
+    }
+
+    @Test func defaultSlotBindingsCoversAllNonCenterSlots() {
+        let bindings = CommonKeys.defaultSlotBindings
+        // All slots except center should have defaults
+        #expect(bindings[GridSlot.topLeft] != nil)
+        #expect(bindings[GridSlot.topCenter] != nil)
+        #expect(bindings[GridSlot.topRight] != nil)
+        #expect(bindings[GridSlot.midLeft] != nil)
+        #expect(bindings[GridSlot.center] == nil) // center has no defaults
+        #expect(bindings[GridSlot.midRight] != nil)
+        #expect(bindings[GridSlot.bottomLeft] != nil)
+        #expect(bindings[GridSlot.bottomCenter] != nil)
+        #expect(bindings[GridSlot.bottomRight] != nil)
+    }
+
+    @Test func midRightSwipeUpIsShift() throws {
+        let midRight = try #require(CommonKeys.defaultSlotBindings[GridSlot.midRight])
+        let shiftBinding = try #require(midRight[.swipeUp])
+        #expect(shiftBinding.action == .switchMode(ModeNames.shifted))
+        #expect(shiftBinding.returnAction == .capitalizeWord(uppercased: true))
+        #expect(shiftBinding.resolvedCategory == .modifier)
+    }
+
+    @Test func topCenterComposeBindings() throws {
+        let topCenter = try #require(CommonKeys.defaultSlotBindings[GridSlot.topCenter])
+        #expect(topCenter[.swipeUp]?.action == .compose(trigger: "^"))
+        #expect(topCenter[.swipeUpLeft]?.action == .compose(trigger: "ˋ"))
+        #expect(topCenter[.swipeUpRight]?.action == .compose(trigger: "´"))
+    }
+
+    @Test func bottomLeftComposeBinding() throws {
+        let bottomLeft = try #require(CommonKeys.defaultSlotBindings[GridSlot.bottomLeft])
+        #expect(bottomLeft[.swipeUp]?.action == .compose(trigger: "¨"))
+    }
+
+    @Test func returnActionsPresent() throws {
+        // Spot-check return actions
+        let topLeft = try #require(CommonKeys.defaultSlotBindings[GridSlot.topLeft])
+        #expect(topLeft[.swipeRight]?.returnAction == .commitText("÷"))
+
+        let topRight = try #require(CommonKeys.defaultSlotBindings[GridSlot.topRight])
+        #expect(topRight[.swipeLeft]?.returnAction == .commitText("¿"))
+    }
+}
+
+// MARK: - StandardArrangements Tests
+
+struct StandardArrangementsTests {
+    @Test func messagEase3x3HasAllFourContexts() {
+        let arrangements = StandardArrangements.messagEase3x3
+        #expect(arrangements.count == 4)
+        #expect(arrangements[.portrait] != nil)
+        #expect(arrangements[.portraitUtilityLeft] != nil)
+        #expect(arrangements[.landscape] != nil)
+        #expect(arrangements[.landscapeUtilityLeft] != nil)
+    }
+
+    @Test func portraitHasFourColumns() throws {
+        let portrait = try #require(StandardArrangements.messagEase3x3[.portrait])
+        #expect(portrait.columns == 4)
+        #expect(portrait.rows.count == 4)
+    }
+
+    @Test func landscapeHasFiveColumns() throws {
+        let landscape = try #require(StandardArrangements.messagEase3x3[.landscape])
+        #expect(landscape.columns == 5)
+        #expect(landscape.rows.count == 3)
+    }
+
+    @Test func portraitUtilityLeftIsMirroredPortrait() throws {
+        let portrait = try #require(StandardArrangements.messagEase3x3[.portrait])
+        let utilityLeft = try #require(StandardArrangements.messagEase3x3[.portraitUtilityLeft])
+        #expect(utilityLeft == portrait.mirroredHorizontally())
+    }
+
+    @Test func landscapeUtilityLeftIsMirroredLandscape() throws {
+        let landscape = try #require(StandardArrangements.messagEase3x3[.landscape])
+        let utilityLeft = try #require(StandardArrangements.messagEase3x3[.landscapeUtilityLeft])
+        #expect(utilityLeft == landscape.mirroredHorizontally())
+    }
+
+    @Test func portraitFirstRowContainsGridAndGlobe() throws {
+        let portrait = try #require(StandardArrangements.messagEase3x3[.portrait])
+        let firstRowIds = portrait.rows[0].map(\.keyId)
+        #expect(firstRowIds == [GridSlot.topLeft, GridSlot.topCenter, GridSlot.topRight, UtilitySlot.globe])
+    }
+
+    @Test func portraitSpaceBarSpansThreeColumns() throws {
+        let portrait = try #require(StandardArrangements.messagEase3x3[.portrait])
+        let space = try #require(portrait.rows[3].first { $0.keyId == UtilitySlot.space })
+        #expect(space.widthMultiplier == 3)
+    }
+
+    @Test func landscapeReturnSpansTwoRows() throws {
+        let landscape = try #require(StandardArrangements.messagEase3x3[.landscape])
+        let returnKey = try #require(landscape.rows[1].first { $0.keyId == UtilitySlot.return })
+        #expect(returnKey.heightMultiplier == 2)
+    }
+}
+
+// MARK: - MessagEaseFactory Tests
+
+struct MessagEaseFactoryTests {
+    /// Minimal test layout for factory testing.
+    static let testLayout = MessagEaseFactory.layout(
+        id: "test_messagease",
+        title: "Test MessagEase",
+        localeIdentifier: "en_US",
+        centerCharacters: [
+            ["a", "b", "c"],
+            ["d", "e", "f"],
+            ["g", "h", "i"],
+        ]
+    )
+
+    @Test func factoryProducesAllModes() {
+        let layout = Self.testLayout
+        #expect(layout.modes[ModeNames.main] != nil)
+        #expect(layout.modes[ModeNames.shifted] != nil)
+        #expect(layout.modes[ModeNames.capsLock] != nil)
+        #expect(layout.modes[ModeNames.numeric] != nil)
+    }
+
+    @Test func factoryResultValidatesWithoutErrors() {
+        let errors = Self.testLayout.validate()
+        #expect(errors.isEmpty, "Validation errors: \(errors)")
+    }
+
+    @Test func mainModeHasAllKeys() throws {
+        let main = try #require(Self.testLayout.modes[ModeNames.main])
+        // 9 grid slots + 5 utility keys = 14
+        #expect(main.keys.count == 14)
+        #expect(main.keys[GridSlot.topLeft] != nil)
+        #expect(main.keys[GridSlot.center] != nil)
+        #expect(main.keys[UtilitySlot.globe] != nil)
+        #expect(main.keys[UtilitySlot.space] != nil)
+    }
+
+    @Test func centerCharactersBecomeTapActions() throws {
+        let main = try #require(Self.testLayout.modes[ModeNames.main])
+        #expect(main.keys[GridSlot.topLeft]?.bindings[.tap]?.action == .commitText("a"))
+        #expect(main.keys[GridSlot.center]?.bindings[.tap]?.action == .commitText("e"))
+        #expect(main.keys[GridSlot.bottomRight]?.bindings[.tap]?.action == .commitText("i"))
+    }
+
+    @Test func defaultBindingsMergedIntoLetterKeys() throws {
+        let main = try #require(Self.testLayout.modes[ModeNames.main])
+        // topLeft should have the default "-" on swipeRight
+        let topLeft = try #require(main.keys[GridSlot.topLeft])
+        #expect(topLeft.bindings[.swipeRight]?.action == .commitText("-"))
+    }
+
+    @Test func shiftedModeAutoTransitionsToMain() throws {
+        let shifted = try #require(Self.testLayout.modes[ModeNames.shifted])
+        #expect(shifted.autoTransitions[.letter] == ModeNames.main)
+    }
+
+    @Test func shiftedModeDoubleTapToCapsLock() throws {
+        let shifted = try #require(Self.testLayout.modes[ModeNames.shifted])
+        #expect(shifted.doubleTapMode == ModeNames.capsLock)
+    }
+
+    @Test func capsLockHasNoAutoTransitions() throws {
+        let capsLock = try #require(Self.testLayout.modes[ModeNames.capsLock])
+        #expect(capsLock.autoTransitions.isEmpty)
+        #expect(capsLock.doubleTapMode == nil)
+    }
+
+    @Test func shiftedLettersAreUppercased() throws {
+        let shifted = try #require(Self.testLayout.modes[ModeNames.shifted])
+        #expect(shifted.keys[GridSlot.topLeft]?.bindings[.tap]?.action == .commitText("A"))
+        #expect(shifted.keys[GridSlot.center]?.bindings[.tap]?.action == .commitText("E"))
+    }
+
+    @Test func directionalOverridesReplaceDefaults() throws {
+        let layout = MessagEaseFactory.layout(
+            id: "test_override",
+            title: "Test Override",
+            localeIdentifier: "en_US",
+            centerCharacters: [
+                ["a", "b", "c"],
+                ["d", "e", "f"],
+                ["g", "h", "i"],
+            ],
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeRight: "x"],
+            ]
+        )
+        let main = try #require(layout.modes[ModeNames.main])
+        // The default "-" on topLeft.swipeRight should be replaced by "x"
+        #expect(main.keys[GridSlot.topLeft]?.bindings[.swipeRight]?.action == .commitText("x"))
+        #expect(main.keys[GridSlot.topLeft]?.bindings[.swipeRight]?.label == "x")
+    }
+
+    @Test func defaultModeIsMain() {
+        #expect(Self.testLayout.defaultMode == ModeNames.main)
+    }
+
+    @Test func localeIsPreserved() {
+        #expect(Self.testLayout.localeIdentifier == "en_US")
+    }
+}

--- a/wurstfingerTests/CommonKeysFactoryTests.swift
+++ b/wurstfingerTests/CommonKeysFactoryTests.swift
@@ -2,7 +2,7 @@
 //  CommonKeysFactoryTests.swift
 //  WurstfingerTests
 //
-//  Tests for CommonKeys, StandardArrangements, and MessagEaseFactory.
+//  Tests for CommonKeys, StandardArrangements, and GridKeyboardFactory.
 //
 
 import Foundation
@@ -93,8 +93,8 @@ struct CommonKeysTests {
 // MARK: - StandardArrangements Tests
 
 struct StandardArrangementsTests {
-    @Test func messagEase3x3HasAllFourContexts() {
-        let arrangements = StandardArrangements.messagEase3x3
+    @Test func grid3x3HasAllFourContexts() {
+        let arrangements = StandardArrangements.grid3x3
         #expect(arrangements.count == 4)
         #expect(arrangements[.portrait] != nil)
         #expect(arrangements[.portraitUtilityLeft] != nil)
@@ -103,53 +103,53 @@ struct StandardArrangementsTests {
     }
 
     @Test func portraitHasFourColumns() throws {
-        let portrait = try #require(StandardArrangements.messagEase3x3[.portrait])
+        let portrait = try #require(StandardArrangements.grid3x3[.portrait])
         #expect(portrait.columns == 4)
         #expect(portrait.rows.count == 4)
     }
 
     @Test func landscapeHasFiveColumns() throws {
-        let landscape = try #require(StandardArrangements.messagEase3x3[.landscape])
+        let landscape = try #require(StandardArrangements.grid3x3[.landscape])
         #expect(landscape.columns == 5)
         #expect(landscape.rows.count == 3)
     }
 
     @Test func portraitUtilityLeftIsMirroredPortrait() throws {
-        let portrait = try #require(StandardArrangements.messagEase3x3[.portrait])
-        let utilityLeft = try #require(StandardArrangements.messagEase3x3[.portraitUtilityLeft])
+        let portrait = try #require(StandardArrangements.grid3x3[.portrait])
+        let utilityLeft = try #require(StandardArrangements.grid3x3[.portraitUtilityLeft])
         #expect(utilityLeft == portrait.mirroredHorizontally())
     }
 
     @Test func landscapeUtilityLeftIsMirroredLandscape() throws {
-        let landscape = try #require(StandardArrangements.messagEase3x3[.landscape])
-        let utilityLeft = try #require(StandardArrangements.messagEase3x3[.landscapeUtilityLeft])
+        let landscape = try #require(StandardArrangements.grid3x3[.landscape])
+        let utilityLeft = try #require(StandardArrangements.grid3x3[.landscapeUtilityLeft])
         #expect(utilityLeft == landscape.mirroredHorizontally())
     }
 
     @Test func portraitFirstRowContainsGridAndGlobe() throws {
-        let portrait = try #require(StandardArrangements.messagEase3x3[.portrait])
+        let portrait = try #require(StandardArrangements.grid3x3[.portrait])
         let firstRowIds = portrait.rows[0].map(\.keyId)
         #expect(firstRowIds == [GridSlot.topLeft, GridSlot.topCenter, GridSlot.topRight, UtilitySlot.globe])
     }
 
     @Test func portraitSpaceBarSpansThreeColumns() throws {
-        let portrait = try #require(StandardArrangements.messagEase3x3[.portrait])
+        let portrait = try #require(StandardArrangements.grid3x3[.portrait])
         let space = try #require(portrait.rows[3].first { $0.keyId == UtilitySlot.space })
         #expect(space.widthMultiplier == 3)
     }
 
     @Test func landscapeReturnSpansTwoRows() throws {
-        let landscape = try #require(StandardArrangements.messagEase3x3[.landscape])
+        let landscape = try #require(StandardArrangements.grid3x3[.landscape])
         let returnKey = try #require(landscape.rows[1].first { $0.keyId == UtilitySlot.return })
         #expect(returnKey.heightMultiplier == 2)
     }
 }
 
-// MARK: - MessagEaseFactory Tests
+// MARK: - GridKeyboardFactory Tests
 
-struct MessagEaseFactoryTests {
+struct GridKeyboardFactoryTests {
     /// Minimal test layout for factory testing.
-    static let testLayout = MessagEaseFactory.layout(
+    static let testLayout = GridKeyboardFactory.layout(
         id: "test_messagease",
         title: "Test MessagEase",
         localeIdentifier: "en_US",
@@ -220,7 +220,7 @@ struct MessagEaseFactoryTests {
     }
 
     @Test func directionalOverridesReplaceDefaults() throws {
-        let layout = MessagEaseFactory.layout(
+        let layout = GridKeyboardFactory.layout(
             id: "test_override",
             title: "Test Override",
             localeIdentifier: "en_US",


### PR DESCRIPTION
## Summary
- **CommonKeys**: shared utility keys (globe, delete, return, symbols, space) and default slot bindings (punctuation, compose triggers, shift/action bindings) with return-swipe variants for all 8 non-center grid slots
- **StandardArrangements**: 4 arrangement contexts (portrait, landscape, each with utility-left mirror) for the 3x3 MessagEase grid
- **GridKeyboardFactory**: generates a complete `KeyboardDefinition` (main, shifted, capsLock, numeric stub) from just center characters and optional directional overrides — all shared structure is derived automatically. Validates input shape via precondition.

PR 5 in the refactoring chain. Builds on GridSlot, UtilitySlot, key factories, and shifted generation from PR 4 (#147, merged).

Replaces #148 which was auto-closed when PR 4 was squash-merged and its base branch deleted.

## Test plan
- [x] 11 CommonKeys tests (utility keys, slot bindings, compose, actions, return actions)
- [x] 8 StandardArrangements tests (contexts, columns, mirroring, space width, return height)
- [x] 12 GridKeyboardFactory tests (modes, validation, key count, tap actions, defaults merge, shift transitions, capsLock, overrides, locale)
- [x] All 505 unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 3×3 grid keyboard layout system with configurable swipe gestures for multiple gesture types
  * Introduced standard portrait and landscape keyboard arrangements that adapt to device orientation
  * Implemented customizable keyboard factory supporting directional gesture overrides and character positioning
  * Added utility key set including globe, delete, return, symbols, and spacebar functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->