### PR TITLE
Guarantee the Keyboard Always Renders a Layout

### DIFF
--- a/wurstfingerKeyboard/Definition/Language/KeyboardInfo.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardInfo.swift
@@ -20,9 +20,10 @@ struct KeyboardInfo: Codable, Identifiable, Equatable {
         self.localeIdentifier = localeIdentifier
     }
 
-    init(from definition: KeyboardDefinition) {
-        id = definition.id
-        title = definition.title
-        localeIdentifier = definition.localeIdentifier
+    /// Builds metadata from a descriptor without materialising its layout.
+    init(from descriptor: LanguageDescriptor) {
+        id = descriptor.id
+        title = descriptor.title
+        localeIdentifier = descriptor.localeIdentifier
     }
 }

--- a/wurstfingerKeyboard/Definition/Language/KeyboardRegistry.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardRegistry.swift
@@ -11,23 +11,31 @@ import Foundation
 /// Exposes lightweight metadata via `available` and loads full definitions on demand.
 enum KeyboardRegistry {
     /// All available keyboard layouts (lightweight metadata only).
+    ///
+    /// Reads descriptor metadata only — no `KeyboardDefinition` is built, so
+    /// listing languages (and the extension's `primaryLanguage` lookup) stays
+    /// cheap at launch.
     static let available: [KeyboardInfo] = LanguageDefinitions.all.map { KeyboardInfo(from: $0) }
 
-    /// Precomputed index for O(1) definition lookup by id.
-    private static let definitionsByID: [String: KeyboardDefinition] =
-        LanguageDefinitions.all.reduce(into: [:]) { dict, def in
-            dict[def.id] = def
+    /// Precomputed index for O(1) descriptor lookup by id. Holds descriptors
+    /// (metadata + lazy builders), not built definitions.
+    private static let descriptorsByID: [String: LanguageDescriptor] =
+        LanguageDefinitions.all.reduce(into: [:]) { dict, descriptor in
+            dict[descriptor.id] = descriptor
         }
 
-    /// Cache for loaded definitions.
+    /// Cache for loaded definitions. Only languages actually loaded via
+    /// `load(id:)` are built and held here.
     private static var cache: [String: KeyboardDefinition] = [:]
 
-    /// Loads the full definition for a keyboard ID, caching the result.
+    /// Loads the full definition for a keyboard ID, building it lazily on first
+    /// use and caching the result.
     static func load(id: String) -> KeyboardDefinition? {
         if let cached = cache[id] { return cached }
-        guard let definition = definitionsByID[id] else {
+        guard let descriptor = descriptorsByID[id] else {
             return nil
         }
+        let definition = descriptor.makeDefinition()
         cache[id] = definition
         return definition
     }
@@ -37,9 +45,16 @@ enum KeyboardRegistry {
         cache.removeValue(forKey: id)
     }
 
-    /// Clears the entire cache.
+    /// Clears the entire cache. Active definitions are rebuilt lazily on next
+    /// `load(id:)`.
     static func evictAll() {
         cache.removeAll()
+    }
+
+    /// Evicts every cached definition except the given id. Used on memory
+    /// warnings to free inactive layouts while keeping the active one resident.
+    static func evictAll(except keepID: String) {
+        cache = cache.filter { $0.key == keepID }
     }
 
     /// Whether a definition is currently cached (for testing).

--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
@@ -8,434 +8,531 @@
 import Foundation
 
 /// All supported keyboard language definitions.
-/// Each definition is a complete KeyboardDefinition produced by GridKeyboardFactory.
+///
+/// Each entry is a ``LanguageDescriptor``: its metadata (id/title/locale) is
+/// available immediately, while the full `KeyboardDefinition` is built lazily
+/// via `makeDefinition()`. The builder reuses the descriptor's metadata
+/// (`meta.id`, …) so the id/title/locale live in exactly one place.
 enum LanguageDefinitions {
     // MARK: - Croatian
 
-    static let croatian = GridKeyboardFactory.layout(
+    static let croatian = LanguageDescriptor(
         id: "hr_HR",
         title: "Hrvatski (Croatian)",
-        localeIdentifier: "hr_HR",
-        centerCharacters: [
-            ["a", "n", "i"],
-            ["h", "o", "r"],
-            ["t", "e", "s"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeUp: "š", .swipeDown: "đ", .swipeDownRight: "v"],
-            GridSlot.topCenter: [.swipeDown: "l"],
-            GridSlot.topRight: [.swipeDownLeft: "x"],
-            GridSlot.midLeft: [.swipeUp: "ć", .swipeDown: "č", .swipeRight: "k"],
-            GridSlot.center: [
-                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
-                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
-                .swipeDownLeft: "g", .swipeLeft: "c",
+        localeIdentifier: "hr_HR"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["h", "o", "r"],
+                ["t", "e", "s"],
             ],
-            GridSlot.midRight: [.swipeLeft: "m"],
-            GridSlot.bottomLeft: [.swipeUp: "ž", .swipeUpRight: "y"],
-            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
-            GridSlot.bottomRight: [.swipeUpLeft: "f"],
-        ]
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeUp: "š", .swipeDown: "đ", .swipeDownRight: "v"],
+                GridSlot.topCenter: [.swipeDown: "l"],
+                GridSlot.topRight: [.swipeDownLeft: "x"],
+                GridSlot.midLeft: [.swipeUp: "ć", .swipeDown: "č", .swipeRight: "k"],
+                GridSlot.center: [
+                    .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                    .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                    .swipeDownLeft: "g", .swipeLeft: "c",
+                ],
+                GridSlot.midRight: [.swipeLeft: "m"],
+                GridSlot.bottomLeft: [.swipeUp: "ž", .swipeUpRight: "y"],
+                GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
+                GridSlot.bottomRight: [.swipeUpLeft: "f"],
+            ]
+        )
+    }
 
     // MARK: - English
 
-    static let english = GridKeyboardFactory.layout(
+    static let english = LanguageDescriptor(
         id: "en_US",
         title: "English",
-        localeIdentifier: "en_US",
-        centerCharacters: [
-            ["a", "n", "i"],
-            ["h", "o", "r"],
-            ["t", "e", "s"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeDownRight: "v"],
-            GridSlot.topCenter: [.swipeDown: "l"],
-            GridSlot.topRight: [.swipeDownLeft: "x"],
-            GridSlot.midLeft: [.swipeRight: "k"],
-            GridSlot.center: [
-                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
-                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
-                .swipeDownLeft: "g", .swipeLeft: "c",
+        localeIdentifier: "en_US"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["h", "o", "r"],
+                ["t", "e", "s"],
             ],
-            GridSlot.midRight: [.swipeLeft: "m"],
-            GridSlot.bottomLeft: [.swipeUpRight: "y"],
-            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
-            GridSlot.bottomRight: [.swipeUpLeft: "f"],
-        ]
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeDownRight: "v"],
+                GridSlot.topCenter: [.swipeDown: "l"],
+                GridSlot.topRight: [.swipeDownLeft: "x"],
+                GridSlot.midLeft: [.swipeRight: "k"],
+                GridSlot.center: [
+                    .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                    .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                    .swipeDownLeft: "g", .swipeLeft: "c",
+                ],
+                GridSlot.midRight: [.swipeLeft: "m"],
+                GridSlot.bottomLeft: [.swipeUpRight: "y"],
+                GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
+                GridSlot.bottomRight: [.swipeUpLeft: "f"],
+            ]
+        )
+    }
 
     // MARK: - Estonian-Finnish
 
