### PR TITLE
Add accent-cycle and circular-gesture pipeline tests

### DIFF
--- a/wurstfingerTests/ActionPipelineTests.swift
+++ b/wurstfingerTests/ActionPipelineTests.swift
@@ -320,6 +320,56 @@ struct ComposeMiddlewareTests {
 
         #expect(sink.received.first?.action == .commitText("!"))
     }
+
+    // MARK: - cycleAccents
+
+    @Test func cyclesAccentWhenCycleExists() {
+        var deleted = 0
+        let middleware = ComposeMiddleware(
+            compose: { _, _ in Issue.record("compose must not run for cycleAccents"); return nil },
+            cycleAccent: { $0 == "ä" ? "â" : nil },
+            previousCharacter: { "ä" },
+            deletePreviousCharacter: { deleted += 1 }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .cycleAccents))
+
+        #expect(sink.received.first?.action == .commitText("â"))
+        #expect(deleted == 1, "Previous character must be consumed when a cycle exists")
+    }
+
+    @Test func cycleAccentsPassesThroughWhenNoPreviousCharacter() {
+        let middleware = ComposeMiddleware(
+            compose: { _, _ in nil },
+            cycleAccent: { _ in Issue.record("cycleAccent must not run without a previous char"); return nil },
+            previousCharacter: { "" },
+            deletePreviousCharacter: { Issue.record("Must not delete without previous char") }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .cycleAccents))
+
+        // No previous character → action forwarded unchanged.
+        #expect(sink.received.first?.action == .cycleAccents)
+    }
+
+    @Test func cycleAccentsPassesThroughWhenNoCycleExists() {
+        let middleware = ComposeMiddleware(
+            compose: { _, _ in nil },
+            cycleAccent: { _ in nil }, // no cycle for this character
+            previousCharacter: { "x" },
+            deletePreviousCharacter: { Issue.record("Must not delete when no cycle exists") }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .cycleAccents))
+
+        #expect(sink.received.first?.action == .cycleAccents)
+    }
 }
 
 // MARK: - TextInputMiddleware

--- a/wurstfingerTests/CircularGesturePipelineTests.swift
+++ b/wurstfingerTests/CircularGesturePipelineTests.swift
@@ -27,7 +27,9 @@ struct CircularGesturePipelineTests {
 
         vm.handleGesture(.circularClockwise, keyId: GridSlot.topLeft, isReturn: false)
 
-        #expect(target.events.contains(.insertText(letter.uppercased())))
+        // Match production: tryCircularUppercase uppercases with the pipeline
+        // locale, so locale-sensitive letters can't drift from the assertion.
+        #expect(target.events.contains(.insertText(letter.uppercased(with: vm.pipelineLocale ?? .current))))
     }
 
     /// Counterclockwise uses the same uppercase fallback (exercises the
@@ -44,7 +46,9 @@ struct CircularGesturePipelineTests {
 
         vm.handleGesture(.circularCounterclockwise, keyId: GridSlot.topLeft, isReturn: false)
 
-        #expect(target.events.contains(.insertText(letter.uppercased())))
+        // Match production: tryCircularUppercase uppercases with the pipeline
+        // locale, so locale-sensitive letters can't drift from the assertion.
+        #expect(target.events.contains(.insertText(letter.uppercased(with: vm.pipelineLocale ?? .current))))
     }
 
     /// Path 1: numeric layer keys carry an explicit circular binding

