### PR TITLE
Fix Landscape Keyboard Crash (Multi-Row Key Rendering)

### DIFF
--- a/wurstfinger/KeyboardShowcaseView.swift
+++ b/wurstfinger/KeyboardShowcaseView.swift
@@ -125,6 +125,13 @@ struct KeyboardShowcaseView: View {
                 viewModel.bindTextInputTarget(actionTarget)
             }
 
+            // Force orientation if specified (for landscape screenshots / UI tests).
+            // The host app never drives orientation into the view model the way the
+            // keyboard extension does, so without this the showcase is always portrait.
+            if ProcessInfo.processInfo.environment["FORCE_ORIENTATION"] == "landscape" {
+                viewModel.updateOrientation(isLandscape: true)
+            }
+
             // Load definition
             viewModel.loadDefinition(for: languageSettings.selectedLanguageId)
 

--- a/wurstfingerKeyboard/Definition/Layout/GridLayoutSolver.swift
+++ b/wurstfingerKeyboard/Definition/Layout/GridLayoutSolver.swift
@@ -1,0 +1,82 @@
+//
+//  GridLayoutSolver.swift
+//  Wurstfinger
+//
+//  Resolves a GridArrangement into absolutely-positioned, spanning cells.
+//
+
+import Foundation
+
+/// A key placed at an absolute grid position with explicit column/row spans.
+struct SolvedCell: Equatable {
+    let keyId: String
+    let row: Int
+    let column: Int
+    let rowSpan: Int
+    let columnSpan: Int
+}
+
+/// Pure resolver that turns a `GridArrangement` — whose rows list placements in
+/// reading order and omit cells already covered by a span from an earlier row —
+/// into absolutely-positioned `SolvedCell`s.
+///
+/// This is what makes height-spanning keys (e.g. the landscape return key with
+/// `heightMultiplier == 2`) renderable: the geometry lives in a pure, testable
+/// function instead of being approximated in the SwiftUI tree. `KeyboardGridView`
+/// consumes the result to place each key, including across multiple rows — the
+/// case the old `Grid`-based renderer could not draw and trapped on.
+enum GridLayoutSolver {
+    /// Resolves an arrangement using first-fit, row-major placement: each
+    /// placement takes the next free column in its row, skipping cells already
+    /// occupied by a span descending from an earlier row.
+    static func solve(_ arrangement: GridArrangement) -> [SolvedCell] {
+        let columns = max(arrangement.columns, 1)
+        var occupied: [[Bool]] = []
+
+        func ensureRow(_ row: Int) {
+            while occupied.count <= row {
+                occupied.append(Array(repeating: false, count: columns))
+            }
+        }
+
+        var cells: [SolvedCell] = []
+        for (rowIndex, row) in arrangement.rows.enumerated() {
+            ensureRow(rowIndex)
+            var column = 0
+            for placement in row {
+                // Advance past cells already covered by a span from above.
+                while column < columns, occupied[rowIndex][column] {
+                    column += 1
+                }
+                guard column < columns else { break }
+
+                let columnSpan = min(max(placement.widthMultiplier, 1), columns - column)
+                let rowSpan = max(placement.heightMultiplier, 1)
+
+                for spanRow in rowIndex ..< (rowIndex + rowSpan) {
+                    ensureRow(spanRow)
+                    for spanColumn in column ..< (column + columnSpan) {
+                        occupied[spanRow][spanColumn] = true
+                    }
+                }
+
+                cells.append(
+                    SolvedCell(
+                        keyId: placement.keyId,
+                        row: rowIndex,
+                        column: column,
+                        rowSpan: rowSpan,
+                        columnSpan: columnSpan
+                    )
+                )
+                column += columnSpan
+            }
+        }
+        return cells
+    }
+
+    /// Total number of grid rows the arrangement occupies, accounting for spans.
+    static func rowCount(_ arrangement: GridArrangement) -> Int {
+        solve(arrangement).map { $0.row + $0.rowSpan }.max() ?? arrangement.rows.count
+    }
+}

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -51,7 +51,11 @@ struct KeyView: View {
             label
             hintOverlay
         }
