### PR TITLE
Run CI Unit Tests Serially to Avoid Flaky Clone Crashes

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -71,6 +71,7 @@ jobs:
             -project Wurstfinger.xcodeproj \
             -destination 'platform=iOS Simulator,id=${{ steps.sim.outputs.simulator_id }}' \
             -only-testing:WurstfingerTests \
+            -parallel-testing-enabled NO \
             -resultBundlePath TestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO \
             | xcpretty --color --report html --output TestResults.html


### PR DESCRIPTION
## Problem

Xcode parallelises tests across cloned simulators by default. A cloned **test-host process occasionally crashes on launch**, which makes Xcode mark *every* test assigned to that clone as failed at `0.000s` — whole unrelated suites (resolvers, compose, haptics, autocapitalization…) "failing" en masse with no real logic error. The signature is unmistakable: all failures on one clone, all instant, while the same tests pass on another clone.

The `pr-tests` job runs only `WurstfingerTests` (no UI tests) and has **no retry**, so a single such infrastructure crash fails the entire run. This matches the project's known flakiness under full parallelism.

## Change

One line: `-parallel-testing-enabled NO` for the unit-test job.

The unit suite runs in ~5–6 minutes serially — comfortably within the existing 30-minute timeout — so the lost parallelism is negligible, and the quality gate becomes deterministic.

### Alternatives considered
- `-retry-tests-on-failure` — keeps parallelism but masks genuinely flaky *tests* too; less clear signal.
- `-maximum-concurrent-test-simulator-destinations 1` — similar effect, less explicit than disabling parallelism outright.

Independent of #190/#191 (touches only the CI workflow).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the automated test run configuration to disable parallel test execution, which can help make test runs more consistent and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->