### PR TITLE
Add ActionPipeline middleware for data-driven action dispatch

### DIFF
--- a/wurstfingerKeyboard/ActionMiddleware.swift
+++ b/wurstfingerKeyboard/ActionMiddleware.swift
@@ -1,0 +1,40 @@
+//
+//  ActionMiddleware.swift
+//  Wurstfinger
+//
+//  Protocol and context type for the action-processing pipeline.
+//
+
+import Foundation
+
+/// Context that flows through the `ActionPipeline`.
+///
+/// Middlewares may mutate the action they forward (e.g. `ComposeMiddleware`
+/// replaces `.compose` with `.commitText`), and subsequent middlewares see
+/// the mutated context. The context intentionally does **not** carry a
+/// `UITextDocumentProxy` reference — middlewares inject whatever host
+/// dependencies they need via their initializer so every middleware can be
+/// unit-tested without a view controller.
+struct ActionContext {
+    /// The action currently being processed. Middlewares may transform it
+    /// before calling `next`.
+    var action: KeyAction
+
+    /// The binding that produced the action, if any. Used for category-based
+    /// decisions (e.g. auto-shift after a `.letter`).
+    let binding: KeyBinding?
+
+    /// Name of the currently active keyboard mode. Middlewares may read it
+    /// for mode-aware decisions; mode transitions themselves are triggered
+    /// via callbacks (see `ModeTransitionMiddleware`).
+    var mode: String
+}
+
+/// A single step in the action-processing pipeline.
+///
+/// A middleware receives the `ActionContext` and must call `next(_:)` zero
+/// or one time to forward a (possibly transformed) context to the next step.
+/// Not calling `next` short-circuits the pipeline.
+protocol ActionMiddleware {
+    func process(_ context: ActionContext, next: (ActionContext) -> Void)
+}

--- a/wurstfingerKeyboard/ActionPipeline.swift
+++ b/wurstfingerKeyboard/ActionPipeline.swift
@@ -1,0 +1,29 @@
+//
+//  ActionPipeline.swift
+//  Wurstfinger
+//
+//  Composes multiple ActionMiddlewares into a processing chain.
+//
+
+import Foundation
+
+/// Composes multiple `ActionMiddleware`s into a processing chain.
+///
+/// Each middleware receives the `ActionContext` and may mutate it before
+/// calling `next`. The pipeline guarantees ordered execution and short-
+/// circuits cleanly if any middleware skips calling `next`.
+struct ActionPipeline {
+    let middlewares: [ActionMiddleware]
+
+    /// Runs `context` through every middleware in order.
+    func process(_ context: ActionContext) {
+        run(index: 0, context: context)
+    }
+
+    private func run(index: Int, context: ActionContext) {
+        guard index < middlewares.count else { return }
+        middlewares[index].process(context) { nextContext in
+            run(index: index + 1, context: nextContext)
+        }
+    }
+}

--- a/wurstfingerKeyboard/AutoCapitalizationMiddleware.swift
+++ b/wurstfingerKeyboard/AutoCapitalizationMiddleware.swift
@@ -1,0 +1,51 @@
+//
+//  AutoCapitalizationMiddleware.swift
+//  Wurstfinger
+//
+//  Re-evaluates auto-capitalization after text-input actions.
+//
+
+import Foundation
+
+/// Runs after the text-mutating middlewares and asks the host whether the
+/// next character should be capitalized.
+///
+/// The actual capitalization decision is delegated to an injected closure
+/// so this file stays independent of the `AutoCapitalization` type (which
+/// is excluded from the `WurstfingerApp` target).
+struct AutoCapitalizationMiddleware: ActionMiddleware {
+    /// Returns `true` when auto-capitalization should engage for the next
+    /// key, `false` when it should disengage, `nil` when no change should
+    /// be made (e.g. auto-capitalization is disabled in settings).
+    let evaluate: () -> Bool?
+
+    /// Invoked when auto-capitalization should engage for the next key.
+    let onCapitalize: () -> Void
+
+    /// Invoked when auto-capitalization should disengage.
+    let onReleaseCapitalize: () -> Void
+
+    func process(_ context: ActionContext, next: (ActionContext) -> Void) {
+        next(context)
+        guard Self.affectsCapitalization(context.action) else { return }
+        switch evaluate() {
+        case .some(true): onCapitalize()
+        case .some(false): onReleaseCapitalize()
+        case .none: break
+        }
+    }
+
+    /// Actions whose result may change whether the next key should be
+    /// auto-capitalized. Kept static so tests can verify the policy
+    /// without constructing a middleware instance.
+    static func affectsCapitalization(_ action: KeyAction) -> Bool {
+        switch action {
+        case .commitText, .space, .newline, .deleteBackward, .deleteForward,
+             .compose, .cycleAccents, .paste, .cut:
+            true
+        case .moveCursor, .switchMode, .capitalizeWord, .advanceToNextInputMode,
+             .dismissKeyboard, .copy, .none:
+            false
+        }
+    }
+}

--- a/wurstfingerKeyboard/ComposeMiddleware.swift
+++ b/wurstfingerKeyboard/ComposeMiddleware.swift
@@ -1,0 +1,51 @@
+//
+//  ComposeMiddleware.swift
+//  Wurstfinger
+//
+//  Resolves .compose actions into concrete .commitText actions.
+//
+
+import Foundation
+
+/// Transforms `.compose(trigger)` into `.commitText(result)` when the
+/// previous character combined with `trigger` has a compose rule.
+///
+/// If no rule matches, the action is transformed to `.commitText(trigger)`
+/// so the user still gets the literal character. Non-compose actions are
+/// passed through untouched.
+///
+/// The compose lookup and document access are injected as closures so this
+/// file does not depend on `ComposeEngine` or `UITextDocumentProxy` —
+/// `ComposeEngine` is excluded from the `WurstfingerApp` target, and
+/// avoiding `UITextDocumentProxy` keeps the middleware unit-testable.
+struct ComposeMiddleware: ActionMiddleware {
+    /// Looks up `(previous, trigger) → replacement`. Returns nil when no
+    /// rule applies.
+    let compose: (_ previous: String, _ trigger: String) -> String?
+
+    /// Reads the last character before the cursor. Empty string when
+    /// there is no preceding character.
+    let previousCharacter: () -> String
+
+    /// Deletes the previous character from the document. Invoked when a
+    /// compose rule matches and consumes the preceding letter.
+    let deletePreviousCharacter: () -> Void
+
+    func process(_ context: ActionContext, next: (ActionContext) -> Void) {
+        guard case let .compose(trigger) = context.action else {
+            next(context)
+            return
+        }
+
+        var transformed = context
+        let previous = previousCharacter()
+        if !previous.isEmpty, let replacement = compose(previous, trigger) {
+            deletePreviousCharacter()
+            transformed.action = .commitText(replacement)
+        } else {
+            // No rule — insert the trigger as plain text.
+            transformed.action = .commitText(trigger)
+        }
+        next(transformed)
+    }
+}