-    static let estonianFinnish = GridKeyboardFactory.layout(
+    static let estonianFinnish = LanguageDescriptor(
         id: "et_EE",
         title: "Eesti-Suomi (Estonian-Finnish)",
-        localeIdentifier: "et_EE",
-        centerCharacters: [
-            ["a", "n", "i"],
-            ["h", "o", "r"],
-            ["t", "e", "s"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeUp: "å", .swipeDown: "ä", .swipeDownRight: "v"],
-            GridSlot.topCenter: [.swipeDown: "l"],
-            GridSlot.topRight: [.swipeDownLeft: "x"],
-            GridSlot.midLeft: [.swipeUp: "ö", .swipeDown: "õ", .swipeRight: "k"],
-            GridSlot.center: [
-                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
-                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
-                .swipeDownLeft: "g", .swipeLeft: "c",
+        localeIdentifier: "et_EE"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["h", "o", "r"],
+                ["t", "e", "s"],
             ],
-            GridSlot.midRight: [.swipeLeft: "m"],
-            GridSlot.bottomLeft: [.swipeUp: "ü", .swipeUpRight: "y"],
-            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "ž"],
-            GridSlot.bottomRight: [.swipeUpLeft: "f", .swipeLeft: "š"],
-        ]
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeUp: "å", .swipeDown: "ä", .swipeDownRight: "v"],
+                GridSlot.topCenter: [.swipeDown: "l"],
+                GridSlot.topRight: [.swipeDownLeft: "x"],
+                GridSlot.midLeft: [.swipeUp: "ö", .swipeDown: "õ", .swipeRight: "k"],
+                GridSlot.center: [
+                    .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                    .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                    .swipeDownLeft: "g", .swipeLeft: "c",
+                ],
+                GridSlot.midRight: [.swipeLeft: "m"],
+                GridSlot.bottomLeft: [.swipeUp: "ü", .swipeUpRight: "y"],
+                GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "ž"],
+                GridSlot.bottomRight: [.swipeUpLeft: "f", .swipeLeft: "š"],
+            ]
+        )
+    }
 
     // MARK: - Finnish
 
-    static let finnish = GridKeyboardFactory.layout(
+    static let finnish = LanguageDescriptor(
         id: "fi_FI",
         title: "Suomi (Finnish)",
-        localeIdentifier: "fi_FI",
-        centerCharacters: [
-            ["a", "n", "i"],
-            ["h", "o", "r"],
-            ["t", "e", "s"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeDown: "ä", .swipeDownRight: "v"],
-            GridSlot.topCenter: [.swipeDown: "l"],
-            GridSlot.topRight: [.swipeDownLeft: "x"],
-            GridSlot.midLeft: [.swipeDown: "ö", .swipeRight: "k"],
-            GridSlot.center: [
-                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
-                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
-                .swipeDownLeft: "g", .swipeLeft: "c",
+        localeIdentifier: "fi_FI"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["h", "o", "r"],
+                ["t", "e", "s"],
             ],
-            GridSlot.midRight: [.swipeLeft: "m"],
-            GridSlot.bottomLeft: [.swipeUpRight: "y"],
-            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
-            GridSlot.bottomRight: [.swipeUpLeft: "f"],
-        ]
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeDown: "ä", .swipeDownRight: "v"],
+                GridSlot.topCenter: [.swipeDown: "l"],
+                GridSlot.topRight: [.swipeDownLeft: "x"],
+                GridSlot.midLeft: [.swipeDown: "ö", .swipeRight: "k"],
+                GridSlot.center: [
+                    .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                    .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                    .swipeDownLeft: "g", .swipeLeft: "c",
+                ],
+                GridSlot.midRight: [.swipeLeft: "m"],
+                GridSlot.bottomLeft: [.swipeUpRight: "y"],
+                GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
+                GridSlot.bottomRight: [.swipeUpLeft: "f"],
+            ]
+        )
+    }
 
     // MARK: - French
 
-    static let french = GridKeyboardFactory.layout(
+    static let french = LanguageDescriptor(
         id: "fr_FR",
         title: "Français (French)",
-        localeIdentifier: "fr_FR",
-        centerCharacters: [
-            ["a", "n", "i"],
-            ["u", "o", "r"],
-            ["t", "e", "s"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeUpRight: "à", .swipeDown: "â", .swipeDownRight: "v"],
-            GridSlot.topCenter: [.swipeDown: "l"],
-            GridSlot.topRight: [.swipeDownLeft: "x"],
-            GridSlot.midLeft: [.swipeUp: "û", .swipeDown: "ç", .swipeRight: "k"],
-            GridSlot.center: [
-                .swipeUpLeft: "q", .swipeUp: "h", .swipeUpRight: "p",
-                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
-                .swipeDownLeft: "g", .swipeLeft: "c",
+        localeIdentifier: "fr_FR"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["u", "o", "r"],
+                ["t", "e", "s"],
             ],
-            GridSlot.midRight: [.swipeLeft: "m"],
-            GridSlot.bottomLeft: [.swipeUp: "ê", .swipeRight: "è", .swipeDown: "ù", .swipeUpRight: "y"],
-            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "é"],
-            GridSlot.bottomRight: [.swipeUpLeft: "f"],
-        ]
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeUpRight: "à", .swipeDown: "â", .swipeDownRight: "v"],
+                GridSlot.topCenter: [.swipeDown: "l"],
+                GridSlot.topRight: [.swipeDownLeft: "x"],
+                GridSlot.midLeft: [.swipeUp: "û", .swipeDown: "ç", .swipeRight: "k"],
+                GridSlot.center: [
+                    .swipeUpLeft: "q", .swipeUp: "h", .swipeUpRight: "p",
+                    .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                    .swipeDownLeft: "g", .swipeLeft: "c",
+                ],
+                GridSlot.midRight: [.swipeLeft: "m"],
+                GridSlot.bottomLeft: [.swipeUp: "ê", .swipeRight: "è", .swipeDown: "ù", .swipeUpRight: "y"],
+                GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "é"],
+                GridSlot.bottomRight: [.swipeUpLeft: "f"],
+            ]
+        )
+    }
 
     // MARK: - German
 
