### PR TITLE
Add end-to-end typing UI tests

### DIFF
--- a/wurstfinger/KeyboardShowcaseView.swift
+++ b/wurstfinger/KeyboardShowcaseView.swift
@@ -10,13 +10,14 @@ import SwiftUI
 /// Captures pipeline actions for UI testing.
 ///
 /// Always counts actions (for dead-zone testing). When `capturesText` is set
-/// it additionally accumulates the produced text into `typedText` and exposes
-/// it as `documentContextBeforeInput`, so typing UI tests can assert the
-/// actual output (and context-dependent actions like compose / capitalize
-/// behave realistically).
+/// it models a minimal document — text split into `before` and `after` the
+/// cursor — so typing UI tests can assert the actual output, including
+/// cursor-aware behaviour (space-drag moves the insertion point) and
+/// context-dependent actions (compose / capitalize).
 private class ActionCountTarget: TextInputTarget, ObservableObject {
     @Published var count: Int = 0
-    @Published var typedText: String = ""
+    @Published private var before: String = ""
+    @Published private var after: String = ""
 
     private let capturesText: Bool
 
@@ -24,12 +25,17 @@ private class ActionCountTarget: TextInputTarget, ObservableObject {
         self.capturesText = capturesText
     }
 
+    /// Full captured text (before + after the cursor).
+    var typedText: String {
+        before + after
+    }
+
     var documentContextBeforeInput: String? {
-        capturesText ? typedText : nil
+        capturesText ? before : nil
     }
 
     var documentContextAfterInput: String? {
-        nil
+        capturesText ? after : nil
     }
 
     var selectedText: String? {
@@ -42,16 +48,26 @@ private class ActionCountTarget: TextInputTarget, ObservableObject {
 
     func insertText(_ text: String) {
         count += 1
-        if capturesText { typedText += text }
+        if capturesText { before += text }
     }
 
     func deleteBackward() {
         count += 1
-        if capturesText, !typedText.isEmpty { typedText.removeLast() }
+        if capturesText, !before.isEmpty { before.removeLast() }
     }
 
-    func adjustTextPosition(byCharacterOffset _: Int) {
+    func adjustTextPosition(byCharacterOffset offset: Int) {
         count += 1
+        guard capturesText, offset != 0 else { return }
+        if offset > 0 {
+            let n = min(offset, after.count)
+            before += after.prefix(n)
+            after.removeFirst(n)
+        } else {
+            let n = min(-offset, before.count)
+            after = String(before.suffix(n)) + after
+            before.removeLast(n)
+        }
     }
 }
 

--- a/wurstfinger/KeyboardShowcaseView.swift
+++ b/wurstfinger/KeyboardShowcaseView.swift
@@ -7,11 +7,25 @@
 
 import SwiftUI
 
-/// Counts pipeline actions for dead zone testing.
+/// Captures pipeline actions for UI testing.
+///
+/// Always counts actions (for dead-zone testing). When `capturesText` is set
+/// it additionally accumulates the produced text into `typedText` and exposes
+/// it as `documentContextBeforeInput`, so typing UI tests can assert the
+/// actual output (and context-dependent actions like compose / capitalize
+/// behave realistically).
 private class ActionCountTarget: TextInputTarget, ObservableObject {
     @Published var count: Int = 0
+    @Published var typedText: String = ""
+
+    private let capturesText: Bool
+
+    init(capturesText: Bool = false) {
+        self.capturesText = capturesText
+    }
+
     var documentContextBeforeInput: String? {
-        nil
+        capturesText ? typedText : nil
     }
 
     var documentContextAfterInput: String? {
@@ -26,12 +40,14 @@ private class ActionCountTarget: TextInputTarget, ObservableObject {
         false
     }
 
-    func insertText(_: String) {
+    func insertText(_ text: String) {
         count += 1
+        if capturesText { typedText += text }
     }
 
     func deleteBackward() {
         count += 1
+        if capturesText, !typedText.isEmpty { typedText.removeLast() }
     }
 
     func adjustTextPosition(byCharacterOffset _: Int) {
@@ -42,10 +58,13 @@ private class ActionCountTarget: TextInputTarget, ObservableObject {
 struct KeyboardShowcaseView: View {
     @StateObject private var viewModel = KeyboardViewModel(shouldPersistSettings: false)
     @StateObject private var languageSettings = LanguageSettings.shared
-    @StateObject private var actionTarget = ActionCountTarget()
+    @StateObject private var actionTarget = ActionCountTarget(
+        capturesText: ProcessInfo.processInfo.environment["TYPING_TEST"] != nil
+    )
     @State private var colorScheme: ColorScheme?
 
     private let isDeadZoneTest = ProcessInfo.processInfo.environment["DEAD_ZONE_TEST"] != nil
+    private let isTypingTest = ProcessInfo.processInfo.environment["TYPING_TEST"] != nil
 
     var body: some View {
         VStack(spacing: 0) {
@@ -64,6 +83,17 @@ struct KeyboardShowcaseView: View {
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
+
+            if isTypingTest {
+                // Visible placeholder keeps the element present when empty;
+                // the exact text (incl. empty / trailing spaces) is exposed
+                // via accessibilityValue and read by tests as `.value`.
+                Text(actionTarget.typedText.isEmpty ? "—" : actionTarget.typedText)
+                    .accessibilityIdentifier("typedText")
+                    .accessibilityValue(actionTarget.typedText)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
         }
         .background(Color(.systemBackground))
         .preferredColorScheme(colorScheme)
@@ -74,8 +104,8 @@ struct KeyboardShowcaseView: View {
                 languageSettings.selectedLanguageId = forcedLanguage
             }
 
-            // Wire up dead zone counter
-            if isDeadZoneTest {
+            // Wire up the capturing target for dead-zone and typing tests
+            if isDeadZoneTest || isTypingTest {
                 viewModel.bindTextInputTarget(actionTarget)
             }
 

--- a/wurstfingerTests/MultiLanguageTypingTests.swift
+++ b/wurstfingerTests/MultiLanguageTypingTests.swift
@@ -1,0 +1,73 @@
+//
+//  MultiLanguageTypingTests.swift
+//  WurstfingerTests
+//
+//  Integration tests that exercise the typing pipeline for every registered
+//  language — verifying each definition loads and its keys produce the
+//  expected characters, not just German.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct MultiLanguageTypingTests {
+    private func inserts(_ target: MockTextTarget) -> [String] {
+        target.events.compactMap { if case let .insertText(t) = $0 { t } else { nil } }
+    }
+
+    /// For every registered language, tapping the center key produces that
+    /// language's center character (its tap binding label / action).
+    @Test func everyLanguageTypesItsCenterCharacter() {
+        for info in KeyboardRegistry.available {
+            let (vm, target) = makeViewModel(languageId: info.id)
+
+            guard let center = vm.activeModeFromDefinition?.key(for: GridSlot.center),
+                  case let .commitText(expected) = center.bindings[.tap]?.action
+            else {
+                // Center without a plain commit-text tap — nothing to assert here.
+                continue
+            }
+
+            vm.handleGesture(.tap, keyId: GridSlot.center, isReturn: false)
+
+            #expect(
+                inserts(target).last == expected,
+                "Language \(info.id): center tap should produce '\(expected)', got '\(inserts(target).last ?? "nil")'"
+            )
+        }
+    }
+
+    /// For every language, a directional swipe on the center key produces a
+    /// character (the layouts populate the center's swipe directions).
+    @Test func everyLanguageProducesOutputForCenterSwipe() {
+        for info in KeyboardRegistry.available {
+            let (vm, target) = makeViewModel(languageId: info.id)
+
+            guard let center = vm.activeModeFromDefinition?.key(for: GridSlot.center),
+                  case let .commitText(expected) = center.bindings[.swipeUp]?.action
+            else {
+                continue
+            }
+
+            vm.handleGesture(.swipeUp, keyId: GridSlot.center, isReturn: false)
+
+            #expect(
+                inserts(target).last == expected,
+                "Language \(info.id): center swipe-up should produce '\(expected)', got '\(inserts(target).last ?? "nil")'"
+            )
+        }
+    }
+
+    /// Every registered language loads a definition with a main mode and a
+    /// resolvable center key (guards against an unloadable/empty layout).
+    @Test func everyLanguageLoadsWithCenterKey() {
+        for info in KeyboardRegistry.available {
+            let (vm, _) = makeViewModel(languageId: info.id)
+            #expect(
+                vm.activeModeFromDefinition?.key(for: GridSlot.center) != nil,
+                "Language \(info.id) should load with a center key"
+            )
+        }
+    }
+}

--- a/wurstfingerTests/MultiLanguageTypingTests.swift
+++ b/wurstfingerTests/MultiLanguageTypingTests.swift
@@ -25,7 +25,9 @@ struct MultiLanguageTypingTests {
             guard let center = vm.activeModeFromDefinition?.key(for: GridSlot.center),
                   case let .commitText(expected) = center.bindings[.tap]?.action
             else {
-                // Center without a plain commit-text tap — nothing to assert here.
+                // Every language's center key is expected to commit a literal
+                // character; a missing/changed binding is a layout regression.
+                Issue.record("Language \(info.id): center key has no commit-text tap binding")
                 continue
             }
 

--- a/wurstfingerTests/ReturnSwipePipelineTests.swift
+++ b/wurstfingerTests/ReturnSwipePipelineTests.swift
@@ -1,0 +1,79 @@
+//
+//  ReturnSwipePipelineTests.swift
+//  WurstfingerTests
+//
+//  Integration tests for the return-swipe path through KeyboardViewModel.
+//
+//  A return swipe (out and back to the start) is an out-and-back continuous
+//  drag that XCUITest cannot synthesize, so it is verified here at the
+//  pipeline level instead: handleGesture(..., isReturn: true) must resolve
+//  the binding's returnAction rather than its primary action.
+//
+//  ReturnSwipeLanguageTests already covers center-key letter overrides; this
+//  complements it with the shared symbol-slot return actions.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct ReturnSwipePipelineTests {
+    private func inserts(_ target: MockTextTarget) -> [String] {
+        target.events.compactMap { if case let .insertText(t) = $0 { t } else { nil } }
+    }
+
+    /// A return swipe on a symbol slot produces its `returnAction`, not its
+    /// primary action.
+    @Test func returnSwipeOnSymbolSlotProducesReturnAction() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+
+        // topCenter ↗ has a compose primary action and a distinct return action.
+        guard let key = vm.activeModeFromDefinition?.key(for: GridSlot.topCenter),
+              let binding = key.bindings[.swipeUpRight],
+              case let .commitText(expected) = binding.returnAction
+        else {
+            Issue.record("Expected topCenter ↗ to carry a commitText return action")
+            return
+        }
+
+        vm.handleGesture(.swipeUpRight, keyId: GridSlot.topCenter, isReturn: true)
+
+        #expect(inserts(target).last == expected)
+    }
+
+    /// The same gesture without the return flag does NOT emit the return
+    /// action — guarding against the two paths collapsing.
+    @Test func plainSwipeDoesNotProduceReturnAction() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+
+        guard let key = vm.activeModeFromDefinition?.key(for: GridSlot.topCenter),
+              let binding = key.bindings[.swipeUpRight],
+              case let .commitText(returnText) = binding.returnAction
+        else {
+            Issue.record("Expected topCenter ↗ to carry a commitText return action")
+            return
+        }
+
+        vm.handleGesture(.swipeUpRight, keyId: GridSlot.topCenter, isReturn: false)
+
+        #expect(!inserts(target).contains(returnText))
+    }
+
+    /// A return swipe on a plain punctuation slot commits its return character.
+    @Test func returnSwipeOnPunctuationSlotCommitsReturnCharacter() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+
+        // topLeft → (swipeRight) maps "-" with a "÷" return action.
+        guard let key = vm.activeModeFromDefinition?.key(for: GridSlot.topLeft),
+              let binding = key.bindings[.swipeRight],
+              case let .commitText(expected) = binding.returnAction
+        else {
+            Issue.record("Expected topLeft → to carry a commitText return action")
+            return
+        }
+
+        vm.handleGesture(.swipeRight, keyId: GridSlot.topLeft, isReturn: true)
+
+        #expect(inserts(target).last == expected)
+    }
+}

--- a/wurstfingerTests/ReturnSwipePipelineTests.swift
+++ b/wurstfingerTests/ReturnSwipePipelineTests.swift
@@ -76,4 +76,31 @@ struct ReturnSwipePipelineTests {
 
         #expect(inserts(target).last == expected)
     }
+
+    // MARK: - Newline
+
+    /// The newline swipe (topRight ↗) inserts a line break.
+    @Test func newlineSwipeInsertsLineBreak() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+
+        guard let key = vm.activeModeFromDefinition?.key(for: GridSlot.topRight),
+              case .commitText("\n") = key.bindings[.swipeUpRight]?.action
+        else {
+            Issue.record("Expected topRight ↗ to commit a newline")
+            return
+        }
+
+        vm.handleGesture(.swipeUpRight, keyId: GridSlot.topRight, isReturn: false)
+
+        #expect(inserts(target).last == "\n")
+    }
+
+    /// Tapping the return utility key inserts a line break.
+    @Test func returnKeyInsertsLineBreak() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+
+        vm.handleGesture(.tap, keyId: UtilitySlot.return, isReturn: false)
+
+        #expect(inserts(target).last == "\n")
+    }
 }

--- a/wurstfingerTests/TelexTypingTests.swift
+++ b/wurstfingerTests/TelexTypingTests.swift
@@ -1,0 +1,70 @@
+//
+//  TelexTypingTests.swift
+//  WurstfingerTests
+//
+//  Integration tests for the Vietnamese Telex input method end-to-end through
+//  KeyboardViewModel: typing key gestures on the vi_VN layout should trigger
+//  TelexMiddleware composition (digraphs and tone marks), not just commit the
+//  raw letters.
+//
+//  vi_VN center grid (taps):  a n i / h o r / t e s
+//  → topLeft = "a", center = "o", bottomRight = "s", center ↓ = "d".
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+@Suite(.serialized)
+struct TelexTypingTests {
+    /// Doubling a vowel composes its circumflex (a + a → â).
+    @Test func doublingVowelComposesCircumflex() {
+        let (vm, target) = makeViewModel(languageId: "vi_VN")
+
+        vm.handleGesture(.tap, keyId: GridSlot.topLeft, isReturn: false) // a
+        vm.handleGesture(.tap, keyId: GridSlot.topLeft, isReturn: false) // a → â
+
+        #expect(target.documentContextBeforeInput == "â")
+    }
+
+    /// Doubling "o" composes ô (independent vowel, via the center key).
+    @Test func doublingOComposesOCircumflex() {
+        let (vm, target) = makeViewModel(languageId: "vi_VN")
+
+        vm.handleGesture(.tap, keyId: GridSlot.center, isReturn: false) // o
+        vm.handleGesture(.tap, keyId: GridSlot.center, isReturn: false) // o → ô
+
+        #expect(target.documentContextBeforeInput == "ô")
+    }
+
+    /// The "s" key applies the acute tone to the preceding vowel (a + s → á).
+    @Test func toneKeyAppliesAcuteAccent() {
+        let (vm, target) = makeViewModel(languageId: "vi_VN")
+
+        vm.handleGesture(.tap, keyId: GridSlot.topLeft, isReturn: false) // a
+        vm.handleGesture(.tap, keyId: GridSlot.bottomRight, isReturn: false) // s → á
+
+        #expect(target.documentContextBeforeInput == "á")
+    }
+
+    /// Doubling "d" composes the đ consonant (d is the center down-swipe).
+    @Test func doublingDComposesDStroke() {
+        let (vm, target) = makeViewModel(languageId: "vi_VN")
+
+        vm.handleGesture(.swipeDown, keyId: GridSlot.center, isReturn: false) // d
+        vm.handleGesture(.swipeDown, keyId: GridSlot.center, isReturn: false) // d → đ
+
+        #expect(target.documentContextBeforeInput == "đ")
+    }
+
+    /// A non-Telex language (de_DE) does NOT apply Telex composition — typing
+    /// "a" then "a" yields "aa", guarding against the middleware misfiring.
+    @Test func telexDoesNotApplyForNonTelexLanguage() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+
+        vm.handleGesture(.tap, keyId: GridSlot.topLeft, isReturn: false) // a
+        vm.handleGesture(.tap, keyId: GridSlot.topLeft, isReturn: false) // a
+
+        #expect(target.documentContextBeforeInput == "aa")
+    }
+}

--- a/wurstfingerUITests/TypingTests.swift
+++ b/wurstfingerUITests/TypingTests.swift
@@ -79,6 +79,15 @@ final class TypingTests: XCTestCase {
         return label
     }
 
+    /// Drags from a key's center by (dx, dy) points — long enough to register
+    /// as a directional swipe. Negative dy is up; positive dx is right.
+    private func swipe(on id: String, dx: CGFloat, dy: CGFloat) {
+        let element = key(id)
+        let start = element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+        let end = start.withOffset(CGVector(dx: dx, dy: dy))
+        start.press(forDuration: 0.05, thenDragTo: end)
+    }
+
     // MARK: - Tests
 
     /// Tapping letter keys appends each key's character in order.
@@ -133,6 +142,21 @@ final class TypingTests: XCTestCase {
             result, .completed,
             "Swipe up should produce a character other than the tap label '\(tapLabel)', got '\(typedText())'"
         )
+    }
+
+    /// Compose: typing a base letter, then swiping the acute-accent trigger
+    /// (topCenter ↗, `.compose(trigger: "´")`), composes the accented letter
+    /// (´ + a → á).
+    @MainActor
+    func testComposeAcuteAccentProducesAccentedLetter() {
+        let base = tapKey("topLeft") // "a" in de_DE
+        XCTAssertEqual(base, "a", "Test assumes topLeft is 'a' on the de_DE lower layer")
+        assertTypedText(equals: "a")
+
+        // Swipe up-right on topCenter → emits .compose(trigger: "´").
+        swipe(on: "topCenter", dx: 40, dy: -40)
+
+        assertTypedText(equals: "á")
     }
 
     /// Switching to the numeric layer via the symbols key lets digits be typed.

--- a/wurstfingerUITests/TypingTests.swift
+++ b/wurstfingerUITests/TypingTests.swift
@@ -1,0 +1,151 @@
+//
+//  TypingTests.swift
+//  wurstfingerUITests
+//
+//  End-to-end UI tests that drive real gestures on the in-app keyboard
+//  (KeyboardShowcaseView with TYPING_TEST) and assert the produced text,
+//  not just that an action occurred.
+//
+//  Expectations are derived from each key's accessibility label (its printed
+//  character), so these stay valid when the concrete letter layout changes.
+//
+
+import XCTest
+
+final class TypingTests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = ["SCREENSHOT_MODE"]
+        app.launchEnvironment["TYPING_TEST"] = "1"
+        app.launchEnvironment["FORCE_LANGUAGE"] = "de_DE"
+        app.launchEnvironment["FORCE_LAYER"] = "lower"
+        app.launchEnvironment["FORCE_APPEARANCE"] = "light"
+        app.launch()
+        waitForKeyboard()
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    // MARK: - Helpers
+
+    private func key(_ id: String) -> XCUIElement {
+        app.buttons[id]
+    }
+
+    /// Current captured text, read from the harness' `typedText` element.
+    private func typedText() -> String {
+        (app.staticTexts["typedText"].value as? String) ?? ""
+    }
+
+    private func waitForKeyboard() {
+        XCTAssertTrue(key("center").waitForExistence(timeout: 5), "Keyboard not loaded")
+        XCTAssertTrue(
+            app.staticTexts["typedText"].waitForExistence(timeout: 2),
+            "Typing harness not present"
+        )
+    }
+
+    /// Polls until the captured text equals `expected` (UI updates are async).
+    private func assertTypedText(
+        equals expected: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let predicate = NSPredicate { _, _ in self.typedText() == expected }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        let result = XCTWaiter.wait(for: [expectation], timeout: 3.0)
+        XCTAssertEqual(
+            result, .completed,
+            "Expected typed text '\(expected)', got '\(typedText())'",
+            file: file, line: line
+        )
+    }
+
+    /// Taps a key and returns the accessibility label it carried (its tap char).
+    @discardableResult
+    private func tapKey(_ id: String, file: StaticString = #filePath, line: UInt = #line) -> String {
+        let element = key(id)
+        guard element.waitForExistence(timeout: 2) else {
+            XCTFail("Key '\(id)' not found", file: file, line: line)
+            return ""
+        }
+        let label = element.label
+        element.tap()
+        return label
+    }
+
+    // MARK: - Tests
+
+    /// Tapping letter keys appends each key's character in order.
+    @MainActor
+    func testTappingKeysSpellsTheirLabels() {
+        var expected = ""
+        for id in ["topLeft", "topCenter", "topRight"] {
+            expected += tapKey(id)
+            assertTypedText(equals: expected)
+        }
+    }
+
+    /// The delete key removes the last typed character.
+    @MainActor
+    func testDeleteRemovesLastCharacter() {
+        let first = tapKey("topLeft")
+        let second = tapKey("topCenter")
+        assertTypedText(equals: first + second)
+
+        tapKey("delete")
+        assertTypedText(equals: first)
+    }
+
+    /// The space key inserts a space between characters.
+    @MainActor
+    func testSpaceInsertsSpace() {
+        let first = tapKey("topLeft")
+        tapKey("space")
+        let second = tapKey("topCenter")
+        assertTypedText(equals: "\(first) \(second)")
+    }
+
+    /// A directional swipe produces a different character than a plain tap.
+    @MainActor
+    func testSwipeUpProducesDifferentCharacterThanTap() {
+        let element = key("topLeft")
+        XCTAssertTrue(element.waitForExistence(timeout: 2))
+        let tapLabel = element.label
+
+        element.swipeUp()
+
+        // Something was produced, and it differs from the tap (center) output.
+        let predicate = NSPredicate { _, _ in
+            let t = self.typedText()
+            return !t.isEmpty && t != tapLabel
+        }
+        let result = XCTWaiter.wait(
+            for: [XCTNSPredicateExpectation(predicate: predicate, object: nil)],
+            timeout: 3.0
+        )
+        XCTAssertEqual(
+            result, .completed,
+            "Swipe up should produce a character other than the tap label '\(tapLabel)', got '\(typedText())'"
+        )
+    }
+
+    /// Switching to the numeric layer via the symbols key lets digits be typed.
+    @MainActor
+    func testLayerSwitchToNumbersTypesDigit() {
+        tapKey("symbols")
+
+        // After switching, the center key carries a numeric-layer character.
+        let center = key("center")
+        XCTAssertTrue(center.waitForExistence(timeout: 2), "Center key missing after layer switch")
+        let label = center.label
+        center.tap()
+
+        assertTypedText(equals: label)
+    }
+}