--- a/wurstfingerTests/CircularGesturePipelineTests.swift
+++ b/wurstfingerTests/CircularGesturePipelineTests.swift
@@ -1,0 +1,78 @@
+//
+//  CircularGesturePipelineTests.swift
+//  WurstfingerTests
+//
+//  Tests for KeyboardViewModel's circular-gesture handling (handleCircular /
+//  tryCircularUppercase / dispatchBinding), driven end-to-end through the
+//  data-driven pipeline via makeViewModel + MockTextTarget.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct CircularGesturePipelineTests {
+    /// Path 2: a plain letter key with no explicit circular binding inserts
+    /// the uppercase center character.
+    @Test func clockwiseOnLetterKeyInsertsUppercase() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+
+        guard let key = vm.activeModeFromDefinition?.key(for: GridSlot.topLeft),
+              case let .commitText(letter) = key.bindings[.tap]?.action,
+              key.bindings[.circularClockwise] == nil
+        else {
+            Issue.record("Expected topLeft to be a plain letter key without an explicit circular binding")
+            return
+        }
+
+        vm.handleGesture(.circularClockwise, keyId: GridSlot.topLeft, isReturn: false)
+
+        #expect(target.events.contains(.insertText(letter.uppercased())))
+    }
+
+    /// Counterclockwise uses the same uppercase fallback (exercises the
+    /// opposite-direction computation too).
+    @Test func counterclockwiseOnLetterKeyInsertsUppercase() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+
+        guard let key = vm.activeModeFromDefinition?.key(for: GridSlot.topLeft),
+              case let .commitText(letter) = key.bindings[.tap]?.action
+        else {
+            Issue.record("Expected topLeft to be a letter key")
+            return
+        }
+
+        vm.handleGesture(.circularCounterclockwise, keyId: GridSlot.topLeft, isReturn: false)
+
+        #expect(target.events.contains(.insertText(letter.uppercased())))
+    }
+
+    /// Path 1: numeric layer keys carry an explicit circular binding
+    /// (superscripts / math symbols) which takes precedence over uppercasing.
+    @Test func circularInNumericModeDispatchesExplicitBinding() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+
+        vm.handleGesture(.tap, keyId: UtilitySlot.symbols, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.numeric)
+
+        guard let key = vm.activeModeFromDefinition?.key(for: GridSlot.topLeft),
+              case let .commitText(symbol) = key.bindings[.circularClockwise]?.action
+        else {
+            Issue.record("Expected numeric topLeft to carry an explicit circular binding")
+            return
+        }
+
+        vm.handleGesture(.circularClockwise, keyId: GridSlot.topLeft, isReturn: false)
+
+        #expect(target.events.contains(.insertText(symbol)))
+    }
+
+    /// An unknown key id is ignored (guard in handleCircular).
+    @Test func circularOnUnknownKeyIsNoop() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+
+        vm.handleGesture(.circularClockwise, keyId: "nonexistent-key", isReturn: false)
+
+        #expect(target.events.isEmpty)
+    }
+}


### PR DESCRIPTION
## What

Closes two remaining logic gaps from the coverage analysis.

### ComposeMiddleware — 69 % → 100 %
The `.cycleAccents` branch was untested. New cases: cycle present (previous character is consumed), no previous character, no cycle present. (Added to `ComposeMiddlewareTests`, using the existing helpers.)

### KeyboardViewModel circular handling — `handleCircular` 0 % → ~71 %
New file `CircularGesturePipelineTests`, end-to-end via `makeViewModel` + `MockTextTarget`:
- Letter key → uppercase via `tryCircularUppercase` (clockwise/counter-clockwise)
- Numeric layer → explicit circular binding (superscripts/symbols) via `dispatchBinding`
- Unknown keyId → no-op (guard)

Expected values are derived from the loaded definition (robust against classic/phone numpad).

## Note
While writing these tests, I noticed that the shared test helper `makeViewModel` sporadically crashes in `UserDefaults(suiteName:)` (force-unwrap) under full parallelism. Run in isolation/repeatedly, all tests are green — could be hardened separately.

## Test run
13 tests green on `iPhone 17 Pro` (3 new ComposeMiddleware + 4 circular + existing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for accent-cycling behavior, including replacement, no-op, and fallback cases.
  * Added end-to-end coverage for circular gesture input, verifying uppercase fallback, explicit gesture mappings, and no-op handling for unknown keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->