### PR TITLE
Gesten-Tuning: Delete-Step, Turn-Winkel, Slide-Dead-Zone (M10/M11/L9)

### DIFF
--- a/wurstfingerKeyboard/Runtime/Gesture/GestureFeatureCalculations.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GestureFeatureCalculations.swift
@@ -165,7 +165,13 @@ enum GestureCalculations {
 
     /// Calculates turn consistency (how consistently the path turns in one direction)
     /// 1.0 = all turns same direction (circle), ~0.5 = mixed directions (return swipe)
-    static func turnConsistency(of points: [CGPoint], turnThreshold: CGFloat = 0.5) -> CGFloat {
+    ///
+    /// `turnThreshold` is the minimum turn **angle** in radians (default ~8.6°)
+    /// for a segment pair to count as a turn. Using the angle keeps the cutoff
+    /// scale-invariant; a raw cross product has magnitude `|v1||v2|sin θ` (px²),
+    /// so a fixed cross threshold would make the effective angle depend on
+    /// segment length (large gestures count nearly every wobble, tiny ones none).
+    static func turnConsistency(of points: [CGPoint], turnThreshold: CGFloat = 0.15) -> CGFloat {
         guard points.count >= 3 else { return 1.0 }
 
         var cwCount = 0
@@ -174,11 +180,13 @@ enum GestureCalculations {
         for i in 1 ..< (points.count - 1) {
             let v1 = Vector2D(from: points[i - 1], to: points[i])
             let v2 = Vector2D(from: points[i], to: points[i + 1])
-            let cross = v1.cross(v2)
+            // Skip degenerate segments — turn angle is undefined for zero length.
+            guard v1.magnitudeSquared > 0, v2.magnitudeSquared > 0 else { continue }
+            let turn = v1.angle(to: v2) // signed radians: + = CCW, - = CW
 
-            if cross > turnThreshold {
+            if turn > turnThreshold {
                 ccwCount += 1
-            } else if cross < -turnThreshold {
+            } else if turn < -turnThreshold {
                 cwCount += 1
             }
         }

--- a/wurstfingerKeyboard/Runtime/Gesture/GestureFeatureCalculations.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GestureFeatureCalculations.swift
@@ -172,14 +172,21 @@ enum GestureCalculations {
     /// so a fixed cross threshold would make the effective angle depend on
     /// segment length (large gestures count nearly every wobble, tiny ones none).
     static func turnConsistency(of points: [CGPoint], turnThreshold: CGFloat = 0.15) -> CGFloat {
-        guard points.count >= 3 else { return 1.0 }
+        // Drop consecutive duplicate samples first; a repeated point (A→B→B→C)
+        // would otherwise split the real A→B / B→C turn across two zero-length
+        // segments and never count it.
+        var pts: [CGPoint] = []
+        for p in points where pts.last != p {
+            pts.append(p)
+        }
+        guard pts.count >= 3 else { return 1.0 }
 
         var cwCount = 0
         var ccwCount = 0
 
-        for i in 1 ..< (points.count - 1) {
-            let v1 = Vector2D(from: points[i - 1], to: points[i])
-            let v2 = Vector2D(from: points[i], to: points[i + 1])
+        for i in 1 ..< (pts.count - 1) {
+            let v1 = Vector2D(from: pts[i - 1], to: pts[i])
+            let v2 = Vector2D(from: pts[i], to: pts[i + 1])
             // Skip degenerate segments — turn angle is undefined for zero length.
             guard v1.magnitudeSquared > 0, v2.magnitudeSquared > 0 else { continue }
             let turn = v1.angle(to: v2) // signed radians: + = CCW, - = CW

--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -54,16 +54,22 @@ struct SlideGestureHandler: ViewModifier {
                             if abs(currentX) >= threshold {
                                 isSliding = true
                                 isActive = true
-                                lastTranslationX = currentX
+                                // Anchor at the threshold crossing (not the full
+                                // translation) so the travel beyond the threshold
+                                // is reported on the same tick instead of being
+                                // dropped — otherwise the first `threshold` points
+                                // are a dead zone.
+                                lastTranslationX = currentX < 0 ? -threshold : threshold
                                 onSlide(.began)
-                                return
                             }
                         }
 
                         if isSliding {
                             let deltaX = currentX - lastTranslationX
-                            lastTranslationX = currentX
-                            onSlide(.changed(deltaX: deltaX))
+                            if deltaX != 0 {
+                                lastTranslationX = currentX
+                                onSlide(.changed(deltaX: deltaX))
+                            }
                         }
 
                         isActive = true

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -294,15 +294,16 @@ extension KeyboardViewModel {
         case let .changed(deltaX):
             guard isDeleteDragging, deltaX != 0 else { return }
             deleteDragResidual += deltaX
-            while deleteDragResidual <= -KeyboardConstants.SpaceGestures.dragStep {
+            let step = KeyboardConstants.DeleteGestures.dragStep
+            while deleteDragResidual <= -step {
                 dispatchAction(.deleteBackward)
                 feedbackDrag()
-                deleteDragResidual += KeyboardConstants.SpaceGestures.dragStep
+                deleteDragResidual += step
             }
-            while deleteDragResidual >= KeyboardConstants.SpaceGestures.dragStep {
+            while deleteDragResidual >= step {
                 dispatchAction(.deleteForward)
                 feedbackDrag()
-                deleteDragResidual -= KeyboardConstants.SpaceGestures.dragStep
+                deleteDragResidual -= step
             }
         case .ended:
             isDeleteDragging = false

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -149,6 +149,11 @@ enum KeyboardConstants {
         /// Distance to activate slide-delete (continuous deletion).
         static let slideActivationThreshold: CGFloat = 28
 
+        /// Distance per deletion step during slide-delete (one character).
+        /// Decoupled from `SpaceGestures.dragStep` so delete and cursor
+        /// sensitivity can be tuned independently.
+        static let dragStep: CGFloat = 14
+
         /// Distance for word-at-a-time deletion gesture.
         static let wordSwipeThreshold: CGFloat = 40
 

--- a/wurstfingerTests/GestureCalculationsTests.swift
+++ b/wurstfingerTests/GestureCalculationsTests.swift
@@ -301,6 +301,26 @@ struct GestureCalculationsTests {
         #expect(consistency < 0.7)
     }
 
+    @Test func turnConsistencyIsScaleInvariant() {
+        // Same zig-zag shape at two scales. With the old px²-cross threshold the
+        // small version registered no turns (→ 1.0, falsely "consistent");
+        // angle-based it matches the large one and is correctly inconsistent.
+        let large: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 10, y: 10),
+            CGPoint(x: 20, y: 0),
+            CGPoint(x: 30, y: 10),
+            CGPoint(x: 40, y: 0)
+        ]
+        let small = large.map { CGPoint(x: $0.x / 10, y: $0.y / 10) }
+
+        let largeConsistency = GestureCalculations.turnConsistency(of: large)
+        let smallConsistency = GestureCalculations.turnConsistency(of: small)
+
+        #expect(abs(largeConsistency - smallConsistency) < 0.001)
+        #expect(smallConsistency < 0.7)
+    }
+
     // MARK: - Oriented Compactness Tests
 
     @Test func orientedCompactnessOfSquare() {

--- a/wurstfingerTests/GestureCalculationsTests.swift
+++ b/wurstfingerTests/GestureCalculationsTests.swift
@@ -302,9 +302,9 @@ struct GestureCalculationsTests {
     }
 
     @Test func turnConsistencyIsScaleInvariant() {
-        // Same zig-zag shape at two scales. With the old px²-cross threshold the
-        // small version registered no turns (→ 1.0, falsely "consistent");
-        // angle-based it matches the large one and is correctly inconsistent.
+        // Same zig-zag shape at two scales. An angle-based turn threshold is
+        // scale-invariant, so both versions register the turns and read as
+        // correctly inconsistent.
         let large: [CGPoint] = [
             CGPoint(x: 0, y: 0),
             CGPoint(x: 10, y: 10),

--- a/wurstfingerTests/GestureCalculationsTests.swift
+++ b/wurstfingerTests/GestureCalculationsTests.swift
@@ -312,7 +312,10 @@ struct GestureCalculationsTests {
             CGPoint(x: 30, y: 10),
             CGPoint(x: 40, y: 0)
         ]
-        let small = large.map { CGPoint(x: $0.x / 10, y: $0.y / 10) }
+        // Scale far down so a raw px²-cross threshold would no longer register
+        // these turns (proving the test guards the angle-based, scale-invariant
+        // implementation rather than passing trivially).
+        let small = large.map { CGPoint(x: $0.x / 100, y: $0.y / 100) }
 
         let largeConsistency = GestureCalculations.turnConsistency(of: large)
         let smallConsistency = GestureCalculations.turnConsistency(of: small)

--- a/wurstfingerTests/ViewModelPipelineTests.swift
+++ b/wurstfingerTests/ViewModelPipelineTests.swift
@@ -238,7 +238,7 @@ struct ViewModelSlideTests {
             return
         }
         vm.handleSlide(deleteKey, phase: .began)
-        let step = KeyboardConstants.SpaceGestures.dragStep
+        let step = KeyboardConstants.DeleteGestures.dragStep
         vm.handleSlide(deleteKey, phase: .changed(deltaX: -step * 2))
         vm.handleSlide(deleteKey, phase: .ended)
         #expect(target.events.contains(.deleteBackward))


### PR DESCRIPTION
Thematischer PR aus dem Code-Review (`CODE_REVIEW.md`) — Gesten-Tuning.

## Findings
- **M10** — `handleDeleteSlide` steppte auf `SpaceGestures.dragStep`; das koppelte die Delete-Geschwindigkeit an das Cursor-Tuning. Neue `DeleteGestures.dragStep` (gleicher Wert 14, aber unabhängig tunebar).
- **M11** — `turnConsistency` verglich ein rohes Cross-Produkt (`|v1||v2|·sin θ`, px²) gegen eine feste Schwelle, wodurch der effektive Turn-Winkel von der Segmentlänge abhing (große Gesten zählten fast jeden Wackler als Turn, winzige keinen). Jetzt winkelbasiert (`Vector2D.angle(to:)`, rad) → scale-invariant. Degenerierte Null-Segmente werden übersprungen.
- **L9** — `SlideGestureHandler` verankerte bei Aktivierung an der vollen Translation und verwarf so den Weg von einem `dragStep` direkt nach Aktivierung (spürbare Dead-Zone). Jetzt wird an der Schwelle verankert und der Rest-Weg sofort gemeldet.

## Tests
Neuer Skaleninvarianz-Test für `turnConsistency` (kleine vs. große Zig-Zag-Geste liefern jetzt dieselbe Konsistenz; die kleine wird korrekt als inkonsistent erkannt statt fälschlich als „konsistent"). **582 Tests grün** (iPhone 17 Pro). M10 ist verhaltensgleich (durch bestehende Delete-Tests gedeckt); L9 ist SwiftUI-Gesten-Plumbing.

## Hinweis
Basis `refactor/pr16-directory-structure`. Überlappt mit #173 nur in `KeyboardViewModel+Pipeline.swift`, aber in getrennten Hunks (handleDeleteSlide vs. handleSpaceSlide).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved turn detection for swipe/shape recognition, including more stable direction counting and better handling of repeated/zero-length points.
  * Tuned gesture turn sensitivity for more consistent results.
  * Fixed delete-slide step sizing so deletions advance at the correct pace.
  * Improved slide gesture updates so the first meaningful drag change is reported sooner.
* **Tests**
  * Added unit coverage to confirm turn detection remains consistent across gesture scales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->