### PR TITLE
Add gesture resolver chain for data-driven dispatch (PR 10)

### DIFF
--- a/wurstfingerKeyboard/GestureResolver.swift
+++ b/wurstfingerKeyboard/GestureResolver.swift
@@ -1,0 +1,24 @@
+//
+//  GestureResolver.swift
+//  Wurstfinger
+//
+//  Resolves a gesture on a key into the binding that should fire.
+//
+
+import Foundation
+
+/// Resolves a gesture on a key into the `KeyBinding` that should fire.
+///
+/// Resolvers are composed into a `GestureResolverChain`. Each resolver in
+/// the chain is asked in order; the first one to return a non-nil binding
+/// wins. Returning `nil` means "I don't know" — the chain falls through to
+/// the next resolver.
+///
+/// Concrete resolvers live in their own files (PrimaryResolver,
+/// ReturnSwipeResolver, GhostKeyResolver) and are intentionally tiny so the
+/// resolution policy is composable rather than hardcoded.
+protocol GestureResolver {
+    /// Tries to resolve `gesture` on the key with `keyId` in `mode`.
+    /// Returns the binding to fire, or `nil` to delegate to the next resolver.
+    func resolve(keyId: String, gesture: GestureType, in mode: KeyboardMode) -> KeyBinding?
+}

--- a/wurstfingerKeyboard/GestureResolverChain.swift
+++ b/wurstfingerKeyboard/GestureResolverChain.swift
@@ -1,0 +1,35 @@
+//
+//  GestureResolverChain.swift
+//  Wurstfinger
+//
+//  Composes multiple GestureResolvers into a priority-ordered pipeline.
+//
+
+import Foundation
+
+/// Composes multiple `GestureResolver`s into a priority-ordered pipeline.
+///
+/// Each resolver is tried in order; the first non-nil result wins. If no
+/// resolver matches, the chain returns `nil` (callers typically fall back to
+/// `KeyAction.none`).
+struct GestureResolverChain {
+    let resolvers: [GestureResolver]
+
+    /// Returns the first matching binding, or `nil` if no resolver in the
+    /// chain handles this gesture.
+    func resolve(keyId: String, gesture: GestureType, in mode: KeyboardMode) -> KeyBinding? {
+        for resolver in resolvers {
+            if let binding = resolver.resolve(keyId: keyId, gesture: gesture, in: mode) {
+                return binding
+            }
+        }
+        return nil
+    }
+
+    /// Convenience that returns the resolved `KeyAction` directly, or
+    /// `.none` if nothing matched. Mirrors the legacy gesture-handler shape
+    /// so PR 11/12 can swap call sites without translation.
+    func resolveAction(keyId: String, gesture: GestureType, in mode: KeyboardMode) -> KeyAction {
+        resolve(keyId: keyId, gesture: gesture, in: mode)?.action ?? .none
+    }
+}

