### PR TITLE
Fix Missing Icons on Function Keys (Globe, Dismiss, Clipboard)

### DIFF
--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -250,8 +250,13 @@ struct KeyView: View {
             let vPad = KeyboardConstants.FontSizes.hintBaseVerticalPadding * fontRatio
 
             ForEach(Array(key.bindings.keys), id: \.self) { gesture in
+                // Render a hint when it has a text label, or when the action
+                // maps to an icon (globe, dismiss, copy/cut/paste). Utility
+                // icon hints carry an empty label on purpose — their glyph is
+                // derived from the action, so gating on the label alone would
+                // hide them entirely.
                 if let binding = key.bindings[gesture],
-                   !binding.label.isEmpty,
+                   !binding.label.isEmpty || Self.hintIcon(for: binding.action) != nil,
                    let alignment = Self.hintAlignments[gesture] {
                     hintContent(for: binding)
                         .fixedSize()


### PR DESCRIPTION
## Problem
The swipe-hint icons are missing on the function keys: the upper-right **globe** key (swipe left → switch keyboard) and **dismiss keyboard** (swipe down), as well as **copy/cut/paste** on the `123` key. Noticed via the regenerated keyboard screenshots (#180).

## Cause
The bindings for these hints **intentionally carry an empty `label`** — the glyph is derived from the action via `hintIcon(for:)` (`.advanceToNextInputMode → globe`, `.dismissKeyboard → keyboard.chevron.compact.down`, copy/cut/paste → symbols). But `KeyView.hintOverlay` only renders a hint when `!binding.label.isEmpty` — so all icon hints with an empty label were never drawn.

The labels were emptied during the data-driven rework (#167 *Fix visual regressions*). It only became visible now because the keyboard screenshot baseline hadn't been regenerated since #158 (before the rework). **No** connection to #172/#178 merged today.

## Fix
One condition in `KeyView.hintOverlay`: render a hint when it has a text label **or** its action maps to an icon:
```swift
!binding.label.isEmpty || Self.hintIcon(for: binding.action) != nil
```
This is more consistent than refilling the labels with emojis, since these hints are icon- (not text-) based.

## Impact
Purely visual — the functionality (swipe globe/dismiss/clipboard) was never affected, only the display/discoverability.

## Verification
- Build compiles cleanly.
- Screenshot showcase regenerated (iPhone 17 Pro): globe, dismiss-keyboard and copy/cut/paste are shown again.

Note: Once merged, the screenshot workflow updates the keyboard baseline with the correct icons (replacing the current #180 state without icons).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hint overlays now appear for keys that use an icon-based hint, even when the text label is empty.
  * Improved display of utility-style key hints so they are no longer hidden unintentionally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->