### PR TITLE
H2: Cursor-Movement-Setting verdrahten (continuous/discrete + Wort-Bewegung)

### DIFF
--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -133,6 +133,9 @@ final class KeyboardViewModel: ObservableObject {
     /// Peak signed displacement during the current space drag. Used by the
     /// discrete cursor-movement mode to classify regular vs. return swipes.
     var spaceDragPeak: CGFloat = 0
+    /// Cursor-movement style captured at the start of the current space drag, so
+    /// a mid-drag settings change cannot switch classification mode mid-gesture.
+    var spaceDragCursorStyle: CursorMovementStyle = .continuous
     var isDeleteDragging = false
     var deleteDragResidual: CGFloat = 0
     private var userDefaultsObserver: NSObjectProtocol?

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -130,6 +130,9 @@ final class KeyboardViewModel: ObservableObject {
     let shouldPersistSettings: Bool
     var isSpaceDragging = false
     var spaceDragResidual: CGFloat = 0
+    /// Peak signed displacement during the current space drag. Used by the
+    /// discrete cursor-movement mode to classify regular vs. return swipes.
+    var spaceDragPeak: CGFloat = 0
     var isDeleteDragging = false
     var deleteDragResidual: CGFloat = 0
     private var userDefaultsObserver: NSObjectProtocol?

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -273,10 +273,13 @@ extension KeyboardViewModel {
             isSpaceDragging = true
             spaceDragResidual = 0
             spaceDragPeak = 0
+            // Snapshot the style once so a mid-drag settings change can't switch
+            // this gesture between discrete and continuous classification.
+            spaceDragCursorStyle = cursorMovementStyle
         case let .changed(deltaX):
             guard isSpaceDragging, deltaX != 0 else { return }
             spaceDragResidual += deltaX
-            if cursorMovementStyle == .discrete {
+            if spaceDragCursorStyle == .discrete {
                 // Track the peak; movement is deferred to `.ended` so the whole
                 // swipe counts as a single discrete step.
                 if abs(spaceDragResidual) > abs(spaceDragPeak) {
@@ -286,7 +289,7 @@ extension KeyboardViewModel {
                 stepContinuousCursor()
             }
         case .ended:
-            if cursorMovementStyle == .discrete {
+            if spaceDragCursorStyle == .discrete {
                 finishDiscreteSpaceSlide()
             }
             isSpaceDragging = false

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -260,30 +260,118 @@ extension KeyboardViewModel {
         }
     }
 
+    /// Cursor-movement style for the space-bar drag. Read per gesture (stable
+    /// for the duration of a drag); defaults to `.continuous`.
+    var cursorMovementStyle: CursorMovementStyle {
+        let raw = sharedDefaults.string(forKey: SettingsKey.cursorMovementStyle.rawValue)
+        return raw.flatMap(CursorMovementStyle.init(rawValue:)) ?? .continuous
+    }
+
     func handleSpaceSlide(phase: SlidePhase, key: KeyConfig) {
         switch phase {
         case .began:
             isSpaceDragging = true
             spaceDragResidual = 0
+            spaceDragPeak = 0
         case let .changed(deltaX):
             guard isSpaceDragging, deltaX != 0 else { return }
             spaceDragResidual += deltaX
-            while spaceDragResidual <= -KeyboardConstants.SpaceGestures.dragStep {
-                dispatchAction(.moveCursor(offset: -1))
-                feedbackDrag()
-                spaceDragResidual += KeyboardConstants.SpaceGestures.dragStep
-            }
-            while spaceDragResidual >= KeyboardConstants.SpaceGestures.dragStep {
-                dispatchAction(.moveCursor(offset: 1))
-                feedbackDrag()
-                spaceDragResidual -= KeyboardConstants.SpaceGestures.dragStep
+            if cursorMovementStyle == .discrete {
+                // Track the peak; movement is deferred to `.ended` so the whole
+                // swipe counts as a single discrete step.
+                if abs(spaceDragResidual) > abs(spaceDragPeak) {
+                    spaceDragPeak = spaceDragResidual
+                }
+            } else {
+                stepContinuousCursor()
             }
         case .ended:
+            if cursorMovementStyle == .discrete {
+                finishDiscreteSpaceSlide()
+            }
             isSpaceDragging = false
             spaceDragResidual = 0
+            spaceDragPeak = 0
         case .tap:
             handleGesture(.tap, keyId: key.id, isReturn: false)
         }
+    }
+
+    /// Continuous (joystick) mode: emit one character move per `dragStep` of
+    /// accumulated travel.
+    private func stepContinuousCursor() {
+        while spaceDragResidual <= -KeyboardConstants.SpaceGestures.dragStep {
+            dispatchAction(.moveCursor(offset: -1))
+            feedbackDrag()
+            spaceDragResidual += KeyboardConstants.SpaceGestures.dragStep
+        }
+        while spaceDragResidual >= KeyboardConstants.SpaceGestures.dragStep {
+            dispatchAction(.moveCursor(offset: 1))
+            feedbackDrag()
+            spaceDragResidual -= KeyboardConstants.SpaceGestures.dragStep
+        }
+    }
+
+    /// Discrete (MessagEase) mode: classify the completed swipe.
+    /// A regular swipe moves one character; a return swipe (finger returns
+    /// toward the origin) moves one whole word in the swipe's direction.
+    private func finishDiscreteSpaceSlide() {
+        let peak = spaceDragPeak
+        let finalX = spaceDragResidual
+        // Ignore taps / tiny jitters that never travelled a full step.
+        guard abs(peak) >= KeyboardConstants.SpaceGestures.dragStep else { return }
+
+        let direction = peak < 0 ? -1 : 1
+        let ratio = abs(finalX) / abs(peak)
+        if ratio < KeyboardConstants.SpaceGestures.returnSwipeThreshold {
+            moveCursorByWord(direction: direction)
+        } else {
+            dispatchAction(.moveCursor(offset: direction))
+        }
+        feedbackDrag()
+    }
+
+    /// Moves the cursor by one word in `direction` (+1 forward, -1 backward)
+    /// by computing the character offset to the nearest word boundary from the
+    /// surrounding document context.
+    private func moveCursorByWord(direction: Int) {
+        let offset: Int = direction > 0
+            ? Self.forwardWordOffset(in: textInputTarget?.documentContextAfterInput ?? "")
+            : -Self.backwardWordOffset(in: textInputTarget?.documentContextBeforeInput ?? "")
+        guard offset != 0 else { return }
+        dispatchAction(.moveCursor(offset: offset))
+    }
+
+    /// Characters from the cursor to the end of the next word: skip leading
+    /// whitespace, then the word itself.
+    static func forwardWordOffset(in text: String) -> Int {
+        var count = 0
+        var seenWord = false
+        for char in text {
+            if char.isWhitespace {
+                if seenWord { break }
+            } else {
+                seenWord = true
+            }
+            count += 1
+        }
+        return count
+    }
+
+    /// Characters from the cursor back to the start of the previous word: skip
+    /// trailing whitespace, then the word itself.
+    static func backwardWordOffset(in text: String) -> Int {
+        var count = 0
+        var seenWord = false
+        for char in text.reversed() {
+            if char.isWhitespace {
+                if seenWord { break }
+            } else {
+                seenWord = true
+            }
+            count += 1
+        }
+        return count
     }
 
     func handleDeleteSlide(phase: SlidePhase, key: KeyConfig) {

--- a/wurstfingerTests/CursorMovementTests.swift
+++ b/wurstfingerTests/CursorMovementTests.swift
@@ -75,3 +75,95 @@ struct CursorMovementPipelineTests {
         #expect(target.events.contains(.deleteBackward))
     }
 }
+
+// MARK: - Discrete cursor movement (one swipe = char, return swipe = word)
+
+@Suite(.serialized)
+struct DiscreteCursorMovementTests {
+    private func makeDiscreteViewModel() -> (KeyboardViewModel, MockTextTarget) {
+        let defaults = UserDefaults(suiteName: "test.\(UUID().uuidString)")!
+        defaults.set(
+            CursorMovementStyle.discrete.rawValue,
+            forKey: SettingsKey.cursorMovementStyle.rawValue
+        )
+        let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
+        let target = MockTextTarget()
+        vm.bindTextInputTarget(target)
+        vm.loadDefinition(for: "de_DE")
+        return (vm, target)
+    }
+
+    private func spaceKey(_ vm: KeyboardViewModel) -> KeyConfig {
+        guard let key = vm.activeModeFromDefinition?.key(for: UtilitySlot.space) else {
+            fatalError("Space key not found in definition")
+        }
+        return key
+    }
+
+    @Test func regularSwipeForwardMovesExactlyOneCharacter() {
+        let (vm, target) = makeDiscreteViewModel()
+        let key = spaceKey(vm)
+        let step = KeyboardConstants.SpaceGestures.dragStep
+        vm.handleSlide(key, phase: .began)
+        // Travels two full steps, but discrete moves a single character.
+        vm.handleSlide(key, phase: .changed(deltaX: step * 2))
+        vm.handleSlide(key, phase: .ended)
+        #expect(target.events == [.adjustCursor(1)])
+    }
+
+    @Test func regularSwipeBackwardMovesExactlyOneCharacter() {
+        let (vm, target) = makeDiscreteViewModel()
+        let key = spaceKey(vm)
+        let step = KeyboardConstants.SpaceGestures.dragStep
+        vm.handleSlide(key, phase: .began)
+        vm.handleSlide(key, phase: .changed(deltaX: -step * 2))
+        vm.handleSlide(key, phase: .ended)
+        #expect(target.events == [.adjustCursor(-1)])
+    }
+
+    @Test func returnSwipeForwardMovesOneWord() {
+        let (vm, target) = makeDiscreteViewModel()
+        let key = spaceKey(vm)
+        target.documentContextAfterInput = "foo bar"
+        vm.handleSlide(key, phase: .began)
+        // Out far, then back toward the origin → return swipe.
+        vm.handleSlide(key, phase: .changed(deltaX: 40))
+        vm.handleSlide(key, phase: .changed(deltaX: -36))
+        vm.handleSlide(key, phase: .ended)
+        // "foo" = 3 characters forward to the word boundary.
+        #expect(target.events == [.adjustCursor(3)])
+    }
+
+    @Test func returnSwipeBackwardMovesOneWord() {
+        let (vm, target) = makeDiscreteViewModel()
+        let key = spaceKey(vm)
+        target.documentContextBeforeInput = "hello world"
+        vm.handleSlide(key, phase: .began)
+        vm.handleSlide(key, phase: .changed(deltaX: -40))
+        vm.handleSlide(key, phase: .changed(deltaX: 36))
+        vm.handleSlide(key, phase: .ended)
+        // "world" = 5 characters backward to the word boundary.
+        #expect(target.events == [.adjustCursor(-5)])
+    }
+
+    @Test func tinyDragDoesNotMove() {
+        let (vm, target) = makeDiscreteViewModel()
+        let key = spaceKey(vm)
+        vm.handleSlide(key, phase: .began)
+        vm.handleSlide(key, phase: .changed(deltaX: 3))
+        vm.handleSlide(key, phase: .ended)
+        #expect(target.events.isEmpty)
+    }
+
+    @Test func forwardWordOffsetSkipsLeadingWhitespace() {
+        #expect(KeyboardViewModel.forwardWordOffset(in: "  foo bar") == 5)
+        #expect(KeyboardViewModel.forwardWordOffset(in: "foo") == 3)
+        #expect(KeyboardViewModel.forwardWordOffset(in: "") == 0)
+    }
+
+    @Test func backwardWordOffsetSkipsTrailingWhitespace() {
+        #expect(KeyboardViewModel.backwardWordOffset(in: "foo bar  ") == 5)
+        #expect(KeyboardViewModel.backwardWordOffset(in: "foo") == 3)
+        #expect(KeyboardViewModel.backwardWordOffset(in: "") == 0)
+    }
+}

--- a/wurstfingerTests/CursorMovementTests.swift
+++ b/wurstfingerTests/CursorMovementTests.swift
@@ -93,16 +93,13 @@ struct DiscreteCursorMovementTests {
         return (vm, target)
     }
 
-    private func spaceKey(_ vm: KeyboardViewModel) -> KeyConfig {
-        guard let key = vm.activeModeFromDefinition?.key(for: UtilitySlot.space) else {
-            fatalError("Space key not found in definition")
-        }
-        return key
+    private func spaceKey(_ vm: KeyboardViewModel) throws -> KeyConfig {
+        try #require(vm.activeModeFromDefinition?.key(for: UtilitySlot.space))
     }
 
-    @Test func regularSwipeForwardMovesExactlyOneCharacter() {
+    @Test func regularSwipeForwardMovesExactlyOneCharacter() throws {
         let (vm, target) = makeDiscreteViewModel()
-        let key = spaceKey(vm)
+        let key = try spaceKey(vm)
         let step = KeyboardConstants.SpaceGestures.dragStep
         vm.handleSlide(key, phase: .began)
         // Travels two full steps, but discrete moves a single character.
@@ -111,9 +108,9 @@ struct DiscreteCursorMovementTests {
         #expect(target.events == [.adjustCursor(1)])
     }
 
-    @Test func regularSwipeBackwardMovesExactlyOneCharacter() {
+    @Test func regularSwipeBackwardMovesExactlyOneCharacter() throws {
         let (vm, target) = makeDiscreteViewModel()
-        let key = spaceKey(vm)
+        let key = try spaceKey(vm)
         let step = KeyboardConstants.SpaceGestures.dragStep
         vm.handleSlide(key, phase: .began)
         vm.handleSlide(key, phase: .changed(deltaX: -step * 2))
@@ -121,9 +118,9 @@ struct DiscreteCursorMovementTests {
         #expect(target.events == [.adjustCursor(-1)])
     }
 
-    @Test func returnSwipeForwardMovesOneWord() {
+    @Test func returnSwipeForwardMovesOneWord() throws {
         let (vm, target) = makeDiscreteViewModel()
-        let key = spaceKey(vm)
+        let key = try spaceKey(vm)
         target.documentContextAfterInput = "foo bar"
         vm.handleSlide(key, phase: .began)
         // Out far, then back toward the origin → return swipe.
@@ -134,9 +131,9 @@ struct DiscreteCursorMovementTests {
         #expect(target.events == [.adjustCursor(3)])
     }
 
-    @Test func returnSwipeBackwardMovesOneWord() {
+    @Test func returnSwipeBackwardMovesOneWord() throws {
         let (vm, target) = makeDiscreteViewModel()
-        let key = spaceKey(vm)
+        let key = try spaceKey(vm)
         target.documentContextBeforeInput = "hello world"
         vm.handleSlide(key, phase: .began)
         vm.handleSlide(key, phase: .changed(deltaX: -40))
@@ -146,11 +143,11 @@ struct DiscreteCursorMovementTests {
         #expect(target.events == [.adjustCursor(-5)])
     }
 
-    @Test func tinyDragDoesNotMove() {
+    @Test func tinyDragDoesNotMove() throws {
         let (vm, target) = makeDiscreteViewModel()
-        let key = spaceKey(vm)
+        let key = try spaceKey(vm)
         vm.handleSlide(key, phase: .began)
-        vm.handleSlide(key, phase: .changed(deltaX: 3))
+        vm.handleSlide(key, phase: .changed(deltaX: KeyboardConstants.SpaceGestures.dragStep / 2))
         vm.handleSlide(key, phase: .ended)
         #expect(target.events.isEmpty)
     }


### PR DESCRIPTION
Behebt **H2** aus dem Code-Review (`CODE_REVIEW.md`): Das `cursorMovementStyle`-Setting (Continuous / Step-by-step) hatte keine Wirkung — der Space-Drag nutzte immer den continuous-Pfad.

## Verhalten
- **continuous** (unverändert): ein Zeichen pro `dragStep` (Joystick-Stil).
- **discrete** (neu): die gesamte Space-Geste wird am Ende klassifiziert:
  - **Reguläre Swipe** → ein Zeichen in Swipe-Richtung.
  - **Return-Swipe** (Finger kehrt zum Ursprung zurück, `ratio < returnSwipeThreshold`) → **ein ganzes Wort** in Swipe-Richtung.

Die Wort-Bewegung berechnet den Zeichen-Offset zur nächsten Wortgrenze aus `documentContextBeforeInput`/`documentContextAfterInput` (`forwardWordOffset`/`backwardWordOffset`) und nutzt das bereits vorhandene `returnSwipeThreshold`-Scaffolding (es gab schon `DiscreteGestureClassificationTests` und einen Hinweis im `TextInputTarget`-Protokoll).

## Tests
7 neue Fälle: Zeichen vor/zurück, Wort vor/zurück, Tiny-Drag-No-Op, Wortgrenzen-Helper. **588 Tests grün** (iPhone 17 Pro).

## Hinweis
Basis `refactor/pr16-directory-structure`. Unabhängig von #172 (überlappt nur in `KeyboardViewModel+Pipeline.swift`, aber in anderen Hunks → Git merged automatisch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new space-bar drag behavior option for cursor movement.
  * Space drags now support both continuous character-by-character movement and a discrete mode that can jump by character or word.

* **Bug Fixes**
  * Improved gesture handling so small drags no longer move the cursor.
  * Word navigation now skips surrounding whitespace more reliably, making return-style swipes land at cleaner word boundaries.

* **Tests**
  * Added coverage for discrete cursor movement, including character moves, word jumps, and no-op drags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->