### PR TITLE
Remove historical meta-comments from codebase (PR 15)

### DIFF
--- a/wurstfingerKeyboard/GestureResolverChain.swift
+++ b/wurstfingerKeyboard/GestureResolverChain.swift
@@ -27,8 +27,7 @@ struct GestureResolverChain {
     }
 
     /// Convenience that returns the resolved `KeyAction` directly, or
-    /// `.none` if nothing matched. Mirrors the legacy gesture-handler shape
-    /// so PR 11/12 can swap call sites without translation.
+    /// `.none` if nothing matched.
     func resolveAction(keyId: String, gesture: GestureType, in mode: KeyboardMode) -> KeyAction {
         resolve(keyId: keyId, gesture: gesture, in: mode)?.action ?? .none
     }

--- a/wurstfingerKeyboard/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/GridKeyboardFactory.swift
@@ -53,8 +53,7 @@ enum GridKeyboardFactory {
                 var bindings = CommonKeys.defaultSlotBindings[slotId] ?? [:]
 
                 // Apply language-specific overrides (replace default binding for that gesture).
-                // Letters get an auto-generated uppercase return action matching the
-                // old KeyboardLayout behavior (return swipe = uppercase).
+                // Letters get an auto-generated uppercase return action.
                 if let overrides = directionalOverrides[slotId] {
                     for (gesture, text) in overrides {
                         let isLetter = text.unicodeScalars.contains { CharacterSet.letters.contains($0) }
@@ -106,8 +105,7 @@ enum GridKeyboardFactory {
             .with(name: ModeNames.capsLock)
             .replacingShiftUpBinding(label: "⇪", action: .switchMode(ModeNames.capsLock))
 
-        // 6. Main mode — remove shift-down hint from midRight.
-        //    Old code hid "⇩" in lower layer; we replicate by omitting the binding.
+        // 6. Main mode — remove shift-down hint from midRight (only shown in shifted/capsLock).
         let mainMode = baseMode
             .removingBinding(keyId: GridSlot.midRight, gesture: .swipeDown)
 

--- a/wurstfingerKeyboard/KeyAction.swift
+++ b/wurstfingerKeyboard/KeyAction.swift
@@ -19,7 +19,6 @@ enum KeyAction: Codable, Equatable {
     case cycleAccents
 
     /// Switch to another mode by name.
-    /// Replaces the old toggleShift/toggleSymbols — arbitrary modes possible.
     /// e.g. "shifted", "numeric", "emoji", "symbols", "main"
     case switchMode(String)
 

--- a/wurstfingerKeyboard/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/KeyGestureRecognizer.swift
@@ -16,8 +16,7 @@ struct GestureClassification {
     let isReturn: Bool
 }
 
-/// Reusable gesture recognition logic shared between `KeyView` (data-driven
-/// path) and potentially `KeyboardButton` (legacy path).
+/// Reusable gesture recognition logic used by `KeyView`.
 ///
 /// Wraps the existing `GesturePreprocessor` + `GestureFeatures` pipeline and
 /// produces `GestureType` values instead of `KeyboardDirection`.

--- a/wurstfingerKeyboard/KeyView.swift
+++ b/wurstfingerKeyboard/KeyView.swift
@@ -110,14 +110,12 @@ struct KeyView: View {
         }
     }
 
-    /// Effective key height accounting for both keyboard scale and aspect ratio,
-    /// matching the old `KeyboardRootView` calculation.
+    /// Effective key height accounting for both keyboard scale and aspect ratio.
     private var effectiveKeyHeight: CGFloat {
         KeyboardConstants.Calculations.keyHeight(aspectRatio: keyAspectRatio) * keyboardScale
     }
 
-    /// Scaled font size proportional to effective key height, matching the old
-    /// `scaledMainLabelSize(for:)` behavior in KeyboardRootView.
+    /// Scaled font size proportional to effective key height.
     private var scaledFontSize: CGFloat {
         let base = Self.baseFontSize(for: key.style)
         let scaled = base * (effectiveKeyHeight / KeyboardConstants.FontSizes.mainLabelReferenceHeight)
@@ -136,8 +134,7 @@ struct KeyView: View {
         style == .utility
     }
 
-    /// Background fill for the key. All keys share the same background,
-    /// matching the old uniform `secondarySystemBackground` / `tertiarySystemFill`.
+    /// Background fill for the key.
     static func backgroundColor(for style: KeyStyle, active: Bool = false) -> Color {
         if active {
             return Color(.tertiarySystemFill)
@@ -172,7 +169,7 @@ struct KeyView: View {
     @ViewBuilder
     private var label: some View {
         if key.style == .spacebar {
-            // Spacebar renders blank, matching the old SpaceKeyButton behavior.
+            // Spacebar renders blank — label is purely for accessibility.
             EmptyView()
         } else {
             let font = Font.system(size: scaledFontSize, weight: .semibold, design: .rounded)
@@ -204,7 +201,6 @@ struct KeyView: View {
     ]
 
     /// Maps certain key actions to SF Symbol names for hint rendering.
-    /// Matches the old GlobeKeyHintOverlay / SymbolsKeyHintOverlay icons.
     private static func hintIcon(for action: KeyAction) -> String? {
         switch action {
         case .advanceToNextInputMode: "globe"
@@ -216,10 +212,9 @@ struct KeyView: View {
         }
     }
 
-    /// Directional edge padding for hint labels, matching the old
-    /// `KeyboardDirection.edgePadding(horizontal:vertical:)` behavior.
-    /// Padding is only applied on the edges where the hint is aligned,
-    /// keeping hints close to the key border and away from the center label.
+    /// Directional edge padding for hint labels. Padding is only applied on
+    /// the edges where the hint is aligned, keeping hints close to the key
+    /// border and away from the center label.
     private static func hintEdgePadding(
         for gesture: GestureType, horizontal: CGFloat, vertical: CGFloat
     ) -> EdgeInsets {
@@ -248,7 +243,7 @@ struct KeyView: View {
     private var hintOverlay: some View {
         GeometryReader { proxy in
             let size = proxy.size
-            // Scale padding proportionally with font size, matching old KeyHintOverlay
+            // Scale padding proportionally with font size
             let fontRatio = scaledHintFontSize / KeyboardConstants.FontSizes.hintReferenceFontSize
             let hPad = KeyboardConstants.FontSizes.hintBaseHorizontalPadding * fontRatio
             let vPad = KeyboardConstants.FontSizes.hintBaseVerticalPadding * fontRatio
@@ -284,12 +279,12 @@ struct KeyView: View {
     private func hintContent(for binding: KeyBinding) -> some View {
         if let iconName = Self.hintIcon(for: binding.action) {
             if Self.isGlobeStyleIcon(for: binding.action) {
-                // Globe / dismiss: larger, bolder (old GlobeKeyHintOverlay)
+                // Globe / dismiss: larger, bolder for discoverability
                 Image(systemName: iconName)
                     .font(.system(size: scaledHintFontSize * 0.75, weight: .medium))
                     .foregroundStyle(Color.primary.opacity(0.5))
             } else {
-                // Copy / paste / cut: smaller, lighter (old SymbolsKeyHintOverlay)
+                // Copy / paste / cut: smaller, lighter to avoid visual clutter
                 Image(systemName: iconName)
                     .font(.system(size: scaledHintFontSize * 0.6, weight: .regular))
                     .foregroundStyle(Color.secondary.opacity(0.45))

--- a/wurstfingerKeyboard/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/KeyboardConstants.swift
@@ -2,7 +2,7 @@
 //  KeyboardConstants.swift
 //  Wurstfinger
 //
-//  Extracted from KeyboardLayout.swift for PR 13 legacy cleanup.
+//  Shared constants for keyboard dimensions, font sizes, and gesture thresholds.
 //
 
 import CoreGraphics

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -92,7 +92,7 @@ final class KeyboardViewController: UIInputViewController {
         super.viewWillLayoutSubviews()
         view.backgroundColor = .clear
         // Update viewModel with current width so SwiftUI re-renders after
-        // orientation changes that happen while the keyboard is backgrounded (Bug #92).
+        // orientation changes that happen while the keyboard is backgrounded.
         viewModel.updateViewWidth(view.bounds.width)
         viewModel.updateOrientation(isLandscape: detectIsLandscape())
     }

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -57,14 +57,14 @@ final class KeyboardViewModel: ObservableObject {
 
     /// Current width of the keyboard's containing view.
     /// Updated by the controller in `viewWillLayoutSubviews()` so that
-    /// SwiftUI re-evaluates layout after orientation changes (Bug #92).
+    /// SwiftUI re-evaluates layout after orientation changes.
     @Published private(set) var viewWidth: CGFloat = UIScreen.main.bounds.width
     /// Whether the device is currently in a landscape orientation.
     /// Driven by the controller via `updateOrientation(isLandscape:)`, since
     /// the keyboard's own bounds are always shorter than tall and cannot
     /// reliably distinguish portrait from landscape on their own.
     @Published private(set) var isLandscape: Bool = false
-    /// The currently active data-driven keyboard mode (PR 9+).
+    /// The currently active keyboard mode.
     @Published var currentMode: KeyboardMode?
     /// Name of the currently active mode in the data-driven definition.
     @Published var activeModeName: String = ModeNames.main
@@ -78,7 +78,7 @@ final class KeyboardViewModel: ObservableObject {
     weak var textInputTarget: TextInputTarget?
     var onAdvanceToNextInputMode: (() -> Void)?
     var onDismissKeyboard: (() -> Void)?
-    /// Locale used by the pipeline (set from definition, separate from legacy locale).
+    /// Locale used by the pipeline (set from the keyboard definition).
     var pipelineLocale: Locale?
 
     // MARK: - Settings (delegated to extracted classes)
@@ -191,7 +191,7 @@ final class KeyboardViewModel: ObservableObject {
         self.isLandscape = isLandscape
     }
 
-    // MARK: - Data-Driven Arrangement Selection (PR 9)
+    // MARK: - Arrangement Selection
 
     /// Determines the active arrangement context based on orientation and
     /// the user's utility-column preference.
@@ -206,7 +206,7 @@ final class KeyboardViewModel: ObservableObject {
     }
 
     /// The grid arrangement for `currentMode` and `currentContext`.
-    /// Returns `nil` while the legacy layout path is still in use.
+    /// Returns `nil` if no definition is loaded.
     var currentArrangement: GridArrangement? {
         currentMode?.arrangement(for: currentContext)
     }

--- a/wurstfingerKeyboard/NumericLayouts.swift
+++ b/wurstfingerKeyboard/NumericLayouts.swift
@@ -25,7 +25,7 @@ enum NumericLayouts {
                 ["7", "8", "9"],
             ],
             // Phone layout swaps digits but keeps circular gestures at their
-            // physical positions (matching the old swapCenterAndCircular logic).
+            // physical positions.
             circularOverrides: phoneCircularOverrides,
             backToAlphaLabel: backToAlphaLabel
         )
@@ -102,7 +102,7 @@ enum NumericLayouts {
     // MARK: - Circular Gestures
 
     /// Circular gesture bindings for the classic (7-8-9) layout.
-    /// Both directions produce the same symbol, matching old MessagEase behavior.
+    /// Both directions produce the same symbol.
     private static let classicCircularOverrides: [String: KeyBinding] = [
         GridSlot.topLeft: KeyBinding(
             label: "∫", action: .commitText("∫"), category: nil,
@@ -144,7 +144,7 @@ enum NumericLayouts {
 
     /// Phone layout: digits 1-2-3 sit in the top row (physical position of
     /// 7-8-9 in classic), so circular gestures follow the digit, not the
-    /// position — matching the old swapCenterAndCircular behavior.
+    /// position, not the grid slot.
     private static let phoneCircularOverrides: [String: KeyBinding] = [
         // Top row (digits 1-2-3 here, circular from classic bottom row)
         GridSlot.topLeft: classicCircularOverrides[GridSlot.bottomLeft]!,

--- a/wurstfingerKeyboard/TextInputMiddleware.swift
+++ b/wurstfingerKeyboard/TextInputMiddleware.swift
@@ -43,10 +43,8 @@ protocol TextInputTarget: AnyObject {
 /// Non-text actions (mode switches, haptics, capitalization) pass through
 /// unchanged so later middlewares can react to them.
 ///
-/// Actions that require more than a direct target call (delete-forward,
-/// word-cursor movement, copy/paste, capitalize-word) are intentionally
-/// left to the view controller in PR 11 — they will migrate in PR 12 when
-/// the pipeline is wired end-to-end.
+/// Advanced actions (delete-forward, word-cursor movement, copy/paste,
+/// capitalize-word) are handled by `AdvancedTextMiddleware`.
 struct TextInputMiddleware: ActionMiddleware {
     /// Host-provided text input target resolver.
     ///

--- a/wurstfingerTests/ActionPipelineTests.swift
+++ b/wurstfingerTests/ActionPipelineTests.swift
@@ -2,8 +2,8 @@
 //  ActionPipelineTests.swift
 //  WurstfingerTests
 //
-//  Tests for PR 11: ActionContext, ActionPipeline, and the middleware
-//  suite (HapticMiddleware, ComposeMiddleware, TextInputMiddleware,
+//  Tests for ActionContext, ActionPipeline, and the middleware suite
+//  (HapticMiddleware, ComposeMiddleware, TextInputMiddleware,
 //  AutoCapitalizationMiddleware, ModeTransitionMiddleware).
 //
 

--- a/wurstfingerTests/GestureResolverTests.swift
+++ b/wurstfingerTests/GestureResolverTests.swift
@@ -2,7 +2,7 @@
 //  GestureResolverTests.swift
 //  WurstfingerTests
 //
-//  Tests for PR 10: PrimaryResolver, ReturnSwipeResolver, GhostKeyResolver,
+//  Tests for PrimaryResolver, ReturnSwipeResolver, GhostKeyResolver,
 //  and GestureResolverChain composition.
 //
 
@@ -344,7 +344,7 @@ struct GestureResolverChainTests {
     }
 
     @Test func chainResolveReturnsBindingNotJustAction() {
-        // The non-action variant exposes the full binding so PR 11 middleware
+        // The non-action variant exposes the full binding so middleware
         // can read category / accessibility metadata.
         let mode = Fixtures.mode(keys: [
             Fixtures.key(id: "a", bindings: [

--- a/wurstfingerTests/KeyboardGridRenderingTests.swift
+++ b/wurstfingerTests/KeyboardGridRenderingTests.swift
@@ -2,7 +2,7 @@
 //  KeyboardGridRenderingTests.swift
 //  WurstfingerTests
 //
-//  Tests for PR 9: ViewModel.currentContext, KeyboardGridView span behavior,
+//  Tests for ViewModel.currentContext, KeyboardGridView span behavior,
 //  and KeyView style-based rendering helpers.
 //
 

--- a/wurstfingerTests/OrientationLayoutTests.swift
+++ b/wurstfingerTests/OrientationLayoutTests.swift
@@ -2,7 +2,7 @@
 //  OrientationLayoutTests.swift
 //  wurstfingerTests
 //
-//  Tests for Bug #92: Keyboard misalignment after orientation change while backgrounded.
+//  Tests for keyboard misalignment after orientation change while backgrounded.
 //
 
 import Combine
@@ -11,7 +11,7 @@ import Testing
 @testable import WurstfingerApp
 
 struct OrientationLayoutTests {
-    /// Bug #92: When the keyboard is backgrounded during an orientation change
+    /// When the keyboard is backgrounded during an orientation change
     /// (e.g. user opens camera in landscape), the keyboard layout uses stale
     /// screen bounds on return because no @Published property triggers a SwiftUI
     /// re-render. viewWillAppear is NOT called when the keyboard was already

--- a/wurstfingerTests/ViewModelPipelineTests.swift
+++ b/wurstfingerTests/ViewModelPipelineTests.swift
@@ -2,9 +2,9 @@
 //  ViewModelPipelineTests.swift
 //  WurstfingerTests
 //
-//  End-to-end tests for the data-driven gesture → resolver → pipeline → text
-//  flow wired in PR 12. Each test constructs a real KeyboardViewModel with a
-//  real KeyboardDefinition and a mock TextInputTarget, then exercises
+//  End-to-end tests for the gesture → resolver → pipeline → text flow.
+//  Each test constructs a real KeyboardViewModel with a real
+//  KeyboardDefinition and a mock TextInputTarget, then exercises
 //  handleGesture/handleSlide to verify observable side effects.
 //
 
@@ -196,7 +196,7 @@ struct ViewModelModeTests {
     @Test func shiftDownHiddenInMainVisibleInShiftedAndCapsLock() throws {
         let (vm, _) = makeViewModel()
 
-        // Main mode: midRight swipeDown is removed (hidden, matching old behavior)
+        // Main mode: midRight swipeDown is removed (only shown in shifted/capsLock)
         let mainMode = try #require(vm.activeModeFromDefinition)
         let mainMidRight = try #require(mainMode.keys[GridSlot.midRight])
         #expect(mainMidRight.bindings[.swipeDown] == nil)


### PR DESCRIPTION
## Summary

Strips implementation-history artifacts from code comments across the keyboard extension and test suite. Comments now describe current behavior rather than migration history.

- Remove PR number references (PR 9, 10, 11, 12, 13)
- Remove "matching the old X" comments referencing deleted code
- Remove "legacy" path references (no legacy path exists anymore)
- Remove Bug # citations (context lives in git history / issue tracker)
- Rewrite affected comments to describe what the code does, not how it got there

16 files changed, 41 insertions, 65 deletions — pure comment cleanup, no behavioral changes.

## Test plan

- [x] All 593 unit tests pass
- [x] Build succeeds
- [ ] Grep confirms no remaining PR/legacy/old references in source

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified and clarified internal documentation comments throughout the keyboard implementation to better reflect current architecture and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->