### PR TITLE
Code-Review-Fixes: Quick Wins + Numpad-Style

### DIFF
--- a/wurstfinger/AspectRatioSettingsView.swift
+++ b/wurstfinger/AspectRatioSettingsView.swift
@@ -43,7 +43,7 @@ struct AspectRatioSettingsView: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
                         Spacer()
-                        Text("Square")
+                        Text("Square · Default")
                             .font(.caption)
                             .foregroundColor(.secondary)
                         Spacer()
@@ -51,7 +51,7 @@ struct AspectRatioSettingsView: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
                         Spacer()
-                        Text("Default")
+                        Text("Wide")
                             .font(.caption)
                             .foregroundColor(.secondary)
                         Spacer()
@@ -65,8 +65,7 @@ struct AspectRatioSettingsView: View {
                     }
                 }
                 Text(
-                    // swiftlint:disable:next line_length
-                    "Adjust the width-to-height ratio of the keys. 1.0 creates square keys, 1.5 is the default appearance, and 1.62 is the golden ratio (widest)."
+                    "Adjust the width-to-height ratio of the keys. 1.0 creates square keys (the default), and 1.62 is the golden ratio (widest)."
                 )
                 .font(.caption)
                 .foregroundColor(.secondary)

--- a/wurstfinger/KeyboardSizePositionSettingsView.swift
+++ b/wurstfinger/KeyboardSizePositionSettingsView.swift
@@ -35,7 +35,7 @@ struct KeyboardSizePositionSettingsView: View {
                 }
 
                 VStack(spacing: 8) {
-                    Slider(value: $scale, in: 0.3 ... 1.0, step: 0.01)
+                    Slider(value: $scale, in: 0.25 ... 1.0, step: 0.01)
                         .onChange(of: scale) { oldValue, newValue in
                             // Reset position to center when scale reaches 100%
                             if newValue >= 1.0 && oldValue < 1.0 {
@@ -44,7 +44,7 @@ struct KeyboardSizePositionSettingsView: View {
                         }
 
                     HStack {
-                        Text("30%")
+                        Text("25%")
                             .font(.caption)
                             .foregroundColor(.secondary)
                         Spacer()
@@ -62,7 +62,7 @@ struct KeyboardSizePositionSettingsView: View {
                     }
                 }
 
-                Text("Scale the keyboard to make it smaller. At 100% it fills the full width, at 30% it's much more compact.")
+                Text("Scale the keyboard to make it smaller. At 100% it fills the full width, at 25% it's much more compact.")
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/wurstfinger/SharedDefaults.swift
+++ b/wurstfinger/SharedDefaults.swift
@@ -13,7 +13,15 @@ enum SharedDefaults {
     /// The app group identifier shared between the main app and keyboard extension
     static let suiteName = "group.de.akator.wurstfinger.shared"
 
-    /// The shared UserDefaults instance
-    /// Falls back to standard UserDefaults if app group is not available (should never happen in production)
-    static let store: UserDefaults = .init(suiteName: suiteName) ?? .standard
+    /// The shared UserDefaults instance.
+    /// Falls back to standard UserDefaults if the app group is unavailable — this
+    /// must never happen in production (app and extension would stop sharing
+    /// settings silently), so flag it loudly in debug builds.
+    static let store: UserDefaults = {
+        guard let shared = UserDefaults(suiteName: suiteName) else {
+            assertionFailure("App group '\(suiteName)' unavailable — settings will not sync between app and keyboard extension")
+            return .standard
+        }
+        return shared
+    }()
 }

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -20,11 +20,6 @@ struct StyleSettingsView: View {
     @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
     private var previewPosition = DeviceLayoutUtils.defaultKeyboardPosition
 
-    private var keyboardStyle: KeyboardStyle {
-        get { KeyboardStyle(rawValue: keyboardStyleRaw) ?? .classic }
-        set { keyboardStyleRaw = newValue.rawValue }
-    }
-
     var body: some View {
         VStack(spacing: 20) {
             // Keyboard Preview

--- a/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
+++ b/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
@@ -14,8 +14,11 @@ enum CommonKeys {
 
     static let globe: KeyConfig = {
         var bindings: [GestureType: KeyBinding] = [:]
+        // Tap is intentionally inert: switching the input method lives on the
+        // swipe-left gesture below. The empty `.none` slot keeps the key's
+        // accessibility label without re-triggering the globe on a plain tap.
         bindings[.tap] = KeyBinding(
-            label: "🌐", action: .advanceToNextInputMode,
+            label: "", action: .none,
             category: .utility, returnAction: nil,
             accessibilityLabel: "Tastatur wechseln"
         )

--- a/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
+++ b/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
@@ -15,7 +15,7 @@ enum CommonKeys {
     static let globe: KeyConfig = {
         var bindings: [GestureType: KeyBinding] = [:]
         bindings[.tap] = KeyBinding(
-            label: "", action: .advanceToNextInputMode,
+            label: "🌐", action: .advanceToNextInputMode,
             category: .utility, returnAction: nil,
             accessibilityLabel: "Tastatur wechseln"
         )

--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -58,7 +58,7 @@ enum GridKeyboardFactory {
                     for (gesture, text) in overrides {
                         let isLetter = text.unicodeScalars.contains { CharacterSet.letters.contains($0) }
                         let returnAction: KeyAction? = isLetter
-                            ? .commitText(text.uppercased(with: locale))
+                            ? .commitText(text.keyboardUppercased(with: locale))
                             : nil
                         bindings[gesture] = KeyBinding(
                             label: text, action: .commitText(text),

--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -126,7 +126,8 @@ enum GridKeyboardFactory {
                 autoCapitalizers: [],
                 composeRuleOverrides: nil,
                 inputMethod: inputMethod
-            )
+            ),
+            numericBackToAlphaLabel: numericBackToAlphaLabel
         )
     }
 }

--- a/wurstfingerKeyboard/Definition/Language/KeyboardDefinition.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardDefinition.swift
@@ -33,9 +33,45 @@ struct KeyboardDefinition: Codable, Equatable {
     /// Keyboard-specific settings
     let settings: KeyboardDefinitionSettings
 
+    /// Label for the numeric layer's "back to alphabet" key (e.g. "abc",
+    /// "אבג", "абв"). Retained on the definition so the numeric mode can be
+    /// rebuilt at load time (e.g. when switching the numpad style) without
+    /// re-deriving the per-language label.
+    let numericBackToAlphaLabel: String
+
+    init(
+        title: String,
+        id: String,
+        localeIdentifier: String,
+        modes: [String: KeyboardMode],
+        defaultMode: String,
+        settings: KeyboardDefinitionSettings,
+        numericBackToAlphaLabel: String = NumericLayouts.defaultBackToAlphaLabel
+    ) {
+        self.title = title
+        self.id = id
+        self.localeIdentifier = localeIdentifier
+        self.modes = modes
+        self.defaultMode = defaultMode
+        self.settings = settings
+        self.numericBackToAlphaLabel = numericBackToAlphaLabel
+    }
+
     /// Convenience: Mode lookup
     func mode(_ name: String) -> KeyboardMode? {
         modes[name]
+    }
+
+    /// Returns a copy with `name`'s mode replaced. Used to swap the numeric
+    /// layer (phone/classic) at load time based on user settings.
+    func replacingMode(_ name: String, with mode: KeyboardMode) -> KeyboardDefinition {
+        var updated = modes
+        updated[name] = mode
+        return KeyboardDefinition(
+            title: title, id: id, localeIdentifier: localeIdentifier,
+            modes: updated, defaultMode: defaultMode, settings: settings,
+            numericBackToAlphaLabel: numericBackToAlphaLabel
+        )
     }
 }
 

--- a/wurstfingerKeyboard/Definition/Language/KeyboardMode+Shifted.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardMode+Shifted.swift
@@ -7,6 +7,20 @@
 
 import Foundation
 
+extension String {
+    /// Uppercases key text for the shifted layer.
+    ///
+    /// Unlike `uppercased(with:)`, this preserves the German capital sharp S
+    /// (ß → ẞ, U+1E9E) instead of expanding to the two-letter "SS", so a single
+    /// ß key maps to a single ẞ. Shared by both the shifted-layer generation
+    /// (`KeyConfig.autoShifted`) and the directional-override return actions in
+    /// `GridKeyboardFactory`, so the two stay consistent.
+    func keyboardUppercased(with locale: Locale) -> String {
+        if self == "ß" { return "ẞ" }
+        return uppercased(with: locale)
+    }
+}
+
 extension KeyboardMode {
     /// Generates the shifted layer from this mode.
     /// - Letter bindings are uppercased using the given locale
@@ -36,8 +50,8 @@ extension KeyConfig {
         let shiftedBindings = bindings.mapValues { binding -> KeyBinding in
             guard binding.resolvedCategory == .letter else { return binding }
             guard case let .commitText(text) = binding.action else { return binding }
-            let upperLabel = binding.label.uppercased(with: locale)
-            let upperText = text.uppercased(with: locale)
+            let upperLabel = binding.label.keyboardUppercased(with: locale)
+            let upperText = text.keyboardUppercased(with: locale)
             return KeyBinding(
                 label: upperLabel,
                 action: .commitText(upperText),

--- a/wurstfingerKeyboard/Runtime/Gesture/GestureFeatureCalculations.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GestureFeatureCalculations.swift
@@ -192,7 +192,7 @@ enum GestureCalculations {
     /// Calculates oriented compactness (width/length along principal axis)
     /// 1.0 = square, 0 = narrow line
     static func orientedCompactness(of points: [CGPoint], principalAngle: CGFloat) -> CGFloat {
-        guard let start = points.first, !points.isEmpty else { return 0 }
+        guard let start = points.first else { return 0 }
 
         let cosA = cos(principalAngle)
         let sinA = sin(principalAngle)

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -15,13 +15,27 @@ extension KeyboardViewModel {
     /// Loads a keyboard definition by ID from the registry and sets up the
     /// resolver chain and action pipeline.
     func loadDefinition(for id: String) {
-        guard let definition = KeyboardRegistry.load(id: id) else { return }
+        guard let base = KeyboardRegistry.load(id: id) else { return }
+        let definition = applyNumpadStyle(to: base)
         currentDefinition = definition
         activeModeName = definition.defaultMode
         pipelineLocale = definition.locale
         currentMode = definition.mode(activeModeName)
         rebuildResolverChain()
         rebuildPipeline()
+    }
+
+    /// Swaps the numeric layer to the classic (7-8-9) ordering when the user
+    /// selected it. The registry caches the phone-style definition, so this
+    /// always derives from the canonical phone layout and never mutates the cache.
+    private func applyNumpadStyle(to definition: KeyboardDefinition) -> KeyboardDefinition {
+        let raw = sharedDefaults.string(forKey: SettingsKey.numpadStyle.rawValue)
+        let style = raw.flatMap(NumpadStyle.init(rawValue:)) ?? .phone
+        guard style == .classic else { return definition }
+        let classicNumeric = NumericLayouts.classic(
+            backToAlphaLabel: definition.numericBackToAlphaLabel
+        )
+        return definition.replacingMode(ModeNames.numeric, with: classicNumeric)
     }
 
     /// Injects the text input target (typically a `DocumentProxyTarget`).

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -24,9 +24,10 @@ enum KeyboardConstants {
         /// Matches iOS 15+ system keyboard style.
         static let cornerRadius: CGFloat = 8
 
-        /// Default key aspect ratio (width/height).
-        /// 1.5 provides a comfortable rectangular key shape similar to standard keyboards.
-        static let defaultAspectRatio: CGFloat = 1.5
+        /// Reference key aspect ratio (width/height) at which `height` is defined.
+        /// Used only as the baseline in `Calculations.keyHeight`; it is NOT the
+        /// user-facing default setting (that is `DeviceLayoutUtils.defaultKeyAspectRatio`).
+        static let referenceAspectRatio: CGFloat = 1.5
 
         /// Total number of rows in the keyboard layout.
         /// 3 rows for main keys + 1 row for space bar = 4 rows.
@@ -176,7 +177,7 @@ enum KeyboardConstants {
     enum Calculations {
         /// Calculates the adjusted key height based on aspect ratio
         static func keyHeight(aspectRatio: CGFloat) -> CGFloat {
-            KeyDimensions.height * (KeyDimensions.defaultAspectRatio / aspectRatio)
+            KeyDimensions.height * (KeyDimensions.referenceAspectRatio / aspectRatio)
         }
 
         /// Calculates the total keyboard base height (without scaling)

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -129,7 +129,7 @@ final class LayoutSettings: ObservableObject {
         didSet { persistIfNeeded(utilityColumnLeading, forKey: .utilityColumnLeading) }
     }
 
-    /// Key aspect ratio (height/width). Range: 1.0 (square) to 1.62 (golden ratio)
+    /// Key aspect ratio (width/height). Range: 1.0 (square) to 1.62 (golden ratio)
     @Published var keyAspectRatio: Double {
         didSet {
             let clamped = Self.clampAspectRatio(keyAspectRatio)

--- a/wurstfingerKeyboard/Settings/SharedDefaults.swift
+++ b/wurstfingerKeyboard/Settings/SharedDefaults.swift
@@ -13,7 +13,15 @@ enum SharedDefaults {
     /// The app group identifier shared between the main app and keyboard extension
     static let suiteName = "group.de.akator.wurstfinger.shared"
 
-    /// The shared UserDefaults instance
-    /// Falls back to standard UserDefaults if app group is not available (should never happen in production)
-    static let store: UserDefaults = .init(suiteName: suiteName) ?? .standard
+    /// The shared UserDefaults instance.
+    /// Falls back to standard UserDefaults if the app group is unavailable — this
+    /// must never happen in production (app and extension would stop sharing
+    /// settings silently), so flag it loudly in debug builds.
+    static let store: UserDefaults = {
+        guard let shared = UserDefaults(suiteName: suiteName) else {
+            assertionFailure("App group '\(suiteName)' unavailable — settings will not sync between app and keyboard extension")
+            return .standard
+        }
+        return shared
+    }()
 }

--- a/wurstfingerTests/CommonKeysFactoryTests.swift
+++ b/wurstfingerTests/CommonKeysFactoryTests.swift
@@ -25,7 +25,9 @@ struct CommonKeysTests {
     @Test func globeKeyAction() {
         let globe = CommonKeys.globe
         #expect(globe.id == UtilitySlot.globe)
-        #expect(globe.bindings[.tap]?.action == .advanceToNextInputMode)
+        // Switching the input method lives on swipe-left; tap is intentionally inert.
+        #expect(globe.bindings[.tap]?.action == KeyAction.none)
+        #expect(globe.bindings[.swipeLeft]?.action == .advanceToNextInputMode)
         #expect(globe.style == .utility)
     }
 

--- a/wurstfingerTests/SlotFactoryShiftedTests.swift
+++ b/wurstfingerTests/SlotFactoryShiftedTests.swift
@@ -201,10 +201,9 @@ struct AutoShiftedTests {
         let key = KeyConfig.letter("bottomLeft", tap: "ß")
         let shifted = key.autoShifted(locale: Locale(identifier: "de_DE"))
 
-        // German ß uppercases to SS (or ẞ depending on locale data, but SS is the standard)
-        let upper = "ß".uppercased(with: Locale(identifier: "de_DE"))
-        #expect(shifted.bindings[.tap]?.label == upper)
-        #expect(shifted.bindings[.tap]?.action == .commitText(upper))
+        // German ß maps to the capital sharp S ẞ (U+1E9E), not the legacy "SS".
+        #expect(shifted.bindings[.tap]?.label == "ẞ")
+        #expect(shifted.bindings[.tap]?.action == .commitText("ẞ"))
     }
 
     @Test func autoShiftedTurkishI() {

--- a/wurstfingerTests/SlotFactoryShiftedTests.swift
+++ b/wurstfingerTests/SlotFactoryShiftedTests.swift
@@ -201,7 +201,7 @@ struct AutoShiftedTests {
         let key = KeyConfig.letter("bottomLeft", tap: "ß")
         let shifted = key.autoShifted(locale: Locale(identifier: "de_DE"))
 
-        // German ß maps to the capital sharp S ẞ (U+1E9E), not the legacy "SS".
+        // German ß maps to the capital sharp S ẞ (U+1E9E), not the two-letter "SS".
         #expect(shifted.bindings[.tap]?.label == "ẞ")
         #expect(shifted.bindings[.tap]?.action == .commitText("ẞ"))
     }

--- a/wurstfingerTests/ViewModelPipelineTests.swift
+++ b/wurstfingerTests/ViewModelPipelineTests.swift
@@ -298,7 +298,36 @@ struct ViewModelVCActionTests {
         let (vm, _) = makeViewModel(
             advanceToNextInputMode: { advanceCalled = true }
         )
-        vm.handleGesture(.tap, keyId: UtilitySlot.globe, isReturn: false)
+        // Input-method switch is bound to swipe-left on the globe key.
+        vm.handleGesture(.swipeLeft, keyId: UtilitySlot.globe, isReturn: false)
         #expect(advanceCalled)
+    }
+}
+
+// MARK: - Numpad style wiring
+
+@Suite(.serialized)
+struct ViewModelNumpadStyleTests {
+    private func loadedNumericTopLeftDigit(numpadStyle: String?) -> String? {
+        let defaults = UserDefaults(suiteName: "test.\(UUID().uuidString)")!
+        if let numpadStyle {
+            defaults.set(numpadStyle, forKey: SettingsKey.numpadStyle.rawValue)
+        }
+        let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
+        vm.loadDefinition(for: "de_DE")
+        return vm.currentDefinition?
+            .mode(ModeNames.numeric)?
+            .keys[GridSlot.topLeft]?
+            .bindings[.tap]?.label
+    }
+
+    @Test func defaultNumpadIsPhone() {
+        // Phone layout: 1-2-3 in the top row.
+        #expect(loadedNumericTopLeftDigit(numpadStyle: nil) == "1")
+    }
+
+    @Test func classicNumpadSwapsTopRow() {
+        // Classic calculator layout: 7-8-9 in the top row.
+        #expect(loadedNumericTopLeftDigit(numpadStyle: NumpadStyle.classic.rawValue) == "7")
     }
 }


### PR DESCRIPTION
Behebt eine Reihe von Findings aus dem aktuellen Code-Review (siehe `CODE_REVIEW.md`). Erster Batch: Quick Wins + das erste „totes Setting"-Feature.

## Enthaltene Findings

**Hoch**
- **H1** — Numpad-Style-Setting verdrahtet: `loadDefinition` tauscht bei `numpadStyle=classic` den Numeric-Modus gegen `NumericLayouts.classic`. Bisher war der Picker wirkungslos (Factory baute immer Phone). Die per-Sprache nötige back-to-alpha-Beschriftung wird dafür auf `KeyboardDefinition` gespeichert.

**Mittel**
- **M1** — `ß` wird im Shift-Layer zu `ẞ` (U+1E9E) statt der Zwei-Zeichen-Folge „SS" (neue geteilte `String.keyboardUppercased(with:)`-Helper).
- **M4** — Uppercasing-Primitive zwischen `autoShifted` und `GridKeyboardFactory` konsolidiert.
- **M6** — `KeyDimensions.defaultAspectRatio` → `referenceAspectRatio` umbenannt (war mit dem User-Default 1.0 verwechselbar); Slider-Label und Doku korrigiert.
- **M9** — Scale-Slider-Minimum 0.3 → 0.25 (entspricht Clamp/iPad-Default).

**Niedrig**
- **L1** — `SharedDefaults`: `assertionFailure` in Debug, wenn die App-Group fehlt (statt stillem Fallback auf `.standard`).
- **L5** — Globe-Taste: Tastatur-Wechsel liegt bewusst auf Swipe-links; der Tap trug die Funktion nur als Überbleibsel und ist jetzt inert (`.none`).
- **L7** — Toten `keyboardStyle`-Setter und redundanten `orientedCompactness`-Guard entfernt.

## Tests
- Neue Coverage für die Numpad-Phone/Classic-Umschaltung.
- `ß→ẞ`- und Globe-Tap-Tests an das neue Verhalten angepasst.
- **583 Tests grün** (`WurstfingerTests`, iPhone 17 Pro).

## Hinweis
Basis ist `refactor/pr16-directory-structure`, da die neue Verzeichnisstruktur (noch) nicht auf `develop` ist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard scale can be set lower (including updated preset/caption text).
  * Aspect-ratio setting labels and descriptions were refreshed.
  * Numpad mode can switch to a classic numeric layout based on the saved style.
  * Shifted-layer text now preserves German “ß” as capital “ẞ”.
* **Bug Fixes**
  * Globe key tap is now inert; input-method switching happens via swipe-left.
* **Documentation**
  * Clarified aspect-ratio terminology (width/height) and baseline description.
* **Tests**
  * Updated/added coverage for globe-key gestures, “ß” handling, and numpad-style selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->