-    static let german = GridKeyboardFactory.layout(
+    static let german = LanguageDescriptor(
         id: "de_DE",
         title: "Deutsch (German)",
-        localeIdentifier: "de_DE",
-        centerCharacters: [
-            ["a", "n", "i"],
-            ["h", "d", "r"],
-            ["t", "e", "s"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeDown: "ä", .swipeDownRight: "v"],
-            GridSlot.topCenter: [.swipeDown: "l"],
-            GridSlot.topRight: [.swipeDownLeft: "x"],
-            GridSlot.midLeft: [.swipeUp: "ü", .swipeDown: "ö", .swipeRight: "k"],
-            GridSlot.center: [
-                .swipeUp: "u", .swipeUpLeft: "q", .swipeLeft: "c",
-                .swipeDownLeft: "g", .swipeDown: "o", .swipeDownRight: "j",
-                .swipeRight: "b", .swipeUpRight: "p",
+        localeIdentifier: "de_DE"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["h", "d", "r"],
+                ["t", "e", "s"],
             ],
-            GridSlot.midRight: [.swipeLeft: "m"],
-            GridSlot.bottomLeft: [.swipeDown: "ß", .swipeUpRight: "y"],
-            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
-            GridSlot.bottomRight: [.swipeUpLeft: "f"],
-        ]
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeDown: "ä", .swipeDownRight: "v"],
+                GridSlot.topCenter: [.swipeDown: "l"],
+                GridSlot.topRight: [.swipeDownLeft: "x"],
+                GridSlot.midLeft: [.swipeUp: "ü", .swipeDown: "ö", .swipeRight: "k"],
+                GridSlot.center: [
+                    .swipeUp: "u", .swipeUpLeft: "q", .swipeLeft: "c",
+                    .swipeDownLeft: "g", .swipeDown: "o", .swipeDownRight: "j",
+                    .swipeRight: "b", .swipeUpRight: "p",
+                ],
+                GridSlot.midRight: [.swipeLeft: "m"],
+                GridSlot.bottomLeft: [.swipeDown: "ß", .swipeUpRight: "y"],
+                GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
+                GridSlot.bottomRight: [.swipeUpLeft: "f"],
+            ]
+        )
+    }
 
     // MARK: - Hebrew
 
-    static let hebrew = GridKeyboardFactory.layout(
+    static let hebrew = LanguageDescriptor(
         id: "he_IL",
         title: "עברית (Hebrew)",
-        localeIdentifier: "he_IL",
-        centerCharacters: [
-            ["ר", "ב", "א"],
-            ["מ", "י", "ו"],
-            ["ת", "ה", "ל"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeDownRight: "ן"],
-            GridSlot.topCenter: [.swipeDown: "ג"],
-            GridSlot.topRight: [.swipeDownLeft: "צ"],
-            GridSlot.midLeft: [.swipeRight: "ם"],
-            GridSlot.center: [
-                .swipeUpLeft: "ק", .swipeUp: "ח", .swipeUpRight: "פ",
-                .swipeRight: "ד", .swipeDownRight: "ש", .swipeDown: "נ",
-                .swipeDownLeft: "כ", .swipeLeft: "ע",
+        localeIdentifier: "he_IL"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["ר", "ב", "א"],
+                ["מ", "י", "ו"],
+                ["ת", "ה", "ל"],
             ],
-            GridSlot.bottomLeft: [.swipeUpRight: "ז"],
-            GridSlot.bottomCenter: [.swipeUp: "ס"],
-            GridSlot.bottomRight: [.swipeUpLeft: "ט"],
-        ],
-        numericBackToAlphaLabel: "אבג"
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeDownRight: "ן"],
+                GridSlot.topCenter: [.swipeDown: "ג"],
+                GridSlot.topRight: [.swipeDownLeft: "צ"],
+                GridSlot.midLeft: [.swipeRight: "ם"],
+                GridSlot.center: [
+                    .swipeUpLeft: "ק", .swipeUp: "ח", .swipeUpRight: "פ",
+                    .swipeRight: "ד", .swipeDownRight: "ש", .swipeDown: "נ",
+                    .swipeDownLeft: "כ", .swipeLeft: "ע",
+                ],
+                GridSlot.bottomLeft: [.swipeUpRight: "ז"],
+                GridSlot.bottomCenter: [.swipeUp: "ס"],
+                GridSlot.bottomRight: [.swipeUpLeft: "ט"],
+            ],
+            numericBackToAlphaLabel: "אבג"
+        )
+    }
 
     // MARK: - Italian
 
-    static let italian = GridKeyboardFactory.layout(
+    static let italian = LanguageDescriptor(
         id: "it_IT",
         title: "Italiano (Italian)",
-        localeIdentifier: "it_IT",
-        centerCharacters: [
-            ["a", "n", "i"],
-            ["l", "o", "r"],
-            ["t", "e", "s"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeUpRight: "à", .swipeDownRight: "v"],
-            GridSlot.topCenter: [.swipeDown: "h"],
-            GridSlot.topRight: [.swipeUpLeft: "ì", .swipeDownLeft: "x"],
-            GridSlot.midLeft: [.swipeUp: "ù", .swipeDown: "ò", .swipeRight: "k"],
-            GridSlot.center: [
-                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
-                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
-                .swipeDownLeft: "g", .swipeLeft: "c",
+        localeIdentifier: "it_IT"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["l", "o", "r"],
+                ["t", "e", "s"],
             ],
-            GridSlot.midRight: [.swipeLeft: "m"],
-            GridSlot.bottomLeft: [.swipeRight: "è", .swipeUpRight: "y"],
-            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "é"],
-            GridSlot.bottomRight: [.swipeUpLeft: "f"],
-        ]
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeUpRight: "à", .swipeDownRight: "v"],
+                GridSlot.topCenter: [.swipeDown: "h"],
+                GridSlot.topRight: [.swipeUpLeft: "ì", .swipeDownLeft: "x"],
+                GridSlot.midLeft: [.swipeUp: "ù", .swipeDown: "ò", .swipeRight: "k"],
+                GridSlot.center: [
+                    .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                    .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                    .swipeDownLeft: "g", .swipeLeft: "c",
+                ],
+                GridSlot.midRight: [.swipeLeft: "m"],
+                GridSlot.bottomLeft: [.swipeRight: "è", .swipeUpRight: "y"],
+                GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "é"],
+                GridSlot.bottomRight: [.swipeUpLeft: "f"],
+            ]
+        )
+    }
 
     // MARK: - Polish
 