--- a/wurstfingerKeyboard/GhostKeyResolver.swift
+++ b/wurstfingerKeyboard/GhostKeyResolver.swift
@@ -19,8 +19,13 @@ struct GhostKeyResolver: GestureResolver {
     let fallbackMode: KeyboardMode
 
     func resolve(keyId: String, gesture: GestureType, in mode: KeyboardMode) -> KeyBinding? {
-        // Only fall through if the primary mode has no binding here.
-        if let key = mode.key(for: keyId), key.bindings[gesture] != nil {
+        // Only fall through if the primary mode has no *reachable* binding
+        // here. A binding declared behind a swipeMode that disallows the
+        // current gesture is effectively unreachable, so ghost fallback
+        // must still apply.
+        if let key = mode.key(for: keyId),
+           key.bindings[gesture] != nil,
+           !gesture.isSwipe || key.swipeMode.allows(gesture) {
             return nil
         }
         // Look up the same key id in the fallback mode.

--- a/wurstfingerKeyboard/GhostKeyResolver.swift
+++ b/wurstfingerKeyboard/GhostKeyResolver.swift
@@ -1,0 +1,33 @@
+//
+//  GhostKeyResolver.swift
+//  Wurstfinger
+//
+//  Resolver that delegates to a fallback mode (e.g. numeric layer) when the
+//  primary mode has no binding for the requested gesture.
+//
+
+import Foundation
+
+/// Resolves a gesture by delegating to a fallback `KeyboardMode` when the
+/// primary mode has no binding for the requested gesture/key combination.
+///
+/// Inspired by Thumb-Key's "ghost keys" — letters that surface a hidden
+/// numeric layer on the same key without a layer switch. The resolver is
+/// constructed with the *resolved* fallback mode (rather than just a name)
+/// so it can run without a `KeyboardDefinition` reference at call time.
+struct GhostKeyResolver: GestureResolver {
+    let fallbackMode: KeyboardMode
+
+    func resolve(keyId: String, gesture: GestureType, in mode: KeyboardMode) -> KeyBinding? {
+        // Only fall through if the primary mode has no binding here.
+        if let key = mode.key(for: keyId), key.bindings[gesture] != nil {
+            return nil
+        }
+        // Look up the same key id in the fallback mode.
+        guard let fallbackKey = fallbackMode.key(for: keyId) else { return nil }
+        if gesture.isSwipe, !fallbackKey.swipeMode.allows(gesture) {
+            return nil
+        }
+        return fallbackKey.bindings[gesture]
+    }
+}

--- a/wurstfingerKeyboard/PrimaryResolver.swift
+++ b/wurstfingerKeyboard/PrimaryResolver.swift
@@ -1,0 +1,23 @@
+//
+//  PrimaryResolver.swift
+//  Wurstfinger
+//
+//  Default resolver: looks up the binding directly on the requested key.
+//
+
+import Foundation
+
+/// Default resolver — returns the binding the key declares for the gesture.
+///
+/// `swipeMode` is consulted only for swipe gestures so that taps, long
+/// presses and circular gestures aren't accidentally filtered out by a key
+/// that declares e.g. `.twoWayHorizontal` for its drag behavior.
+struct PrimaryResolver: GestureResolver {
+    func resolve(keyId: String, gesture: GestureType, in mode: KeyboardMode) -> KeyBinding? {
+        guard let key = mode.key(for: keyId) else { return nil }
+        if gesture.isSwipe, !key.swipeMode.allows(gesture) {
+            return nil
+        }
+        return key.bindings[gesture]
+    }
+}

--- a/wurstfingerKeyboard/ReturnSwipeResolver.swift
+++ b/wurstfingerKeyboard/ReturnSwipeResolver.swift
@@ -1,0 +1,34 @@
+//
+//  ReturnSwipeResolver.swift
+//  Wurstfinger
+//
+//  Resolver for return-swipes (swipe out and back to the start position).
+//
+
+import Foundation
+
+/// Resolver for "return swipes" — when the finger swipes out from a key
+/// and back to the start. Looks up the regular binding for that direction
+/// and substitutes its `returnAction` (if any).
+///
+/// Returns `nil` if the binding has no `returnAction` so the chain can fall
+/// back to the regular swipe action.
+struct ReturnSwipeResolver: GestureResolver {
+    func resolve(keyId: String, gesture: GestureType, in mode: KeyboardMode) -> KeyBinding? {
+        guard let key = mode.key(for: keyId) else { return nil }
+        // Return swipes only make sense for swipe gestures.
+        guard gesture.isSwipe, key.swipeMode.allows(gesture) else { return nil }
+        guard let binding = key.bindings[gesture],
+              let returnAction = binding.returnAction
+        else {
+            return nil
+        }
+        return KeyBinding(
+            label: binding.label,
+            action: returnAction,
+            category: binding.category,
+            returnAction: nil,
+            accessibilityLabel: binding.accessibilityLabel
+        )
+    }
+}

--- a/wurstfingerTests/GestureResolverTests.swift
+++ b/wurstfingerTests/GestureResolverTests.swift
@@ -1,0 +1,329 @@
+//
+//  GestureResolverTests.swift
+//  WurstfingerTests
+//
+//  Tests for PR 10: PrimaryResolver, ReturnSwipeResolver, GhostKeyResolver,
+//  and GestureResolverChain composition.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+// MARK: - Helpers
+
+private enum Fixtures {
+    /// Builds a key with the given bindings; defaults swipeMode to .eightWay.
+    static func key(
+        id: String,
+        bindings: [GestureType: KeyBinding],
+        swipeMode: SwipeMode = .eightWay,
+        style: KeyStyle = .primary
+    ) -> KeyConfig {
+        KeyConfig(
+            id: id,
+            bindings: bindings,
+            swipeMode: swipeMode,
+            slideType: .none,
+            style: style,
+            tapCycleActions: nil
+        )
+    }
+
+    /// Builds a single-mode KeyboardMode from a list of keys.
+    static func mode(name: String = "main", keys: [KeyConfig]) -> KeyboardMode {
+        KeyboardMode(
+            name: name,
+            keys: Dictionary(uniqueKeysWithValues: keys.map { ($0.id, $0) }),
+            arrangements: [.portrait: GridArrangement(columns: 1, rows: [[KeyPlacement(keyId: keys.first?.id ?? "x")]])],
+            autoTransitions: [:],
+            doubleTapMode: nil
+        )
+    }
+
+    static func binding(
+        label: String = "x",
+        action: KeyAction,
+        returnAction: KeyAction? = nil
+    ) -> KeyBinding {
+        KeyBinding(
+            label: label,
+            action: action,
+            category: nil,
+            returnAction: returnAction,
+            accessibilityLabel: nil
+        )
+    }
+}
+
+// MARK: - PrimaryResolver
+
+struct PrimaryResolverTests {
+    @Test func returnsBindingForDeclaredGesture() {
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(id: "a", bindings: [
+                .tap: Fixtures.binding(label: "a", action: .commitText("a")),
+                .swipeUp: Fixtures.binding(label: "1", action: .commitText("1")),
+            ]),
+        ])
+        let resolver = PrimaryResolver()
+        #expect(resolver.resolve(keyId: "a", gesture: .tap, in: mode)?.action == .commitText("a"))
+        #expect(resolver.resolve(keyId: "a", gesture: .swipeUp, in: mode)?.action == .commitText("1"))
+    }
+
+    @Test func returnsNilForUndeclaredGesture() {
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(id: "a", bindings: [.tap: Fixtures.binding(action: .commitText("a"))]),
+        ])
+        #expect(PrimaryResolver().resolve(keyId: "a", gesture: .swipeDown, in: mode) == nil)
+    }
+
+    @Test func returnsNilForMissingKey() {
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(id: "a", bindings: [.tap: Fixtures.binding(action: .commitText("a"))]),
+        ])
+        #expect(PrimaryResolver().resolve(keyId: "missing", gesture: .tap, in: mode) == nil)
+    }
+
+    @Test func swipeModeBlocksDisallowedSwipe() {
+        // twoWayHorizontal allows only swipeLeft / swipeRight.
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(
+                id: "delete",
+                bindings: [
+                    .tap: Fixtures.binding(action: .deleteBackward),
+                    .swipeUp: Fixtures.binding(action: .commitText("blocked")),
+                    .swipeLeft: Fixtures.binding(action: .commitText("ok")),
+                ],
+                swipeMode: .twoWayHorizontal
+            ),
+        ])
+        let resolver = PrimaryResolver()
+        #expect(resolver.resolve(keyId: "delete", gesture: .swipeUp, in: mode) == nil)
+        #expect(resolver.resolve(keyId: "delete", gesture: .swipeLeft, in: mode)?.action == .commitText("ok"))
+    }
+
+    @Test func swipeModeDoesNotBlockNonSwipeGestures() {
+        // .none disallows every swipe but must still pass through .tap.
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(
+                id: "globe",
+                bindings: [.tap: Fixtures.binding(action: .advanceToNextInputMode)],
+                swipeMode: .none
+            ),
+        ])
+        #expect(PrimaryResolver().resolve(keyId: "globe", gesture: .tap, in: mode)?.action == .advanceToNextInputMode)
+    }
+
+    @Test func eightWayAllowsDiagonals() {
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(
+                id: "a",
+                bindings: [.swipeUpLeft: Fixtures.binding(action: .commitText("ul"))],
+                swipeMode: .eightWay
+            ),
+        ])
+        #expect(PrimaryResolver().resolve(keyId: "a", gesture: .swipeUpLeft, in: mode)?.action == .commitText("ul"))
+    }
+
+    @Test func fourWayCrossBlocksDiagonals() {
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(
+                id: "a",
+                bindings: [.swipeUpLeft: Fixtures.binding(action: .commitText("ul"))],
+                swipeMode: .fourWayCross
+            ),
+        ])
+        #expect(PrimaryResolver().resolve(keyId: "a", gesture: .swipeUpLeft, in: mode) == nil)
+    }
+}
+
+// MARK: - ReturnSwipeResolver
+
+struct ReturnSwipeResolverTests {
+    @Test func returnsReturnActionWhenPresent() {
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(id: "a", bindings: [
+                .swipeUp: Fixtures.binding(
+                    label: "1",
+                    action: .commitText("1"),
+                    returnAction: .commitText("!")
+                ),
+            ]),
+        ])
+        let resolved = ReturnSwipeResolver().resolve(keyId: "a", gesture: .swipeUp, in: mode)
+        #expect(resolved?.action == .commitText("!"))
+        // The synthetic binding must clear returnAction so it can't loop.
+        #expect(resolved?.returnAction == nil)
+    }
+
+    @Test func returnsNilWhenNoReturnAction() {
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(id: "a", bindings: [
+                .swipeUp: Fixtures.binding(action: .commitText("1")),
+            ]),
+        ])
+        #expect(ReturnSwipeResolver().resolve(keyId: "a", gesture: .swipeUp, in: mode) == nil)
+    }
+
+    @Test func returnsNilForNonSwipeGesture() {
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(id: "a", bindings: [
+                .tap: Fixtures.binding(
+                    action: .commitText("a"),
+                    returnAction: .commitText("A")
+                ),
+            ]),
+        ])
+        // Return swipes only apply to actual swipe gestures.
+        #expect(ReturnSwipeResolver().resolve(keyId: "a", gesture: .tap, in: mode) == nil)
+    }
+
+    @Test func returnsNilWhenSwipeBlockedByMode() {
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(
+                id: "a",
+                bindings: [
+                    .swipeUp: Fixtures.binding(
+                        action: .commitText("1"),
+                        returnAction: .commitText("!")
+                    ),
+                ],
+                swipeMode: .twoWayHorizontal
+            ),
+        ])
+        #expect(ReturnSwipeResolver().resolve(keyId: "a", gesture: .swipeUp, in: mode) == nil)
+    }
+
+    @Test func returnsNilForMissingKey() {
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(id: "a", bindings: [:]),
+        ])
+        #expect(ReturnSwipeResolver().resolve(keyId: "missing", gesture: .swipeUp, in: mode) == nil)
+    }
+}
+
+// MARK: - GhostKeyResolver
+
+struct GhostKeyResolverTests {
+    @Test func resolvesFromFallbackWhenPrimaryMisses() {
+        let primary = Fixtures.mode(name: "main", keys: [
+            Fixtures.key(id: "a", bindings: [.tap: Fixtures.binding(action: .commitText("a"))]),
+        ])
+        let fallback = Fixtures.mode(name: "numeric", keys: [
+            Fixtures.key(id: "a", bindings: [.swipeUp: Fixtures.binding(action: .commitText("1"))]),
+        ])
+        let resolver = GhostKeyResolver(fallbackMode: fallback)
+        // Primary has tap but no swipeUp → fall back to numeric.
+        #expect(resolver.resolve(keyId: "a", gesture: .swipeUp, in: primary)?.action == .commitText("1"))
+    }
+
+    @Test func returnsNilWhenPrimaryAlreadyHasBinding() {
+        let primary = Fixtures.mode(name: "main", keys: [
+            Fixtures.key(id: "a", bindings: [.swipeUp: Fixtures.binding(action: .commitText("primary"))]),
+        ])
+        let fallback = Fixtures.mode(name: "numeric", keys: [
+            Fixtures.key(id: "a", bindings: [.swipeUp: Fixtures.binding(action: .commitText("ghost"))]),
+        ])
+        // Primary owns the gesture → ghost stays out of the way.
+        #expect(GhostKeyResolver(fallbackMode: fallback).resolve(keyId: "a", gesture: .swipeUp, in: primary) == nil)
+    }
+
+    @Test func returnsNilWhenFallbackHasNoKey() {
+        let primary = Fixtures.mode(name: "main", keys: [
+            Fixtures.key(id: "a", bindings: [:]),
+        ])
+        let fallback = Fixtures.mode(name: "numeric", keys: [
+            Fixtures.key(id: "b", bindings: [.tap: Fixtures.binding(action: .commitText("b"))]),
+        ])
+        #expect(GhostKeyResolver(fallbackMode: fallback).resolve(keyId: "a", gesture: .tap, in: primary) == nil)
+    }
+
+    @Test func respectsFallbackSwipeMode() {
+        let primary = Fixtures.mode(name: "main", keys: [
+            Fixtures.key(id: "a", bindings: [:]),
+        ])
+        let fallback = Fixtures.mode(name: "numeric", keys: [
+            Fixtures.key(
+                id: "a",
+                bindings: [.swipeUpLeft: Fixtures.binding(action: .commitText("ul"))],
+                swipeMode: .fourWayCross
+            ),
+        ])
+        // fourWayCross blocks diagonals even in the fallback mode.
+        #expect(GhostKeyResolver(fallbackMode: fallback).resolve(keyId: "a", gesture: .swipeUpLeft, in: primary) == nil)
+    }
+}
+
+// MARK: - GestureResolverChain
+
+struct GestureResolverChainTests {
+    @Test func chainPriorityFirstHitWins() {
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(id: "a", bindings: [
+                .swipeUp: Fixtures.binding(
+                    action: .commitText("primary"),
+                    returnAction: .commitText("return")
+                ),
+            ]),
+        ])
+        // ReturnSwipeResolver runs first → its result wins over PrimaryResolver.
+        let chain = GestureResolverChain(resolvers: [ReturnSwipeResolver(), PrimaryResolver()])
+        #expect(chain.resolveAction(keyId: "a", gesture: .swipeUp, in: mode) == .commitText("return"))
+    }
+
+    @Test func chainFallsThroughToPrimary() {
+        let mode = Fixtures.mode(keys: [
+            // No returnAction → ReturnSwipeResolver returns nil → PrimaryResolver wins.
+            Fixtures.key(id: "a", bindings: [
+                .swipeUp: Fixtures.binding(action: .commitText("primary")),
+            ]),
+        ])
+        let chain = GestureResolverChain(resolvers: [ReturnSwipeResolver(), PrimaryResolver()])
+        #expect(chain.resolveAction(keyId: "a", gesture: .swipeUp, in: mode) == .commitText("primary"))
+    }
+
+    @Test func chainReturnsNoneWhenAllResolversMiss() {
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(id: "a", bindings: [:]),
+        ])
+        let chain = GestureResolverChain(resolvers: [PrimaryResolver(), ReturnSwipeResolver()])
+        #expect(chain.resolveAction(keyId: "a", gesture: .swipeUp, in: mode) == .none)
+    }
+
+    @Test func chainWithGhostKeysFallsBackToOtherMode() {
+        let primary = Fixtures.mode(name: "main", keys: [
+            Fixtures.key(id: "a", bindings: [.tap: Fixtures.binding(action: .commitText("a"))]),
+        ])
+        let numeric = Fixtures.mode(name: "numeric", keys: [
+            Fixtures.key(id: "a", bindings: [.swipeUp: Fixtures.binding(action: .commitText("1"))]),
+        ])
+        let chain = GestureResolverChain(resolvers: [
+            PrimaryResolver(),
+            GhostKeyResolver(fallbackMode: numeric),
+        ])
+        #expect(chain.resolveAction(keyId: "a", gesture: .swipeUp, in: primary) == .commitText("1"))
+        // Primary still owns its own gestures.
+        #expect(chain.resolveAction(keyId: "a", gesture: .tap, in: primary) == .commitText("a"))
+    }
+
+    @Test func chainResolveReturnsBindingNotJustAction() {
+        // The non-action variant exposes the full binding so PR 11 middleware
+        // can read category / accessibility metadata.
+        let mode = Fixtures.mode(keys: [
+            Fixtures.key(id: "a", bindings: [
+                .tap: KeyBinding(
+                    label: "a",
+                    action: .commitText("a"),
+                    category: .letter,
+                    returnAction: nil,
+                    accessibilityLabel: nil
+                ),
+            ]),
+        ])
+        let chain = GestureResolverChain(resolvers: [PrimaryResolver()])
+        let resolved = chain.resolve(keyId: "a", gesture: .tap, in: mode)
+        #expect(resolved?.label == "a")
+        #expect(resolved?.resolvedCategory == .letter)
+    }
+}