--- a/wurstfingerUITests/TypingTests.swift
+++ b/wurstfingerUITests/TypingTests.swift
@@ -266,6 +266,12 @@ final class TypingTests: XCTestCase {
         let center = key("center")
         XCTAssertTrue(center.waitForExistence(timeout: 2), "Center key missing after layer switch")
         let label = center.label
+        // Verify the switch actually landed on the numeric layer (a digit),
+        // not just any echoable key (e.g. a punctuation/symbols layer).
+        XCTAssertTrue(
+            !label.isEmpty && label.allSatisfy(\.isNumber),
+            "Expected a digit on the numeric layer after the symbols key, got '\(label)'"
+        )
         center.tap()
 
         assertTypedText(equals: label)

--- a/wurstfingerUITests/TypingTests.swift
+++ b/wurstfingerUITests/TypingTests.swift
@@ -96,6 +96,16 @@ final class TypingTests: XCTestCase {
         start.press(forDuration: 0.05, thenDragTo: end)
     }
 
+    /// Horizontal drag across the space bar (moves the cursor). Negative dx
+    /// is left. The press duration lets the slide gesture engage before the
+    /// drag, so XCUITest emits interpolated move events.
+    private func dragSpace(dx: CGFloat) {
+        let space = key("space")
+        let start = space.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+        let end = start.withOffset(CGVector(dx: dx, dy: 0))
+        start.press(forDuration: 0.2, thenDragTo: end)
+    }
+
     // MARK: - Tests
 
     /// Tapping letter keys appends each key's character in order.
@@ -197,6 +207,54 @@ final class TypingTests: XCTestCase {
 
             assertTypedText(equals: label)
         }
+    }
+
+    /// Swiping up on the shift key (midRight) switches to the shifted layer,
+    /// so the next letter is uppercase.
+    @MainActor
+    func testShiftSwipeProducesUppercaseLetter() {
+        swipe(on: "midRight", dx: 0, dy: -45) // ⇧ → shifted
+
+        let typed = tapKey("topLeft")
+        assertTypedText(equals: typed)
+        XCTAssertFalse(typed.isEmpty)
+        XCTAssertEqual(typed, typed.uppercased(), "Shifted layer should produce an uppercase letter")
+    }
+
+    /// A double swipe-up on the shift key engages caps-lock, so several
+    /// letters in a row are uppercase (no auto-transition back to lower).
+    @MainActor
+    func testCapsLockProducesUppercaseSequence() {
+        swipe(on: "midRight", dx: 0, dy: -45) // ⇧ → shifted
+        swipe(on: "midRight", dx: 0, dy: -45) // ⇧⇧ → caps-lock
+
+        let first = tapKey("topLeft")
+        let second = tapKey("topCenter")
+        assertTypedText(equals: first + second)
+        XCTAssertEqual(first, first.uppercased())
+        XCTAssertEqual(second, second.uppercased(), "Caps-lock should keep producing uppercase letters")
+    }
+
+    /// Dragging left on the space bar moves the cursor, so the next character
+    /// is inserted before the end rather than appended.
+    @MainActor
+    func testSpaceDragMovesCursorForMidTextInsertion() {
+        let c1 = tapKey("topLeft")
+        let c2 = tapKey("topCenter")
+        let c3 = tapKey("topRight")
+        assertTypedText(equals: c1 + c2 + c3)
+
+        dragSpace(dx: -120) // move cursor left (several steps)
+
+        let inserted = tapKey("midLeft")
+
+        let result = typedText()
+        XCTAssertEqual(result.count, 4, "Expected four characters, got '\(result)'")
+        XCTAssertTrue(result.contains(inserted), "Inserted character missing from '\(result)'")
+        XCTAssertNotEqual(
+            result, c1 + c2 + c3 + inserted,
+            "Cursor should have moved left, so '\(inserted)' is not appended at the end"
+        )
     }
 
     /// Switching to the numeric layer via the symbols key lets digits be typed.