-    static let polish = GridKeyboardFactory.layout(
+    static let polish = LanguageDescriptor(
         id: "pl_PL",
         title: "Polski (Polish)",
-        localeIdentifier: "pl_PL",
-        centerCharacters: [
-            ["a", "n", "i"],
-            ["w", "o", "r"],
-            ["z", "e", "s"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeDown: "ą", .swipeDownRight: "v"],
-            GridSlot.topCenter: [.swipeUp: "ń", .swipeDown: "l"],
-            GridSlot.topRight: [.swipeUpLeft: "ł", .swipeDownLeft: "x"],
-            GridSlot.midLeft: [.swipeUp: "ó", .swipeDown: "ć", .swipeRight: "k"],
-            GridSlot.center: [
-                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
-                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
-                .swipeDownLeft: "g", .swipeLeft: "c",
+        localeIdentifier: "pl_PL"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["w", "o", "r"],
+                ["z", "e", "s"],
             ],
-            GridSlot.midRight: [.swipeLeft: "m"],
-            GridSlot.bottomLeft: [.swipeDown: "ę", .swipeRight: "ź", .swipeUpRight: "y"],
-            GridSlot.bottomCenter: [.swipeUp: "h", .swipeRight: "t", .swipeLeft: "ż"],
-            GridSlot.bottomRight: [.swipeUpLeft: "f", .swipeLeft: "ś"],
-        ]
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeDown: "ą", .swipeDownRight: "v"],
+                GridSlot.topCenter: [.swipeUp: "ń", .swipeDown: "l"],
+                GridSlot.topRight: [.swipeUpLeft: "ł", .swipeDownLeft: "x"],
+                GridSlot.midLeft: [.swipeUp: "ó", .swipeDown: "ć", .swipeRight: "k"],
+                GridSlot.center: [
+                    .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                    .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                    .swipeDownLeft: "g", .swipeLeft: "c",
+                ],
+                GridSlot.midRight: [.swipeLeft: "m"],
+                GridSlot.bottomLeft: [.swipeDown: "ę", .swipeRight: "ź", .swipeUpRight: "y"],
+                GridSlot.bottomCenter: [.swipeUp: "h", .swipeRight: "t", .swipeLeft: "ż"],
+                GridSlot.bottomRight: [.swipeUpLeft: "f", .swipeLeft: "ś"],
+            ]
+        )
+    }
 
     // MARK: - Russian
 
-    static let russian = GridKeyboardFactory.layout(
+    static let russian = LanguageDescriptor(
         id: "ru_RU",
         title: "Русский (Russian)",
-        localeIdentifier: "ru_RU",
-        centerCharacters: [
-            ["с", "и", "т"],
-            ["в", "о", "а"],
-            ["е", "р", "н"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeDown: "ц", .swipeDownRight: "п"],
-            GridSlot.topCenter: [.swipeUp: "й", .swipeDown: "к"],
-            GridSlot.topRight: [.swipeDownLeft: "ь"],
-            GridSlot.midLeft: [.swipeUp: "б", .swipeDown: "ъ", .swipeRight: "ы"],
-            GridSlot.center: [
-                .swipeUpLeft: "ч", .swipeUp: "м", .swipeUpRight: "х",
-                .swipeRight: "г", .swipeDownRight: "ш", .swipeDown: "я",
-                .swipeDownLeft: "щ", .swipeLeft: "ж",
+        localeIdentifier: "ru_RU"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["с", "и", "т"],
+                ["в", "о", "а"],
+                ["е", "р", "н"],
             ],
-            GridSlot.midRight: [.swipeLeft: "л"],
-            GridSlot.bottomLeft: [.swipeUp: "ё", .swipeRight: "э", .swipeUpRight: "д"],
-            GridSlot.bottomCenter: [.swipeUp: "у", .swipeRight: "з", .swipeLeft: "ю"],
-            GridSlot.bottomRight: [.swipeUpLeft: "ф"],
-        ],
-        numericBackToAlphaLabel: "абв"
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeDown: "ц", .swipeDownRight: "п"],
+                GridSlot.topCenter: [.swipeUp: "й", .swipeDown: "к"],
+                GridSlot.topRight: [.swipeDownLeft: "ь"],
+                GridSlot.midLeft: [.swipeUp: "б", .swipeDown: "ъ", .swipeRight: "ы"],
+                GridSlot.center: [
+                    .swipeUpLeft: "ч", .swipeUp: "м", .swipeUpRight: "х",
+                    .swipeRight: "г", .swipeDownRight: "ш", .swipeDown: "я",
+                    .swipeDownLeft: "щ", .swipeLeft: "ж",
+                ],
+                GridSlot.midRight: [.swipeLeft: "л"],
+                GridSlot.bottomLeft: [.swipeUp: "ё", .swipeRight: "э", .swipeUpRight: "д"],
+                GridSlot.bottomCenter: [.swipeUp: "у", .swipeRight: "з", .swipeLeft: "ю"],
+                GridSlot.bottomRight: [.swipeUpLeft: "ф"],
+            ],
+            numericBackToAlphaLabel: "абв"
+        )
+    }
 
     // MARK: - Spanish-Catalan
 
-    static let spanishCatalan = GridKeyboardFactory.layout(
+    static let spanishCatalan = LanguageDescriptor(
         id: "ca_ES",
         title: "Español-Català (Spanish-Catalan)",
-        localeIdentifier: "ca_ES",
-        centerCharacters: [
-            ["a", "n", "i"],
-            ["d", "o", "r"],
-            ["t", "e", "s"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeUp: "à", .swipeDown: "á", .swipeDownRight: "v"],
-            GridSlot.topCenter: [.swipeUp: "ñ", .swipeDown: "l"],
-            GridSlot.topRight: [.swipeUpLeft: "í", .swipeUpRight: "ï", .swipeDownLeft: "x"],
-            GridSlot.midLeft: [.swipeUp: "ü", .swipeDown: "ç", .swipeRight: "k"],
-            GridSlot.center: [
-                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
-                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "h",
-                .swipeDownLeft: "g", .swipeLeft: "c",
+        localeIdentifier: "ca_ES"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["d", "o", "r"],
+                ["t", "e", "s"],
             ],
-            GridSlot.midRight: [.swipeLeft: "m"],
-            GridSlot.bottomLeft: [.swipeUp: "ú", .swipeDown: "ó", .swipeUpRight: "y"],
-            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "é"],
-            GridSlot.bottomRight: [.swipeUpLeft: "f"],
-        ]
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeUp: "à", .swipeDown: "á", .swipeDownRight: "v"],
+                GridSlot.topCenter: [.swipeUp: "ñ", .swipeDown: "l"],
+                GridSlot.topRight: [.swipeUpLeft: "í", .swipeUpRight: "ï", .swipeDownLeft: "x"],
+                GridSlot.midLeft: [.swipeUp: "ü", .swipeDown: "ç", .swipeRight: "k"],
+                GridSlot.center: [
+                    .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                    .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "h",
+                    .swipeDownLeft: "g", .swipeLeft: "c",
+                ],
+                GridSlot.midRight: [.swipeLeft: "m"],
+                GridSlot.bottomLeft: [.swipeUp: "ú", .swipeDown: "ó", .swipeUpRight: "y"],
+                GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "é"],
+                GridSlot.bottomRight: [.swipeUpLeft: "f"],
+            ]
+        )
+    }
 
     // MARK: - Spanish
 
