### PR TITLE
Korrektheit: AutoCap-Whitespace, Validierung, Force-Unwraps (M2/L2/L3)

### DIFF
--- a/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
+++ b/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
@@ -144,21 +144,25 @@ enum NumericLayouts {
 
     /// Phone layout: digits 1-2-3 sit in the top row (physical position of
     /// 7-8-9 in classic), so circular gestures follow the digit, not the
-    /// position, not the grid slot.
-    private static let phoneCircularOverrides: [String: KeyBinding] = [
-        // Top row (digits 1-2-3 here, circular from classic bottom row)
-        GridSlot.topLeft: classicCircularOverrides[GridSlot.bottomLeft]!,
-        GridSlot.topCenter: classicCircularOverrides[GridSlot.bottomCenter]!,
-        GridSlot.topRight: classicCircularOverrides[GridSlot.bottomRight]!,
-        // Middle row unchanged
-        GridSlot.midLeft: classicCircularOverrides[GridSlot.midLeft]!,
-        GridSlot.center: classicCircularOverrides[GridSlot.center]!,
-        GridSlot.midRight: classicCircularOverrides[GridSlot.midRight]!,
-        // Bottom row (digits 7-8-9 here, circular from classic top row)
-        GridSlot.bottomLeft: classicCircularOverrides[GridSlot.topLeft]!,
-        GridSlot.bottomCenter: classicCircularOverrides[GridSlot.topCenter]!,
-        GridSlot.bottomRight: classicCircularOverrides[GridSlot.topRight]!,
-    ]
+    /// position, not the grid slot. The top and bottom rows therefore swap
+    /// their classic bindings; the middle row is unchanged.
+    private static let phoneCircularOverrides: [String: KeyBinding] = {
+        let slotRemap: [String: String] = [
+            // Top row pulls from the classic bottom row, and vice versa.
+            GridSlot.topLeft: GridSlot.bottomLeft,
+            GridSlot.topCenter: GridSlot.bottomCenter,
+            GridSlot.topRight: GridSlot.bottomRight,
+            GridSlot.midLeft: GridSlot.midLeft,
+            GridSlot.center: GridSlot.center,
+            GridSlot.midRight: GridSlot.midRight,
+            GridSlot.bottomLeft: GridSlot.topLeft,
+            GridSlot.bottomCenter: GridSlot.topCenter,
+            GridSlot.bottomRight: GridSlot.topRight,
+        ]
+        return slotRemap.reduce(into: [:]) { result, pair in
+            result[pair.key] = classicCircularOverrides[pair.value]
+        }
+    }()
 
     // MARK: - Builder
 

--- a/wurstfingerKeyboard/Definition/Model/AutoCapitalization.swift
+++ b/wurstfingerKeyboard/Definition/Model/AutoCapitalization.swift
@@ -15,6 +15,12 @@ enum AutoCapitalization {
         "。", "！", "？", // CJK punctuation
     ]
 
+    /// CJK sentence-ending punctuation. CJK text has no inter-sentence spaces,
+    /// so these trigger capitalization even without trailing whitespace.
+    static let cjkSentenceEnders: Set<Character> = [
+        "。", "！", "？",
+    ]
+
     /// Punctuation that opens a sentence and triggers immediate capitalization.
     static let sentenceOpeners: Set<Character> = [
         "¿", "¡", // Spanish inverted punctuation
@@ -28,12 +34,21 @@ enum AutoCapitalization {
         if context.isEmpty { return true }
 
         // Only whitespace means start of input
-        let trimmed = context.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty { return true }
+        if context.allSatisfy(\.isWhitespace) { return true }
 
-        // Check if last non-whitespace character is a sentence ender
-        guard let lastChar = trimmed.last else { return false }
-        return sentenceEnders.contains(lastChar)
+        guard let lastChar = context.last else { return false }
+
+        if lastChar.isWhitespace {
+            // A Western ender only triggers when actually followed by whitespace,
+            // so "e.g" does not capitalize the "g" (the ender has no trailing
+            // space) while "Hello. " does.
+            guard let lastNonWhitespace = context.reversed().first(where: { !$0.isWhitespace })
+            else { return true }
+            return sentenceEnders.contains(lastNonWhitespace)
+        }
+
+        // No trailing whitespace: only CJK enders (which need no space) trigger.
+        return cjkSentenceEnders.contains(lastChar)
     }
 
     /// Determines if the next character should be capitalized immediately (without space).

--- a/wurstfingerKeyboard/Definition/Model/ValidationError.swift
+++ b/wurstfingerKeyboard/Definition/Model/ValidationError.swift
@@ -115,12 +115,22 @@ extension KeyboardDefinition {
             errors.append(.modeNameMismatch(key: key, modeName: mode.name))
         }
 
-        // All switchMode targets must exist
+        // All switchMode targets must exist — in primary actions, return-swipe
+        // actions, and tap-cycle actions alike.
         for (_, mode) in modes {
             for (_, key) in mode.keys {
                 for (_, binding) in key.bindings {
                     if case let .switchMode(target) = binding.action,
                        modes[target] == nil {
+                        errors.append(.missingMode(target))
+                    }
+                    if case let .switchMode(target)? = binding.returnAction,
+                       modes[target] == nil {
+                        errors.append(.missingMode(target))
+                    }
+                }
+                for action in key.tapCycleActions ?? [] {
+                    if case let .switchMode(target) = action, modes[target] == nil {
                         errors.append(.missingMode(target))
                     }
                 }

--- a/wurstfingerTests/AutoCapitalizationTests.swift
+++ b/wurstfingerTests/AutoCapitalizationTests.swift
@@ -71,6 +71,22 @@ struct AutoCapitalizationTests {
         #expect(!AutoCapitalization.shouldCapitalize(context: "123 "))
     }
 
+    @Test func noCapitalizeAfterWesternEnderWithoutTrailingSpace() {
+        // The ender must actually be followed by whitespace; abbreviations and
+        // decimals (no trailing space) must not capitalize the next letter.
+        #expect(!AutoCapitalization.shouldCapitalize(context: "e."))
+        #expect(!AutoCapitalization.shouldCapitalize(context: "e.g"))
+        #expect(!AutoCapitalization.shouldCapitalize(context: "Mr."))
+        #expect(!AutoCapitalization.shouldCapitalize(context: "3.14"))
+    }
+
+    @Test func capitalizeAfterCjkEnderWithoutSpace() {
+        // CJK has no inter-sentence spaces, so the ender alone triggers.
+        #expect(AutoCapitalization.shouldCapitalize(context: "你好。"))
+        #expect(AutoCapitalization.shouldCapitalize(context: "什么！"))
+        #expect(AutoCapitalization.shouldCapitalize(context: "吗？"))
+    }
+
     // MARK: - shouldCapitalizeImmediately tests (pure logic)
 
     @Test func immediateCapitalizeAfterSpanishOpeningQuestion() {

--- a/wurstfingerTests/ModeDefinitionValidationTests.swift
+++ b/wurstfingerTests/ModeDefinitionValidationTests.swift
@@ -243,6 +243,40 @@ struct ValidationTests {
         #expect(errors.contains(.missingMode("nonexistent")))
     }
 
+    @Test func missingSwitchModeTargetInReturnAction() {
+        let key = KeyConfig(
+            id: "shift",
+            bindings: [.tap: KeyBinding(
+                label: "⇧",
+                action: .commitText("x"),
+                category: nil,
+                returnAction: .switchMode("nonexistent"),
+                accessibilityLabel: nil
+            )],
+            swipeMode: .none, slideType: .none, style: .utility, tapCycleActions: nil
+        )
+        let arrangement = GridArrangement(columns: 1, rows: [[KeyPlacement(keyId: "shift")]])
+        let mode = KeyboardMode(name: "main", keys: ["shift": key], arrangements: [.portrait: arrangement], autoTransitions: [:], doubleTapMode: nil)
+        let def = minimalDefinition(modes: [ModeNames.main: mode])
+        #expect(def.validate().contains(.missingMode("nonexistent")))
+    }
+
+    @Test func missingSwitchModeTargetInTapCycleActions() {
+        let key = KeyConfig(
+            id: "cycle",
+            bindings: [.tap: KeyBinding(
+                label: "c", action: .commitText("c"), category: nil,
+                returnAction: nil, accessibilityLabel: nil
+            )],
+            swipeMode: .none, slideType: .none, style: .primary,
+            tapCycleActions: [.commitText("c"), .switchMode("nonexistent")]
+        )
+        let arrangement = GridArrangement(columns: 1, rows: [[KeyPlacement(keyId: "cycle")]])
+        let mode = KeyboardMode(name: "main", keys: ["cycle": key], arrangements: [.portrait: arrangement], autoTransitions: [:], doubleTapMode: nil)
+        let def = minimalDefinition(modes: [ModeNames.main: mode])
+        #expect(def.validate().contains(.missingMode("nonexistent")))
+    }
+
     @Test func missingAutoTransitionTarget() {
         let mode = minimalMode(autoTransitions: [.letter: "nonexistent"])
         let def = minimalDefinition(modes: [ModeNames.main: mode])


### PR DESCRIPTION
Thematischer PR aus dem Code-Review (`CODE_REVIEW.md`) — Korrektheit & Robustheit.

## Findings
- **M2** — `AutoCapitalization.shouldCapitalize` trimmte alle trailing Whitespaces und prüfte dann das letzte Zeichen, sodass `e.g` zu `e.G` wurde (Abkürzungen/Dezimalzahlen). Jetzt verlangt ein **Western**-Ender (`. ! ? …`) tatsächlich folgendes Whitespace; **CJK**-Ender (`。！？`) triggern weiterhin ohne Leerzeichen (CJK kennt keine Inter-Satz-Spaces). Alle Bestandstests bleiben grün.
- **L2** — `KeyboardDefinition.validate()` prüfte dangling `switchMode`-Ziele nur in `binding.action`. Jetzt auch in `binding.returnAction` und `key.tapCycleActions`.
- **L3** — `phoneCircularOverrides` nutzte neun `classicCircularOverrides[...]!`-Force-Unwraps. Jetzt defensiv per Slot-Remap (`reduce`), kein `!`.

## Tests
+2 AutoCap (Abkürzung ohne Space bleibt klein, CJK ohne Space kapitalisiert), +2 Validierung (switchMode-Ziel in returnAction / tapCycleActions wird erkannt). **585 Tests grün** (iPhone 17 Pro).

## Zurückgestellt
- **M8** (Container-/Key-Höhe-Divergenz): in der Praxis kaum auslösbar (Scale/Aspect werden in der Host-App geändert, nicht bei sichtbarer Tastatur), aber der saubere Fix ist ein nicht-trivialer Layout-Umbau.
- **L4** (No-op-Return-Swipes), **L8** (heightMultiplier-assert): Verhaltens-/Designfragen ohne aktuellen Auslöser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-capitalization for both Western and CJK input, so sentence endings are detected more accurately depending on spacing and punctuation.
  * Strengthened keyboard definition validation to catch missing mode targets in more action types, helping prevent broken mode switches.
  * Improved internal override mapping logic for keyboard layouts, keeping layout behavior consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->