### PR TITLE
H3: Gesten-Ursprung bei Ringpuffer-Overflow re-verankern

### DIFF
--- a/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
@@ -66,12 +66,27 @@ struct KeyGestureRecognizer: ViewModifier {
                             )
                         )
                         let classification = Self.classify(
-                            positions: positions.elements,
+                            positions: Self.anchoringOrigin(positions.elements),
                             aspectRatio: aspectRatio
                         )
                         onGestureRecognized(classification)
                     }
             )
+    }
+
+    /// Guarantees the touch-down origin `(0,0)` is the first sample.
+    ///
+    /// Every recorded point is a translation relative to touch-down, so the
+    /// true gesture origin is always `(0,0)` — appended first in `onChanged`.
+    /// On a long gesture (more samples than the position buffer's capacity)
+    /// the ring buffer evicts that origin, leaving a mid-gesture point as
+    /// `elements[0]`. Since all start-relative features (maxDisplacement,
+    /// returnRatio, dominant angle, circularity) measure from `points.first`,
+    /// a lost origin mis-classifies the gesture. When the origin was evicted
+    /// (`elements[0] != .zero`), re-anchor it.
+    static func anchoringOrigin(_ points: [CGPoint]) -> [CGPoint] {
+        guard let first = points.first, first != .zero else { return points }
+        return [.zero] + points
     }
 
     // MARK: - Classification (Pure Function)

--- a/wurstfingerTests/OriginAnchoringTests.swift
+++ b/wurstfingerTests/OriginAnchoringTests.swift
@@ -1,0 +1,56 @@
+//
+//  OriginAnchoringTests.swift
+//  WurstfingerTests
+//
+//  Tests for KeyGestureRecognizer.anchoringOrigin, which restores the
+//  touch-down origin (0,0) when a long gesture overflows the position ring
+//  buffer and the origin sample is evicted.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct OriginAnchoringTests {
+    // MARK: - Pure function
+
+    @Test func emptyStaysEmpty() {
+        #expect(KeyGestureRecognizer.anchoringOrigin([]).isEmpty)
+    }
+
+    @Test func leadingOriginIsUnchanged() {
+        let points = [CGPoint.zero, CGPoint(x: 10, y: 0), CGPoint(x: 20, y: 0)]
+        #expect(KeyGestureRecognizer.anchoringOrigin(points) == points)
+    }
+
+    @Test func evictedOriginIsReAnchored() {
+        // Buffer overflowed: first retained sample is mid-gesture, not (0,0).
+        let evicted = [CGPoint(x: 30, y: 0), CGPoint(x: 40, y: 0)]
+        let result = KeyGestureRecognizer.anchoringOrigin(evicted)
+        #expect(result.first == .zero)
+        #expect(result == [.zero] + evicted)
+    }
+
+    // MARK: - End-to-end classification
+
+    @Test func longReturnSwipeIsRecognizedAfterOriginEviction() {
+        // A rightward return swipe (out and back) long enough that the ring
+        // buffer evicted the origin and the early outward samples — the
+        // retained points start mid-gesture at x=40.
+        var evicted: [CGPoint] = []
+        for x in stride(from: 40, through: 60, by: 4) {
+            evicted.append(CGPoint(x: CGFloat(x), y: 0))
+        }
+        for x in stride(from: 56, through: 4, by: -4) {
+            evicted.append(CGPoint(x: CGFloat(x), y: 0))
+        }
+
+        // Re-anchoring restores (0,0) as the origin, so the gesture reads as a
+        // rightward return swipe again.
+        let anchored = KeyGestureRecognizer.anchoringOrigin(evicted)
+        let features = GestureFeatures.extract(from: anchored)
+        #expect(features.isReturn)
+        #expect(KeyGestureRecognizer.angleToGestureType(features.maxDisplacementAngle) == .swipeRight)
+    }
+}

--- a/wurstfingerTests/OriginAnchoringTests.swift
+++ b/wurstfingerTests/OriginAnchoringTests.swift
@@ -47,10 +47,11 @@ struct OriginAnchoringTests {
         }
 
         // Re-anchoring restores (0,0) as the origin, so the gesture reads as a
-        // rightward return swipe again.
+        // rightward return swipe again — checked through the production
+        // classify(positions:) pipeline rather than a hand-rolled extraction.
         let anchored = KeyGestureRecognizer.anchoringOrigin(evicted)
-        let features = GestureFeatures.extract(from: anchored)
-        #expect(features.isReturn)
-        #expect(KeyGestureRecognizer.angleToGestureType(features.maxDisplacementAngle) == .swipeRight)
+        let classification = KeyGestureRecognizer.classify(positions: anchored)
+        #expect(classification.isReturn)
+        #expect(classification.gesture == .swipeRight)
     }
 }


### PR DESCRIPTION
Behebt **H3** aus dem Code-Review (`CODE_REVIEW.md`).

## Problem
Alle Touch-Punkte sind Translationen relativ zum Touch-Down; der Ursprung `(0,0)` wird als erstes Sample angehängt. Der Positions-Ringpuffer fasst `positionBufferSize = 60` Punkte. Bei langen/langsamen Gesten (>60 Samples — bei 120 Hz ProMotion in ~0,5 s erreicht) überschreibt der Puffer genau den Ursprung. Da alle **start-relativen** Features (`maxDisplacement`, `returnRatio`, dominanter Winkel, Circularity) ab `points.first` messen, wird die Geste dann gegen einen Mittelpunkt gemessen und Return-/Kreisgesten werden fehlklassifiziert.

## Fix
`KeyGestureRecognizer.anchoringOrigin(_:)` stellt `(0,0)` wieder voran, wenn `elements[0] != .zero` — was genau dem Overflow-Fall entspricht (ohne Overflow ist das erste Sample immer der angehängte Ursprung). Reine, testbare Funktion; minimaler Eingriff, Puffergröße unverändert (Memory-Budget der Extension).

## Tests
- Pure-Cases (leer / führender Ursprung / evicted).
- End-to-End: eine lange Right-Return-Swipe, deren Ursprung der Puffer verworfen hat, wird nach Re-Verankerung wieder korrekt als Return-Swipe nach rechts erkannt.
- **585 Tests grün** (iPhone 17 Pro).

## Hinweis
Basis `refactor/pr16-directory-structure`. Unabhängig von #172/#173 (eigene Datei + isolierte Funktion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gesture recognition by preserving the original touch-down point during long swipes, reducing misclassification when earlier samples are no longer retained.
* **Tests**
  * Added new test coverage for gesture anchoring behavior, including empty/edge cases and long swipe scenarios that validate correct gesture classification and direction mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->