--- a/wurstfingerTests/GestureResolverTests.swift
+++ b/wurstfingerTests/GestureResolverTests.swift
@@ -253,6 +253,42 @@ struct GhostKeyResolverTests {
         // fourWayCross blocks diagonals even in the fallback mode.
         #expect(GhostKeyResolver(fallbackMode: fallback).resolve(keyId: "a", gesture: .swipeUpLeft, in: primary) == nil)
     }
+
+    @Test func fallsThroughWhenPrimaryBindingUnreachableDueToSwipeMode() {
+        // Primary declares a diagonal binding but uses fourWayCross, which
+        // blocks diagonals. The declared binding is effectively unreachable,
+        // so ghost fallback must still apply.
+        let primary = Fixtures.mode(name: "main", keys: [
+            Fixtures.key(
+                id: "a",
+                bindings: [.swipeUpLeft: Fixtures.binding(action: .commitText("unreachable"))],
+                swipeMode: .fourWayCross
+            ),
+        ])
+        let fallback = Fixtures.mode(name: "numeric", keys: [
+            Fixtures.key(id: "a", bindings: [.swipeUpLeft: Fixtures.binding(action: .commitText("ghost"))]),
+        ])
+        #expect(
+            GhostKeyResolver(fallbackMode: fallback)
+                .resolve(keyId: "a", gesture: .swipeUpLeft, in: primary)?.action == .commitText("ghost")
+        )
+    }
+
+    @Test func primaryNonSwipeBindingStillOwnsEvenIfSwipeModeIsNone() {
+        // A non-swipe primary binding (e.g. tap) must not be shadowed by
+        // ghost fallback, even when swipeMode is .none.
+        let primary = Fixtures.mode(name: "main", keys: [
+            Fixtures.key(
+                id: "a",
+                bindings: [.tap: Fixtures.binding(action: .commitText("primary"))],
+                swipeMode: .none
+            ),
+        ])
+        let fallback = Fixtures.mode(name: "numeric", keys: [
+            Fixtures.key(id: "a", bindings: [.tap: Fixtures.binding(action: .commitText("ghost"))]),
+        ])
+        #expect(GhostKeyResolver(fallbackMode: fallback).resolve(keyId: "a", gesture: .tap, in: primary) == nil)
+    }
 }
 
 // MARK: - GestureResolverChain


