### PR TITLE
Add Label Visibility Settings (#87)

### DIFF
--- a/wurstfinger.xcodeproj/project.pbxproj
+++ b/wurstfinger.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 				KeyboardViewController.swift,
 				KeyboardViewModel.swift,
 				KeyHintOverlay.swift,
+				LabelCategory.swift,
 				LanguageConfig.swift,
 				LanguageDefinitions.swift,
 				LanguageSettings.swift,

--- a/wurstfinger/LabelVisibilitySettingsView.swift
+++ b/wurstfinger/LabelVisibilitySettingsView.swift
@@ -1,0 +1,65 @@
+//
+//  LabelVisibilitySettingsView.swift
+//  wurstfinger
+//
+//  Lets the user hide categories of key labels to practice the
+//  keyboard layout from memory.
+//
+
+import SwiftUI
+
+struct LabelVisibilitySettingsView: View {
+    @AppStorage(SettingsKey.hideLetters.rawValue, store: SharedDefaults.store)
+    private var hideLetters = false
+
+    @AppStorage(SettingsKey.hideStandardSymbols.rawValue, store: SharedDefaults.store)
+    private var hideStandardSymbols = false
+
+    @AppStorage(SettingsKey.hideExtraSymbols.rawValue, store: SharedDefaults.store)
+    private var hideExtraSymbols = false
+
+    @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
+    private var previewAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
+
+    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
+    private var previewScale = DeviceLayoutUtils.defaultKeyboardScale
+
+    @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
+    private var previewPosition = DeviceLayoutUtils.defaultKeyboardPosition
+
+    var body: some View {
+        VStack(spacing: 16) {
+            InteractiveKeyboardPreview(aspectRatio: $previewAspectRatio, scale: $previewScale, position: $previewPosition)
+                .padding(.horizontal, 16)
+
+            Form {
+                Section {
+                    Toggle("Show Letters", isOn: Binding(
+                        get: { !hideLetters },
+                        set: { hideLetters = !$0 }
+                    ))
+
+                    Toggle("Show Standard Symbols", isOn: Binding(
+                        get: { !hideStandardSymbols },
+                        set: { hideStandardSymbols = !$0 }
+                    ))
+
+                    Toggle("Show Extra Symbols", isOn: Binding(
+                        get: { !hideExtraSymbols },
+                        set: { hideExtraSymbols = !$0 }
+                    ))
+                } footer: {
+                    Text("Hide labels to practice the layout from memory. Numbers and control keys are always visible.")
+                }
+            }
+        }
+        .navigationTitle("Label Visibility")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        LabelVisibilitySettingsView()
+    }
+}

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -45,6 +45,15 @@ struct SettingsView: View {
     @AppStorage(SettingsKey.expertModeEnabled.rawValue, store: SharedDefaults.store)
     private var expertModeEnabled = false
 
+    @AppStorage(SettingsKey.hideLetters.rawValue, store: SharedDefaults.store)
+    private var hideLetters = false
+
+    @AppStorage(SettingsKey.hideStandardSymbols.rawValue, store: SharedDefaults.store)
+    private var hideStandardSymbols = false
+
+    @AppStorage(SettingsKey.hideExtraSymbols.rawValue, store: SharedDefaults.store)
+    private var hideExtraSymbols = false
+
     var body: some View {
         NavigationStack {
             Form {
@@ -125,6 +134,15 @@ struct SettingsView: View {
                 Text("Classic (7-8-9)").tag(NumpadStyle.classic.rawValue)
             } label: {
                 SettingsRow(icon: "number.square", color: .purple, title: "Numpad Style", subtitle: numpadStyleDescription)
+            }
+
+            NavigationLink(destination: LabelVisibilitySettingsView()) {
+                SettingsRow(
+                    icon: "eye",
+                    color: .mint,
+                    title: "Label Visibility",
+                    subtitle: labelVisibilityDescription
+                )
             }
         } header: {
             Text("Appearance")
@@ -250,6 +268,15 @@ struct SettingsView: View {
             return "Off"
         }
         return "\(Int(round(value * 100)))%"
+    }
+
+    private var labelVisibilityDescription: String {
+        let hiddenCount = [hideLetters, hideStandardSymbols, hideExtraSymbols].count(where: { $0 })
+        switch hiddenCount {
+        case 0: return "All visible"
+        case 3: return "All hidden"
+        default: return "\(hiddenCount) hidden"
+        }
     }
 }
 

--- a/wurstfinger/wurstfingerApp.swift
+++ b/wurstfinger/wurstfingerApp.swift
@@ -21,7 +21,10 @@ struct wurstfingerApp: App {
         let defaults: [String: Any] = [
             SettingsKey.keyAspectRatio.rawValue: DeviceLayoutUtils.defaultKeyAspectRatio,
             SettingsKey.keyboardScale.rawValue: DeviceLayoutUtils.defaultKeyboardScale,
-            SettingsKey.keyboardHorizontalPosition.rawValue: DeviceLayoutUtils.defaultKeyboardPosition
+            SettingsKey.keyboardHorizontalPosition.rawValue: DeviceLayoutUtils.defaultKeyboardPosition,
+            SettingsKey.hideLetters.rawValue: false,
+            SettingsKey.hideStandardSymbols.rawValue: false,
+            SettingsKey.hideExtraSymbols.rawValue: false
         ]
         SharedDefaults.store.register(defaults: defaults)
 

--- a/wurstfingerKeyboard/KeyHintOverlay.swift
+++ b/wurstfingerKeyboard/KeyHintOverlay.swift
@@ -14,6 +14,7 @@ struct KeyHintOverlay: View {
     let isCapsLockActive: Bool
     let locale: Locale
     let keyHeight: CGFloat
+    let labelVisibility: LabelVisibilitySettings
 
     private let directions: [KeyboardDirection] = KeyboardDirection.allCases.filter { $0 != .center }
 
@@ -37,11 +38,13 @@ struct KeyHintOverlay: View {
             let scaledVerticalPadding = KeyboardConstants.FontSizes.hintBaseVerticalPadding * fontRatio
 
             ForEach(directions, id: \.self) { direction in
-                if let label = key.primaryLabel(for: direction, isCapsLock: isCapsLockActive) {
+                if let label = key.primaryLabel(for: direction, isCapsLock: isCapsLockActive),
+                   let output = key.output(for: direction) {
+                    let category = output.labelCategory
                     // Hide down icon on r-key when not in caps mode
-                    if shouldShowLabel(for: direction) {
-                        let displayLabel = transformLabel(label, activeLayer: activeLayer)
-                        hintText(displayLabel, isLetter: isLetter(displayLabel))
+                    if shouldShowLabel(for: direction), labelVisibility.isVisible(category) {
+                        let displayLabel = transformLabel(label, category: category)
+                        hintText(displayLabel, category: category)
                             .fixedSize()
                             .padding(direction.edgePadding(
                                 horizontal: scaledHorizontalPadding,
@@ -63,9 +66,9 @@ struct KeyHintOverlay: View {
         return true
     }
 
-    private func transformLabel(_ label: String, activeLayer: KeyboardLayer) -> String {
+    private func transformLabel(_ label: String, category: LabelCategory) -> String {
         // Transform label based on active layer (for shift/caps)
-        guard isLetter(label) else { return label }
+        guard category == .letter else { return label }
 
         switch activeLayer {
         case .upper:
@@ -77,13 +80,7 @@ struct KeyHintOverlay: View {
         }
     }
 
-    private func isLetter(_ text: String) -> Bool {
-        // Check if the text is a letter (any alphabet, including non-Latin scripts)
-        guard let firstChar = text.first else { return false }
-        return firstChar.isLetter
-    }
-
-    private func hintText(_ text: String, isLetter: Bool) -> some View {
+    private func hintText(_ text: String, category: LabelCategory) -> some View {
         // Three-tier color system similar to MessagEase:
         // 1. Center character (not shown here): primary color (highest priority)
         // 2. Letter hints: medium priority - between primary and secondary
@@ -93,7 +90,7 @@ struct KeyHintOverlay: View {
         let opacity: CGFloat
         let weight: Font.Weight
 
-        if isLetter {
+        if category == .letter {
             // Letters: medium priority, blend between primary and secondary
             color = Color.primary
             opacity = 0.65

--- a/wurstfingerKeyboard/KeyboardRootView.swift
+++ b/wurstfingerKeyboard/KeyboardRootView.swift
@@ -167,7 +167,8 @@ struct KeyboardRootView: View {
                         activeLayer: viewModel.activeLayer,
                         isCapsLockActive: viewModel.isCapsLockActive,
                         locale: viewModel.currentLocale(),
-                        keyHeight: keyHeight
+                        keyHeight: keyHeight,
+                        labelVisibility: viewModel.labelVisibilitySettings
                     ),
                     config: KeyboardButtonConfig(fontSize: scaledMainLabelSize(for: keyHeight)),
                     callbacks: KeyboardButtonCallbacks(

--- a/wurstfingerKeyboard/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/KeyboardSettings.swift
@@ -29,6 +29,9 @@ enum SettingsKey: String {
     case keyboardStyle
     case keyboardFullAccess
     case cursorMovementStyle
+    case hideLetters
+    case hideStandardSymbols
+    case hideExtraSymbols
 }
 
 // MARK: - Haptic Settings
@@ -220,6 +223,65 @@ final class LayoutSettings: ObservableObject {
     /// Position range: 0.0 (left) to 1.0 (right)
     private static func clampPosition(_ value: Double) -> Double {
         min(1.0, max(0.0, value))
+    }
+
+    private func persistIfNeeded(_ value: some Any, forKey key: SettingsKey) {
+        guard shouldPersist else { return }
+        defaults.set(value, forKey: key.rawValue)
+    }
+}
+
+// MARK: - Label Visibility Settings
+
+/// Controls which categories of key labels are visible on the keyboard.
+/// Letters, standard symbols, and extra symbols can each be independently hidden
+/// so users can practice the layout from memory. Numbers and functional keys
+/// are always visible.
+final class LabelVisibilitySettings: ObservableObject {
+    private let defaults: UserDefaults
+    private let shouldPersist: Bool
+
+    @Published var hideLetters: Bool {
+        didSet { persistIfNeeded(hideLetters, forKey: .hideLetters) }
+    }
+
+    @Published var hideStandardSymbols: Bool {
+        didSet { persistIfNeeded(hideStandardSymbols, forKey: .hideStandardSymbols) }
+    }
+
+    @Published var hideExtraSymbols: Bool {
+        didSet { persistIfNeeded(hideExtraSymbols, forKey: .hideExtraSymbols) }
+    }
+
+    init(defaults: UserDefaults = SharedDefaults.store, shouldPersist: Bool = true) {
+        self.defaults = defaults
+        self.shouldPersist = shouldPersist
+
+        hideLetters = defaults.object(forKey: SettingsKey.hideLetters.rawValue) as? Bool ?? false
+        hideStandardSymbols = defaults.object(forKey: SettingsKey.hideStandardSymbols.rawValue) as? Bool ?? false
+        hideExtraSymbols = defaults.object(forKey: SettingsKey.hideExtraSymbols.rawValue) as? Bool ?? false
+    }
+
+    /// Reload settings from UserDefaults (e.g., after changes from host app).
+    func reload() {
+        let newHideLetters = defaults.object(forKey: SettingsKey.hideLetters.rawValue) as? Bool ?? false
+        if hideLetters != newHideLetters { hideLetters = newHideLetters }
+
+        let newHideStandard = defaults.object(forKey: SettingsKey.hideStandardSymbols.rawValue) as? Bool ?? false
+        if hideStandardSymbols != newHideStandard { hideStandardSymbols = newHideStandard }
+
+        let newHideExtra = defaults.object(forKey: SettingsKey.hideExtraSymbols.rawValue) as? Bool ?? false
+        if hideExtraSymbols != newHideExtra { hideExtraSymbols = newHideExtra }
+    }
+
+    /// Returns whether a label of the given category should be visible.
+    func isVisible(_ category: LabelCategory) -> Bool {
+        switch category {
+        case .letter: !hideLetters
+        case .standardSymbol: !hideStandardSymbols
+        case .extraSymbol: !hideExtraSymbols
+        case .number, .functional: true
+        }
     }
 
     private func persistIfNeeded(_ value: some Any, forKey key: SettingsKey) {

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -108,6 +108,7 @@ final class KeyboardViewModel: ObservableObject {
 
     let hapticSettings: HapticSettings
     let layoutSettings: LayoutSettings
+    let labelVisibilitySettings: LabelVisibilitySettings
     private let hapticManager: HapticFeedbackManager
 
     // MARK: - Computed Properties for Backward Compatibility
@@ -173,6 +174,7 @@ final class KeyboardViewModel: ObservableObject {
         // Initialize extracted settings classes
         hapticSettings = HapticSettings(defaults: defaults, shouldPersist: shouldPersistSettings)
         layoutSettings = LayoutSettings(defaults: defaults, shouldPersist: shouldPersistSettings)
+        labelVisibilitySettings = LabelVisibilitySettings(defaults: defaults, shouldPersist: shouldPersistSettings)
         hapticManager = HapticFeedbackManager(settings: hapticSettings)
 
         // Load layout based on selected language or use provided layout
@@ -195,6 +197,9 @@ final class KeyboardViewModel: ObservableObject {
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &settingsCancellables)
         layoutSettings.objectWillChange
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &settingsCancellables)
+        labelVisibilitySettings.objectWillChange
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &settingsCancellables)
 
@@ -256,6 +261,7 @@ final class KeyboardViewModel: ObservableObject {
         // Delegate to extracted settings classes - eliminates duplicate code
         hapticSettings.reload()
         layoutSettings.reload()
+        labelVisibilitySettings.reload()
 
         // Reload language if it changed
         reloadLanguage()
@@ -314,7 +320,11 @@ final class KeyboardViewModel: ObservableObject {
     }
 
     func displayText(for key: MessagEaseKey) -> String {
-        switch activeLayer {
+        // Hide the center label when its category is toggled off in settings.
+        // Numbers (in .numbers layer) and functional characters are never hidden.
+        let category = LabelCategory.classify(key.center)
+        guard labelVisibilitySettings.isVisible(category) else { return "" }
+        return switch activeLayer {
         case .lower:
             key.center.lowercased()
         case .upper:

--- a/wurstfingerKeyboard/LabelCategory.swift
+++ b/wurstfingerKeyboard/LabelCategory.swift
@@ -1,0 +1,68 @@
+//
+//  LabelCategory.swift
+//  Wurstfinger
+//
+//  Classification of key outputs for label visibility toggling.
+//
+
+import Foundation
+
+/// Classifies a key label for visibility toggling.
+/// Letters, standard symbols, and extra symbols can each be independently hidden.
+/// Numbers and functional labels are always visible.
+enum LabelCategory {
+    /// Alphabetic characters (a-z, ä, ö, ß, etc.)
+    case letter
+    /// Common everyday punctuation (. , ! ? - + / = ( ) @ * " ' : ; & ° € %)
+    case standardSymbol
+    /// Technical/rare symbols ($ ^ ~ ` ´ \ { } [ ] | _ < > # tab ∫ ∏ ∑ …)
+    case extraSymbol
+    /// Digits (0-9, superscripts) — never hidden
+    case number
+    /// Control keys (Shift, Symbols toggle, capitalizeWord, etc.) — never hidden
+    case functional
+
+    /// Whether this category participates in user-controlled visibility toggling.
+    var isHideable: Bool {
+        switch self {
+        case .letter, .standardSymbol, .extraSymbol: true
+        case .number, .functional: false
+        }
+    }
+}
+
+extension LabelCategory {
+    /// Characters classified as "standard" everyday punctuation.
+    /// Everything not in this set and not a letter/digit is treated as .extraSymbol.
+    private static let standardSymbolCharacters: Set<Character> = [
+        ".", ",", "!", "?", "-", "+", "/", "=",
+        "(", ")", "@", "*", "\"", "'", ":", ";",
+        "&", "°", "€", "%"
+    ]
+
+    /// Classifies a plain text label by its first character.
+    /// Letters and digits are recognized via Unicode properties;
+    /// symbols fall back to an explicit standard set.
+    static func classify(_ text: String) -> LabelCategory {
+        guard let first = text.first else { return .extraSymbol }
+        if first.isLetter { return .letter }
+        if first.isNumber { return .number }
+        if standardSymbolCharacters.contains(first) { return .standardSymbol }
+        return .extraSymbol
+    }
+}
+
+extension MessagEaseOutput {
+    /// The display category for this output, used to decide label visibility.
+    var labelCategory: LabelCategory {
+        switch self {
+        case let .text(value):
+            LabelCategory.classify(value)
+        case .compose:
+            // Accent/compose triggers (^, ~, `, ´, ¨, ˘, etc.) are always extra.
+            .extraSymbol
+        case .toggleShift, .toggleSymbols, .capitalizeWord, .cycleAccents:
+            .functional
+        }
+    }
+}

--- a/wurstfingerUITests/wurstfingerUITests.swift
+++ b/wurstfingerUITests/wurstfingerUITests.swift
@@ -85,6 +85,12 @@ final class wurstfingerUITests: XCTestCase {
         // Check main settings rows exist
         XCTAssertTrue(app.staticTexts["Language"].waitForExistence(timeout: 2), "Language row missing")
         XCTAssertTrue(app.staticTexts["Key Aspect Ratio"].exists, "Key Aspect Ratio row missing")
+
+        // Haptic Feedback is in a later section — scroll until visible
+        for _ in 0 ..< 5 {
+            if app.staticTexts["Haptic Feedback"].exists { break }
+            app.swipeUp()
+        }
         XCTAssertTrue(app.staticTexts["Haptic Feedback"].exists, "Haptic Feedback row missing")
 
         // Version is in the About section at the bottom — scroll until visible
@@ -113,6 +119,12 @@ final class wurstfingerUITests: XCTestCase {
     @MainActor
     func testSettingsHapticFeedbackNavigation() {
         app.tabBars.buttons["Settings"].tap()
+
+        // Haptic Feedback is in a later section — scroll until visible
+        for _ in 0 ..< 5 {
+            if app.staticTexts["Haptic Feedback"].exists { break }
+            app.swipeUp()
+        }
 
         // Tap on Haptic Feedback row
         app.staticTexts["Haptic Feedback"].tap()


### PR DESCRIPTION
## Summary
- Adds three independent toggles to hide letters, standard symbols, and extra symbols on the keyboard so users can practice the MessagEase layout from memory
- Introduces a character-based `LabelCategory` classification so language-specific overrides (ä, ö, ü, …) inherit the correct category automatically
- New `Label Visibility` settings screen with a live `InteractiveKeyboardPreview`
- Numbers and functional keys are never hidden

Closes #87

## Implementation notes
- `LabelCategory.swift`: classifies a character into `letter` / `standardSymbol` / `extraSymbol` / `number` / `functional`; also exposes `MessagEaseOutput.labelCategory` for hint labels
- `LabelVisibilitySettings`: `SharedDefaults`-backed `ObservableObject`, same pattern as `HapticSettings` / `LayoutSettings`; wired into `KeyboardViewModel`
- `KeyboardViewModel.displayText(for:)` returns an empty string when the center character's category is hidden
- `KeyHintOverlay` consults the settings per direction and skips rendering hidden hints
- Host app: `LabelVisibilitySettingsView` with three "Show …" toggles (inverted bindings against the `hide*` keys) and a footer explaining the feature; linked from the Appearance section of `SettingsView`
- Defaults (`false` for all three) registered in `wurstfingerApp.init()`

## Test plan
- [x] `xcodebuild build` on iPhone 17 Pro simulator (iOS 26)
- [x] Full test suite: 548/548 passing
- [x] Existing Settings UI tests updated with scroll loops since the new row pushes "Haptic Feedback" off-screen
- [ ] Manual smoke test in simulator: toggle each category and confirm the preview + real keyboard update, and numbers/functional keys stay visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Label Visibility" settings screen to customize keyboard display.
  * Users can independently toggle the visibility of letters, standard symbols, and extra symbols on keys.
  * Preferences are automatically saved and persist across app sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->