--- a/wurstfingerKeyboard/HapticMiddleware.swift
+++ b/wurstfingerKeyboard/HapticMiddleware.swift
@@ -1,0 +1,24 @@
+//
+//  HapticMiddleware.swift
+//  Wurstfinger
+//
+//  Triggers haptic feedback as an action flows through the pipeline.
+//
+
+import Foundation
+
+/// Triggers haptic feedback for the current action, then forwards the
+/// context unchanged.
+///
+/// The concrete feedback implementation is injected as a closure so this
+/// file stays free of UIKit/`HapticFeedbackManager` dependencies. Wiring
+/// happens in `KeyboardViewModel` when the pipeline is assembled.
+struct HapticMiddleware: ActionMiddleware {
+    /// Called with the action before it is forwarded.
+    let trigger: (KeyAction) -> Void
+
+    func process(_ context: ActionContext, next: (ActionContext) -> Void) {
+        trigger(context.action)
+        next(context)
+    }
+}

--- a/wurstfingerKeyboard/ModeTransitionMiddleware.swift
+++ b/wurstfingerKeyboard/ModeTransitionMiddleware.swift
@@ -1,0 +1,33 @@
+//
+//  ModeTransitionMiddleware.swift
+//  Wurstfinger
+//
+//  Applies KeyboardMode.autoTransitions after an action completes.
+//
+
+import Foundation
+
+/// Runs after all other middlewares and applies the state machine defined
+/// in `KeyboardMode.autoTransitions`.
+///
+/// If the current mode declares a transition for the category of the
+/// action's binding (e.g. `.letter → main` in `shifted`), `onModeChange`
+/// is invoked with the target mode name.
+///
+/// The middleware does not mutate state itself — the owner of the pipeline
+/// decides what to do with the callback (update a `@Published` mode name,
+/// re-configure arrangements, …).
+struct ModeTransitionMiddleware: ActionMiddleware {
+    let definition: KeyboardDefinition
+    let onModeChange: (String) -> Void
+
+    func process(_ context: ActionContext, next: (ActionContext) -> Void) {
+        next(context)
+        guard let currentMode = definition.modes[context.mode] else { return }
+        let category = context.binding?.resolvedCategory
+            ?? context.action.inferredCategory
+        guard let nextMode = currentMode.nextMode(after: category) else { return }
+        guard nextMode != context.mode else { return }
+        onModeChange(nextMode)
+    }
+}