### PR DESCRIPTION
## Summary

Adds a Chain-of-Responsibility for gesture resolution as **additive** infrastructure. Each resolver independently decides whether a gesture should fire and which binding wins, so PR 11/12 can compose behaviors (return swipes, ghost keys, future per-mode rules) without hardcoded switch statements.

- **`GestureResolver`** — protocol returning an Optional `KeyBinding` so the chain can fall through.
- **`PrimaryResolver`** — looks up the binding directly on the requested key. Only consults `swipeMode` for *actual* swipe gestures so taps and circular gestures aren't blocked by drag-only modes (e.g. `.twoWayHorizontal` on the delete key).
- **`ReturnSwipeResolver`** — substitutes the binding's `returnAction` when the finger swipes out and back. Returns `nil` for non-swipe gestures and when no `returnAction` is configured. Clears the synthetic binding's `returnAction` so it can't loop.
- **`GhostKeyResolver`** — delegates to a fallback `KeyboardMode` when the primary mode has no binding for a given gesture (Thumb-Key style ghost numerics). Constructed with the *resolved* fallback mode rather than just a name, so it doesn't need a `KeyboardDefinition` reference at call time.
- **`GestureResolverChain`** — composes resolvers in priority order; first non-nil wins. `resolveAction(...)` convenience returns `.none` on miss to match the legacy gesture-handler shape.

