### PR TITLE
Fix visual regressions in data-driven keyboard (PR 14)

### DIFF
--- a/wurstfingerKeyboard/CommonKeys.swift
+++ b/wurstfingerKeyboard/CommonKeys.swift
@@ -46,23 +46,26 @@ enum CommonKeys {
         accessibilityLabel: "Zeilenumbruch"
     )
 
+    /// Clipboard swipe bindings shared between the symbols key and numeric back-to-main key.
+    static let clipboardSwipes: [GestureType: KeyBinding] = [
+        .swipeUp: KeyBinding(
+            label: "", action: .copy, category: .utility,
+            returnAction: nil, accessibilityLabel: "Kopieren"
+        ),
+        .swipeUpRight: KeyBinding(
+            label: "", action: .cut, category: .utility,
+            returnAction: nil, accessibilityLabel: "Ausschneiden"
+        ),
+        .swipeDown: KeyBinding(
+            label: "", action: .paste, category: .utility,
+            returnAction: nil, accessibilityLabel: "Einsetzen"
+        ),
+    ]
+
     static let symbols = KeyConfig.utility(
         UtilitySlot.symbols, label: "123", action: .switchMode(ModeNames.numeric),
         swipeMode: .eightWay,
-        swipes: [
-            .swipeUp: KeyBinding(
-                label: "", action: .copy, category: .utility,
-                returnAction: nil, accessibilityLabel: "Kopieren"
-            ),
-            .swipeUpRight: KeyBinding(
-                label: "", action: .cut, category: .utility,
-                returnAction: nil, accessibilityLabel: "Ausschneiden"
-            ),
-            .swipeDown: KeyBinding(
-                label: "", action: .paste, category: .utility,
-                returnAction: nil, accessibilityLabel: "Einsetzen"
-            ),
-        ]
+        swipes: clipboardSwipes
     )
 
     static let spacebar = KeyConfig(

--- a/wurstfingerKeyboard/CommonKeys.swift
+++ b/wurstfingerKeyboard/CommonKeys.swift
@@ -148,7 +148,7 @@ enum CommonKeys {
 
         GridSlot.topRight: [
             .swipeUpRight: KeyBinding(
-                label: "⏎", action: .commitText("\n"), category: nil,
+                label: "", action: .commitText("\n"), category: nil,
                 returnAction: .commitText("\n"), accessibilityLabel: nil
             ),
             .swipeDownRight: KeyBinding(
@@ -291,7 +291,7 @@ enum CommonKeys {
                 returnAction: .commitText("›"), accessibilityLabel: nil
             ),
             .swipeDownRight: KeyBinding(
-                label: "⎵", action: .commitText(" "), category: nil,
+                label: "", action: .commitText(" "), category: nil,
                 returnAction: .commitText(" "), accessibilityLabel: nil
             ),
             .swipeDownLeft: KeyBinding(

--- a/wurstfingerKeyboard/CommonKeys.swift
+++ b/wurstfingerKeyboard/CommonKeys.swift
@@ -12,10 +12,28 @@ import Foundation
 enum CommonKeys {
     // MARK: - Utility Keys
 
-    static let globe = KeyConfig.utility(
-        UtilitySlot.globe, label: "🌐", action: .advanceToNextInputMode,
-        accessibilityLabel: "Tastatur wechseln"
-    )
+    static let globe: KeyConfig = {
+        var bindings: [GestureType: KeyBinding] = [:]
+        bindings[.tap] = KeyBinding(
+            label: "", action: .advanceToNextInputMode,
+            category: .utility, returnAction: nil,
+            accessibilityLabel: "Tastatur wechseln"
+        )
+        bindings[.swipeLeft] = KeyBinding(
+            label: "🌐", action: .advanceToNextInputMode,
+            category: .utility, returnAction: nil, accessibilityLabel: nil
+        )
+        bindings[.swipeDown] = KeyBinding(
+            label: "⌨↓", action: .dismissKeyboard,
+            category: .utility, returnAction: nil,
+            accessibilityLabel: "Tastatur ausblenden"
+        )
+        return KeyConfig(
+            id: UtilitySlot.globe, bindings: bindings,
+            swipeMode: .fourWayCross, slideType: .none,
+            style: .utility, tapCycleActions: nil
+        )
+    }()
 
     static let delete = KeyConfig.utility(
         UtilitySlot.delete, label: "⌫", action: .deleteBackward,
@@ -29,12 +47,36 @@ enum CommonKeys {
     )
 
     static let symbols = KeyConfig.utility(
-        UtilitySlot.symbols, label: "123", action: .switchMode(ModeNames.numeric)
+        UtilitySlot.symbols, label: "123", action: .switchMode(ModeNames.numeric),
+        swipeMode: .eightWay,
+        swipes: [
+            .swipeUp: KeyBinding(
+                label: "copy", action: .copy, category: .utility,
+                returnAction: nil, accessibilityLabel: "Kopieren"
+            ),
+            .swipeUpRight: KeyBinding(
+                label: "cut", action: .cut, category: .utility,
+                returnAction: nil, accessibilityLabel: "Ausschneiden"
+            ),
+            .swipeDown: KeyBinding(
+                label: "paste", action: .paste, category: .utility,
+                returnAction: nil, accessibilityLabel: "Einsetzen"
+            ),
+        ]
     )
 
-    static let spacebar = KeyConfig.utility(
-        UtilitySlot.space, label: "␣", action: .space,
-        slideType: .moveCursor
+    static let spacebar = KeyConfig(
+        id: UtilitySlot.space,
+        bindings: [
+            .tap: KeyBinding(
+                label: "␣", action: .space, category: .utility,
+                returnAction: nil, accessibilityLabel: nil
+            ),
+        ],
+        swipeMode: .none,
+        slideType: .moveCursor,
+        style: .spacebar,
+        tapCycleActions: nil
     )
 
     /// All utility keys as dictionary, mergeable with language keys.
@@ -56,7 +98,7 @@ enum CommonKeys {
 
         GridSlot.topLeft: [
             .swipeUpLeft: KeyBinding(
-                label: "àá", action: .cycleAccents, category: .compose,
+                label: "\u{1F152}", action: .cycleAccents, category: .compose,
                 returnAction: .cycleAccents, accessibilityLabel: nil
             ),
             .swipeRight: KeyBinding(
@@ -64,7 +106,7 @@ enum CommonKeys {
                 returnAction: .commitText("÷"), accessibilityLabel: nil
             ),
             .swipeDownLeft: KeyBinding(
-                label: "$", action: .commitText("$"), category: nil,
+                label: "$", action: .compose(trigger: "$"), category: .compose,
                 returnAction: .commitText("¥"), accessibilityLabel: nil
             ),
         ],
@@ -187,7 +229,7 @@ enum CommonKeys {
 
         GridSlot.bottomLeft: [
             .swipeUpLeft: KeyBinding(
-                label: "~", action: .commitText("~"), category: nil,
+                label: "~", action: .compose(trigger: "~"), category: .compose,
                 returnAction: .commitText("˜"), accessibilityLabel: nil
             ),
             .swipeUp: KeyBinding(
@@ -195,7 +237,7 @@ enum CommonKeys {
                 returnAction: .commitText("˝"), accessibilityLabel: nil
             ),
             .swipeRight: KeyBinding(
-                label: "*", action: .commitText("*"), category: nil,
+                label: "*", action: .compose(trigger: "*"), category: .compose,
                 returnAction: .commitText("†"), accessibilityLabel: nil
             ),
             .swipeDownRight: KeyBinding(
@@ -241,7 +283,7 @@ enum CommonKeys {
                 returnAction: .commitText("§"), accessibilityLabel: nil
             ),
             .swipeUpRight: KeyBinding(
-                label: "°", action: .commitText("°"), category: nil,
+                label: "°", action: .compose(trigger: "°"), category: .compose,
                 returnAction: .commitText("º"), accessibilityLabel: nil
             ),
             .swipeRight: KeyBinding(

--- a/wurstfingerKeyboard/CommonKeys.swift
+++ b/wurstfingerKeyboard/CommonKeys.swift
@@ -20,11 +20,11 @@ enum CommonKeys {
             accessibilityLabel: "Tastatur wechseln"
         )
         bindings[.swipeLeft] = KeyBinding(
-            label: "🌐", action: .advanceToNextInputMode,
+            label: "", action: .advanceToNextInputMode,
             category: .utility, returnAction: nil, accessibilityLabel: nil
         )
         bindings[.swipeDown] = KeyBinding(
-            label: "⌨↓", action: .dismissKeyboard,
+            label: "", action: .dismissKeyboard,
             category: .utility, returnAction: nil,
             accessibilityLabel: "Tastatur ausblenden"
         )
@@ -51,15 +51,15 @@ enum CommonKeys {
         swipeMode: .eightWay,
         swipes: [
             .swipeUp: KeyBinding(
-                label: "copy", action: .copy, category: .utility,
+                label: "", action: .copy, category: .utility,
                 returnAction: nil, accessibilityLabel: "Kopieren"
             ),
             .swipeUpRight: KeyBinding(
-                label: "cut", action: .cut, category: .utility,
+                label: "", action: .cut, category: .utility,
                 returnAction: nil, accessibilityLabel: "Ausschneiden"
             ),
             .swipeDown: KeyBinding(
-                label: "paste", action: .paste, category: .utility,
+                label: "", action: .paste, category: .utility,
                 returnAction: nil, accessibilityLabel: "Einsetzen"
             ),
         ]

--- a/wurstfingerKeyboard/CommonKeys.swift
+++ b/wurstfingerKeyboard/CommonKeys.swift
@@ -73,7 +73,7 @@ enum CommonKeys {
         bindings: [
             .tap: KeyBinding(
                 label: "␣", action: .space, category: .utility,
-                returnAction: nil, accessibilityLabel: nil
+                returnAction: nil, accessibilityLabel: "Leerzeichen"
             ),
         ],
         swipeMode: .none,

--- a/wurstfingerKeyboard/ComposeMiddleware.swift
+++ b/wurstfingerKeyboard/ComposeMiddleware.swift
@@ -2,26 +2,30 @@
 //  ComposeMiddleware.swift
 //  Wurstfinger
 //
-//  Resolves .compose actions into concrete .commitText actions.
+//  Resolves .compose and .cycleAccents actions.
 //
 
 import Foundation
 
-/// Transforms `.compose(trigger)` into `.commitText(result)` when the
-/// previous character combined with `trigger` has a compose rule.
+/// Handles compose-related actions:
 ///
-/// If no rule matches, the action is transformed to `.commitText(trigger)`
-/// so the user still gets the literal character. Non-compose actions are
-/// passed through untouched.
+/// - `.compose(trigger)`: checks `ComposeEngine` for a rule combining the
+///   previous character with the trigger. Inserts the trigger as plain text
+///   when no rule matches.
+/// - `.cycleAccents`: cycles through accent variants of the previous character.
+///
+/// All other actions pass through untouched.
 ///
 /// The compose lookup and document access are injected as closures so this
-/// file does not depend on `ComposeEngine` or `UITextDocumentProxy` —
-/// `ComposeEngine` is excluded from the `WurstfingerApp` target, and
-/// avoiding `UITextDocumentProxy` keeps the middleware unit-testable.
+/// file does not depend on `ComposeEngine` or `UITextDocumentProxy`.
 struct ComposeMiddleware: ActionMiddleware {
     /// Looks up `(previous, trigger) → replacement`. Returns nil when no
     /// rule applies.
     let compose: (_ previous: String, _ trigger: String) -> String?
+
+    /// Cycles through accent variants for a character (ä → â → à → …).
+    /// Returns nil when no cycle exists.
+    let cycleAccent: (_ character: String) -> String?
 
     /// Reads the last character before the cursor. Empty string when
     /// there is no preceding character.
@@ -32,20 +36,32 @@ struct ComposeMiddleware: ActionMiddleware {
     let deletePreviousCharacter: () -> Void
 
     func process(_ context: ActionContext, next: (ActionContext) -> Void) {
-        guard case let .compose(trigger) = context.action else {
-            next(context)
-            return
-        }
+        switch context.action {
+        case let .compose(trigger):
+            var transformed = context
+            let previous = previousCharacter()
+            if !previous.isEmpty, let replacement = compose(previous, trigger) {
+                deletePreviousCharacter()
+                transformed.action = .commitText(replacement)
+            } else {
+                // No rule — insert the trigger as plain text.
+                transformed.action = .commitText(trigger)
+            }
+            next(transformed)
 
-        var transformed = context
-        let previous = previousCharacter()
-        if !previous.isEmpty, let replacement = compose(previous, trigger) {
+        case .cycleAccents:
+            let previous = previousCharacter()
+            guard !previous.isEmpty, let replacement = cycleAccent(previous) else {
+                next(context)
+                return
+            }
+            var transformed = context
             deletePreviousCharacter()
             transformed.action = .commitText(replacement)
-        } else {
-            // No rule — insert the trigger as plain text.
-            transformed.action = .commitText(trigger)
+            next(transformed)
+
+        default:
+            next(context)
         }
-        next(transformed)
     }
 }

--- a/wurstfingerKeyboard/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/DataDrivenKeyboardRootView.swift
@@ -14,27 +14,60 @@ import SwiftUI
 struct DataDrivenKeyboardRootView: View {
     @ObservedObject var viewModel: KeyboardViewModel
 
+    /// Optional width override used by InteractiveKeyboardPreview.
+    /// When nil, falls back to `viewModel.viewWidth`.
+    var overrideWidth: CGFloat?
+
+    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
+    private var keyboardStyle: KeyboardStyle = .classic
+
     var body: some View {
-        if let mode = viewModel.activeModeFromDefinition,
-           let arrangement = mode.arrangement(for: viewModel.currentContext) {
-            KeyboardGridView(
-                arrangement: arrangement,
-                keys: mode.keys,
-                onGesture: { key, gesture, isReturn in
-                    viewModel.handleGesture(gesture, keyId: key.id, isReturn: isReturn)
-                },
-                onTouchDown: {
-                    viewModel.feedbackTap()
-                },
-                onSlide: { key, phase in
-                    viewModel.handleSlide(key, phase: phase)
-                }
-            )
-            .scaleEffect(viewModel.keyboardScale)
-            .frame(maxWidth: .infinity)
-        } else {
-            // Fallback: show nothing while definition loads.
-            // This should only flash for a single frame at most.
+        let screenBounds = DeviceLayoutUtils.screenBounds
+        let screenShortestSide = min(screenBounds.width, screenBounds.height)
+        let currentWidth = overrideWidth ?? viewModel.viewWidth
+        let baseWidth = min(currentWidth, screenShortestSide)
+        let scaledWidth = baseWidth * viewModel.keyboardScale
+        let availableSpace = currentWidth - scaledWidth
+        let horizontalOffset = availableSpace * (viewModel.keyboardHorizontalPosition - 0.5)
+
+        ZStack {
+            keyboardBackground
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            if let mode = viewModel.activeModeFromDefinition,
+               let arrangement = mode.arrangement(for: viewModel.currentContext) {
+                KeyboardGridView(
+                    arrangement: arrangement,
+                    keys: mode.keys,
+                    activeModeName: viewModel.activeModeName,
+                    onGesture: { key, gesture, isReturn in
+                        viewModel.handleGesture(gesture, keyId: key.id, isReturn: isReturn)
+                    },
+                    onTouchDown: {
+                        viewModel.feedbackTap()
+                    },
+                    onSlide: { key, phase in
+                        viewModel.handleSlide(key, phase: phase)
+                    }
+                )
+                .padding(.horizontal, KeyboardConstants.Layout.horizontalPadding)
+                .padding(.top, KeyboardConstants.Layout.verticalPaddingTop)
+                .padding(.bottom, KeyboardConstants.Layout.verticalPaddingBottom)
+                .frame(width: scaledWidth)
+                .offset(x: horizontalOffset)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Background
+
+    @ViewBuilder
+    private var keyboardBackground: some View {
+        switch keyboardStyle {
+        case .classic:
+            Color(.systemBackground)
+        case .liquidGlass:
             Color.clear
         }
     }

--- a/wurstfingerKeyboard/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/DataDrivenKeyboardRootView.swift
@@ -39,7 +39,6 @@ struct DataDrivenKeyboardRootView: View {
                 KeyboardGridView(
                     arrangement: arrangement,
                     keys: mode.keys,
-                    activeModeName: viewModel.activeModeName,
                     onGesture: { key, gesture, isReturn in
                         viewModel.handleGesture(gesture, keyId: key.id, isReturn: isReturn)
                     },

--- a/wurstfingerKeyboard/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/GridKeyboardFactory.swift
@@ -93,15 +93,16 @@ enum GridKeyboardFactory {
             doubleTapMode: nil
         )
 
-        // 4. Shifted — generated from base (keeps shift-down "⇩" hint).
-        //    Shift-up points directly to capsLock (label stays ⇧).
-        let shiftedMode = baseMode.generateShifted(locale: locale)
+        // Generate the shifted base once and derive both shifted + caps lock.
+        let shiftedBase = baseMode.generateShifted(locale: locale)
+
+        // 4. Shifted — shift-up points directly to capsLock (label stays ⇧).
+        let shiftedMode = shiftedBase
             .with(autoTransitions: [.letter: ModeNames.main])
             .replacingShiftUpBinding(label: "⇧", action: .switchMode(ModeNames.capsLock))
 
-        // 5. Caps lock — generated from base (keeps shift-down "⇩" hint).
-        //    Shift-up is no-op (stays in capsLock), label shows ⇪.
-        let capsLockMode = baseMode.generateShifted(locale: locale)
+        // 5. Caps lock — shift-up is no-op (stays in capsLock), label shows ⇪.
+        let capsLockMode = shiftedBase
             .with(name: ModeNames.capsLock)
             .replacingShiftUpBinding(label: "⇪", action: .switchMode(ModeNames.capsLock))
 

--- a/wurstfingerKeyboard/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/GridKeyboardFactory.swift
@@ -52,12 +52,18 @@ enum GridKeyboardFactory {
                 // Start with shared defaults for this slot
                 var bindings = CommonKeys.defaultSlotBindings[slotId] ?? [:]
 
-                // Apply language-specific overrides (replace default binding for that gesture)
+                // Apply language-specific overrides (replace default binding for that gesture).
+                // Letters get an auto-generated uppercase return action matching the
+                // old KeyboardLayout behavior (return swipe = uppercase).
                 if let overrides = directionalOverrides[slotId] {
                     for (gesture, text) in overrides {
+                        let isLetter = text.unicodeScalars.contains { CharacterSet.letters.contains($0) }
+                        let returnAction: KeyAction? = isLetter
+                            ? .commitText(text.uppercased(with: locale))
+                            : nil
                         bindings[gesture] = KeyBinding(
                             label: text, action: .commitText(text),
-                            category: nil, returnAction: nil, accessibilityLabel: nil
+                            category: nil, returnAction: returnAction, accessibilityLabel: nil
                         )
                     }
                 }

--- a/wurstfingerKeyboard/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/GridKeyboardFactory.swift
@@ -84,8 +84,8 @@ enum GridKeyboardFactory {
         // 2. Merge utility keys
         let allKeys = letterKeys.merging(CommonKeys.allUtilityKeys) { letter, _ in letter }
 
-        // 3. Main mode — stays active, no auto-transitions
-        let mainMode = KeyboardMode(
+        // 3. Build base mode with all keys (includes shift-down on midRight)
+        let baseMode = KeyboardMode(
             name: ModeNames.main,
             keys: allKeys,
             arrangements: arrangements,
@@ -93,15 +93,24 @@ enum GridKeyboardFactory {
             doubleTapMode: nil
         )
 
-        // 4. Shifted — after typing a letter, returns to main
-        let shiftedMode = mainMode.generateShifted(locale: locale)
-            .with(autoTransitions: [.letter: ModeNames.main], doubleTapMode: ModeNames.capsLock)
+        // 4. Shifted — generated from base (keeps shift-down "⇩" hint).
+        //    Shift-up points directly to capsLock (label stays ⇧).
+        let shiftedMode = baseMode.generateShifted(locale: locale)
+            .with(autoTransitions: [.letter: ModeNames.main])
+            .replacingShiftUpBinding(label: "⇧", action: .switchMode(ModeNames.capsLock))
 
-        // 5. Caps lock — like shifted but stays active
-        let capsLockMode = mainMode.generateShifted(locale: locale)
+        // 5. Caps lock — generated from base (keeps shift-down "⇩" hint).
+        //    Shift-up is no-op (stays in capsLock), label shows ⇪.
+        let capsLockMode = baseMode.generateShifted(locale: locale)
             .with(name: ModeNames.capsLock)
+            .replacingShiftUpBinding(label: "⇪", action: .switchMode(ModeNames.capsLock))
 
-        // 6. Assemble definition
+        // 6. Main mode — remove shift-down hint from midRight.
+        //    Old code hid "⇩" in lower layer; we replicate by omitting the binding.
+        let mainMode = baseMode
+            .removingBinding(keyId: GridSlot.midRight, gesture: .swipeDown)
+
+        // 7. Assemble definition
         return KeyboardDefinition(
             title: title,
             id: id,

--- a/wurstfingerKeyboard/GridSlot.swift
+++ b/wurstfingerKeyboard/GridSlot.swift
@@ -19,6 +19,8 @@ enum GridSlot {
     static let bottomLeft = "bottomLeft"
     static let bottomCenter = "bottomCenter"
     static let bottomRight = "bottomRight"
+    /// Extra slot for the "0" digit key (only used in numeric mode).
+    static let zero = "zero"
 
     /// Ordered list of all slots (for mapping from centerCharacters arrays)
     static let allSlots: [[String]] = [

--- a/wurstfingerKeyboard/KeyView.swift
+++ b/wurstfingerKeyboard/KeyView.swift
@@ -17,7 +17,6 @@ import SwiftUI
 /// swipe/tap/circular gesture classification.
 struct KeyView: View {
     let key: KeyConfig
-    let activeModeName: String
     let onGesture: (KeyConfig, GestureType, Bool) -> Void
     var onTouchDown: (() -> Void)?
     var onSlide: ((KeyConfig, SlidePhase) -> Void)?
@@ -52,6 +51,7 @@ struct KeyView: View {
             label
             hintOverlay
         }
+        .frame(height: effectiveKeyHeight)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityAddTraits(.isButton)
@@ -136,20 +136,13 @@ struct KeyView: View {
         style == .utility
     }
 
-    /// Background fill for the key. Highlighted styles get a slightly tinted
-    /// background to distinguish them from primary keys.
+    /// Background fill for the key. All keys share the same background,
+    /// matching the old uniform `secondarySystemBackground` / `tertiarySystemFill`.
     static func backgroundColor(for style: KeyStyle, active: Bool = false) -> Color {
         if active {
-            return Color(.systemGray3)
+            return Color(.tertiarySystemFill)
         }
-        switch style {
-        case .primary, .accent:
-            return Color(.systemGray5)
-        case .secondary:
-            return Color(.systemGray6)
-        case .utility, .spacebar:
-            return Color(.systemGray4)
-        }
+        return Color(.secondarySystemBackground)
     }
 
     // MARK: - Gesture Selection
@@ -210,15 +203,6 @@ struct KeyView: View {
         .swipeDownRight: .bottomTrailing,
     ]
 
-    /// Returns true if the binding switches to the mode we're already in —
-    /// these hints are hidden because the action is a no-op.
-    private func isSwitchToCurrentMode(_ binding: KeyBinding) -> Bool {
-        if case let .switchMode(target) = binding.action {
-            return target == activeModeName
-        }
-        return false
-    }
-
     /// Maps certain key actions to SF Symbol names for hint rendering.
     /// Matches the old GlobeKeyHintOverlay / SymbolsKeyHintOverlay icons.
     private static func hintIcon(for action: KeyAction) -> String? {
@@ -271,8 +255,8 @@ struct KeyView: View {
 
             ForEach(Array(key.bindings.keys), id: \.self) { gesture in
                 if let binding = key.bindings[gesture],
-                   let alignment = Self.hintAlignments[gesture],
-                   !isSwitchToCurrentMode(binding) {
+                   !binding.label.isEmpty,
+                   let alignment = Self.hintAlignments[gesture] {
                     hintContent(for: binding)
                         .fixedSize()
                         .padding(Self.hintEdgePadding(for: gesture, horizontal: hPad, vertical: vPad))
@@ -287,13 +271,29 @@ struct KeyView: View {
         .allowsHitTesting(false)
     }
 
+    /// Whether the icon is a "globe-style" hint (globe, dismiss) that gets
+    /// larger, bolder styling vs. a "symbols-style" hint (copy, paste, cut).
+    private static func isGlobeStyleIcon(for action: KeyAction) -> Bool {
+        switch action {
+        case .advanceToNextInputMode, .dismissKeyboard: true
+        default: false
+        }
+    }
+
     @ViewBuilder
     private func hintContent(for binding: KeyBinding) -> some View {
         if let iconName = Self.hintIcon(for: binding.action) {
-            // SF Symbol for utility actions (copy, paste, cut, dismiss)
-            Image(systemName: iconName)
-                .font(.system(size: scaledHintFontSize * 0.6, weight: .regular))
-                .foregroundStyle(Color.secondary.opacity(0.45))
+            if Self.isGlobeStyleIcon(for: binding.action) {
+                // Globe / dismiss: larger, bolder (old GlobeKeyHintOverlay)
+                Image(systemName: iconName)
+                    .font(.system(size: scaledHintFontSize * 0.75, weight: .medium))
+                    .foregroundStyle(Color.primary.opacity(0.5))
+            } else {
+                // Copy / paste / cut: smaller, lighter (old SymbolsKeyHintOverlay)
+                Image(systemName: iconName)
+                    .font(.system(size: scaledHintFontSize * 0.6, weight: .regular))
+                    .foregroundStyle(Color.secondary.opacity(0.45))
+            }
         } else {
             // Text hint — letters get higher prominence than symbols
             let isLetter = binding.label.first?.isLetter ?? false

--- a/wurstfingerKeyboard/KeyView.swift
+++ b/wurstfingerKeyboard/KeyView.swift
@@ -69,7 +69,7 @@ struct KeyView: View {
                 onGestureRecognized: { classification in
                     onGesture(key, classification.gesture, classification.isReturn)
                 },
-                onTouchDown: onTouchDown,
+                onTouchDown: { onTouchDown?() },
                 aspectRatio: keyAspectRatio,
                 isActive: $isActive
             ))

--- a/wurstfingerKeyboard/KeyView.swift
+++ b/wurstfingerKeyboard/KeyView.swift
@@ -17,12 +17,29 @@ import SwiftUI
 /// swipe/tap/circular gesture classification.
 struct KeyView: View {
     let key: KeyConfig
+    let activeModeName: String
     let onGesture: (KeyConfig, GestureType, Bool) -> Void
     var onTouchDown: (() -> Void)?
     var onSlide: ((KeyConfig, SlidePhase) -> Void)?
     var spanRatio: CGFloat = 1.0
 
     @State private var isActive = false
+
+    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
+    private var keyboardStyle: KeyboardStyle = .classic
+
+    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
+    private var keyboardScale: Double = DeviceLayoutUtils.defaultKeyboardScale
+
+    @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
+    private var keyAspectRatio: Double = DeviceLayoutUtils.defaultKeyAspectRatio
+
+    /// Maps emoji labels to SF Symbol names for utility keys.
+    private static let sfSymbolMap: [String: String] = [
+        "🌐": "globe",
+        "⌫": "delete.backward",
+        "↵": "return",
+    ]
 
     var body: some View {
         keyContent
@@ -52,8 +69,8 @@ struct KeyView: View {
                 onGestureRecognized: { classification in
                     onGesture(key, classification.gesture, classification.isReturn)
                 },
-                onTouchDown: { onTouchDown?() },
-                aspectRatio: spanRatio,
+                onTouchDown: onTouchDown,
+                aspectRatio: keyAspectRatio,
                 isActive: $isActive
             ))
         }
@@ -77,9 +94,8 @@ struct KeyView: View {
         return primaryLabel
     }
 
-    /// Font size derived from the visual style. Pure function so it can be
-    /// unit tested without rendering the SwiftUI tree.
-    static func fontSize(for style: KeyStyle) -> CGFloat {
+    /// Base font size derived from the visual style.
+    static func baseFontSize(for style: KeyStyle) -> CGFloat {
         switch style {
         case .primary:
             KeyboardConstants.FontSizes.mainLabelBaseSize
@@ -92,6 +108,27 @@ struct KeyView: View {
         case .accent:
             KeyboardConstants.FontSizes.mainLabelBaseSize
         }
+    }
+
+    /// Effective key height accounting for both keyboard scale and aspect ratio,
+    /// matching the old `KeyboardRootView` calculation.
+    private var effectiveKeyHeight: CGFloat {
+        KeyboardConstants.Calculations.keyHeight(aspectRatio: keyAspectRatio) * keyboardScale
+    }
+
+    /// Scaled font size proportional to effective key height, matching the old
+    /// `scaledMainLabelSize(for:)` behavior in KeyboardRootView.
+    private var scaledFontSize: CGFloat {
+        let base = Self.baseFontSize(for: key.style)
+        let scaled = base * (effectiveKeyHeight / KeyboardConstants.FontSizes.mainLabelReferenceHeight)
+        return min(max(scaled, KeyboardConstants.FontSizes.mainLabelMinSize), KeyboardConstants.FontSizes.mainLabelMaxSize)
+    }
+
+    /// Scaled hint font size proportional to effective key height.
+    private var scaledHintFontSize: CGFloat {
+        let base = KeyboardConstants.FontSizes.hintBaseSize
+        let scaled = base * (effectiveKeyHeight / KeyboardConstants.FontSizes.hintReferenceHeight)
+        return min(max(scaled, KeyboardConstants.FontSizes.hintMinSize), KeyboardConstants.FontSizes.hintMaxSize)
     }
 
     /// Whether the key should be rendered as an icon-only key (no text label).
@@ -125,15 +162,37 @@ struct KeyView: View {
 
     // MARK: - View Construction
 
+    @ViewBuilder
     private var background: some View {
-        RoundedRectangle(cornerRadius: KeyboardConstants.KeyDimensions.cornerRadius)
-            .fill(Self.backgroundColor(for: key.style, active: isActive))
+        let shape = RoundedRectangle(cornerRadius: KeyboardConstants.KeyDimensions.cornerRadius)
+        switch keyboardStyle {
+        case .classic:
+            shape.fill(Self.backgroundColor(for: key.style, active: isActive))
+        case .liquidGlass:
+            shape.fill(.bar)
+                .overlay(
+                    shape.strokeBorder(Color.primary.opacity(0.1), lineWidth: 0.5)
+                )
+        }
     }
 
+    @ViewBuilder
     private var label: some View {
-        Text(primaryLabel)
-            .font(.system(size: Self.fontSize(for: key.style), weight: .regular))
-            .foregroundColor(.primary)
+        if key.style == .spacebar {
+            // Spacebar renders blank, matching the old SpaceKeyButton behavior.
+            EmptyView()
+        } else {
+            let font = Font.system(size: scaledFontSize, weight: .semibold, design: .rounded)
+            if let sfName = Self.sfSymbolMap[primaryLabel] {
+                Image(systemName: sfName)
+                    .font(font)
+                    .foregroundColor(.primary)
+            } else {
+                Text(primaryLabel)
+                    .font(font)
+                    .foregroundColor(.primary)
+            }
+        }
     }
 
     // MARK: - Hint Overlay
@@ -151,20 +210,72 @@ struct KeyView: View {
         .swipeDownRight: .bottomTrailing,
     ]
 
+    /// Returns true if the binding switches to the mode we're already in —
+    /// these hints are hidden because the action is a no-op.
+    private func isSwitchToCurrentMode(_ binding: KeyBinding) -> Bool {
+        if case let .switchMode(target) = binding.action {
+            return target == activeModeName
+        }
+        return false
+    }
+
+    /// Maps certain key actions to SF Symbol names for hint rendering.
+    /// Matches the old GlobeKeyHintOverlay / SymbolsKeyHintOverlay icons.
+    private static func hintIcon(for action: KeyAction) -> String? {
+        switch action {
+        case .advanceToNextInputMode: "globe"
+        case .dismissKeyboard: "keyboard.chevron.compact.down"
+        case .copy: "doc.on.doc"
+        case .paste: "doc.on.clipboard"
+        case .cut: "scissors"
+        default: nil
+        }
+    }
+
+    /// Directional edge padding for hint labels, matching the old
+    /// `KeyboardDirection.edgePadding(horizontal:vertical:)` behavior.
+    /// Padding is only applied on the edges where the hint is aligned,
+    /// keeping hints close to the key border and away from the center label.
+    private static func hintEdgePadding(
+        for gesture: GestureType, horizontal: CGFloat, vertical: CGFloat
+    ) -> EdgeInsets {
+        switch gesture {
+        case .swipeUp:
+            EdgeInsets(top: vertical, leading: 0, bottom: 0, trailing: 0)
+        case .swipeDown:
+            EdgeInsets(top: 0, leading: 0, bottom: vertical, trailing: 0)
+        case .swipeLeft:
+            EdgeInsets(top: 0, leading: horizontal, bottom: 0, trailing: 0)
+        case .swipeRight:
+            EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: horizontal)
+        case .swipeUpLeft:
+            EdgeInsets(top: vertical, leading: horizontal, bottom: 0, trailing: 0)
+        case .swipeUpRight:
+            EdgeInsets(top: vertical, leading: 0, bottom: 0, trailing: horizontal)
+        case .swipeDownLeft:
+            EdgeInsets(top: 0, leading: horizontal, bottom: vertical, trailing: 0)
+        case .swipeDownRight:
+            EdgeInsets(top: 0, leading: 0, bottom: vertical, trailing: horizontal)
+        default:
+            EdgeInsets()
+        }
+    }
+
     private var hintOverlay: some View {
         GeometryReader { proxy in
             let size = proxy.size
+            // Scale padding proportionally with font size, matching old KeyHintOverlay
+            let fontRatio = scaledHintFontSize / KeyboardConstants.FontSizes.hintReferenceFontSize
+            let hPad = KeyboardConstants.FontSizes.hintBaseHorizontalPadding * fontRatio
+            let vPad = KeyboardConstants.FontSizes.hintBaseVerticalPadding * fontRatio
+
             ForEach(Array(key.bindings.keys), id: \.self) { gesture in
                 if let binding = key.bindings[gesture],
-                   let alignment = Self.hintAlignments[gesture] {
-                    Text(binding.label)
-                        .font(.system(
-                            size: KeyboardConstants.FontSizes.hintBaseSize,
-                            weight: .regular
-                        ))
-                        .foregroundColor(.secondary)
+                   let alignment = Self.hintAlignments[gesture],
+                   !isSwitchToCurrentMode(binding) {
+                    hintContent(for: binding)
                         .fixedSize()
-                        .padding(4)
+                        .padding(Self.hintEdgePadding(for: gesture, horizontal: hPad, vertical: vPad))
                         .frame(
                             width: size.width,
                             height: size.height,
@@ -174,5 +285,31 @@ struct KeyView: View {
             }
         }
         .allowsHitTesting(false)
+    }
+
+    @ViewBuilder
+    private func hintContent(for binding: KeyBinding) -> some View {
+        if let iconName = Self.hintIcon(for: binding.action) {
+            // SF Symbol for utility actions (copy, paste, cut, dismiss)
+            Image(systemName: iconName)
+                .font(.system(size: scaledHintFontSize * 0.6, weight: .regular))
+                .foregroundStyle(Color.secondary.opacity(0.45))
+        } else {
+            // Text hint — letters get higher prominence than symbols
+            let isLetter = binding.label.first?.isLetter ?? false
+            Text(binding.label)
+                .font(.system(
+                    size: scaledHintFontSize,
+                    weight: isLetter ? .medium : .regular,
+                    design: .rounded
+                ))
+                .foregroundStyle(
+                    isLetter
+                        ? Color.primary.opacity(0.65)
+                        : Color.secondary.opacity(0.55)
+                )
+                .minimumScaleFactor(0.6)
+                .lineLimit(1)
+        }
     }
 }

--- a/wurstfingerKeyboard/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/KeyboardGridView.swift
@@ -20,6 +20,7 @@ import SwiftUI
 struct KeyboardGridView: View {
     let arrangement: GridArrangement
     let keys: [String: KeyConfig]
+    let activeModeName: String
     let onGesture: (KeyConfig, GestureType, Bool) -> Void
     var onTouchDown: (() -> Void)?
     var onSlide: ((KeyConfig, SlidePhase) -> Void)?
@@ -52,6 +53,7 @@ struct KeyboardGridView: View {
         if let key = keys[placement.keyId] {
             KeyView(
                 key: key,
+                activeModeName: activeModeName,
                 onGesture: onGesture,
                 onTouchDown: onTouchDown,
                 onSlide: onSlide,

--- a/wurstfingerKeyboard/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/KeyboardGridView.swift
@@ -20,7 +20,6 @@ import SwiftUI
 struct KeyboardGridView: View {
     let arrangement: GridArrangement
     let keys: [String: KeyConfig]
-    let activeModeName: String
     let onGesture: (KeyConfig, GestureType, Bool) -> Void
     var onTouchDown: (() -> Void)?
     var onSlide: ((KeyConfig, SlidePhase) -> Void)?
@@ -53,7 +52,6 @@ struct KeyboardGridView: View {
         if let key = keys[placement.keyId] {
             KeyView(
                 key: key,
-                activeModeName: activeModeName,
                 onGesture: onGesture,
                 onTouchDown: onTouchDown,
                 onSlide: onSlide,

--- a/wurstfingerKeyboard/KeyboardMode.swift
+++ b/wurstfingerKeyboard/KeyboardMode.swift
@@ -63,4 +63,47 @@ struct KeyboardMode: Codable, Equatable {
             doubleTapMode: doubleTapMode ?? self.doubleTapMode
         )
     }
+
+    /// Returns a copy with a specific binding removed from a key.
+    func removingBinding(keyId: String, gesture: GestureType) -> KeyboardMode {
+        guard var key = keys[keyId] else { return self }
+        var bindings = key.bindings
+        bindings.removeValue(forKey: gesture)
+        key = KeyConfig(
+            id: key.id, bindings: bindings, swipeMode: key.swipeMode,
+            slideType: key.slideType, style: key.style,
+            tapCycleActions: key.tapCycleActions
+        )
+        var updatedKeys = keys
+        updatedKeys[keyId] = key
+        return KeyboardMode(
+            name: name, keys: updatedKeys, arrangements: arrangements,
+            autoTransitions: autoTransitions, doubleTapMode: doubleTapMode
+        )
+    }
+
+    /// Returns a copy where the shift-up binding on midRight is replaced.
+    /// Used to point shifted → capsLock and capsLock → capsLock (no-op).
+    func replacingShiftUpBinding(label: String, action: KeyAction) -> KeyboardMode {
+        guard var midRight = keys[GridSlot.midRight],
+              let existing = midRight.bindings[.swipeUp]
+        else { return self }
+        var bindings = midRight.bindings
+        bindings[.swipeUp] = KeyBinding(
+            label: label, action: action,
+            category: existing.category, returnAction: existing.returnAction,
+            accessibilityLabel: existing.accessibilityLabel
+        )
+        midRight = KeyConfig(
+            id: midRight.id, bindings: bindings, swipeMode: midRight.swipeMode,
+            slideType: midRight.slideType, style: midRight.style,
+            tapCycleActions: midRight.tapCycleActions
+        )
+        var updatedKeys = keys
+        updatedKeys[GridSlot.midRight] = midRight
+        return KeyboardMode(
+            name: name, keys: updatedKeys, arrangements: arrangements,
+            autoTransitions: autoTransitions, doubleTapMode: doubleTapMode
+        )
+    }
 }

--- a/wurstfingerKeyboard/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel+Pipeline.swift
@@ -220,25 +220,8 @@ extension KeyboardViewModel {
         return true
     }
 
-    /// Handles `.switchMode` actions with double-tap → capsLock detection.
+    /// Handles `.switchMode` actions.
     func handleSwitchMode(_ targetMode: String) {
-        let now = Date()
-        let doubleTapInterval: TimeInterval = 0.4
-
-        if let lastTime = lastSwitchModeTime,
-           let lastTarget = lastSwitchModeTarget,
-           lastTarget == targetMode,
-           now.timeIntervalSince(lastTime) < doubleTapInterval {
-            if let dtMode = currentDefinition?.mode(targetMode)?.doubleTapMode {
-                switchToMode(dtMode)
-                lastSwitchModeTime = nil
-                lastSwitchModeTarget = nil
-                return
-            }
-        }
-
-        lastSwitchModeTime = now
-        lastSwitchModeTarget = targetMode
         switchToMode(targetMode)
     }
 

--- a/wurstfingerKeyboard/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel+Pipeline.swift
@@ -193,14 +193,14 @@ extension KeyboardViewModel {
 
         // 1. Explicit binding for this direction
         if let binding = key.bindings[gesture] {
-            dispatchAction(binding.action)
+            dispatchBinding(binding)
             return
         }
         // 2. Uppercase of center character (letter keys)
         if tryCircularUppercase(key: key) { return }
         // 3. Fallback to opposite direction's binding
         if let binding = key.bindings[opposite] {
-            dispatchAction(binding.action)
+            dispatchBinding(binding)
         }
     }
 
@@ -298,9 +298,15 @@ extension KeyboardViewModel {
         }
     }
 
-    /// Dispatches a raw action through the pipeline.
+    /// Dispatches a raw action through the pipeline (no binding context).
     func dispatchAction(_ action: KeyAction) {
         let context = ActionContext(action: action, binding: nil, mode: activeModeName)
+        pipeline?.process(context)
+    }
+
+    /// Dispatches a binding through the pipeline, preserving its category context.
+    private func dispatchBinding(_ binding: KeyBinding) {
+        let context = ActionContext(action: binding.action, binding: binding, mode: activeModeName)
         pipeline?.process(context)
     }
 }

--- a/wurstfingerKeyboard/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel+Pipeline.swift
@@ -71,10 +71,13 @@ extension KeyboardViewModel {
             self?.triggerHapticTap()
         }))
 
-        // 2. Compose
+        // 2. Compose + Cycle Accents
         middlewares.append(ComposeMiddleware(
             compose: { previous, trigger in
                 ComposeEngine.compose(previous: previous, trigger: trigger)
+            },
+            cycleAccent: { character in
+                ComposeEngine.cycleAccent(for: character)
             },
             previousCharacter: { [weak self] in
                 self?.textInputTarget?.documentContextBeforeInput?.last.map(String.init) ?? ""
@@ -157,6 +160,12 @@ extension KeyboardViewModel {
     func handleGesture(_ gesture: GestureType, keyId: String, isReturn: Bool) {
         guard let mode = activeModeFromDefinition else { return }
 
+        // Circular gestures: try requested direction, fall back to opposite.
+        if gesture == .circularClockwise || gesture == .circularCounterclockwise {
+            handleCircular(keyId: keyId, in: mode, gesture: gesture)
+            return
+        }
+
         let chain = isReturn ? returnSwipeResolverChain : resolverChain
         guard let binding = chain?.resolve(keyId: keyId, gesture: gesture, in: mode) else { return }
 
@@ -174,6 +183,41 @@ extension KeyboardViewModel {
             mode: activeModeName
         )
         pipeline?.process(context)
+    }
+
+    /// Handles a circular gesture. Checks for an explicit binding first
+    /// (e.g. superscripts on the numeric layer), then falls back to
+    /// inserting the uppercase center character, then tries the opposite
+    /// direction's binding.
+    private func handleCircular(keyId: String, in mode: KeyboardMode, gesture: GestureType) {
+        guard let key = mode.key(for: keyId) else { return }
+        let opposite: GestureType = gesture == .circularClockwise
+            ? .circularCounterclockwise : .circularClockwise
+
+        // 1. Explicit binding for this direction
+        if let binding = key.bindings[gesture] {
+            dispatchAction(binding.action)
+            return
+        }
+        // 2. Uppercase of center character (letter keys)
+        if tryCircularUppercase(key: key) { return }
+        // 3. Fallback to opposite direction's binding
+        if let binding = key.bindings[opposite] {
+            dispatchAction(binding.action)
+        }
+    }
+
+    /// Tries to insert the uppercase center character.
+    @discardableResult
+    private func tryCircularUppercase(key: KeyConfig) -> Bool {
+        guard let tapBinding = key.bindings[.tap],
+              case let .commitText(text) = tapBinding.action,
+              text.first?.isLetter == true
+        else { return false }
+        let locale = pipelineLocale ?? Locale.current
+        let uppercased = text.uppercased(with: locale)
+        dispatchAction(.commitText(uppercased))
+        return true
     }
 
     /// Handles `.switchMode` actions with double-tap → capsLock detection.

--- a/wurstfingerKeyboard/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel+Pipeline.swift
@@ -174,9 +174,6 @@ extension KeyboardViewModel {
             return
         }
 
-        lastSwitchModeTime = nil
-        lastSwitchModeTarget = nil
-
         let context = ActionContext(
             action: binding.action,
             binding: binding,

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -78,8 +78,6 @@ final class KeyboardViewModel: ObservableObject {
     weak var textInputTarget: TextInputTarget?
     var onAdvanceToNextInputMode: (() -> Void)?
     var onDismissKeyboard: (() -> Void)?
-    var lastSwitchModeTime: Date?
-    var lastSwitchModeTarget: String?
     /// Locale used by the pipeline (set from definition, separate from legacy locale).
     var pipelineLocale: Locale?
 

--- a/wurstfingerKeyboard/NumericLayouts.swift
+++ b/wurstfingerKeyboard/NumericLayouts.swift
@@ -50,20 +50,7 @@ enum NumericLayouts {
         KeyConfig.utility(
             UtilitySlot.symbols, label: label, action: .switchMode(ModeNames.main),
             swipeMode: .eightWay,
-            swipes: [
-                .swipeUp: KeyBinding(
-                    label: "", action: .copy, category: .utility,
-                    returnAction: nil, accessibilityLabel: "Kopieren"
-                ),
-                .swipeUpRight: KeyBinding(
-                    label: "", action: .cut, category: .utility,
-                    returnAction: nil, accessibilityLabel: "Ausschneiden"
-                ),
-                .swipeDown: KeyBinding(
-                    label: "", action: .paste, category: .utility,
-                    returnAction: nil, accessibilityLabel: "Einsetzen"
-                ),
-            ]
+            swipes: CommonKeys.clipboardSwipes
         )
     }
 

--- a/wurstfingerKeyboard/NumericLayouts.swift
+++ b/wurstfingerKeyboard/NumericLayouts.swift
@@ -48,7 +48,22 @@ enum NumericLayouts {
 
     private static func backToMain(label: String) -> KeyConfig {
         KeyConfig.utility(
-            UtilitySlot.symbols, label: label, action: .switchMode(ModeNames.main)
+            UtilitySlot.symbols, label: label, action: .switchMode(ModeNames.main),
+            swipeMode: .eightWay,
+            swipes: [
+                .swipeUp: KeyBinding(
+                    label: "copy", action: .copy, category: .utility,
+                    returnAction: nil, accessibilityLabel: "Kopieren"
+                ),
+                .swipeUpRight: KeyBinding(
+                    label: "cut", action: .cut, category: .utility,
+                    returnAction: nil, accessibilityLabel: "Ausschneiden"
+                ),
+                .swipeDown: KeyBinding(
+                    label: "paste", action: .paste, category: .utility,
+                    returnAction: nil, accessibilityLabel: "Einsetzen"
+                ),
+            ]
         )
     }
 

--- a/wurstfingerKeyboard/NumericLayouts.swift
+++ b/wurstfingerKeyboard/NumericLayouts.swift
@@ -179,6 +179,8 @@ enum NumericLayouts {
 
                 // Start with shared punctuation defaults (same as letter layer),
                 // but remove shift/capsLock bindings that don't apply to numeric.
+                // This intentionally drops the entire binding including any returnAction
+                // (e.g. midRight.swipeUp carries capitalizeWord as returnAction).
                 var bindings: [GestureType: KeyBinding] = [:]
                 for (gesture, binding) in CommonKeys.defaultSlotBindings[slotId] ?? [:] {
                     if case .switchMode = binding.action { continue }

--- a/wurstfingerKeyboard/NumericLayouts.swift
+++ b/wurstfingerKeyboard/NumericLayouts.swift
@@ -213,7 +213,7 @@ enum NumericLayouts {
 
         let utilities = utilityKeys(backToAlphaLabel: backToAlphaLabel)
         precondition(
-            digitKeys.keys.isDisjoint(with: utilities.keys),
+            Set(digitKeys.keys).isDisjoint(with: utilities.keys),
             "digit and utility key IDs must not overlap"
         )
         let allKeys = digitKeys.merging(utilities) { digit, _ in digit }

--- a/wurstfingerKeyboard/NumericLayouts.swift
+++ b/wurstfingerKeyboard/NumericLayouts.swift
@@ -63,7 +63,7 @@ enum NumericLayouts {
                 category: .digit, returnAction: nil, accessibilityLabel: nil
             ),
         ],
-        swipeMode: .eightWay,
+        swipeMode: .none,
         slideType: .none,
         style: .primary,
         tapCycleActions: nil
@@ -211,7 +211,12 @@ enum NumericLayouts {
             }
         }
 
-        let allKeys = digitKeys.merging(utilityKeys(backToAlphaLabel: backToAlphaLabel)) { digit, _ in digit }
+        let utilities = utilityKeys(backToAlphaLabel: backToAlphaLabel)
+        precondition(
+            digitKeys.keys.isDisjoint(with: utilities.keys),
+            "digit and utility key IDs must not overlap"
+        )
+        let allKeys = digitKeys.merging(utilities) { digit, _ in digit }
 
         return KeyboardMode(
             name: ModeNames.numeric,

--- a/wurstfingerKeyboard/NumericLayouts.swift
+++ b/wurstfingerKeyboard/NumericLayouts.swift
@@ -52,15 +52,15 @@ enum NumericLayouts {
             swipeMode: .eightWay,
             swipes: [
                 .swipeUp: KeyBinding(
-                    label: "copy", action: .copy, category: .utility,
+                    label: "", action: .copy, category: .utility,
                     returnAction: nil, accessibilityLabel: "Kopieren"
                 ),
                 .swipeUpRight: KeyBinding(
-                    label: "cut", action: .cut, category: .utility,
+                    label: "", action: .cut, category: .utility,
                     returnAction: nil, accessibilityLabel: "Ausschneiden"
                 ),
                 .swipeDown: KeyBinding(
-                    label: "paste", action: .paste, category: .utility,
+                    label: "", action: .paste, category: .utility,
                     returnAction: nil, accessibilityLabel: "Einsetzen"
                 ),
             ]
@@ -108,12 +108,6 @@ enum NumericLayouts {
             .swipeRight: KeyBinding(
                 label: "≥", action: .commitText("≥"), category: nil,
                 returnAction: nil, accessibilityLabel: nil
-            ),
-        ],
-        GridSlot.bottomCenter: [
-            .swipeUpRight: KeyBinding(
-                label: "'", action: .commitText("'"), category: nil,
-                returnAction: .commitText("\u{201D}"), accessibilityLabel: nil
             ),
         ],
     ]

--- a/wurstfingerKeyboard/NumericLayouts.swift
+++ b/wurstfingerKeyboard/NumericLayouts.swift
@@ -3,6 +3,8 @@
 //  Wurstfinger
 //
 //  Numeric keyboard modes (phone and classic digit ordering).
+//  Swipe bindings are inherited from CommonKeys.defaultSlotBindings so that
+//  the numeric layer has the same punctuation layout as the letter layer.
 //
 
 import Foundation
@@ -22,6 +24,9 @@ enum NumericLayouts {
                 ["4", "5", "6"],
                 ["7", "8", "9"],
             ],
+            // Phone layout swaps digits but keeps circular gestures at their
+            // physical positions (matching the old swapCenterAndCircular logic).
+            circularOverrides: phoneCircularOverrides,
             backToAlphaLabel: backToAlphaLabel
         )
     }
@@ -34,86 +39,138 @@ enum NumericLayouts {
                 ["4", "5", "6"],
                 ["1", "2", "3"],
             ],
+            circularOverrides: classicCircularOverrides,
             backToAlphaLabel: backToAlphaLabel
         )
     }
 
     // MARK: - Numeric Utility Keys
 
-    /// Builds the symbols key in numeric mode, which switches back to main.
-    /// The label is locale/script-aware so non-Latin keyboards (e.g. Hebrew,
-    /// Russian) can show an appropriate label instead of the Latin "abc".
     private static func backToMain(label: String) -> KeyConfig {
         KeyConfig.utility(
             UtilitySlot.symbols, label: label, action: .switchMode(ModeNames.main)
         )
     }
 
-    /// Space key with "0" on tap in numeric mode.
-    private static let spaceWithZero = KeyConfig.utility(
-        UtilitySlot.space, label: "0", action: .commitText("0"),
-        slideType: .moveCursor
+    /// Standalone "0" digit key in the bottom row.
+    private static let zeroKey = KeyConfig(
+        id: GridSlot.zero,
+        bindings: [
+            .tap: KeyBinding(
+                label: "0", action: .commitText("0"),
+                category: .digit, returnAction: nil, accessibilityLabel: nil
+            ),
+        ],
+        swipeMode: .eightWay,
+        slideType: .none,
+        style: .primary,
+        tapCycleActions: nil
     )
 
-    /// Builds the utility-key dictionary for numeric mode using the supplied
-    /// back-to-alpha label.
     private static func utilityKeys(backToAlphaLabel: String) -> [String: KeyConfig] {
         [
             UtilitySlot.globe: CommonKeys.globe,
             UtilitySlot.delete: CommonKeys.delete,
             UtilitySlot.return: CommonKeys.return,
             UtilitySlot.symbols: backToMain(label: backToAlphaLabel),
-            UtilitySlot.space: spaceWithZero,
+            UtilitySlot.space: CommonKeys.spacebar,
+            GridSlot.zero: zeroKey,
         ]
     }
 
-    // MARK: - Symbol Swipes per Digit
+    // MARK: - Numeric-Specific Overrides
 
-    /// Default symbol swipes for each digit key position.
-    private static let digitSwipes: [String: [GestureType: String]] = [
+    /// Extra swipe bindings that only appear on the numeric layer
+    /// (beyond what CommonKeys.defaultSlotBindings provides).
+    private static let numericExtraSwipes: [String: [GestureType: KeyBinding]] = [
         GridSlot.topLeft: [
-            .swipeRight: "#",
-            .swipeDown: "(",
-            .swipeDownRight: "/",
-        ],
-        GridSlot.topCenter: [
-            .swipeDown: "$",
-            .swipeLeft: "+",
-            .swipeRight: "!",
+            .swipeLeft: KeyBinding(
+                label: "≤", action: .commitText("≤"), category: nil,
+                returnAction: nil, accessibilityLabel: nil
+            ),
         ],
         GridSlot.topRight: [
-            .swipeLeft: ")",
-            .swipeDown: "=",
-            .swipeDownLeft: "\\",
-        ],
-        GridSlot.midLeft: [
-            .swipeRight: "*",
-            .swipeUp: "[",
-            .swipeDown: "{",
-        ],
-        GridSlot.midRight: [
-            .swipeLeft: "%",
-            .swipeUp: "]",
-            .swipeDown: "}",
-        ],
-        GridSlot.bottomLeft: [
-            .swipeRight: "-",
-            .swipeUp: "<",
+            .swipeRight: KeyBinding(
+                label: "≥", action: .commitText("≥"), category: nil,
+                returnAction: nil, accessibilityLabel: nil
+            ),
         ],
         GridSlot.bottomCenter: [
-            .swipeDown: ".",
-            .swipeLeft: ",",
-            .swipeRight: ":",
+            .swipeUpRight: KeyBinding(
+                label: "'", action: .commitText("'"), category: nil,
+                returnAction: .commitText("\u{201D}"), accessibilityLabel: nil
+            ),
         ],
-        GridSlot.bottomRight: [
-            .swipeLeft: "@",
-            .swipeUp: ">",
-        ],
+    ]
+
+    // MARK: - Circular Gestures
+
+    /// Circular gesture bindings for the classic (7-8-9) layout.
+    /// Both directions produce the same symbol, matching old MessagEase behavior.
+    private static let classicCircularOverrides: [String: KeyBinding] = [
+        GridSlot.topLeft: KeyBinding(
+            label: "∫", action: .commitText("∫"), category: nil,
+            returnAction: nil, accessibilityLabel: nil
+        ),
+        GridSlot.topCenter: KeyBinding(
+            label: "∏", action: .commitText("∏"), category: nil,
+            returnAction: nil, accessibilityLabel: nil
+        ),
+        GridSlot.topRight: KeyBinding(
+            label: "∑", action: .commitText("∑"), category: nil,
+            returnAction: nil, accessibilityLabel: nil
+        ),
+        GridSlot.midLeft: KeyBinding(
+            label: "¼", action: .commitText("¼"), category: nil,
+            returnAction: nil, accessibilityLabel: nil
+        ),
+        GridSlot.center: KeyBinding(
+            label: "a", action: .commitText("a"), category: nil,
+            returnAction: nil, accessibilityLabel: nil
+        ),
+        GridSlot.midRight: KeyBinding(
+            label: "ⁿ", action: .commitText("ⁿ"), category: nil,
+            returnAction: nil, accessibilityLabel: nil
+        ),
+        GridSlot.bottomLeft: KeyBinding(
+            label: "¹", action: .commitText("¹"), category: nil,
+            returnAction: nil, accessibilityLabel: nil
+        ),
+        GridSlot.bottomCenter: KeyBinding(
+            label: "²", action: .commitText("²"), category: nil,
+            returnAction: nil, accessibilityLabel: nil
+        ),
+        GridSlot.bottomRight: KeyBinding(
+            label: "³", action: .commitText("³"), category: nil,
+            returnAction: nil, accessibilityLabel: nil
+        ),
+    ]
+
+    /// Phone layout: digits 1-2-3 sit in the top row (physical position of
+    /// 7-8-9 in classic), so circular gestures follow the digit, not the
+    /// position — matching the old swapCenterAndCircular behavior.
+    private static let phoneCircularOverrides: [String: KeyBinding] = [
+        // Top row (digits 1-2-3 here, circular from classic bottom row)
+        GridSlot.topLeft: classicCircularOverrides[GridSlot.bottomLeft]!,
+        GridSlot.topCenter: classicCircularOverrides[GridSlot.bottomCenter]!,
+        GridSlot.topRight: classicCircularOverrides[GridSlot.bottomRight]!,
+        // Middle row unchanged
+        GridSlot.midLeft: classicCircularOverrides[GridSlot.midLeft]!,
+        GridSlot.center: classicCircularOverrides[GridSlot.center]!,
+        GridSlot.midRight: classicCircularOverrides[GridSlot.midRight]!,
+        // Bottom row (digits 7-8-9 here, circular from classic top row)
+        GridSlot.bottomLeft: classicCircularOverrides[GridSlot.topLeft]!,
+        GridSlot.bottomCenter: classicCircularOverrides[GridSlot.topCenter]!,
+        GridSlot.bottomRight: classicCircularOverrides[GridSlot.topRight]!,
     ]
 
     // MARK: - Builder
 
-    private static func buildMode(centerDigits: [[String]], backToAlphaLabel: String) -> KeyboardMode {
+    private static func buildMode(
+        centerDigits: [[String]],
+        circularOverrides: [String: KeyBinding],
+        backToAlphaLabel: String
+    ) -> KeyboardMode {
         precondition(
             centerDigits.count == 3 && centerDigits.allSatisfy { $0.count == 3 },
             "centerDigits must be a 3×3 matrix"
@@ -123,23 +180,33 @@ enum NumericLayouts {
         for (rowIdx, row) in centerDigits.enumerated() {
             for (colIdx, digit) in row.enumerated() {
                 let slotId = GridSlot.allSlots[rowIdx][colIdx]
+
+                // Start with shared punctuation defaults (same as letter layer),
+                // but remove shift/capsLock bindings that don't apply to numeric.
                 var bindings: [GestureType: KeyBinding] = [:]
+                for (gesture, binding) in CommonKeys.defaultSlotBindings[slotId] ?? [:] {
+                    if case .switchMode = binding.action { continue }
+                    bindings[gesture] = binding
+                }
+
+                // Merge numeric-specific extras (doesn't replace existing)
+                if let extras = numericExtraSwipes[slotId] {
+                    for (gesture, binding) in extras where bindings[gesture] == nil {
+                        bindings[gesture] = binding
+                    }
+                }
+
+                // Add circular gesture bindings
+                if let circBinding = circularOverrides[slotId] {
+                    bindings[.circularClockwise] = circBinding
+                    bindings[.circularCounterclockwise] = circBinding
+                }
 
                 // Tap → digit
                 bindings[.tap] = KeyBinding(
                     label: digit, action: .commitText(digit),
                     category: .digit, returnAction: nil, accessibilityLabel: nil
                 )
-
-                // Symbol swipes
-                if let swipes = digitSwipes[slotId] {
-                    for (gesture, symbol) in swipes {
-                        bindings[gesture] = KeyBinding(
-                            label: symbol, action: .commitText(symbol),
-                            category: nil, returnAction: nil, accessibilityLabel: nil
-                        )
-                    }
-                }
 
                 digitKeys[slotId] = KeyConfig(
                     id: slotId, bindings: bindings, swipeMode: .eightWay,
@@ -148,18 +215,12 @@ enum NumericLayouts {
             }
         }
 
-        let utilityKeyMap = utilityKeys(backToAlphaLabel: backToAlphaLabel)
-        let duplicateIds = Set(digitKeys.keys).intersection(utilityKeyMap.keys)
-        precondition(
-            duplicateIds.isEmpty,
-            "Duplicate key ids in numeric layout: \(duplicateIds)"
-        )
-        let allKeys = digitKeys.merging(utilityKeyMap) { digit, _ in digit }
+        let allKeys = digitKeys.merging(utilityKeys(backToAlphaLabel: backToAlphaLabel)) { digit, _ in digit }
 
         return KeyboardMode(
             name: ModeNames.numeric,
             keys: allKeys,
-            arrangements: StandardArrangements.grid3x3,
+            arrangements: StandardArrangements.numeric3x3,
             autoTransitions: [:],
             doubleTapMode: nil
         )

--- a/wurstfingerKeyboard/StandardArrangements.swift
+++ b/wurstfingerKeyboard/StandardArrangements.swift
@@ -55,6 +55,52 @@ enum StandardArrangements {
         ]
     )
 
+    // MARK: - Numeric Portrait
+
+    /// Numeric mode portrait: bottom row has [0 (1 col)] [space (2 cols)] [return (1 col)].
+    private static let numericPortrait = GridArrangement(
+        columns: 4,
+        rows: [
+            [.init(keyId: GridSlot.topLeft), .init(keyId: GridSlot.topCenter), .init(keyId: GridSlot.topRight), .init(keyId: UtilitySlot.globe)],
+            [.init(keyId: GridSlot.midLeft), .init(keyId: GridSlot.center), .init(keyId: GridSlot.midRight), .init(keyId: UtilitySlot.symbols)],
+            [
+                .init(keyId: GridSlot.bottomLeft),
+                .init(keyId: GridSlot.bottomCenter),
+                .init(keyId: GridSlot.bottomRight),
+                .init(keyId: UtilitySlot.delete),
+            ],
+            [.init(keyId: GridSlot.zero), .init(keyId: UtilitySlot.space, widthMultiplier: 2), .init(keyId: UtilitySlot.return)],
+        ]
+    )
+
+    // MARK: - Numeric Landscape
+
+    private static let numericLandscape = GridArrangement(
+        columns: 5,
+        rows: [
+            [
+                .init(keyId: UtilitySlot.globe),
+                .init(keyId: GridSlot.topLeft),
+                .init(keyId: GridSlot.topCenter),
+                .init(keyId: GridSlot.topRight),
+                .init(keyId: UtilitySlot.delete),
+            ],
+            [
+                .init(keyId: UtilitySlot.symbols),
+                .init(keyId: GridSlot.midLeft),
+                .init(keyId: GridSlot.center),
+                .init(keyId: GridSlot.midRight),
+                .init(keyId: UtilitySlot.return, heightMultiplier: 2),
+            ],
+            [
+                .init(keyId: GridSlot.zero),
+                .init(keyId: GridSlot.bottomLeft),
+                .init(keyId: GridSlot.bottomCenter),
+                .init(keyId: GridSlot.bottomRight),
+            ],
+        ]
+    )
+
     // MARK: - All 4 Contexts
 
     /// All 4 arrangement contexts for 3x3 grid layouts.
@@ -63,5 +109,13 @@ enum StandardArrangements {
         .portraitUtilityLeft: portrait.mirroredHorizontally(),
         .landscape: landscape,
         .landscapeUtilityLeft: landscape.mirroredHorizontally(),
+    ]
+
+    /// Numeric mode: same as grid3x3 but with an extra "0" key in the bottom row.
+    static let numeric3x3: [ArrangementContext: GridArrangement] = [
+        .portrait: numericPortrait,
+        .portraitUtilityLeft: numericPortrait.mirroredHorizontally(),
+        .landscape: numericLandscape,
+        .landscapeUtilityLeft: numericLandscape.mirroredHorizontally(),
     ]
 }

--- a/wurstfingerTests/ActionPipelineTests.swift
+++ b/wurstfingerTests/ActionPipelineTests.swift
@@ -227,6 +227,7 @@ struct ComposeMiddlewareTests {
             compose: { previous, trigger in
                 (previous == "a" && trigger == "¨") ? "ä" : nil
             },
+            cycleAccent: { _ in nil },
             previousCharacter: { "a" },
             deletePreviousCharacter: { deleted += 1 }
         )
@@ -243,6 +244,7 @@ struct ComposeMiddlewareTests {
         var deleted = 0
         let middleware = ComposeMiddleware(
             compose: { _, _ in nil },
+            cycleAccent: { _ in nil },
             previousCharacter: { "x" },
             deletePreviousCharacter: { deleted += 1 }
         )
@@ -258,6 +260,7 @@ struct ComposeMiddlewareTests {
     @Test func insertsTriggerWhenNoPreviousCharacter() {
         let middleware = ComposeMiddleware(
             compose: { _, _ in "should not run" },
+            cycleAccent: { _ in nil },
             previousCharacter: { "" },
             deletePreviousCharacter: { Issue.record("Must not delete without previous char") }
         )
@@ -269,18 +272,53 @@ struct ComposeMiddlewareTests {
         #expect(sink.received.first?.action == .commitText("'"))
     }
 
-    @Test func passesThroughNonComposeActions() {
+    @Test func passesThroughNonTextActions() {
         let middleware = ComposeMiddleware(
-            compose: { _, _ in Issue.record("compose must not run for non-.compose actions"); return nil },
+            compose: { _, _ in Issue.record("compose must not run for non-text actions"); return nil },
+            cycleAccent: { _ in nil },
             previousCharacter: { "a" },
-            deletePreviousCharacter: { Issue.record("delete must not run for non-.compose actions") }
+            deletePreviousCharacter: { Issue.record("delete must not run for non-text actions") }
         )
         let sink = RecordingMiddleware()
         let pipeline = ActionPipeline(middlewares: [middleware, sink])
 
-        pipeline.process(PipelineFixtures.context(action: .commitText("a")))
+        pipeline.process(PipelineFixtures.context(action: .deleteBackward))
 
-        #expect(sink.received.first?.action == .commitText("a"))
+        #expect(sink.received.first?.action == .deleteBackward)
+    }
+
+    @Test func composeTriggerProducesComposedCharacter() {
+        var deleted = 0
+        let middleware = ComposeMiddleware(
+            compose: { previous, trigger in
+                (previous == "a" && trigger == "°") ? "å" : nil
+            },
+            cycleAccent: { _ in nil },
+            previousCharacter: { "a" },
+            deletePreviousCharacter: { deleted += 1 }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .compose(trigger: "°")))
+
+        #expect(sink.received.first?.action == .commitText("å"))
+        #expect(deleted == 1)
+    }
+
+    @Test func passesThroughCommitTextWithoutComposeCheck() {
+        let middleware = ComposeMiddleware(
+            compose: { _, _ in Issue.record("compose must not run for commitText"); return nil },
+            cycleAccent: { _ in nil },
+            previousCharacter: { "a" },
+            deletePreviousCharacter: { Issue.record("Must not delete for commitText") }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .commitText("!")))
+
+        #expect(sink.received.first?.action == .commitText("!"))
     }
 }
 
@@ -737,6 +775,7 @@ struct PipelineIntegrationTests {
         var deleted = 0
         let compose = ComposeMiddleware(
             compose: { prev, trig in (prev == "a" && trig == "¨") ? "ä" : nil },
+            cycleAccent: { _ in nil },
             previousCharacter: { "a" },
             deletePreviousCharacter: { deleted += 1 }
         )
@@ -770,6 +809,7 @@ struct PipelineIntegrationTests {
         let haptic = HapticMiddleware(trigger: { _ in steps.append("haptic") })
         let compose = ComposeMiddleware(
             compose: { _, _ in nil },
+            cycleAccent: { _ in nil },
             previousCharacter: { "" },
             deletePreviousCharacter: {}
         )

--- a/wurstfingerTests/CommonKeysFactoryTests.swift
+++ b/wurstfingerTests/CommonKeysFactoryTests.swift
@@ -202,15 +202,34 @@ struct GridKeyboardFactoryTests {
         #expect(shifted.autoTransitions[.letter] == ModeNames.main)
     }
 
-    @Test func shiftedModeDoubleTapToCapsLock() throws {
+    @Test func shiftedSwipeUpPointsToCapsLock() throws {
         let shifted = try #require(Self.testLayout.modes[ModeNames.shifted])
-        #expect(shifted.doubleTapMode == ModeNames.capsLock)
+        let midRight = try #require(shifted.keys[GridSlot.midRight])
+        let swipeUp = try #require(midRight.bindings[.swipeUp])
+        #expect(swipeUp.action == .switchMode(ModeNames.capsLock))
+        #expect(swipeUp.label == "⇧")
+    }
+
+    @Test func capsLockSwipeUpIsNoOpWithCapsLockIcon() throws {
+        let capsLock = try #require(Self.testLayout.modes[ModeNames.capsLock])
+        let midRight = try #require(capsLock.keys[GridSlot.midRight])
+        let swipeUp = try #require(midRight.bindings[.swipeUp])
+        #expect(swipeUp.action == .switchMode(ModeNames.capsLock))
+        #expect(swipeUp.label == "⇪")
     }
 
     @Test func capsLockHasNoAutoTransitions() throws {
         let capsLock = try #require(Self.testLayout.modes[ModeNames.capsLock])
         #expect(capsLock.autoTransitions.isEmpty)
         #expect(capsLock.doubleTapMode == nil)
+    }
+
+    @Test func mainModeShiftLabelIsUpArrow() throws {
+        let main = try #require(Self.testLayout.modes[ModeNames.main])
+        let midRight = try #require(main.keys[GridSlot.midRight])
+        let swipeUp = try #require(midRight.bindings[.swipeUp])
+        #expect(swipeUp.action == .switchMode(ModeNames.shifted))
+        #expect(swipeUp.label == "⇧")
     }
 
     @Test func shiftedLettersAreUppercased() throws {

--- a/wurstfingerTests/KeyboardGridRenderingTests.swift
+++ b/wurstfingerTests/KeyboardGridRenderingTests.swift
@@ -167,7 +167,7 @@ struct KeyViewStyleTests {
             style: .primary,
             tapCycleActions: nil
         )
-        let view = KeyView(key: key, activeModeName: "main", onGesture: { _, _, _ in }, onTouchDown: {})
+        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {})
         #expect(view.primaryLabel == "midLeft")
     }
 
@@ -186,7 +186,7 @@ struct KeyViewStyleTests {
             style: .primary,
             tapCycleActions: nil
         )
-        let view = KeyView(key: key, activeModeName: "main", onGesture: { _, _, _ in }, onTouchDown: {})
+        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {})
         #expect(view.primaryLabel == "d")
     }
 
@@ -205,7 +205,7 @@ struct KeyViewStyleTests {
             style: .utility,
             tapCycleActions: nil
         )
-        let view = KeyView(key: key, activeModeName: "main", onGesture: { _, _, _ in }, onTouchDown: {})
+        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {})
         #expect(view.accessibilityLabel == "Löschen")
     }
 }

--- a/wurstfingerTests/KeyboardGridRenderingTests.swift
+++ b/wurstfingerTests/KeyboardGridRenderingTests.swift
@@ -143,8 +143,8 @@ struct KeyViewStyleTests {
         // Primary keys are large, utility keys use the utility label size.
         // The exact values don't matter; the test guards against the two
         // styles ever collapsing onto the same rendering path.
-        let primary = KeyView.fontSize(for: .primary)
-        let utility = KeyView.fontSize(for: .utility)
+        let primary = KeyView.baseFontSize(for: .primary)
+        let utility = KeyView.baseFontSize(for: .utility)
         #expect(primary != utility)
     }
 
@@ -167,7 +167,7 @@ struct KeyViewStyleTests {
             style: .primary,
             tapCycleActions: nil
         )
-        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {})
+        let view = KeyView(key: key, activeModeName: "main", onGesture: { _, _, _ in }, onTouchDown: {})
         #expect(view.primaryLabel == "midLeft")
     }
 
@@ -186,7 +186,7 @@ struct KeyViewStyleTests {
             style: .primary,
             tapCycleActions: nil
         )
-        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {})
+        let view = KeyView(key: key, activeModeName: "main", onGesture: { _, _, _ in }, onTouchDown: {})
         #expect(view.primaryLabel == "d")
     }
 
@@ -205,7 +205,7 @@ struct KeyViewStyleTests {
             style: .utility,
             tapCycleActions: nil
         )
-        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {})
+        let view = KeyView(key: key, activeModeName: "main", onGesture: { _, _, _ in }, onTouchDown: {})
         #expect(view.accessibilityLabel == "Löschen")
     }
 }

--- a/wurstfingerTests/LanguageDefinitionTests.swift
+++ b/wurstfingerTests/LanguageDefinitionTests.swift
@@ -115,22 +115,28 @@ struct NumericLayoutTests {
         #expect(phone.keys[UtilitySlot.symbols]?.bindings[.tap]?.action == .switchMode(ModeNames.main))
     }
 
-    @Test func spaceKeyOutputsZero() {
+    @Test func zeroKeyIsStandaloneDigit() {
         let phone = NumericLayouts.phone()
-        #expect(phone.keys[UtilitySlot.space]?.bindings[.tap]?.action == .commitText("0"))
+        #expect(phone.keys[GridSlot.zero]?.bindings[.tap]?.action == .commitText("0"))
+    }
+
+    @Test func spaceKeyIsSpace() {
+        let phone = NumericLayouts.phone()
+        #expect(phone.keys[UtilitySlot.space]?.bindings[.tap]?.action == .space)
     }
 
     @Test func hasSymbolSwipes() {
         let phone = NumericLayouts.phone()
-        // Spot-check a few symbol swipes
+        // Spot-check symbol swipes inherited from CommonKeys.defaultSlotBindings
         #expect(phone.keys[GridSlot.bottomCenter]?.bindings[.swipeDown]?.action == .commitText("."))
-        #expect(phone.keys[GridSlot.bottomCenter]?.bindings[.swipeLeft]?.action == .commitText(","))
+        #expect(phone.keys[GridSlot.bottomCenter]?.bindings[.swipeDownLeft]?.action == .commitText(","))
     }
 
     @Test func phoneHasAllGridAndUtilityKeys() {
         let phone = NumericLayouts.phone()
         let expectedKeys = Set(
             GridSlot.allSlots.flatMap(\.self) + [
+                GridSlot.zero,
                 UtilitySlot.globe,
                 UtilitySlot.delete,
                 UtilitySlot.return,

--- a/wurstfingerTests/ReturnSwipeLanguageTests.swift
+++ b/wurstfingerTests/ReturnSwipeLanguageTests.swift
@@ -13,17 +13,16 @@ import Testing
 @Suite(.serialized)
 struct ReturnSwipeLanguageTests {
     /// French layout: return swipe up on center key (O) should produce the
-    /// regular swipe character "h" (no special returnAction is defined for
-    /// language-specific directional overrides in the data-driven pipeline).
-    @Test func frenchReturnSwipeUpOnCenterKeyProducesH() {
+    /// uppercase version "H" (letter overrides auto-generate uppercase return actions).
+    @Test func frenchReturnSwipeUpOnCenterKeyProducesUppercaseH() {
         let (vm, target) = makeViewModel(languageId: "fr_FR")
 
         vm.handleGesture(.swipeUp, keyId: GridSlot.center, isReturn: true)
 
         let inserts = target.events.compactMap { if case let .insertText(t) = $0 { t } else { nil } }
         #expect(
-            inserts.last == "h",
-            "French return swipe up on center key should produce h (regular swipe fallback), got \(inserts.last ?? "nil")"
+            inserts.last == "H",
+            "French return swipe up on center key should produce H (uppercase), got \(inserts.last ?? "nil")"
         )
     }
 

--- a/wurstfingerTests/ViewModelPipelineTests.swift
+++ b/wurstfingerTests/ViewModelPipelineTests.swift
@@ -119,14 +119,36 @@ struct ViewModelModeTests {
         #expect(target.events.contains(.insertText("A")))
     }
 
-    @Test func doubleTapShiftActivatesCapsLock() {
+    @Test func shiftWhileShiftedActivatesCapsLock() {
         let (vm, _) = makeViewModel()
         // First shift → shifted
         vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
         #expect(vm.activeModeName == ModeNames.shifted)
-        // Second shift within interval → capsLock
+        // Second shift while shifted → capsLock (direct switchMode)
         vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
         #expect(vm.activeModeName == ModeNames.capsLock)
+    }
+
+    @Test func capsLockSwipeUpStaysInCapsLock() {
+        let (vm, _) = makeViewModel()
+        // Activate capsLock
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.capsLock)
+        // Third swipe up — stays in capsLock (no-op)
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.capsLock)
+    }
+
+    @Test func capsLockSwipeDownGoesToMain() {
+        let (vm, _) = makeViewModel()
+        // Activate capsLock
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.capsLock)
+        // Swipe down → back to main
+        vm.handleGesture(.swipeDown, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.main)
     }
 
     @Test func capsLockStaysAfterLetter() {
@@ -146,6 +168,50 @@ struct ViewModelModeTests {
         // Tap symbols key → numeric mode
         vm.handleGesture(.tap, keyId: UtilitySlot.symbols, isReturn: false)
         #expect(vm.activeModeName == ModeNames.numeric)
+    }
+
+    @Test func shiftLabelChangesPerMode() throws {
+        let (vm, _) = makeViewModel()
+
+        // Main mode: midRight swipeUp label = "⇧"
+        let mainMode = try #require(vm.activeModeFromDefinition)
+        let mainMidRight = try #require(mainMode.keys[GridSlot.midRight])
+        #expect(mainMidRight.bindings[.swipeUp]?.label == "⇧")
+
+        // Shifted mode: midRight swipeUp label = "⇧"
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.shifted)
+        let shiftedMode = try #require(vm.activeModeFromDefinition)
+        let shiftedMidRight = try #require(shiftedMode.keys[GridSlot.midRight])
+        #expect(shiftedMidRight.bindings[.swipeUp]?.label == "⇧")
+
+        // CapsLock mode: midRight swipeUp label = "⇪"
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.capsLock)
+        let capsMode = try #require(vm.activeModeFromDefinition)
+        let capsMidRight = try #require(capsMode.keys[GridSlot.midRight])
+        #expect(capsMidRight.bindings[.swipeUp]?.label == "⇪")
+    }
+
+    @Test func shiftDownHiddenInMainVisibleInShiftedAndCapsLock() throws {
+        let (vm, _) = makeViewModel()
+
+        // Main mode: midRight swipeDown is removed (hidden, matching old behavior)
+        let mainMode = try #require(vm.activeModeFromDefinition)
+        let mainMidRight = try #require(mainMode.keys[GridSlot.midRight])
+        #expect(mainMidRight.bindings[.swipeDown] == nil)
+
+        // Shifted mode: swipeDown "⇩" is visible
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        let shiftedMode = try #require(vm.activeModeFromDefinition)
+        let shiftedMidRight = try #require(shiftedMode.keys[GridSlot.midRight])
+        #expect(shiftedMidRight.bindings[.swipeDown]?.label == "⇩")
+
+        // CapsLock mode: swipeDown "⇩" is visible
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        let capsMode = try #require(vm.activeModeFromDefinition)
+        let capsMidRight = try #require(capsMode.keys[GridSlot.midRight])
+        #expect(capsMidRight.bindings[.swipeDown]?.label == "⇩")
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes visual regressions introduced by the PR 12/13 data-driven keyboard rendering path, restoring pixel-accurate appearance matching the old `KeyboardRootView` + `KeyCap` + `KeyHintOverlay` stack.

- **Uniform key backgrounds**: Revert per-style `systemGray` variants to uniform `secondarySystemBackground` / `tertiarySystemFill` matching old `KeyCap` behavior
- **Explicit key height**: Add `.frame(height: effectiveKeyHeight)` to `KeyView` so Grid cell size matches font size calculations (fixes "&" touching "9" on numeric layer)
- **Differentiate SF Symbol hint icons**: Globe/dismiss use `0.75×/.medium/primary@0.5` (old `GlobeKeyHintOverlay`), copy/paste/cut use `0.6×/.regular/secondary@0.45` (old `SymbolsKeyHintOverlay`)
- **Hide invisible labels**: Newline (⏎) and space (⎵) swipe labels set to empty string
- **CapsLock/Shift labels per mode**: Shifted swipe-up shows ⇧ → capsLock, capsLock shows ⇪ (no-op), main hides ⇩ hint
- **Numeric layer**: Restore copy/paste/cut swipes on back-to-alpha key
- **Remove double-tap capsLock timer**: Replaced by direct mode switching via `replacingShiftUpBinding`
- **Clean up**: Remove `activeModeName` from `KeyView`/`KeyboardGridView` (no longer needed)

## Test plan

- [ ] All unit tests pass (593/593)
- [ ] Visual comparison: numeric layer dark mode matches reference screenshot
- [ ] Key backgrounds uniform across all key styles (grid, utility, spacebar)
- [ ] Globe/dismiss icons are larger and bolder than copy/paste/cut icons
- [ ] CapsLock label shows ⇪, shifted shows ⇧, main hides ⇩
- [ ] "&" no longer touches "9" on numeric layer
- [ ] Newline and space swipe hints are invisible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Eight-way clipboard swipes (copy/cut/paste), accent-cycling, circular gestures, improved mode-switch gestures, and a dedicated numeric layout with a standalone 0 key.

* **UI/Visual Changes**
  * Keyboard style preference (classic/liquid glass), adjustable scale/aspect ratio, refined key sizing/spacing, hint icons/SF symbol labels, blank spacebar, and clarified shift/caps labels (⇧ / ⇪).

* **Tests**
  * Added and adjusted tests covering compose/cycle accents, numeric layout, and mode/shift behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->