-        .frame(height: effectiveKeyHeight)
+        // Fill the cell frame imposed by KeyboardGridLayout. The layout sizes
+        // rows from the same effective key height, so single-row keys are
+        // unchanged while a spanning key (e.g. landscape return) grows to cover
+        // multiple rows.
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityIdentifier(key.id)

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -75,7 +75,10 @@ struct KeyView: View {
                     onGesture(key, classification.gesture, classification.isReturn)
                 },
                 onTouchDown: { onTouchDown?() },
-                aspectRatio: keyAspectRatio,
+                // Account for the spanned cell: a multi-row/-column key is not
+                // 1×1, so scale the base aspect ratio by columnSpan/rowSpan
+                // (spanRatio) to classify swipes against the real geometry.
+                aspectRatio: CGFloat(keyAspectRatio) * spanRatio,
                 isActive: $isActive
             ))
         }

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridLayout.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridLayout.swift
@@ -1,0 +1,55 @@
+//
+//  KeyboardGridLayout.swift
+//  Wurstfinger
+//
+//  SwiftUI Layout that positions keys with both column and row spans.
+//
+
+import SwiftUI
+
+/// Positions keyboard keys on a fixed grid, honouring **both** column and row
+/// spans. SwiftUI's `Grid` only supports column spans (`gridCellColumns`), which
+/// is why a row-spanning key (e.g. the landscape return key) previously could
+/// not be drawn — the old renderer trapped on it instead.
+///
+/// Cells are pre-resolved by `GridLayoutSolver`; the subviews handed to the
+/// layout must be in the same order as `cells`. Each cell is given an explicit
+/// frame, so a key can span multiple rows and/or columns.
+struct KeyboardGridLayout: Layout {
+    let cells: [SolvedCell]
+    let columns: Int
+    let rowHeight: CGFloat
+    let horizontalSpacing: CGFloat
+    let verticalSpacing: CGFloat
+
+    private var rowCount: Int {
+        cells.map { $0.row + $0.rowSpan }.max() ?? 0
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews _: Subviews, cache _: inout ()) -> CGSize {
+        let width = proposal.width ?? 0
+        let rows = rowCount
+        let height = CGFloat(rows) * rowHeight + CGFloat(max(rows - 1, 0)) * verticalSpacing
+        return CGSize(width: width, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
+        guard columns > 0 else { return }
+        let totalHorizontalSpacing = CGFloat(columns - 1) * horizontalSpacing
+        let columnWidth = max((bounds.width - totalHorizontalSpacing) / CGFloat(columns), 0)
+
+        for (index, cell) in cells.enumerated() where index < subviews.count {
+            let originX = bounds.minX + CGFloat(cell.column) * (columnWidth + horizontalSpacing)
+            let originY = bounds.minY + CGFloat(cell.row) * (rowHeight + verticalSpacing)
+            let width = CGFloat(cell.columnSpan) * columnWidth
+                + CGFloat(cell.columnSpan - 1) * horizontalSpacing
+            let height = CGFloat(cell.rowSpan) * rowHeight
+                + CGFloat(cell.rowSpan - 1) * verticalSpacing
+            subviews[index].place(
+                at: CGPoint(x: originX, y: originY),
+                anchor: .topLeading,
+                proposal: ProposedViewSize(width: width, height: height)
+            )
+        }
+    }
+}

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -2,21 +2,18 @@
 //  KeyboardGridView.swift
 //  Wurstfinger
 //
-//  Generic SwiftUI Grid renderer for any GridArrangement + key pool.
+//  Generic SwiftUI grid renderer for any GridArrangement + key pool.
 //
 
 import SwiftUI
 
-/// Generic grid renderer that lays out a `GridArrangement` using SwiftUI's
-/// `Grid` view (iOS 16+). Width multipliers map directly onto
-/// `gridCellColumns`, so multi-column keys (e.g. space) are supported
-/// without hardcoding any positions.
+/// Generic grid renderer for a `GridArrangement` and key pool.
 ///
-/// **Height-spanning keys.** SwiftUI's `Grid` does not expose a built-in
-/// `gridCellRows` modifier. Multi-row placements (e.g. landscape return key)
-/// are tracked in the model via `KeyPlacement.heightMultiplier` but the
-/// rendering is not yet implemented here. Currently all placements fed to
-/// this view must have `heightMultiplier == 1`.
+/// Uses `GridLayoutSolver` to resolve the arrangement into absolutely
+/// positioned cells and `KeyboardGridLayout` to place them, so keys can span
+/// multiple columns **and** rows (e.g. the landscape return key with
+/// `heightMultiplier == 2`). Width/height multipliers map directly onto the
+/// cell's column/row span, without hardcoding any positions.
 struct KeyboardGridView: View {
     let arrangement: GridArrangement
     let keys: [String: KeyConfig]
@@ -24,45 +21,47 @@ struct KeyboardGridView: View {
     var onTouchDown: (() -> Void)?
     var onSlide: ((KeyConfig, SlidePhase) -> Void)?
 
+    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
+    private var keyboardScale: Double = DeviceLayoutUtils.defaultKeyboardScale
+
+    @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
+    private var keyAspectRatio: Double = DeviceLayoutUtils.defaultKeyAspectRatio
+
+    /// Height of a single grid row, matching `KeyView`'s effective key height so
+    /// portrait layouts are unchanged and a 2-row key is exactly twice as tall
+    /// (plus the inter-row spacing).
+    private var rowHeight: CGFloat {
+        KeyboardConstants.Calculations.keyHeight(aspectRatio: keyAspectRatio) * keyboardScale
+    }
+
     var body: some View {
-        Grid(
+        let cells = GridLayoutSolver.solve(arrangement)
+        KeyboardGridLayout(
+            cells: cells,
+            columns: arrangement.columns,
+            rowHeight: rowHeight,
             horizontalSpacing: KeyboardConstants.Layout.gridHorizontalSpacing,
             verticalSpacing: KeyboardConstants.Layout.gridVerticalSpacing
         ) {
-            ForEach(Array(arrangement.rows.enumerated()), id: \.offset) { _, row in
-                GridRow {
-                    ForEach(Array(row.enumerated()), id: \.offset) { _, placement in
-                        cell(for: placement)
-                    }
-                }
+            ForEach(Array(cells.enumerated()), id: \.offset) { _, cell in
+                cellContent(for: cell)
             }
         }
     }
 
-    private func cell(for placement: KeyPlacement) -> some View {
-        assert(
-            placement.heightMultiplier == 1,
-            "Multi-row rendering is not yet implemented in KeyboardGridView"
-        )
-        return cellContent(for: placement)
-    }
-
     @ViewBuilder
-    private func cellContent(for placement: KeyPlacement) -> some View {
-        if let key = keys[placement.keyId] {
+    private func cellContent(for cell: SolvedCell) -> some View {
+        if let key = keys[cell.keyId] {
             KeyView(
                 key: key,
                 onGesture: onGesture,
                 onTouchDown: onTouchDown,
                 onSlide: onSlide,
-                spanRatio: CGFloat(placement.widthMultiplier) / CGFloat(placement.heightMultiplier)
+                spanRatio: CGFloat(cell.columnSpan) / CGFloat(cell.rowSpan)
             )
-            .gridCellColumns(placement.widthMultiplier)
-            .gridCellAnchor(.top)
-            .id(placement.keyId)
+            .id(cell.keyId)
         } else {
             Color.clear
-                .gridCellColumns(placement.widthMultiplier)
         }
     }
 

--- a/wurstfingerTests/GridLayoutSolverTests.swift
+++ b/wurstfingerTests/GridLayoutSolverTests.swift
@@ -68,7 +68,9 @@ struct GridLayoutSolverInvariantTests {
         let name = item.name
         let arrangement = item.arrangement
         let cells = GridLayoutSolver.solve(arrangement)
-        let rows = GridLayoutSolver.rowCount(arrangement)
+        // Derive expected rows from the fixture, not the function under test,
+        // so a rowCount regression can't also lower the expected tiled area.
+        let rows = arrangement.rows.count
         var covered = Set<[Int]>()
         for cell in cells {
             for row in cell.row ..< (cell.row + cell.rowSpan) {

--- a/wurstfingerTests/GridLayoutSolverTests.swift
+++ b/wurstfingerTests/GridLayoutSolverTests.swift
@@ -1,0 +1,98 @@
+//
+//  GridLayoutSolverTests.swift
+//  WurstfingerTests
+//
+//  Reproduces the landscape multi-row return-key crash and verifies the
+//  GridLayoutSolver resolves spans correctly.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct GridLayoutSolverReproTests {
+    /// Reproduces the *crash input*: the landscape arrangement feeds the
+    /// renderer a return key with `heightMultiplier == 2`. The old
+    /// `KeyboardGridView.cell(for:)` rejected that with
+    /// `assert(heightMultiplier == 1)`, trapping (EXC_BREAKPOINT) when the
+    /// keyboard laid out in landscape. (A literal trap can't be caught
+    /// in-process on the iOS simulator, so we pin the triggering data and
+    /// verify the solver now handles it below.)
+    @Test func landscapeArrangementContainsMultiRowReturnKey() {
+        let landscape = StandardArrangements.grid3x3[.landscape]
+        let placements = landscape?.rows.flatMap(\.self) ?? []
+        let returnPlacement = placements.first { $0.keyId == UtilitySlot.return }
+        #expect(returnPlacement?.heightMultiplier == 2)
+    }
+
+    /// The fix: the solver spans the return key across two rows at the correct
+    /// position, instead of trapping.
+    @Test func solverSpansLandscapeReturnKeyAcrossTwoRows() throws {
+        let landscape = try #require(StandardArrangements.grid3x3[.landscape])
+        let cells = GridLayoutSolver.solve(landscape)
+        let returnCell = try #require(cells.first { $0.keyId == UtilitySlot.return })
+        #expect(returnCell.rowSpan == 2)
+        // In the 5-column landscape grid the return key sits in row 1, column 4.
+        #expect(returnCell.row == 1)
+        #expect(returnCell.column == 4)
+    }
+
+    /// The row below the spanning key must skip the occupied column: the
+    /// bottom-row keys land in columns 0...3, never under the return key.
+    @Test func cellsBelowSpanSkipOccupiedColumn() throws {
+        let landscape = try #require(StandardArrangements.grid3x3[.landscape])
+        let cells = GridLayoutSolver.solve(landscape)
+        let returnCell = try #require(cells.first { $0.keyId == UtilitySlot.return })
+        let lastRow = returnCell.row + returnCell.rowSpan - 1
+        let cellsInLastRow = cells.filter { $0.row == lastRow && $0.keyId != UtilitySlot.return }
+        #expect(cellsInLastRow.allSatisfy { $0.column < returnCell.column })
+    }
+}
+
+/// A named arrangement so parameterised tests report which one failed.
+struct NamedArrangement: CustomStringConvertible {
+    let name: String
+    let arrangement: GridArrangement
+    var description: String {
+        name
+    }
+}
+
+struct GridLayoutSolverInvariantTests {
+    /// Every standard arrangement (all contexts, alpha + numeric) must resolve
+    /// to a fully tiled grid with no overlapping cells. This is the property the
+    /// old renderer violated; it guards every layout, not just the one that
+    /// happened to crash.
+    @Test(arguments: GridLayoutSolverInvariantTests.allArrangements)
+    func arrangementTilesWithoutOverlap(_ item: NamedArrangement) {
+        let name = item.name
+        let arrangement = item.arrangement
+        let cells = GridLayoutSolver.solve(arrangement)
+        let rows = GridLayoutSolver.rowCount(arrangement)
+        var covered = Set<[Int]>()
+        for cell in cells {
+            for row in cell.row ..< (cell.row + cell.rowSpan) {
+                for column in cell.column ..< (cell.column + cell.columnSpan) {
+                    let key = [row, column]
+                    #expect(!covered.contains(key), "\(name): overlap at \(key)")
+                    covered.insert(key)
+                }
+            }
+        }
+        // No cell escapes the declared column count.
+        #expect(cells.allSatisfy { $0.column + $0.columnSpan <= arrangement.columns }, "\(name): column overflow")
+        // Every grid slot is covered exactly once (full tiling).
+        #expect(covered.count == rows * arrangement.columns, "\(name): grid not fully tiled")
+    }
+
+    static let allArrangements: [NamedArrangement] = {
+        var result: [NamedArrangement] = []
+        for (context, arrangement) in StandardArrangements.grid3x3 {
+            result.append(NamedArrangement(name: "grid3x3.\(context)", arrangement: arrangement))
+        }
+        for (context, arrangement) in StandardArrangements.numeric3x3 {
+            result.append(NamedArrangement(name: "numeric3x3.\(context)", arrangement: arrangement))
+        }
+        return result
+    }()
+}


### PR DESCRIPTION
## Problem — a real crash, found in the device logs

The keyboard "doesn't open reliably" in landscape because of a **recurring crash**, not (only) memory. Device crash logs (`DeviceLogs/.../Wurstfinger-*.ips`, recurring 06-07 … 06-28) all show the same fault:

```
EXC_BREAKPOINT (SIGTRAP)
  libswiftCore  _assertionFailure(...)
  KeyboardGridView.cell(for:)
  ... _UIHostingView.layoutSubviews
  ... -[UIViewController window:willAnimateRotationToInterfaceOrientation:...]
```

Root cause:
- The landscape arrangements place the return key with `heightMultiplier: 2` (`StandardArrangements.swift:47,93`).
- `KeyboardGridView.cell(for:)` asserted `heightMultiplier == 1` because SwiftUI's `Grid` has no `gridCellRows` — row spanning was never implemented.
- Laying out in landscape (or rotating into it) → `assert` traps → the extension dies → iOS shows the system keyboard.

`assert()` is stripped in Release, so App Store users get a misrendered (not crashed) landscape return key, while **Debug/dev builds hard-crash** — which is what the recurring `.ips` logs are.

## Fix — real multi-row rendering

- **`GridLayoutSolver`** (pure): resolves a `GridArrangement` into absolutely positioned cells with column **and** row spans, handling occupancy (the row below a span skips the occupied column).
- **`KeyboardGridLayout`** (custom `Layout`): places each cell with an explicit frame, so a key can span multiple rows. Row height matches `KeyView`'s effective key height → portrait is unchanged; a 2-row key is exactly twice as tall plus spacing.
- **`KeyboardGridView`** now uses the solver + layout; the `assert` and the `Grid`/`gridCellColumns` path are gone.
- **`KeyView`** fills the layout-imposed cell instead of pinning its own height.
- **`KeyboardShowcaseView`** gains a `FORCE_ORIENTATION=landscape` hook (consistent with the existing `FORCE_LANGUAGE`/`FORCE_LAYER`/`FORCE_APPEARANCE` hooks) for landscape screenshots/UI tests.

## Reproduction & tests

- `GridLayoutSolverReproTests` pins the exact crashing input (landscape return key, `heightMultiplier == 2`) and verifies the solver now spans it across rows 1–2 at column 4. *(A literal in-process trap test isn't possible on the iOS simulator — a Swift trap kills the test host and Swift-Testing exit tests aren't supported there — so the reproduction pins the triggering data + the .ips logs are the in-the-wild crash.)*
- `GridLayoutSolverInvariantTests` checks **every** standard arrangement (portrait/landscape × alpha/numeric × mirrored) tiles fully with no overlaps — the property the old renderer violated.
- Existing `gridCellSpan` / rendering tests retained.

## Verification

- Serial unit tests: **TEST SUCCEEDED**, 0 failures ✅
- SwiftFormat + SwiftLint `--strict` clean ✅
- Simulator screenshots: landscape return key spans two rows (renders, no crash); portrait unchanged ✅

Independent of #190/#191/#192 (base `develop`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard layouts now support keys that span multiple rows and columns, improving placement for larger keys in grid-based keyboards.
  * The keyboard showcase can optionally start in landscape mode when that environment setting is enabled.

* **Bug Fixes**
  * Fixed an issue where spanning keys were constrained to a single-row height.
  * Improved keyboard grid sizing and placement to better match the available layout space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->