### PR TITLE
Harden makeViewModel against UserDefaults suite crash

### DIFF
--- a/wurstfingerTests/TestHelpers.swift
+++ b/wurstfingerTests/TestHelpers.swift
@@ -41,13 +41,70 @@ final class MockTextTarget: TextInputTarget {
     }
 }
 
+/// Isolated, in-memory `UserDefaults` for tests.
+///
+/// Replaces the previous `UserDefaults(suiteName: "test.<UUID>")!` pattern,
+/// which created a fresh on-disk suite per call. Under parallel test
+/// execution that spammed the prefs directory and could return `nil`,
+/// crashing on the force-unwrap. This backing store never touches disk,
+/// never returns `nil`, and is fully isolated per instance.
+///
+/// `KeyboardSettings` reads/writes the injected store only via
+/// `object(forKey:)` / `set(_:forKey:)` / `removeObject(forKey:)`; the typed
+/// accessors are overridden too as a safety net.
+final class InMemoryUserDefaults: UserDefaults {
+    private var storage: [String: Any] = [:]
+    private let lock = NSLock()
+
+    convenience init() {
+        // suiteName nil backs `super` with the standard domain, but every
+        // accessor below is overridden so that domain is never consulted.
+        self.init(suiteName: nil)!
+    }
+
+    override func object(forKey defaultName: String) -> Any? {
+        lock.lock(); defer { lock.unlock() }
+        return storage[defaultName]
+    }
+
+    override func set(_ value: Any?, forKey defaultName: String) {
+        lock.lock(); defer { lock.unlock() }
+        storage[defaultName] = value
+    }
+
+    override func removeObject(forKey defaultName: String) {
+        lock.lock(); defer { lock.unlock() }
+        storage[defaultName] = nil
+    }
+
+    override func string(forKey defaultName: String) -> String? {
+        object(forKey: defaultName) as? String
+    }
+
+    override func bool(forKey defaultName: String) -> Bool {
+        (object(forKey: defaultName) as? NSNumber)?.boolValue ?? false
+    }
+
+    override func integer(forKey defaultName: String) -> Int {
+        (object(forKey: defaultName) as? NSNumber)?.intValue ?? 0
+    }
+
+    override func double(forKey defaultName: String) -> Double {
+        (object(forKey: defaultName) as? NSNumber)?.doubleValue ?? 0
+    }
+
+    override func float(forKey defaultName: String) -> Float {
+        (object(forKey: defaultName) as? NSNumber)?.floatValue ?? 0
+    }
+}
+
 /// Creates a KeyboardViewModel wired to a MockTextTarget for testing.
 func makeViewModel(
     languageId: String = "de_DE",
     advanceToNextInputMode: @escaping () -> Void = {},
     dismissKeyboard: @escaping () -> Void = {}
 ) -> (KeyboardViewModel, MockTextTarget) {
-    let defaults = UserDefaults(suiteName: "test.\(UUID().uuidString)")!
+    let defaults = InMemoryUserDefaults()
     let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
     let target = MockTextTarget()
     vm.bindTextInputTarget(target)


### PR DESCRIPTION
## Problem

`makeViewModel` (in `TestHelpers.swift`) created a fresh on-disk suite on every call:

```swift
let defaults = UserDefaults(suiteName: "test.\(UUID().uuidString)")!
```

Under full test parallelism this spams the prefs directory with plist files and can sporadically return `nil` → crash on the force-unwrap. This explains the occasional `makeViewModel` crashes (and contributed to the general load under which, among others, `LanguageDefinitionValidationTests` timed out).

## Fix

`InMemoryUserDefaults` — a `UserDefaults` subclass with dictionary backing:
- never touches the file system, never returns `nil`, fully isolated per instance
- `KeyboardSettings` only uses `object`/`set`/`removeObject` on the injected store; the typed accessors are also overridden as a safety net (thread-safe via `NSLock`)

## Verification

Full `WurstfingerTests` target run: **591 passed, 0 failed**, stable across two consecutive runs — including the previously flaky `LanguageDefinitionValidationTests`.

Pure test-infrastructure change, no production code affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by switching test storage to an isolated in-memory solution.
  * Reduced the chance of cross-test interference and leftover state between runs.
  * Made common value lookups in tests behave consistently, even when no value has been set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->