### PR TITLE
Add robustness, accessibility and compose-integrity tests

### DIFF
--- a/wurstfingerTests/AccessibilityLabelTests.swift
+++ b/wurstfingerTests/AccessibilityLabelTests.swift
@@ -1,0 +1,76 @@
+//
+//  AccessibilityLabelTests.swift
+//  WurstfingerTests
+//
+//  Ensures every key in every mode of every registered language exposes a
+//  usable VoiceOver label — i.e. a tap binding with a non-empty label, so the
+//  rendered key never falls back to reading the raw slot id ("topLeft", …).
+//
+//  Complements LayoutValidationTests.allGridKeyTapBindingsAreNonEmpty, which
+//  only checks grid keys in the main mode.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct AccessibilityLabelTests {
+    private var definitions: [KeyboardDefinition] {
+        KeyboardRegistry.available.compactMap { KeyboardRegistry.load(id: $0.id) }
+    }
+
+    /// Mirrors KeyView's accessibility-label resolution
+    /// (custom accessibility label → tap label → slot id fallback).
+    private func accessibilityLabel(for key: KeyConfig) -> String {
+        if let tap = key.bindings[.tap] {
+            return tap.accessibilityLabel ?? tap.label
+        }
+        return key.id
+    }
+
+    @Test func definitionsLoad() {
+        #expect(!definitions.isEmpty, "Expected registered languages to load")
+    }
+
+    @Test func everyKeyHasATapBinding() {
+        for def in definitions {
+            for (modeName, mode) in def.modes {
+                for (keyId, key) in mode.keys {
+                    #expect(
+                        key.bindings[.tap] != nil,
+                        "\(def.id)/\(modeName)/\(keyId) has no .tap binding — VoiceOver would read the raw slot id"
+                    )
+                }
+            }
+        }
+    }
+
+    @Test func everyKeyHasANonEmptyAccessibilityLabel() {
+        for def in definitions {
+            for (modeName, mode) in def.modes {
+                for (keyId, key) in mode.keys {
+                    let label = accessibilityLabel(for: key)
+                    #expect(
+                        !label.isEmpty,
+                        "\(def.id)/\(modeName)/\(keyId) resolves to an empty accessibility label"
+                    )
+                }
+            }
+        }
+    }
+
+    @Test func accessibilityLabelNeverFallsBackToSlotId() {
+        let slotIds = Set(GridSlot.allSlots.flatMap(\.self))
+        for def in definitions {
+            for (modeName, mode) in def.modes {
+                for (keyId, key) in mode.keys where slotIds.contains(keyId) {
+                    let label = accessibilityLabel(for: key)
+                    #expect(
+                        label != keyId,
+                        "\(def.id)/\(modeName)/\(keyId) accessibility label is the raw slot id"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/wurstfingerTests/ComposeDataIntegrityTests.swift
+++ b/wurstfingerTests/ComposeDataIntegrityTests.swift
@@ -1,0 +1,69 @@
+//
+//  ComposeDataIntegrityTests.swift
+//  WurstfingerTests
+//
+//  Data-integrity checks for the compose rules: every rule is well-formed,
+//  the engine resolves every rule consistently, and every compose trigger
+//  used by a layout actually has rules.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct ComposeDataIntegrityTests {
+    private let rules = ComposeRuleSet.global.rules
+
+    @Test func everyRuleIsWellFormed() {
+        for (trigger, map) in rules {
+            #expect(!trigger.isEmpty, "Empty compose trigger key")
+            #expect(!map.isEmpty, "Trigger '\(trigger)' has no entries")
+            for (previous, result) in map {
+                #expect(!previous.isEmpty, "Trigger '\(trigger)' has an empty previous-character key")
+                #expect(!result.isEmpty, "Rule \(trigger)+\(previous) → empty result")
+                #expect(
+                    result.count == 1,
+                    "Rule \(trigger)+\(previous) → '\(result)' is not a single grapheme"
+                )
+            }
+        }
+    }
+
+    @Test func engineResolvesEveryRuleConsistently() {
+        for (trigger, map) in rules {
+            for (previous, result) in map {
+                #expect(
+                    ComposeEngine.shared.compose(previous: previous, trigger: trigger) == result,
+                    "Engine disagrees with data for \(trigger)+\(previous): expected '\(result)'"
+                )
+            }
+        }
+    }
+
+    @Test func everyLayoutComposeTriggerHasRules() {
+        var triggers = Set<String>()
+        for info in KeyboardRegistry.available {
+            guard let def = KeyboardRegistry.load(id: info.id) else { continue }
+            for (_, mode) in def.modes {
+                for (_, key) in mode.keys {
+                    for (_, binding) in key.bindings {
+                        if case let .compose(trigger) = binding.action {
+                            triggers.insert(trigger)
+                        }
+                        if case let .compose(trigger)? = binding.returnAction {
+                            triggers.insert(trigger)
+                        }
+                    }
+                }
+            }
+        }
+
+        #expect(!triggers.isEmpty, "Expected layouts to use compose triggers")
+        for trigger in triggers {
+            #expect(
+                rules[trigger] != nil,
+                "Layout uses compose trigger '\(trigger)' but ComposeRuleSet.global has no rules for it"
+            )
+        }
+    }
+}

