### PR TITLE
Screenshot-Script aufräumen: gezielter Test + echte Datei-Liste

### DIFF
--- a/scripts/generate-screenshots.sh
+++ b/scripts/generate-screenshots.sh
@@ -34,7 +34,7 @@ else
 fi
 
 DESTINATION="platform=iOS Simulator,name=$DEVICE_NAME"
-TEST_TARGET="WurstfingerUITests/ScreenshotTests"
+TEST_TARGET="WurstfingerUITests/ScreenshotTests/testGenerateScreenshots"
 DOCS_DIR="$PROJECT_ROOT/docs/images"
 DERIVED_DATA="/tmp/WurstfingerScreenshots"
 
@@ -273,10 +273,7 @@ if [ $COPIED -gt 0 ]; then
   echo -e "${GREEN}✅ Success! Created $COPIED WebP screenshot(s) in $DOCS_DIR${NC}"
   echo ""
   echo -e "${BLUE}📝 Generated screenshots:${NC}"
-  echo "    - keyboard-lower-light.webp"
-  echo "    - keyboard-lower-dark.webp"
-  echo "    - keyboard-numbers-light.webp"
-  echo "    - keyboard-numbers-dark.webp"
+  ls -1 "$DOCS_DIR"/*.webp 2>/dev/null | while read -r f; do echo "    - $(basename "$f")"; done
 else
   echo -e "${RED}❌ No screenshots found${NC}"
   echo ""


### PR DESCRIPTION
Kleine Aufräum-Verbesserungen an `scripts/generate-screenshots.sh`, geborgen aus einem verworfenen lokalen Entwurf:

- **Gezieltes Test-Target:** `WurstfingerUITests/ScreenshotTests/testGenerateScreenshots` statt der ganzen `ScreenshotTests`-Klasse → nur der Generierungs-Test läuft (schneller, keine Seiteneffekte anderer Tests).
- **Echte Datei-Liste:** Die abschließende Ausgabe listet jetzt die tatsächlich erzeugten `.webp`-Dateien per `ls` statt einer hartcodierten, veralteten Namensliste (die noch `keyboard-lower-light.webp` etc. nannte).

Rein im Helfer-Script, keine Auswirkung auf App oder CI-Logik. `bash -n` sauber.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot generation to target the correct test case more precisely.
  * Updated the output to automatically list generated image files, making screenshot results easier to verify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->