--- a/wurstfingerKeyboard/TelexMiddleware.swift
+++ b/wurstfingerKeyboard/TelexMiddleware.swift
@@ -65,6 +65,14 @@ struct TelexMiddleware: ActionMiddleware {
                String(chars[chars.count - 1]),
                text
            ) {
+            // Defensive guard: `deleteCount` comes from an injected closure.
+            // Reject out-of-range values (including negatives and values
+            // larger than the visible lookback) so a buggy rule table cannot
+            // delete unrelated text before the forwarded commit.
+            guard (1 ... chars.count).contains(deleteCount) else {
+                next(context)
+                return
+            }
             for _ in 0 ..< deleteCount {
                 deleteBackward()
             }

--- a/wurstfingerKeyboard/TelexMiddleware.swift
+++ b/wurstfingerKeyboard/TelexMiddleware.swift
@@ -70,6 +70,7 @@ struct TelexMiddleware: ActionMiddleware {
             // larger than the visible lookback) so a buggy rule table cannot
             // delete unrelated text before the forwarded commit.
             guard (1 ... chars.count).contains(deleteCount) else {
+                assertionFailure("Telex digraph returned invalid deleteCount=\(deleteCount) for lookback size \(chars.count)")
                 next(context)
                 return
             }

--- a/wurstfingerKeyboard/TelexMiddleware.swift
+++ b/wurstfingerKeyboard/TelexMiddleware.swift
@@ -1,0 +1,87 @@
+//
+//  TelexMiddleware.swift
+//  Wurstfinger
+//
+//  Rewrites single-character `.commitText` actions according to the
+//  Vietnamese Telex input method when Telex is active.
+//
+
+import Foundation
+
+/// Applies Vietnamese Telex composition to single-character text commits.
+///
+/// Telex is a stateful input method: the meaning of a key depends on the
+/// previous 1–2 characters in the document. This middleware reads those
+/// characters via `documentContextBefore`, asks the injected compose closures
+/// (which point at `ComposeEngine.composeTelexDigraph` / `composeTelex`) for
+/// a replacement, and rewrites the action to the composed result — deleting
+/// the consumed characters via `deleteBackward` before forwarding.
+///
+/// The middleware is inert when `isActive` returns `false`, so non-Vietnamese
+/// layouts pay no runtime cost beyond a single closure call.
+///
+/// Injected closures keep this file independent of `ComposeEngine` (which is
+/// excluded from the `WurstfingerApp` target), mirroring the pattern used by
+/// `ComposeMiddleware`.
+struct TelexMiddleware: ActionMiddleware {
+    /// Whether Telex composition should be applied. Typically bound to the
+    /// currently selected keyboard language.
+    let isActive: () -> Bool
+
+    /// Returns the document context immediately before the cursor. The
+    /// middleware only inspects the last two characters.
+    let documentContextBefore: () -> String?
+
+    /// Deletes one character from the document. Called 1–2 times when a
+    /// composition consumes preceding characters.
+    let deleteBackward: () -> Void
+
+    /// Two-char lookback composition. Returns `(replacement, charsToDelete)`
+    /// or `nil`. Bound to `ComposeEngine.composeTelexDigraph`.
+    let composeDigraph: (_ prev2: String, _ prev1: String, _ trigger: String) -> (String, Int)?
+
+    /// Single-char composition. Returns the composed replacement or `nil`.
+    /// Bound to `ComposeEngine.composeTelex`.
+    let composeSingle: (_ previous: String, _ trigger: String) -> String?
+
+    func process(_ context: ActionContext, next: (ActionContext) -> Void) {
+        guard isActive(),
+              case let .commitText(text) = context.action,
+              text.count == 1,
+              let documentContext = documentContextBefore(),
+              !documentContext.isEmpty
+        else {
+            next(context)
+            return
+        }
+
+        let chars = Array(documentContext.suffix(2))
+        var transformed = context
+
+        // Try two-char digraph lookback first (e.g. "uo" + "w" → "ươ").
+        if chars.count >= 2,
+           let (replacement, deleteCount) = composeDigraph(
+               String(chars[chars.count - 2]),
+               String(chars[chars.count - 1]),
+               text
+           ) {
+            for _ in 0 ..< deleteCount {
+                deleteBackward()
+            }
+            transformed.action = .commitText(replacement)
+            next(transformed)
+            return
+        }
+
+        // Fall back to single-char composition (e.g. "a" + "s" → "á").
+        if let last = chars.last,
+           let composed = composeSingle(String(last), text) {
+            deleteBackward()
+            transformed.action = .commitText(composed)
+            next(transformed)
+            return
+        }
+
+        next(context)
+    }
+}

--- a/wurstfingerKeyboard/TextInputMiddleware.swift
+++ b/wurstfingerKeyboard/TextInputMiddleware.swift
@@ -19,6 +19,11 @@ protocol TextInputTarget: AnyObject {
     func insertText(_ text: String)
     func deleteBackward()
     func adjustTextPosition(byCharacterOffset offset: Int)
+
+    /// Text immediately before the cursor (up to the current paragraph start).
+    /// Required for lookback-based composition (e.g. Vietnamese Telex digraphs).
+    /// `nil` when no context is available yet.
+    var documentContextBeforeInput: String? { get }
 }
 
 /// Applies text-mutating actions (`.commitText`, `.deleteBackward`,

--- a/wurstfingerKeyboard/TextInputMiddleware.swift
+++ b/wurstfingerKeyboard/TextInputMiddleware.swift
@@ -37,8 +37,13 @@ protocol TextInputTarget: AnyObject {
 /// left to the view controller in PR 11 — they will migrate in PR 12 when
 /// the pipeline is wired end-to-end.
 struct TextInputMiddleware: ActionMiddleware {
-    /// Host-provided text input target. Weakly held so the middleware
-    /// cannot extend the lifetime of the view controller that owns it.
+    /// Host-provided text input target resolver.
+    ///
+    /// The closure itself is strongly retained by the middleware, so *callers*
+    /// are responsible for capturing the owning object (typically the keyboard
+    /// view controller) weakly when constructing it. The standard pattern is
+    /// `{ [weak controller] in controller?.textInputTarget }`, which keeps the
+    /// middleware from extending the controller's lifetime.
     private let targetProvider: () -> TextInputTarget?
 
     init(target: @escaping () -> TextInputTarget?) {

--- a/wurstfingerKeyboard/TextInputMiddleware.swift
+++ b/wurstfingerKeyboard/TextInputMiddleware.swift
@@ -1,0 +1,68 @@
+//
+//  TextInputMiddleware.swift
+//  Wurstfinger
+//
+//  Executes text-input actions against an injected TextInputTarget.
+//
+
+import Foundation
+
+/// Minimal protocol for the text-input operations `TextInputMiddleware`
+/// performs. A thin wrapper around `UITextDocumentProxy` (declared in the
+/// keyboard extension target where UIKit is available) conforms to this
+/// protocol at pipeline construction time.
+///
+/// Using a dedicated protocol keeps the middleware testable without the
+/// full `UITextDocumentProxy` contract (which has dozens of required
+/// members from `UIKeyInput` and `UITextInputTraits`).
+protocol TextInputTarget: AnyObject {
+    func insertText(_ text: String)
+    func deleteBackward()
+    func adjustTextPosition(byCharacterOffset offset: Int)
+}
+
+/// Applies text-mutating actions (`.commitText`, `.deleteBackward`,
+/// `.space`, `.newline`, `.moveCursor`) to the injected target.
+///
+/// Non-text actions (mode switches, haptics, capitalization) pass through
+/// unchanged so later middlewares can react to them.
+///
+/// Actions that require more than a direct target call (delete-forward,
+/// word-cursor movement, copy/paste, capitalize-word) are intentionally
+/// left to the view controller in PR 11 — they will migrate in PR 12 when
+/// the pipeline is wired end-to-end.
+struct TextInputMiddleware: ActionMiddleware {
+    /// Host-provided text input target. Weakly held so the middleware
+    /// cannot extend the lifetime of the view controller that owns it.
+    private let targetProvider: () -> TextInputTarget?
+
+    init(target: @escaping () -> TextInputTarget?) {
+        targetProvider = target
+    }
+
+    func process(_ context: ActionContext, next: (ActionContext) -> Void) {
+        if let target = targetProvider() {
+            apply(action: context.action, to: target)
+        }
+        next(context)
+    }
+
+    private func apply(action: KeyAction, to target: TextInputTarget) {
+        switch action {
+        case let .commitText(text):
+            target.insertText(text)
+        case .deleteBackward:
+            target.deleteBackward()
+        case .space:
+            target.insertText(" ")
+        case .newline:
+            target.insertText("\n")
+        case let .moveCursor(offset):
+            target.adjustTextPosition(byCharacterOffset: offset)
+        case .compose, .cycleAccents, .switchMode, .capitalizeWord,
+             .advanceToNextInputMode, .dismissKeyboard, .deleteForward,
+             .copy, .paste, .cut, .none:
+            break
+        }
+    }
+}

--- a/wurstfingerTests/ActionPipelineTests.swift
+++ b/wurstfingerTests/ActionPipelineTests.swift
@@ -87,19 +87,36 @@ private enum PipelineFixtures {
     }
 }
 
+/// Shared event log used to assert execution order across multiple
+/// `RecordingMiddleware` instances in the same pipeline.
+private final class OrderLog {
+    var events: [String] = []
+}
+
 /// A recording middleware that captures the context it received and
 /// forwards it unchanged. Used to verify pipeline ordering and
 /// short-circuit behavior.
+///
+/// Optionally also appends `name` to a shared `OrderLog` when invoked,
+/// so multi-middleware tests can assert the exact execution order
+/// rather than just reachability.
 private final class RecordingMiddleware: ActionMiddleware {
     var received: [ActionContext] = []
     private let shouldForward: Bool
+    private let name: String?
+    private let orderLog: OrderLog?
 
-    init(forwards: Bool = true) {
+    init(forwards: Bool = true, name: String? = nil, orderLog: OrderLog? = nil) {
         shouldForward = forwards
+        self.name = name
+        self.orderLog = orderLog
     }
 
     func process(_ context: ActionContext, next: (ActionContext) -> Void) {
         received.append(context)
+        if let name {
+            orderLog?.events.append(name)
+        }
         if shouldForward {
             next(context)
         }
@@ -125,13 +142,15 @@ private final class RewritingMiddleware: ActionMiddleware {
 
 struct ActionPipelineTests {
     @Test func runsMiddlewaresInOrder() {
-        let a = RecordingMiddleware()
-        let b = RecordingMiddleware()
-        let c = RecordingMiddleware()
+        let log = OrderLog()
+        let a = RecordingMiddleware(name: "A", orderLog: log)
+        let b = RecordingMiddleware(name: "B", orderLog: log)
+        let c = RecordingMiddleware(name: "C", orderLog: log)
         let pipeline = ActionPipeline(middlewares: [a, b, c])
 
         pipeline.process(PipelineFixtures.context(action: .commitText("a")))
 
+        #expect(log.events == ["A", "B", "C"])
         #expect(a.received.count == 1)
         #expect(b.received.count == 1)
         #expect(c.received.count == 1)
@@ -328,12 +347,23 @@ struct TextInputMiddlewareTests {
 
     @Test func nonTextActionsAreIgnored() {
         let target = MockTextInputTarget()
-        let pipe = pipeline(target: target)
-        pipe.process(PipelineFixtures.context(action: .advanceToNextInputMode))
-        pipe.process(PipelineFixtures.context(action: .switchMode("numeric")))
-        pipe.process(PipelineFixtures.context(action: .dismissKeyboard))
-        pipe.process(PipelineFixtures.context(action: .copy))
+        let sink = RecordingMiddleware()
+        let middleware = TextInputMiddleware(target: { target })
+        let pipe = ActionPipeline(middlewares: [middleware, sink])
+
+        let actions: [KeyAction] = [
+            .advanceToNextInputMode,
+            .switchMode("numeric"),
+            .dismissKeyboard,
+            .copy,
+        ]
+        for action in actions {
+            pipe.process(PipelineFixtures.context(action: action))
+        }
+
         #expect(target.events.isEmpty)
+        // Pipeline contract: no-op branches must still forward unchanged.
+        #expect(sink.received.map(\.action) == actions)
     }
 
     @Test func missingTargetIsToleratedAndForwardsContext() {
@@ -522,13 +552,21 @@ struct AutoCapitalizationMiddlewareTests {
             onCapitalize: {},
             onReleaseCapitalize: {}
         )
-        let pipe = ActionPipeline(middlewares: [middleware])
+        let sink = RecordingMiddleware()
+        let pipe = ActionPipeline(middlewares: [middleware, sink])
 
-        pipe.process(PipelineFixtures.context(action: .moveCursor(offset: 1)))
-        pipe.process(PipelineFixtures.context(action: .copy))
-        pipe.process(PipelineFixtures.context(action: .advanceToNextInputMode))
+        let actions: [KeyAction] = [
+            .moveCursor(offset: 1),
+            .copy,
+            .advanceToNextInputMode,
+        ]
+        for action in actions {
+            pipe.process(PipelineFixtures.context(action: action))
+        }
 
         #expect(evaluated == 0, "Cursor moves and clipboard-only actions don't affect caps")
+        // Pipeline contract: skipped branch must still forward downstream.
+        #expect(sink.received.map(\.action) == actions)
     }
 
     @Test func affectsCapitalizationPolicyIsStable() {
@@ -607,12 +645,15 @@ struct ModeTransitionMiddlewareTests {
             definition: modeTransitionDefinition(shiftedAutoTransitions: [.letter: "main"]),
             onModeChange: { changes.append($0) }
         )
-        let pipe = ActionPipeline(middlewares: [middleware])
+        let sink = RecordingMiddleware()
+        let pipe = ActionPipeline(middlewares: [middleware, sink])
 
         let binding = PipelineFixtures.binding(action: .commitText("A"), category: .letter)
         pipe.process(ActionContext(action: .commitText("A"), binding: binding, mode: "capsLock"))
 
         #expect(changes.isEmpty)
+        // Pipeline contract: no transition still forwards downstream.
+        #expect(sink.received.map(\.action) == [.commitText("A")])
     }
 
     @Test func unknownModeIsIgnored() {
@@ -621,12 +662,15 @@ struct ModeTransitionMiddlewareTests {
             definition: modeTransitionDefinition(shiftedAutoTransitions: [.letter: "main"]),
             onModeChange: { changes.append($0) }
         )
-        let pipe = ActionPipeline(middlewares: [middleware])
+        let sink = RecordingMiddleware()
+        let pipe = ActionPipeline(middlewares: [middleware, sink])
 
         let binding = PipelineFixtures.binding(action: .commitText("A"), category: .letter)
         pipe.process(ActionContext(action: .commitText("A"), binding: binding, mode: "ghost"))
 
         #expect(changes.isEmpty)
+        // Pipeline contract: unknown mode still forwards downstream.
+        #expect(sink.received.map(\.action) == [.commitText("A")])
     }
 
     @Test func fallsBackToInferredCategoryWhenBindingMissing() {
@@ -650,12 +694,15 @@ struct ModeTransitionMiddlewareTests {
             definition: modeTransitionDefinition(shiftedAutoTransitions: [.letter: "shifted"]),
             onModeChange: { changes.append($0) }
         )
-        let pipe = ActionPipeline(middlewares: [middleware])
+        let sink = RecordingMiddleware()
+        let pipe = ActionPipeline(middlewares: [middleware, sink])
 
         let binding = PipelineFixtures.binding(action: .commitText("A"), category: .letter)
         pipe.process(ActionContext(action: .commitText("A"), binding: binding, mode: "shifted"))
 
         #expect(changes.isEmpty)
+        // Pipeline contract: suppressed transition still forwards downstream.
+        #expect(sink.received.map(\.action) == [.commitText("A")])
     }
 
     @Test func runsAfterDownstreamMiddlewares() {

--- a/wurstfingerTests/ActionPipelineTests.swift
+++ b/wurstfingerTests/ActionPipelineTests.swift
@@ -275,6 +275,7 @@ private final class MockTextInputTarget: TextInputTarget {
     }
 
     var events: [Event] = []
+    var documentContextBeforeInput: String?
 
     func insertText(_ text: String) {
         events.append(.insertText(text))
@@ -343,6 +344,121 @@ struct TextInputMiddlewareTests {
         pipe.process(PipelineFixtures.context(action: .commitText("x")))
 
         #expect(sink.received.count == 1, "Pipeline must continue even without a target")
+    }
+}
+
+// MARK: - TelexMiddleware
+
+struct TelexMiddlewareTests {
+    /// Shared spy capturing deleteBackward calls and exposing a mutable
+    /// documentContextBefore. Tests configure the context, dispatch through
+    /// the pipeline, and then inspect what the middleware forwarded.
+    private final class Spy {
+        var deletes = 0
+        var context: String?
+        func deleteBackward() {
+            deletes += 1
+        }
+    }
+
+    private func pipeline(
+        spy: Spy,
+        isActive: @escaping () -> Bool = { true },
+        digraph: @escaping (String, String, String) -> (String, Int)? = { _, _, _ in nil },
+        single: @escaping (String, String) -> String? = { _, _ in nil }
+    ) -> (ActionPipeline, RecordingMiddleware) {
+        let telex = TelexMiddleware(
+            isActive: isActive,
+            documentContextBefore: { spy.context },
+            deleteBackward: { spy.deleteBackward() },
+            composeDigraph: digraph,
+            composeSingle: single
+        )
+        let sink = RecordingMiddleware()
+        return (ActionPipeline(middlewares: [telex, sink]), sink)
+    }
+
+    @Test func inactiveMiddlewarePassesThroughUnchanged() {
+        let spy = Spy()
+        spy.context = "a"
+        let (pipe, sink) = pipeline(
+            spy: spy,
+            isActive: { false },
+            single: { _, _ in "á" }
+        )
+        pipe.process(PipelineFixtures.context(action: .commitText("s")))
+        #expect(sink.received.count == 1)
+        #expect(sink.received.first?.action == .commitText("s"))
+        #expect(spy.deletes == 0)
+    }
+
+    @Test func singleCharComposeReplacesAction() {
+        let spy = Spy()
+        spy.context = "a"
+        let (pipe, sink) = pipeline(
+            spy: spy,
+            single: { prev, trig in prev == "a" && trig == "s" ? "á" : nil }
+        )
+        pipe.process(PipelineFixtures.context(action: .commitText("s")))
+        #expect(sink.received.first?.action == .commitText("á"))
+        #expect(spy.deletes == 1)
+    }
+
+    @Test func digraphComposePrefersTwoCharLookback() {
+        let spy = Spy()
+        spy.context = "uo"
+        // Both would match — the middleware must prefer the digraph.
+        let (pipe, sink) = pipeline(
+            spy: spy,
+            digraph: { p2, p1, t in p2 == "u" && p1 == "o" && t == "w" ? ("ươ", 2) : nil },
+            single: { _, _ in "should-not-win" }
+        )
+        pipe.process(PipelineFixtures.context(action: .commitText("w")))
+        #expect(sink.received.first?.action == .commitText("ươ"))
+        #expect(spy.deletes == 2)
+    }
+
+    @Test func nonMatchingTriggerIsForwardedUnchanged() {
+        let spy = Spy()
+        spy.context = "x"
+        let (pipe, sink) = pipeline(spy: spy)
+        pipe.process(PipelineFixtures.context(action: .commitText("q")))
+        #expect(sink.received.first?.action == .commitText("q"))
+        #expect(spy.deletes == 0)
+    }
+
+    @Test func multiCharCommitIsNotComposed() {
+        let spy = Spy()
+        spy.context = "a"
+        let (pipe, sink) = pipeline(
+            spy: spy,
+            single: { _, _ in "á" }
+        )
+        pipe.process(PipelineFixtures.context(action: .commitText("ss")))
+        #expect(sink.received.first?.action == .commitText("ss"))
+        #expect(spy.deletes == 0)
+    }
+
+    @Test func emptyDocumentContextPassesThrough() {
+        let spy = Spy()
+        spy.context = nil
+        let (pipe, sink) = pipeline(
+            spy: spy,
+            single: { _, _ in "á" }
+        )
+        pipe.process(PipelineFixtures.context(action: .commitText("s")))
+        #expect(sink.received.first?.action == .commitText("s"))
+        #expect(spy.deletes == 0)
+    }
+
+    @Test func nonCommitTextActionsAreForwardedUnchanged() {
+        let spy = Spy()
+        spy.context = "a"
+        let (pipe, sink) = pipeline(spy: spy)
+        pipe.process(PipelineFixtures.context(action: .deleteBackward))
+        pipe.process(PipelineFixtures.context(action: .space))
+        #expect(sink.received.map(\.action) == [.deleteBackward, .space])
+        #expect(spy.deletes == 0)
     }
 }
 

--- a/wurstfingerTests/ActionPipelineTests.swift
+++ b/wurstfingerTests/ActionPipelineTests.swift
@@ -469,7 +469,7 @@ struct TelexMiddlewareTests {
         #expect(spy.deletes == 0)
     }
 
-    @Test func emptyDocumentContextPassesThrough() {
+    @Test func nilDocumentContextPassesThrough() {
         let spy = Spy()
         spy.context = nil
         let (pipe, sink) = pipeline(

--- a/wurstfingerTests/ActionPipelineTests.swift
+++ b/wurstfingerTests/ActionPipelineTests.swift
@@ -1,0 +1,635 @@
+//
+//  ActionPipelineTests.swift
+//  WurstfingerTests
+//
+//  Tests for PR 11: ActionContext, ActionPipeline, and the middleware
+//  suite (HapticMiddleware, ComposeMiddleware, TextInputMiddleware,
+//  AutoCapitalizationMiddleware, ModeTransitionMiddleware).
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+// MARK: - Helpers
+
+private enum PipelineFixtures {
+    static func context(
+        action: KeyAction,
+        binding: KeyBinding? = nil,
+        mode: String = "main"
+    ) -> ActionContext {
+        ActionContext(action: action, binding: binding, mode: mode)
+    }
+
+    static func binding(
+        label: String = "x",
+        action: KeyAction,
+        category: KeyCategory? = nil
+    ) -> KeyBinding {
+        KeyBinding(
+            label: label,
+            action: action,
+            category: category,
+            returnAction: nil,
+            accessibilityLabel: nil
+        )
+    }
+
+    static func key(
+        id: String,
+        bindings: [GestureType: KeyBinding]
+    ) -> KeyConfig {
+        KeyConfig(
+            id: id,
+            bindings: bindings,
+            swipeMode: .eightWay,
+            slideType: .none,
+            style: .primary,
+            tapCycleActions: nil
+        )
+    }
+
+    static func mode(
+        name: String,
+        autoTransitions: [KeyCategory: String] = [:],
+        keys: [KeyConfig] = []
+    ) -> KeyboardMode {
+        let keyMap = Dictionary(uniqueKeysWithValues: keys.map { ($0.id, $0) })
+        return KeyboardMode(
+            name: name,
+            keys: keyMap,
+            arrangements: [
+                .portrait: GridArrangement(
+                    columns: 1,
+                    rows: [[KeyPlacement(keyId: keys.first?.id ?? "x")]]
+                ),
+            ],
+            autoTransitions: autoTransitions,
+            doubleTapMode: nil
+        )
+    }
+
+    static func definition(modes: [KeyboardMode]) -> KeyboardDefinition {
+        let modeMap = Dictionary(uniqueKeysWithValues: modes.map { ($0.name, $0) })
+        return KeyboardDefinition(
+            title: "Fixture",
+            id: "fixture",
+            localeIdentifier: "en_US",
+            modes: modeMap,
+            defaultMode: modes.first?.name ?? "main",
+            settings: KeyboardDefinitionSettings(
+                autoCapitalize: true,
+                autoCapitalizers: [],
+                composeRuleOverrides: nil
+            )
+        )
+    }
+}
+
+/// A recording middleware that captures the context it received and
+/// forwards it unchanged. Used to verify pipeline ordering and
+/// short-circuit behavior.
+private final class RecordingMiddleware: ActionMiddleware {
+    var received: [ActionContext] = []
+    private let shouldForward: Bool
+
+    init(forwards: Bool = true) {
+        shouldForward = forwards
+    }
+
+    func process(_ context: ActionContext, next: (ActionContext) -> Void) {
+        received.append(context)
+        if shouldForward {
+            next(context)
+        }
+    }
+}
+
+/// A middleware that rewrites the action before forwarding.
+private final class RewritingMiddleware: ActionMiddleware {
+    private let rewrite: (KeyAction) -> KeyAction
+
+    init(rewrite: @escaping (KeyAction) -> KeyAction) {
+        self.rewrite = rewrite
+    }
+
+    func process(_ context: ActionContext, next: (ActionContext) -> Void) {
+        var transformed = context
+        transformed.action = rewrite(context.action)
+        next(transformed)
+    }
+}
+
+// MARK: - ActionPipeline
+
+struct ActionPipelineTests {
+    @Test func runsMiddlewaresInOrder() {
+        let a = RecordingMiddleware()
+        let b = RecordingMiddleware()
+        let c = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [a, b, c])
+
+        pipeline.process(PipelineFixtures.context(action: .commitText("a")))
+
+        #expect(a.received.count == 1)
+        #expect(b.received.count == 1)
+        #expect(c.received.count == 1)
+    }
+
+    @Test func shortCircuitsWhenMiddlewareSkipsNext() {
+        let a = RecordingMiddleware()
+        let stopper = RecordingMiddleware(forwards: false)
+        let c = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [a, stopper, c])
+
+        pipeline.process(PipelineFixtures.context(action: .commitText("a")))
+
+        #expect(a.received.count == 1)
+        #expect(stopper.received.count == 1)
+        #expect(c.received.isEmpty, "Downstream middleware must not run when next is skipped")
+    }
+
+    @Test func middlewareCanTransformAction() {
+        let rewriter = RewritingMiddleware { _ in .commitText("Y") }
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [rewriter, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .commitText("x")))
+
+        #expect(sink.received.first?.action == .commitText("Y"))
+    }
+
+    @Test func emptyPipelineIsNoop() {
+        let pipeline = ActionPipeline(middlewares: [])
+        // Should not crash.
+        pipeline.process(PipelineFixtures.context(action: .commitText("a")))
+    }
+}
+
+// MARK: - HapticMiddleware
+
+struct HapticMiddlewareTests {
+    @Test func triggersFeedbackForAction() {
+        var triggered: [KeyAction] = []
+        let middleware = HapticMiddleware(trigger: { triggered.append($0) })
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .commitText("a")))
+
+        #expect(triggered == [.commitText("a")])
+        #expect(sink.received.first?.action == .commitText("a"))
+    }
+
+    @Test func forwardsContextUnchanged() {
+        let middleware = HapticMiddleware(trigger: { _ in })
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        let original = PipelineFixtures.context(
+            action: .deleteBackward,
+            binding: PipelineFixtures.binding(action: .deleteBackward),
+            mode: "shifted"
+        )
+        pipeline.process(original)
+
+        #expect(sink.received.first?.action == .deleteBackward)
+        #expect(sink.received.first?.mode == "shifted")
+    }
+}
+
+// MARK: - ComposeMiddleware
+
+struct ComposeMiddlewareTests {
+    @Test func composesWhenRuleMatches() {
+        var deleted = 0
+        let middleware = ComposeMiddleware(
+            compose: { previous, trigger in
+                (previous == "a" && trigger == "¨") ? "ä" : nil
+            },
+            previousCharacter: { "a" },
+            deletePreviousCharacter: { deleted += 1 }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .compose(trigger: "¨")))
+
+        #expect(sink.received.first?.action == .commitText("ä"))
+        #expect(deleted == 1, "Previous character must be consumed when compose succeeds")
+    }
+
+    @Test func insertsTriggerWhenNoRuleMatches() {
+        var deleted = 0
+        let middleware = ComposeMiddleware(
+            compose: { _, _ in nil },
+            previousCharacter: { "x" },
+            deletePreviousCharacter: { deleted += 1 }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .compose(trigger: "¨")))
+
+        #expect(sink.received.first?.action == .commitText("¨"))
+        #expect(deleted == 0, "No rule → no previous-character deletion")
+    }
+
+    @Test func insertsTriggerWhenNoPreviousCharacter() {
+        let middleware = ComposeMiddleware(
+            compose: { _, _ in "should not run" },
+            previousCharacter: { "" },
+            deletePreviousCharacter: { Issue.record("Must not delete without previous char") }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .compose(trigger: "'")))
+
+        #expect(sink.received.first?.action == .commitText("'"))
+    }
+
+    @Test func passesThroughNonComposeActions() {
+        let middleware = ComposeMiddleware(
+            compose: { _, _ in Issue.record("compose must not run for non-.compose actions"); return nil },
+            previousCharacter: { "a" },
+            deletePreviousCharacter: { Issue.record("delete must not run for non-.compose actions") }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .commitText("a")))
+
+        #expect(sink.received.first?.action == .commitText("a"))
+    }
+}
+
+// MARK: - TextInputMiddleware
+
+private final class MockTextInputTarget: TextInputTarget {
+    enum Event: Equatable {
+        case insertText(String)
+        case deleteBackward
+        case adjustCursor(Int)
+    }
+
+    var events: [Event] = []
+
+    func insertText(_ text: String) {
+        events.append(.insertText(text))
+    }
+
+    func deleteBackward() {
+        events.append(.deleteBackward)
+    }
+
+    func adjustTextPosition(byCharacterOffset offset: Int) {
+        events.append(.adjustCursor(offset))
+    }
+}
+
+struct TextInputMiddlewareTests {
+    private func pipeline(target: MockTextInputTarget) -> ActionPipeline {
+        let middleware = TextInputMiddleware(target: { target })
+        return ActionPipeline(middlewares: [middleware])
+    }
+
+    @Test func commitTextInsertsText() {
+        let target = MockTextInputTarget()
+        pipeline(target: target).process(PipelineFixtures.context(action: .commitText("hi")))
+        #expect(target.events == [.insertText("hi")])
+    }
+
+    @Test func deleteBackwardDeletes() {
+        let target = MockTextInputTarget()
+        pipeline(target: target).process(PipelineFixtures.context(action: .deleteBackward))
+        #expect(target.events == [.deleteBackward])
+    }
+
+    @Test func spaceInsertsSpaceCharacter() {
+        let target = MockTextInputTarget()
+        pipeline(target: target).process(PipelineFixtures.context(action: .space))
+        #expect(target.events == [.insertText(" ")])
+    }
+
+    @Test func newlineInsertsLineBreak() {
+        let target = MockTextInputTarget()
+        pipeline(target: target).process(PipelineFixtures.context(action: .newline))
+        #expect(target.events == [.insertText("\n")])
+    }
+
+    @Test func moveCursorAdjustsPosition() {
+        let target = MockTextInputTarget()
+        pipeline(target: target).process(PipelineFixtures.context(action: .moveCursor(offset: -3)))
+        #expect(target.events == [.adjustCursor(-3)])
+    }
+
+    @Test func nonTextActionsAreIgnored() {
+        let target = MockTextInputTarget()
+        let pipe = pipeline(target: target)
+        pipe.process(PipelineFixtures.context(action: .advanceToNextInputMode))
+        pipe.process(PipelineFixtures.context(action: .switchMode("numeric")))
+        pipe.process(PipelineFixtures.context(action: .dismissKeyboard))
+        pipe.process(PipelineFixtures.context(action: .copy))
+        #expect(target.events.isEmpty)
+    }
+
+    @Test func missingTargetIsToleratedAndForwardsContext() {
+        let middleware = TextInputMiddleware(target: { nil })
+        let sink = RecordingMiddleware()
+        let pipe = ActionPipeline(middlewares: [middleware, sink])
+
+        pipe.process(PipelineFixtures.context(action: .commitText("x")))
+
+        #expect(sink.received.count == 1, "Pipeline must continue even without a target")
+    }
+}
+
+// MARK: - AutoCapitalizationMiddleware
+
+struct AutoCapitalizationMiddlewareTests {
+    @Test func engagesCapitalizationWhenEvaluateReturnsTrue() {
+        var capitalized = 0
+        var released = 0
+        let middleware = AutoCapitalizationMiddleware(
+            evaluate: { true },
+            onCapitalize: { capitalized += 1 },
+            onReleaseCapitalize: { released += 1 }
+        )
+        let pipe = ActionPipeline(middlewares: [middleware])
+
+        pipe.process(PipelineFixtures.context(action: .commitText(".")))
+        pipe.process(PipelineFixtures.context(action: .space))
+
+        #expect(capitalized == 2)
+        #expect(released == 0)
+    }
+
+    @Test func releasesCapitalizationWhenEvaluateReturnsFalse() {
+        var capitalized = 0
+        var released = 0
+        let middleware = AutoCapitalizationMiddleware(
+            evaluate: { false },
+            onCapitalize: { capitalized += 1 },
+            onReleaseCapitalize: { released += 1 }
+        )
+        let pipe = ActionPipeline(middlewares: [middleware])
+
+        pipe.process(PipelineFixtures.context(action: .deleteBackward))
+
+        #expect(capitalized == 0)
+        #expect(released == 1)
+    }
+
+    @Test func skipsWhenEvaluateReturnsNil() {
+        // nil means "auto-capitalization disabled in settings".
+        var capitalized = 0
+        var released = 0
+        let middleware = AutoCapitalizationMiddleware(
+            evaluate: { nil },
+            onCapitalize: { capitalized += 1 },
+            onReleaseCapitalize: { released += 1 }
+        )
+        let pipe = ActionPipeline(middlewares: [middleware])
+
+        pipe.process(PipelineFixtures.context(action: .commitText("a")))
+
+        #expect(capitalized == 0)
+        #expect(released == 0)
+    }
+
+    @Test func ignoresActionsThatDoNotAffectCapitalization() {
+        var evaluated = 0
+        let middleware = AutoCapitalizationMiddleware(
+            evaluate: { evaluated += 1; return true },
+            onCapitalize: {},
+            onReleaseCapitalize: {}
+        )
+        let pipe = ActionPipeline(middlewares: [middleware])
+
+        pipe.process(PipelineFixtures.context(action: .moveCursor(offset: 1)))
+        pipe.process(PipelineFixtures.context(action: .copy))
+        pipe.process(PipelineFixtures.context(action: .advanceToNextInputMode))
+
+        #expect(evaluated == 0, "Cursor moves and clipboard-only actions don't affect caps")
+    }
+
+    @Test func affectsCapitalizationPolicyIsStable() {
+        // Sanity check the static policy so future additions to KeyAction
+        // force a deliberate decision here.
+        #expect(AutoCapitalizationMiddleware.affectsCapitalization(.commitText("a")))
+        #expect(AutoCapitalizationMiddleware.affectsCapitalization(.space))
+        #expect(AutoCapitalizationMiddleware.affectsCapitalization(.newline))
+        #expect(AutoCapitalizationMiddleware.affectsCapitalization(.deleteBackward))
+        #expect(AutoCapitalizationMiddleware.affectsCapitalization(.paste))
+        #expect(!AutoCapitalizationMiddleware.affectsCapitalization(.moveCursor(offset: 1)))
+        #expect(!AutoCapitalizationMiddleware.affectsCapitalization(.switchMode("main")))
+        #expect(!AutoCapitalizationMiddleware.affectsCapitalization(.copy))
+    }
+
+    @Test func evaluateRunsAfterDownstreamMiddlewares() {
+        // AutoCap must call next first, then re-evaluate the proxy state
+        // (which downstream middlewares may have changed).
+        var evaluationOrder: [String] = []
+        let autoCap = AutoCapitalizationMiddleware(
+            evaluate: { evaluationOrder.append("evaluate"); return nil },
+            onCapitalize: {},
+            onReleaseCapitalize: {}
+        )
+        let rewriter = RewritingMiddleware { action in
+            evaluationOrder.append("downstream")
+            return action
+        }
+        let pipe = ActionPipeline(middlewares: [autoCap, rewriter])
+
+        pipe.process(PipelineFixtures.context(action: .commitText("x")))
+
+        #expect(evaluationOrder == ["downstream", "evaluate"])
+    }
+}
+
+// MARK: - ModeTransitionMiddleware
+
+private func modeTransitionDefinition(
+    shiftedAutoTransitions: [KeyCategory: String]
+) -> KeyboardDefinition {
+    let main = PipelineFixtures.mode(
+        name: "main",
+        keys: [PipelineFixtures.key(id: "a", bindings: [:])]
+    )
+    let shifted = PipelineFixtures.mode(
+        name: "shifted",
+        autoTransitions: shiftedAutoTransitions,
+        keys: [PipelineFixtures.key(id: "a", bindings: [:])]
+    )
+    let capsLock = PipelineFixtures.mode(
+        name: "capsLock",
+        keys: [PipelineFixtures.key(id: "a", bindings: [:])]
+    )
+    return PipelineFixtures.definition(modes: [main, shifted, capsLock])
+}
+
+struct ModeTransitionMiddlewareTests {
+    @Test func shiftedLetterReturnsToMain() {
+        var changes: [String] = []
+        let middleware = ModeTransitionMiddleware(
+            definition: modeTransitionDefinition(shiftedAutoTransitions: [.letter: "main"]),
+            onModeChange: { changes.append($0) }
+        )
+        let pipe = ActionPipeline(middlewares: [middleware])
+
+        let binding = PipelineFixtures.binding(action: .commitText("A"), category: .letter)
+        pipe.process(ActionContext(action: .commitText("A"), binding: binding, mode: "shifted"))
+
+        #expect(changes == ["main"])
+    }
+
+    @Test func capsLockDoesNotTransition() {
+        var changes: [String] = []
+        let middleware = ModeTransitionMiddleware(
+            definition: modeTransitionDefinition(shiftedAutoTransitions: [.letter: "main"]),
+            onModeChange: { changes.append($0) }
+        )
+        let pipe = ActionPipeline(middlewares: [middleware])
+
+        let binding = PipelineFixtures.binding(action: .commitText("A"), category: .letter)
+        pipe.process(ActionContext(action: .commitText("A"), binding: binding, mode: "capsLock"))
+
+        #expect(changes.isEmpty)
+    }
+
+    @Test func unknownModeIsIgnored() {
+        var changes: [String] = []
+        let middleware = ModeTransitionMiddleware(
+            definition: modeTransitionDefinition(shiftedAutoTransitions: [.letter: "main"]),
+            onModeChange: { changes.append($0) }
+        )
+        let pipe = ActionPipeline(middlewares: [middleware])
+
+        let binding = PipelineFixtures.binding(action: .commitText("A"), category: .letter)
+        pipe.process(ActionContext(action: .commitText("A"), binding: binding, mode: "ghost"))
+
+        #expect(changes.isEmpty)
+    }
+
+    @Test func fallsBackToInferredCategoryWhenBindingMissing() {
+        // No explicit binding → category derived from action (.commitText("a") → .letter).
+        var changes: [String] = []
+        let middleware = ModeTransitionMiddleware(
+            definition: modeTransitionDefinition(shiftedAutoTransitions: [.letter: "main"]),
+            onModeChange: { changes.append($0) }
+        )
+        let pipe = ActionPipeline(middlewares: [middleware])
+
+        pipe.process(ActionContext(action: .commitText("a"), binding: nil, mode: "shifted"))
+
+        #expect(changes == ["main"])
+    }
+
+    @Test func doesNotFireForSameModeTransition() {
+        // Guard against infinite loops if a transition maps to itself.
+        var changes: [String] = []
+        let middleware = ModeTransitionMiddleware(
+            definition: modeTransitionDefinition(shiftedAutoTransitions: [.letter: "shifted"]),
+            onModeChange: { changes.append($0) }
+        )
+        let pipe = ActionPipeline(middlewares: [middleware])
+
+        let binding = PipelineFixtures.binding(action: .commitText("A"), category: .letter)
+        pipe.process(ActionContext(action: .commitText("A"), binding: binding, mode: "shifted"))
+
+        #expect(changes.isEmpty)
+    }
+
+    @Test func runsAfterDownstreamMiddlewares() {
+        var order: [String] = []
+        let downstream = RewritingMiddleware { action in
+            order.append("downstream")
+            return action
+        }
+        let transition = ModeTransitionMiddleware(
+            definition: modeTransitionDefinition(shiftedAutoTransitions: [.letter: "main"]),
+            onModeChange: { _ in order.append("transition") }
+        )
+        let pipe = ActionPipeline(middlewares: [transition, downstream])
+
+        let binding = PipelineFixtures.binding(action: .commitText("A"), category: .letter)
+        pipe.process(ActionContext(action: .commitText("A"), binding: binding, mode: "shifted"))
+
+        #expect(order == ["downstream", "transition"])
+    }
+}
+
+// MARK: - Pipeline Integration
+
+struct PipelineIntegrationTests {
+    @Test func composeThenTextInputProducesCommittedCharacter() {
+        // ComposeMiddleware rewrites the action; TextInputMiddleware then
+        // inserts the rewritten text into the target.
+        let target = MockTextInputTarget()
+        var deleted = 0
+        let compose = ComposeMiddleware(
+            compose: { prev, trig in (prev == "a" && trig == "¨") ? "ä" : nil },
+            previousCharacter: { "a" },
+            deletePreviousCharacter: { deleted += 1 }
+        )
+        let input = TextInputMiddleware(target: { target })
+        let pipe = ActionPipeline(middlewares: [compose, input])
+
+        pipe.process(PipelineFixtures.context(action: .compose(trigger: "¨")))
+
+        #expect(deleted == 1)
+        #expect(target.events == [.insertText("ä")])
+    }
+
+    @Test func hapticsFireBeforeTextInput() {
+        var order: [String] = []
+        let target = MockTextInputTarget()
+        let haptic = HapticMiddleware(trigger: { _ in order.append("haptic") })
+        let input = TextInputMiddleware(target: { () -> TextInputTarget? in
+            order.append("input")
+            return target
+        })
+        let pipe = ActionPipeline(middlewares: [haptic, input])
+
+        pipe.process(PipelineFixtures.context(action: .commitText("x")))
+
+        #expect(order == ["haptic", "input"])
+    }
+
+    @Test func fullPipelineRunsAllMiddlewaresInOrder() {
+        var steps: [String] = []
+        let target = MockTextInputTarget()
+        let haptic = HapticMiddleware(trigger: { _ in steps.append("haptic") })
+        let compose = ComposeMiddleware(
+            compose: { _, _ in nil },
+            previousCharacter: { "" },
+            deletePreviousCharacter: {}
+        )
+        let input = TextInputMiddleware(target: {
+            steps.append("input")
+            return target
+        })
+        let autoCap = AutoCapitalizationMiddleware(
+            evaluate: { steps.append("evaluate"); return nil },
+            onCapitalize: {},
+            onReleaseCapitalize: {}
+        )
+        let transition = ModeTransitionMiddleware(
+            definition: modeTransitionDefinition(
+                shiftedAutoTransitions: [.letter: "main"]
+            ),
+            onModeChange: { _ in steps.append("transition") }
+        )
+        let pipe = ActionPipeline(middlewares: [haptic, compose, input, autoCap, transition])
+
+        let binding = PipelineFixtures.binding(action: .commitText("a"), category: .letter)
+        pipe.process(ActionContext(action: .commitText("a"), binding: binding, mode: "shifted"))
+
+        // autoCap and transition both run post-`next`, so they unwind in
+        // reverse order: transition (deepest) fires before autoCap.evaluate.
+        #expect(steps == ["haptic", "input", "transition", "evaluate"])
+        #expect(target.events == [.insertText("a")])
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Phase 4.2** of `REFACTORING_PLAN.md`: a middleware pipeline for action processing, complementing the PR 10 `GestureResolverChain`. Actions flow through an ordered pipeline of composable middlewares, each of which may transform, short-circuit, or react to the `ActionContext`.

### New files

| File | Role |
| --- | --- |
| `ActionMiddleware.swift` | `ActionMiddleware` protocol + `ActionContext` value type |
| `ActionPipeline.swift` | Ordered chain that runs middlewares recursively via `next` callbacks |
| `HapticMiddleware.swift` | Triggers haptic feedback via an injected `(KeyAction) -> Void` closure |
| `ComposeMiddleware.swift` | Transforms `.compose(trigger)` → `.commitText(result)` using injected compose/delete closures |
| `TextInputMiddleware.swift` | Applies `.commitText` / `.deleteBackward` / `.space` / `.newline` / `.moveCursor` to a `TextInputTarget` protocol |
| `AutoCapitalizationMiddleware.swift` | Re-evaluates auto-cap after text-mutating actions via an injected `evaluate` closure |
| `ModeTransitionMiddleware.swift` | Applies `KeyboardMode.autoTransitions` after actions, calls back `onModeChange` |

### Design notes

- **Closure injection over type dependencies.** `HapticFeedbackManager`, `ComposeEngine`, `AutoCapitalization`, and `UITextDocumentProxy` are all excluded from the `WurstfingerApp` target, so middlewares depend on closures / small protocols (`TextInputTarget`) instead of those concrete types. This keeps every middleware file UIKit-free and unit-testable, and lets all new files compile in `WurstfingerApp` without touching `project.pbxproj`.
- **`ActionContext` is intentionally minimal.** It carries only `action`, `binding`, and `mode`. Host dependencies are bound at pipeline construction, not passed through each call.
- **Pipeline semantics.** Middlewares that want post-processing (`AutoCapitalizationMiddleware`, `ModeTransitionMiddleware`) call `next` first, so they unwind after downstream middlewares finish — verified in the integration test `fullPipelineRunsAllMiddlewaresInOrder`.
- **No wiring yet.** PR 11 adds the infrastructure and tests only; PR 12 will wire the pipeline into `KeyboardViewModel` / `KeyboardViewController` and remove the legacy `perform(action:)` switch.

## Test plan

- [x] `ActionPipelineTests` — order, short-circuit, action transformation, empty pipeline
- [x] `HapticMiddlewareTests` — trigger fires, context forwarded unchanged
- [x] `ComposeMiddlewareTests` — rule match → commitText + delete; no match → literal trigger; no previous char → literal trigger; non-compose pass-through
- [x] `TextInputMiddlewareTests` — per-action proxy calls via `MockTextInputTarget`, non-text actions ignored, missing target tolerated
- [x] `AutoCapitalizationMiddlewareTests` — engage / release / nil-skip, policy for affected actions, runs post-`next`
- [x] `ModeTransitionMiddlewareTests` — shifted→main, capsLock stays, unknown mode ignored, inferred category fallback, self-transition suppressed, post-`next` ordering
- [x] `PipelineIntegrationTests` — compose→textInput chain, haptic-before-input ordering, full 5-middleware pipeline

All new tests pass locally alongside the existing `WurstfingerTests` suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an action-processing pipeline and middleware system for keyboard events
  * Added compose key functionality for composite characters
  * Implemented Vietnamese Telex input method support
  * Enhanced auto-capitalization detection and adjustment
  * Integrated haptic feedback on key actions
  * Added keyboard mode transition handling
  * Improved text input delivery and cursor handling

* **Tests**
  * Added comprehensive tests covering middleware sequencing, short-circuiting, transformations, and integration scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->