--- a/wurstfingerTests/GesturePreprocessorRobustnessTests.swift
+++ b/wurstfingerTests/GesturePreprocessorRobustnessTests.swift
@@ -1,0 +1,74 @@
+//
+//  GesturePreprocessorRobustnessTests.swift
+//  WurstfingerTests
+//
+//  Robustness tests for the gesture input path: degenerate and adversarial
+//  point sequences (empty, single, identical, non-finite, huge jumps, paths
+//  longer than the position buffer) must classify without trapping.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct GesturePreprocessorRobustnessTests {
+    private func classify(_ points: [CGPoint]) -> GestureType {
+        KeyGestureRecognizer.classify(positions: points).gesture
+    }
+
+    @Test func emptyInputClassifiesAsTap() {
+        #expect(classify([]) == .tap)
+    }
+
+    @Test func singlePointClassifiesAsTap() {
+        #expect(classify([CGPoint(x: 7, y: 7)]) == .tap)
+    }
+
+    @Test func repeatedIdenticalPointsClassifyAsTap() {
+        let points = Array(repeating: CGPoint(x: 12, y: 34), count: 80)
+        #expect(classify(points) == .tap)
+    }
+
+    @Test func nonFiniteCoordinatesDoNotCrash() {
+        let points = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: CGFloat.nan, y: 10),
+            CGPoint(x: CGFloat.infinity, y: -CGFloat.infinity),
+            CGPoint(x: 20, y: CGFloat.nan),
+        ]
+        // Must return some valid gesture rather than trapping.
+        #expect(GestureType.allCases.contains(classify(points)))
+    }
+
+    @Test func hugeCoordinateJumpsDoNotCrash() {
+        let points = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 1_000_000, y: -1_000_000),
+            CGPoint(x: -5_000_000, y: 3_000_000),
+            CGPoint(x: 0, y: 0),
+        ]
+        #expect(GestureType.allCases.contains(classify(points)))
+    }
+
+    @Test func pathLongerThanPositionBufferStaysClassifiable() {
+        // More samples than KeyboardConstants.Gesture.positionBufferSize (60),
+        // a straight rightward drag — must still classify as a right swipe.
+        let points = (0 ... 500).map { CGPoint(x: CGFloat($0), y: 0) }
+        #expect(classify(points) == .swipeRight)
+    }
+
+    @Test func preprocessHandlesDegenerateInput() {
+        let preprocessor = GesturePreprocessor()
+        #expect(preprocessor.preprocess([]).isEmpty)
+
+        let single = [CGPoint(x: 1, y: 2)]
+        #expect(preprocessor.preprocess(single) == single)
+    }
+
+    @Test func featureExtractionOnEmptyInputIsTap() {
+        let features = GestureFeatures.extract(from: [])
+        #expect(features.isTap)
+        #expect(!features.isCircular)
+    }
+}


### PR DESCRIPTION
## Was

Drei Test-Suiten, die Regressionen beim Wachsen des Projekts absichern (besonders beim Ziel „mehr Sprachen").

### `GesturePreprocessorRobustnessTests` — Eingabe-Kernpfad härten
Degenerierte/adversariale Punktfolgen klassifizieren ohne zu traps:
- leer / einzelner Punkt / viele identische Punkte → `.tap`
- nicht-finite Koordinaten (NaN/±Inf), riesige Sprünge → kein Crash
- Pfad länger als der Position-Buffer (60) → bleibt klassifizierbar (gerader Rechts-Swipe)

### `AccessibilityLabelTests` — VoiceOver-Sicherheit
Für **jede Taste in jedem Mode jeder der 15 Sprachen**: ein `.tap`-Binding und ein nicht-leeres Label, das nie auf die rohe Slot-ID („topLeft") zurückfällt. Erweitert `LayoutValidationTests.allGridKeyTapBindingsAreNonEmpty` (nur Grid-Tasten im Main-Mode).

### `ComposeDataIntegrityTests` — Akzent-/Compose-Daten
- jede globale Regel ist ein einzelnes, nicht-leeres Graphem
- die Engine löst **jede** Regel konsistent zur Datenlage auf
- jeder im Layout verwendete `.compose`-Trigger hat tatsächlich Regeln

## Nicht dupliziert
Definitions-Invarianten (switchMode-Ziele, Arrangement↔Keys, auto-transition/double-tap-Ziele) werden bereits von `KeyboardDefinition.validate()` + `LayoutValidationTests.allLanguageDefinitionsPassValidation` erzwungen — daher bewusst weggelassen.

## Verifikation
15/15 grün auf `iPhone 17 Pro` (8 Robustheit + 4 Accessibility + 3 Compose).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for VoiceOver labeling to ensure keys always expose a meaningful accessibility label instead of raw slot IDs.
  * Added compose-data integrity checks to validate trigger mappings and keep compose results consistent.
  * Added robustness tests for gesture handling so edge-case inputs remain classifiable and stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->