--- a/wurstfingerUITests/TypingTests.swift
+++ b/wurstfingerUITests/TypingTests.swift
@@ -50,6 +50,14 @@ final class TypingTests: XCTestCase {
         )
     }
 
+    /// Relaunches the app forcing a specific keyboard language.
+    private func relaunch(language: String) {
+        app.terminate()
+        app.launchEnvironment["FORCE_LANGUAGE"] = language
+        app.launch()
+        waitForKeyboard()
+    }
+
     /// Polls until the captured text equals `expected` (UI updates are async).
     private func assertTypedText(
         equals expected: String,
@@ -157,6 +165,38 @@ final class TypingTests: XCTestCase {
         swipe(on: "topCenter", dx: 40, dy: -40)
 
         assertTypedText(equals: "á")
+    }
+
+    /// The return key inserts a line break between characters.
+    @MainActor
+    func testReturnKeyInsertsSeparator() {
+        let first = tapKey("topLeft") // "a"
+        tapKey("return")
+        let second = tapKey("topCenter") // "b"
+
+        // Accessibility may render the newline as "\n" or normalize it to a
+        // space; either way there must be a separator between the two letters.
+        // The exact "\n" is asserted in ReturnSwipePipelineTests.
+        let value = typedText()
+        XCTAssertEqual(value.count, 3, "Expected 3 characters with a separator, got '\(value)'")
+        XCTAssertEqual(value.first.map(String.init), first)
+        XCTAssertEqual(value.last.map(String.init), second)
+        XCTAssertNotEqual(value, first + second, "Return should insert a separator")
+    }
+
+    /// Typing works across different scripts/layouts, not just German.
+    @MainActor
+    func testTypingWorksAcrossLanguages() {
+        for language in ["fr_FR", "ru_RU"] {
+            relaunch(language: language)
+
+            let center = key("center")
+            XCTAssertTrue(center.waitForExistence(timeout: 3), "center key missing for \(language)")
+            let label = center.label
+            center.tap()
+
+            assertTypedText(equals: label)
+        }
     }
 
     /// Switching to the numeric layer via the symbols key lets digits be typed.


### PR DESCRIPTION
## Was

Die bestehenden UI-Tests prüften nur *dass* eine Aktion passiert (DeadZone-Counter) oder Navigation — **keiner verifizierte den tatsächlich erzeugten Text**. Diese PR fügt Tipp-Verhalten end-to-end hinzu (UI) und ergänzt schwer per-UI-testbare Pfade auf Pipeline-Ebene.

### Harness-Erweiterung (`KeyboardShowcaseView`)
Neuer `TYPING_TEST`-Modus: das (bisher nur zählende) `ActionCountTarget` modelliert jetzt ein Mini-Dokument (Text **vor/nach dem Cursor**) und exponiert den Text als Accessibility-Element `typedText` (via `accessibilityValue`). Damit sind cursor-bewusstes Einfügen und kontextabhängige Aktionen (Compose) beobachtbar. DEAD_ZONE_TEST (nur Zählen) bleibt unverändert.

### UI-Suite `TypingTests` (echte Gesten → Text-Assertions)
- Buchstaben-Tasten ergeben ihre Labels in Reihenfolge; Delete entfernt das letzte Zeichen; Space fügt ein Leerzeichen ein
- ein Swipe erzeugt ein anderes Zeichen als ein Tap; Wechsel auf den Numeric-Layer tippt eine Ziffer
- **Compose**: „a" + Akut-Trigger swipen (topCenter ↗) → **á**
- **Return/Newline**: die Return-Taste fügt einen Separator ein
- **Mehrere Sprachen**: Center-Taste über fr_FR und ru_RU
- **Shift**: Swipe-up auf der Shift-Taste → nächster Buchstabe groß
- **Caps-Lock**: Doppel-Swipe-up → ganze Sequenz groß (kein Auto-Rückwechsel)
- **Cursor**: Links-Drag auf der Space-Leiste bewegt den Cursor → nächstes Zeichen wird mitten im Text eingefügt

Erwartungswerte aus den Accessibility-Labels → **layout- und sprach-unabhängig**.

### Integrations-Suiten (Pfade, die XCUITest nicht synthetisieren kann)
- **`ReturnSwipePipelineTests`**: Return-Swipe (kein Mehrpunkt-Drag-API in XCUITest) → `handleGesture(..., isReturn: true)` löst die `returnAction` auf (Symbol-/Punktuations-Slots); plus exakte Newline-Assertions (`topRight ↗` und Return-Taste → `\n`).
- **`MultiLanguageTypingTests`**: treibt die Pipeline für **alle 15 Sprachen** (Center-Tap/-Swipe erzeugen die jeweiligen Zeichen).
- **`TelexTypingTests`**: vi_VN end-to-end — Vokal-Verdopplung (aa→â, oo→ô), Tonzeichen (a+s→á), đ-Konsonant (dd→đ), plus Guard, dass eine Nicht-Telex-Sprache „aa" unverändert lässt.

## Verifikation
- `TypingTests`: 11/11 grün (riskante Gesten — Shift/Caps/Cursor — über zwei Läufe stabil)
- `ReturnSwipePipelineTests` 5/5 · `MultiLanguageTypingTests` 3/3 · `TelexTypingTests` 5/5 grün
- `DeadZoneTests`: weiterhin grün → keine Regression durch den Harness-Umbau

`iPhone 17 Pro`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible typed-text display for typing tests, making it easier to verify captured input on-screen.
  * Expanded gesture typing support across multiple languages, including language-specific composition and swipe behaviors.

* **Bug Fixes**
  * Improved return-swipe behavior so the correct character or newline is inserted in more cases.
  * Refined typing and cursor movement behavior, including delete/backspace and space-bar drag interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->