-    static let spanish = GridKeyboardFactory.layout(
+    static let spanish = LanguageDescriptor(
         id: "es_ES",
         title: "Español (Spanish)",
-        localeIdentifier: "es_ES",
-        centerCharacters: [
-            ["a", "n", "i"],
-            ["d", "o", "r"],
-            ["t", "e", "s"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeDown: "á", .swipeDownRight: "v"],
-            GridSlot.topCenter: [.swipeUp: "ñ", .swipeDown: "l"],
-            GridSlot.topRight: [.swipeUpLeft: "í", .swipeDownLeft: "x"],
-            GridSlot.midLeft: [.swipeUp: "ü", .swipeRight: "k"],
-            GridSlot.center: [
-                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
-                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "h",
-                .swipeDownLeft: "g", .swipeLeft: "c",
+        localeIdentifier: "es_ES"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["d", "o", "r"],
+                ["t", "e", "s"],
             ],
-            GridSlot.midRight: [.swipeLeft: "m"],
-            GridSlot.bottomLeft: [.swipeUp: "ú", .swipeDown: "ó", .swipeUpRight: "y"],
-            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "é"],
-            GridSlot.bottomRight: [.swipeUpLeft: "f"],
-        ]
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeDown: "á", .swipeDownRight: "v"],
+                GridSlot.topCenter: [.swipeUp: "ñ", .swipeDown: "l"],
+                GridSlot.topRight: [.swipeUpLeft: "í", .swipeDownLeft: "x"],
+                GridSlot.midLeft: [.swipeUp: "ü", .swipeRight: "k"],
+                GridSlot.center: [
+                    .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                    .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "h",
+                    .swipeDownLeft: "g", .swipeLeft: "c",
+                ],
+                GridSlot.midRight: [.swipeLeft: "m"],
+                GridSlot.bottomLeft: [.swipeUp: "ú", .swipeDown: "ó", .swipeUpRight: "y"],
+                GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z", .swipeLeft: "é"],
+                GridSlot.bottomRight: [.swipeUpLeft: "f"],
+            ]
+        )
+    }
 
     // MARK: - Swedish
 
-    static let swedish = GridKeyboardFactory.layout(
+    static let swedish = LanguageDescriptor(
         id: "sv_SE",
         title: "Svenska (Swedish)",
-        localeIdentifier: "sv_SE",
-        centerCharacters: [
-            ["a", "n", "i"],
-            ["h", "d", "r"],
-            ["t", "e", "s"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeUp: "å", .swipeDown: "ä", .swipeDownRight: "v"],
-            GridSlot.topCenter: [.swipeDown: "l"],
-            GridSlot.topRight: [.swipeDownLeft: "x"],
-            GridSlot.midLeft: [.swipeDown: "ö", .swipeRight: "k"],
-            GridSlot.center: [
-                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
-                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "o",
-                .swipeDownLeft: "g", .swipeLeft: "c",
+        localeIdentifier: "sv_SE"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["h", "d", "r"],
+                ["t", "e", "s"],
             ],
-            GridSlot.midRight: [.swipeLeft: "m"],
-            GridSlot.bottomLeft: [.swipeUpRight: "y"],
-            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
-            GridSlot.bottomRight: [.swipeUpLeft: "f"],
-        ]
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeUp: "å", .swipeDown: "ä", .swipeDownRight: "v"],
+                GridSlot.topCenter: [.swipeDown: "l"],
+                GridSlot.topRight: [.swipeDownLeft: "x"],
+                GridSlot.midLeft: [.swipeDown: "ö", .swipeRight: "k"],
+                GridSlot.center: [
+                    .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                    .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "o",
+                    .swipeDownLeft: "g", .swipeLeft: "c",
+                ],
+                GridSlot.midRight: [.swipeLeft: "m"],
+                GridSlot.bottomLeft: [.swipeUpRight: "y"],
+                GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
+                GridSlot.bottomRight: [.swipeUpLeft: "f"],
+            ]
+        )
+    }
 
     // MARK: - Tagalog
 
-    static let tagalog = GridKeyboardFactory.layout(
+    static let tagalog = LanguageDescriptor(
         id: "tl_PH",
         title: "Tagalog (Filipino)",
-        localeIdentifier: "tl_PH",
-        centerCharacters: [
-            ["a", "n", "i"],
-            ["h", "o", "r"],
-            ["t", "e", "s"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeDownRight: "v"],
-            GridSlot.topCenter: [.swipeUp: "ñ", .swipeDown: "l"],
-            GridSlot.topRight: [.swipeDownLeft: "x"],
-            GridSlot.midLeft: [.swipeRight: "k"],
-            GridSlot.center: [
-                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
-                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
-                .swipeDownLeft: "g", .swipeLeft: "c",
+        localeIdentifier: "tl_PH"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["h", "o", "r"],
+                ["t", "e", "s"],
             ],
-            GridSlot.midRight: [.swipeLeft: "m"],
-            GridSlot.bottomLeft: [.swipeUpRight: "y"],
-            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
-            GridSlot.bottomRight: [.swipeUpLeft: "f"],
-        ]
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeDownRight: "v"],
+                GridSlot.topCenter: [.swipeUp: "ñ", .swipeDown: "l"],
+                GridSlot.topRight: [.swipeDownLeft: "x"],
+                GridSlot.midLeft: [.swipeRight: "k"],
+                GridSlot.center: [
+                    .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                    .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                    .swipeDownLeft: "g", .swipeLeft: "c",
+                ],
+                GridSlot.midRight: [.swipeLeft: "m"],
+                GridSlot.bottomLeft: [.swipeUpRight: "y"],
+                GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
+                GridSlot.bottomRight: [.swipeUpLeft: "f"],
+            ]
+        )
+    }
 
     // MARK: - Vietnamese (Telex)
 
-    static let vietnamese = GridKeyboardFactory.layout(
+    static let vietnamese = LanguageDescriptor(
         id: "vi_VN",
         title: "Tiếng Việt (Vietnamese-Telex)",
-        localeIdentifier: "vi_VN",
-        centerCharacters: [
-            ["a", "n", "i"],
-            ["h", "o", "r"],
-            ["t", "e", "s"],
-        ],
-        directionalOverrides: [
-            GridSlot.topLeft: [.swipeDown: "đ", .swipeDownRight: "v"],
-            GridSlot.topCenter: [.swipeDown: "l"],
-            GridSlot.topRight: [.swipeDownLeft: "x"],
-            GridSlot.midLeft: [.swipeRight: "k"],
-            GridSlot.center: [
-                .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
-                .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
-                .swipeDownLeft: "g", .swipeLeft: "c",
+        localeIdentifier: "vi_VN"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["h", "o", "r"],
+                ["t", "e", "s"],
             ],
-            GridSlot.midRight: [.swipeLeft: "m"],
-            GridSlot.bottomLeft: [.swipeUpRight: "y"],
-            GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
-            GridSlot.bottomRight: [.swipeUpLeft: "f"],
-        ],
-        inputMethod: .telex
-    )
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeDown: "đ", .swipeDownRight: "v"],
+                GridSlot.topCenter: [.swipeDown: "l"],
+                GridSlot.topRight: [.swipeDownLeft: "x"],
+                GridSlot.midLeft: [.swipeRight: "k"],
+                GridSlot.center: [
+                    .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                    .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "d",
+                    .swipeDownLeft: "g", .swipeLeft: "c",
+                ],
+                GridSlot.midRight: [.swipeLeft: "m"],
+                GridSlot.bottomLeft: [.swipeUpRight: "y"],
+                GridSlot.bottomCenter: [.swipeUp: "w", .swipeRight: "z"],
+                GridSlot.bottomRight: [.swipeUpLeft: "f"],
+            ],
+            inputMethod: .telex
+        )
+    }
 
     // MARK: - Registry
 