## Tests (21 new, 506 total)

- **PrimaryResolver:** declared gestures resolve, undeclared/missing return nil, `.twoWayHorizontal` blocks vertical swipes but allows horizontal, `.none` does NOT block tap, `.eightWay` allows diagonals, `.fourWayCross` blocks them.
- **ReturnSwipeResolver:** `returnAction` substitution clears the loop, missing `returnAction` returns nil, non-swipe gestures return nil even with a `returnAction`, blocked-by-`swipeMode` returns nil, missing key returns nil.
- **GhostKeyResolver:** falls through when primary misses; stays out of the way when primary owns the gesture; nil when fallback has no key; respects fallback's `swipeMode`.
- **GestureResolverChain:** priority (first hit wins), fall-through to next resolver, returns `.none` when all miss, ghost-keys composition with primary, full-binding access for upcoming middleware (PR 11).

## Test plan

- [x] `xcodebuild test -only-testing:WurstfingerTests` green (506 / 506)
- [ ] Wired into `KeyboardViewController` in PR 12

Refactoring plan: PR 10 of 13. Phase 4.1. Depends on PR 8 (#151). Parallel to PR 9 (#155).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modularized gesture handling into a layered resolution system for more consistent gesture behavior.

* **New Features**
  * Added cross-mode fallback for missing gestures so alternate key modes can supply missing bindings.
  * Return-swipe gestures now reliably invoke configured return actions when present.

* **Tests**
  * Added extensive tests covering resolver priority, fallback behavior, and swipe validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->