-    /// All available language definitions, sorted alphabetically by title.
-    static let all: [KeyboardDefinition] = [
+    /// All available language descriptors, sorted alphabetically by title.
+    ///
+    /// Holds metadata only; definitions are built lazily via
+    /// `LanguageDescriptor.makeDefinition()` (see `KeyboardRegistry`).
+    static let all: [LanguageDescriptor] = [
         spanishCatalan,
         croatian,
         english,

--- a/wurstfingerKeyboard/Definition/Language/LanguageDescriptor.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDescriptor.swift
@@ -1,0 +1,48 @@
+//
+//  LanguageDescriptor.swift
+//  Wurstfinger
+//
+//  Lazy, lightweight handle to a keyboard language.
+//
+
+import Foundation
+
+/// A lazy handle to a keyboard language.
+///
+/// Holds only the cheap metadata (`id`, `title`, `localeIdentifier`) eagerly.
+/// The full `KeyboardDefinition` — which allocates every key, binding and grid
+/// arrangement for all modes — is produced on demand via `makeDefinition()`.
+///
+/// This is what keeps the keyboard **extension launch** cheap: the registry can
+/// list every available language and resolve the active one's metadata without
+/// materialising a single layout, and only the language actually in use is ever
+/// built (and then cached by `KeyboardRegistry`). Loading all layouts eagerly
+/// added avoidable memory pressure under the extension's tight budget.
+struct LanguageDescriptor: Identifiable {
+    let id: String
+    let title: String
+    let localeIdentifier: String
+
+    /// Builds the full definition. Receives the descriptor so the layout can
+    /// reuse the metadata above instead of repeating the literals — keeping the
+    /// id/title/locale a single source of truth.
+    private let builder: @Sendable (LanguageDescriptor) -> KeyboardDefinition
+
+    init(
+        id: String,
+        title: String,
+        localeIdentifier: String,
+        builder: @escaping @Sendable (LanguageDescriptor) -> KeyboardDefinition
+    ) {
+        self.id = id
+        self.title = title
+        self.localeIdentifier = localeIdentifier
+        self.builder = builder
+    }
+
+    /// Produces the full keyboard definition. This allocates the entire layout
+    /// on every call, so callers should cache the result (see `KeyboardRegistry`).
+    func makeDefinition() -> KeyboardDefinition {
+        builder(self)
+    }
+}

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -15,14 +15,28 @@ final class KeyboardViewController: UIInputViewController {
     private var heightConstraint: NSLayoutConstraint?
     private var documentProxyTarget: DocumentProxyTarget?
 
+    /// The language id currently loaded into the view model. Used to skip
+    /// redundant definition reloads when the keyboard reappears unchanged.
+    private var loadedLanguageId: String?
+
+    /// The language selected in the host app, falling back to the detected
+    /// system language. Determines which definition is loaded.
+    private var selectedLanguageId: String {
+        SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue)
+            ?? LanguageSettings.detectSystemLanguage()
+    }
+
     /// Reports the active keyboard language to iOS (shown in Settings > Keyboards).
     /// Reads directly from SharedDefaults to pick up language changes made in the host app,
     /// since the LanguageSettings singleton may hold a stale value from its init.
     override var primaryLanguage: String? {
         get {
+            // Resolve the locale from lightweight registry metadata only. iOS may
+            // query this eagerly/repeatedly, so it must never build a layout.
             let languageId = SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue)
-            let config = languageId.flatMap { LanguageConfig.language(withId: $0) } ?? .english
-            return config.locale.identifier
+            return languageId
+                .flatMap { id in KeyboardRegistry.available.first { $0.id == id }?.localeIdentifier }
+                ?? LanguageConfig.english.locale.identifier
         }
         set {
             super.primaryLanguage = newValue
@@ -31,6 +45,7 @@ final class KeyboardViewController: UIInputViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        KeyboardMemoryLog.record("viewDidLoad.start")
 
         // Set background immediately to avoid flash
         view.backgroundColor = .clear
@@ -45,10 +60,9 @@ final class KeyboardViewController: UIInputViewController {
         )
 
         // Load the keyboard definition for the selected language
-        let languageId = SharedDefaults.store.string(
-            forKey: SettingsKey.selectedLanguageId.rawValue
-        ) ?? LanguageSettings.detectSystemLanguage()
+        let languageId = selectedLanguageId
         viewModel.loadDefinition(for: languageId)
+        loadedLanguageId = languageId
 
         // Configure hosting synchronously so the SwiftUI view exists
         // before viewWillAppear sets the height constraint. Deferring via
@@ -56,6 +70,7 @@ final class KeyboardViewController: UIInputViewController {
         // viewWillAppear ran before configureHosting, leaving the extension
         // with a height constraint but no content.
         configureHosting()
+        KeyboardMemoryLog.record("viewDidLoad.end")
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -64,12 +79,24 @@ final class KeyboardViewController: UIInputViewController {
         SharedDefaults.store.set(hasFullAccess, forKey: SettingsKey.keyboardFullAccess.rawValue)
         // Reload settings every time keyboard appears
         viewModel.reloadSettings()
-        // Reload definition if language changed while keyboard was backgrounded
-        let languageId = SharedDefaults.store.string(
-            forKey: SettingsKey.selectedLanguageId.rawValue
-        ) ?? LanguageSettings.detectSystemLanguage()
-        viewModel.loadDefinition(for: languageId)
+        // Reload the definition only if the language changed while the keyboard
+        // was backgrounded. Rebuilding the resolver chain and pipeline on every
+        // appearance is wasted work when nothing changed.
+        let languageId = selectedLanguageId
+        if languageId != loadedLanguageId {
+            viewModel.loadDefinition(for: languageId)
+            loadedLanguageId = languageId
+        }
         updateKeyboardHeight()
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        KeyboardMemoryLog.record("didReceiveMemoryWarning")
+        // Free cached layouts for languages other than the active one. The
+        // active definition stays resident (the view model holds a strong
+        // reference) and remains cached for fast reuse.
+        KeyboardRegistry.evictAll(except: selectedLanguageId)
     }
 
     private func updateKeyboardHeight() {

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -19,11 +19,13 @@ final class KeyboardViewController: UIInputViewController {
     /// redundant definition reloads when the keyboard reappears unchanged.
     private var loadedLanguageId: String?
 
-    /// The language selected in the host app, falling back to the detected
-    /// system language. Determines which definition is loaded.
+    /// The language selected in the host app, normalised to an id that is
+    /// guaranteed to exist in the registry (falling back to the system language,
+    /// then English). Determines which definition is loaded.
     private var selectedLanguageId: String {
-        SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue)
-            ?? LanguageSettings.detectSystemLanguage()
+        LanguageSettings.resolvedLanguageId(
+            SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue)
+        )
     }
 
     /// Reports the active keyboard language to iOS (shown in Settings > Keyboards).
@@ -33,9 +35,8 @@ final class KeyboardViewController: UIInputViewController {
         get {
             // Resolve the locale from lightweight registry metadata only. iOS may
             // query this eagerly/repeatedly, so it must never build a layout.
-            let languageId = SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue)
-            return languageId
-                .flatMap { id in KeyboardRegistry.available.first { $0.id == id }?.localeIdentifier }
+            let id = selectedLanguageId
+            return (KeyboardRegistry.available.first { $0.id == id }?.localeIdentifier)
                 ?? LanguageConfig.english.locale.identifier
         }
         set {

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -15,7 +15,12 @@ extension KeyboardViewModel {
     /// Loads a keyboard definition by ID from the registry and sets up the
     /// resolver chain and action pipeline.
     func loadDefinition(for id: String) {
-        guard let base = KeyboardRegistry.load(id: id) else { return }
+        // Fall back to English if the requested language can't be resolved (e.g.
+        // a stale stored id for a language removed in a later version) so the
+        // keyboard always renders a layout instead of coming up blank.
+        guard let base = KeyboardRegistry.load(id: id)
+            ?? KeyboardRegistry.load(id: LanguageConfig.english.id)
+        else { return }
         let definition = applyNumpadStyle(to: base)
         currentDefinition = definition
         activeModeName = definition.defaultMode

--- a/wurstfingerKeyboard/Settings/KeyboardMemoryLog.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardMemoryLog.swift
@@ -1,0 +1,32 @@
+//
+//  KeyboardMemoryLog.swift
+//  Wurstfinger
+//
+//  Debug-only memory diagnostics for the keyboard extension.
+//
+
+import Foundation
+import os
+
+/// Lightweight, debug-only memory logging for the keyboard extension.
+///
+/// Keyboard extensions run under a tight (~48–66 MB) memory budget. Exceeding it
+/// makes iOS terminate (jetsam) the extension, which users experience as the
+/// system keyboard appearing instead of Wurstfinger — intermittently, in
+/// memory-hungry host apps. This records the memory still available before
+/// termination at key lifecycle points so regressions are observable on-device
+/// via Console.app, while compiling to nothing in release builds.
+enum KeyboardMemoryLog {
+    #if DEBUG
+        private static let logger = Logger(subsystem: "de.akator.wurstfinger", category: "memory")
+    #endif
+
+    /// Logs the memory currently available to the extension before iOS would
+    /// jetsam it. No-op in release builds.
+    static func record(_ label: String) {
+        #if DEBUG
+            let availableMB = Double(os_proc_available_memory()) / (1024 * 1024)
+            logger.log("[\(label, privacy: .public)] available: \(availableMB, format: .fixed(precision: 1)) MB")
+        #endif
+    }
+}

--- a/wurstfingerKeyboard/Settings/LanguageSettings.swift
+++ b/wurstfingerKeyboard/Settings/LanguageSettings.swift
@@ -35,6 +35,18 @@ class LanguageSettings: ObservableObject {
         }
     }
 
+    /// Resolves a raw/stored language id to one guaranteed to exist in the
+    /// registry. If the stored value is missing or stale (e.g. a language
+    /// removed in a later version), falls back to the detected system language
+    /// — which itself falls back to English. Callers therefore always receive a
+    /// renderable language id, so the keyboard never comes up blank.
+    static func resolvedLanguageId(_ storedId: String?) -> String {
+        if let storedId, LanguageConfig.language(withId: storedId) != nil {
+            return storedId
+        }
+        return detectSystemLanguage()
+    }
+
     /// Detects the system language and returns matching language ID, or English as fallback
     static func detectSystemLanguage(preferredLanguages: [String]? = nil) -> String {
         let preferredLanguages = preferredLanguages ?? Locale.preferredLanguages

--- a/wurstfingerTests/KeyboardRegistryTests.swift
+++ b/wurstfingerTests/KeyboardRegistryTests.swift
@@ -12,12 +12,12 @@ import Testing
 // MARK: - KeyboardInfo
 
 struct KeyboardInfoTests {
-    @Test func initFromDefinition() {
-        let definition = LanguageDefinitions.german
-        let info = KeyboardInfo(from: definition)
-        #expect(info.id == definition.id)
-        #expect(info.title == definition.title)
-        #expect(info.localeIdentifier == definition.localeIdentifier)
+    @Test func initFromDescriptor() {
+        let descriptor = LanguageDefinitions.german
+        let info = KeyboardInfo(from: descriptor)
+        #expect(info.id == descriptor.id)
+        #expect(info.title == descriptor.title)
+        #expect(info.localeIdentifier == descriptor.localeIdentifier)
     }
 
     @Test func identifiable() {

--- a/wurstfingerTests/LanguageDefinitionTests.swift
+++ b/wurstfingerTests/LanguageDefinitionTests.swift
@@ -12,13 +12,13 @@ import Testing
 // MARK: - All Layouts Validate
 
 struct LanguageDefinitionValidationTests {
-    @Test(arguments: LanguageDefinitions.all)
+    @Test(arguments: LanguageDefinitions.all.map { $0.makeDefinition() })
     func layoutValidatesWithoutErrors(layout: KeyboardDefinition) {
         let errors = layout.validate()
         #expect(errors.isEmpty, "Validation errors for \(layout.id): \(errors)")
     }
 
-    @Test(arguments: LanguageDefinitions.all)
+    @Test(arguments: LanguageDefinitions.all.map { $0.makeDefinition() })
     func layoutHasRequiredModes(layout: KeyboardDefinition) {
         #expect(layout.modes[ModeNames.main] != nil, "\(layout.id) missing main mode")
         #expect(layout.modes[ModeNames.shifted] != nil, "\(layout.id) missing shifted mode")
@@ -43,7 +43,7 @@ struct LanguageDefinitionValidationTests {
 // MARK: - German Layout Tests
 
 struct GermanLayoutTests {
-    static let german = LanguageDefinitions.german
+    static let german = LanguageDefinitions.german.makeDefinition()
 
     @Test func centerCharacters() throws {
         let main = try #require(Self.german.modes[ModeNames.main])
@@ -158,13 +158,13 @@ struct NumericLayoutTests {
     }
 
     @Test func hebrewLayoutUsesHebrewBackToAlphaLabel() throws {
-        let hebrew = LanguageDefinitions.hebrew
+        let hebrew = LanguageDefinitions.hebrew.makeDefinition()
         let numeric = try #require(hebrew.modes[ModeNames.numeric])
         #expect(numeric.keys[UtilitySlot.symbols]?.bindings[.tap]?.label == "אבג")
     }
 
     @Test func russianLayoutUsesCyrillicBackToAlphaLabel() throws {
-        let russian = LanguageDefinitions.russian
+        let russian = LanguageDefinitions.russian.makeDefinition()
         let numeric = try #require(russian.modes[ModeNames.numeric])
         #expect(numeric.keys[UtilitySlot.symbols]?.bindings[.tap]?.label == "абв")
     }

--- a/wurstfingerTests/LanguageDescriptorTests.swift
+++ b/wurstfingerTests/LanguageDescriptorTests.swift
@@ -1,0 +1,73 @@
+//
+//  LanguageDescriptorTests.swift
+//  WurstfingerTests
+//
+//  Tests for LanguageDescriptor's lazy-build contract.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct LanguageDescriptorTests {
+    /// Records whether a descriptor's builder ran. `@unchecked Sendable` so it
+    /// can be captured by the `@Sendable` builder closure.
+    private final class BuildFlag: @unchecked Sendable {
+        var didBuild = false
+    }
+
+    /// Reading a descriptor's metadata — including via `KeyboardInfo` — must not
+    /// trigger the builder. This is the property that keeps keyboard-extension
+    /// launch cheap: the registry can list and resolve languages without
+    /// materialising any layout.
+    @Test func readingMetadataDoesNotBuildDefinition() {
+        let flag = BuildFlag()
+        let descriptor = LanguageDescriptor(
+            id: "xx_XX",
+            title: "Test",
+            localeIdentifier: "xx_XX"
+        ) { meta in
+            flag.didBuild = true
+            return GridKeyboardFactory.layout(
+                id: meta.id,
+                title: meta.title,
+                localeIdentifier: meta.localeIdentifier,
+                centerCharacters: [
+                    ["a", "n", "i"],
+                    ["h", "o", "r"],
+                    ["t", "e", "s"],
+                ],
+                directionalOverrides: [:]
+            )
+        }
+
+        _ = descriptor.id
+        _ = descriptor.title
+        _ = descriptor.localeIdentifier
+        _ = KeyboardInfo(from: descriptor)
+        #expect(flag.didBuild == false, "Reading metadata must not build the definition")
+
+        _ = descriptor.makeDefinition()
+        #expect(flag.didBuild == true, "makeDefinition() must build the definition")
+    }
+
+    /// The whole registry path must stay metadata-only: `KeyboardRegistry.available`
+    /// is derived from descriptors and must list every language without building
+    /// any of them.
+    @Test func registryAvailableExposesEveryDescriptor() {
+        let descriptorIDs = Set(LanguageDefinitions.all.map(\.id))
+        let availableIDs = Set(KeyboardRegistry.available.map(\.id))
+        #expect(availableIDs == descriptorIDs)
+    }
+
+    /// Each built definition must carry exactly the metadata declared on its
+    /// descriptor. Guards against a builder hardcoding a different id/title/locale
+    /// instead of threading `meta`, which would silently desync the registry.
+    @Test(arguments: LanguageDefinitions.all)
+    func builtDefinitionMatchesDescriptorMetadata(descriptor: LanguageDescriptor) {
+        let definition = descriptor.makeDefinition()
+        #expect(definition.id == descriptor.id)
+        #expect(definition.title == descriptor.title)
+        #expect(definition.localeIdentifier == descriptor.localeIdentifier)
+    }
+}

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -287,3 +287,25 @@ struct InfoPlistLanguageTests {
         )
     }
 }
+
+// MARK: - resolvedLanguageId
+
+struct ResolvedLanguageIdTests {
+    @Test("Keeps a valid stored id")
+    func keepsValidId() {
+        #expect(LanguageSettings.resolvedLanguageId("de_DE") == "de_DE")
+    }
+
+    @Test("Falls back for a stale/unknown id")
+    func fallsBackForUnknownId() {
+        let resolved = LanguageSettings.resolvedLanguageId("xx_XX")
+        // Must resolve to a language that actually exists in the registry.
+        #expect(LanguageConfig.language(withId: resolved) != nil)
+    }
+
+    @Test("Falls back for nil")
+    func fallsBackForNil() {
+        let resolved = LanguageSettings.resolvedLanguageId(nil)
+        #expect(LanguageConfig.language(withId: resolved) != nil)
+    }
+}

--- a/wurstfingerTests/ViewModelPipelineTests.swift
+++ b/wurstfingerTests/ViewModelPipelineTests.swift
@@ -273,12 +273,14 @@ struct ViewModelDefinitionTests {
         #expect(vm.currentArrangement != nil)
     }
 
-    @Test func unknownLanguageIdDoesNotCrash() throws {
+    @Test func unknownLanguageIdFallsBackToEnglish() throws {
         let defaults = try #require(UserDefaults(suiteName: "test.\(UUID().uuidString)"))
         let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
         vm.loadDefinition(for: "nonexistent_XX")
-        #expect(vm.currentDefinition == nil)
-        #expect(vm.activeModeFromDefinition == nil)
+        // Must never leave the keyboard blank — falls back to a renderable layout.
+        #expect(vm.currentDefinition != nil)
+        #expect(vm.currentDefinition?.id == LanguageConfig.english.id)
+        #expect(vm.activeModeFromDefinition != nil)
     }
 
     @Test func allLanguagesLoadSuccessfully() {


### PR DESCRIPTION
> ⚠️ **Stacked on #190** (`harden/keyboard-memory`). Review/merge #190 first. Before squash-merging #190, retarget this PR's base to `develop` to avoid the chain-merge pitfall.

## Problem

Follow-up hardening in the same "keyboard doesn't open / comes up blank" class as #190. Two residual gaps where a **stale stored language id** (e.g. a language removed or renamed in a later app version) could leave the keyboard blank:

1. `loadDefinition(for:)` did `guard let base = KeyboardRegistry.load(id:) else { return }` — an unresolvable id silently left `currentDefinition` nil → empty keyboard.
2. The controller read the raw stored language id directly (bypassing `LanguageSettings`' normalisation) at two sites, so an invalid stored id was passed through unvalidated.

The normal path was already safe (`detectSystemLanguage()` always returns a valid id); this is defense-in-depth for the edge cases.

## Changes

- **`loadDefinition(for:)` fallback:** falls back to English when the requested id — or, as a last resort, English itself — can't be loaded. `currentDefinition` is never left nil; the keyboard always renders something.
- **`LanguageSettings.resolvedLanguageId(_:)`:** centralises normalising a raw stored id to one guaranteed to exist in the registry (stored → system → English), mirroring the existing init-time logic. The controller now routes both definition loading and the `primaryLanguage` getter through it.
- **Tests:** `resolvedLanguageId` (valid / stale / nil) + updated unknown-id behaviour (now falls back to English instead of no-op).

## Verification

- `xcodebuild build` ✅
- Unit tests (serial): **TEST SUCCEEDED**, 0 failures ✅
- SwiftFormat + SwiftLint `--strict` clean ✅