### PR TITLE
Trim Keyboard Re-Render Overhead

### DIFF
--- a/wurstfinger/KeyboardShowcaseView.swift
+++ b/wurstfinger/KeyboardShowcaseView.swift
@@ -125,6 +125,13 @@ struct KeyboardShowcaseView: View {
                 viewModel.bindTextInputTarget(actionTarget)
             }
 
+            // Force orientation if specified (for landscape screenshots / UI tests).
+            // The host app never drives orientation into the view model the way the
+            // keyboard extension does, so without this the showcase is always portrait.
+            if ProcessInfo.processInfo.environment["FORCE_ORIENTATION"] == "landscape" {
+                viewModel.updateOrientation(isLandscape: true)
+            }
+
             // Load definition
             viewModel.loadDefinition(for: languageSettings.selectedLanguageId)
 

--- a/wurstfingerKeyboard/Definition/Layout/GridArrangement.swift
+++ b/wurstfingerKeyboard/Definition/Layout/GridArrangement.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// A concrete spatial arrangement of keys.
 /// Multiple arrangements can lay out the same key pool differently.
-struct GridArrangement: Codable, Equatable {
+struct GridArrangement: Codable, Equatable, Hashable {
     /// Number of logical columns.
     /// The sum of widthMultipliers in each row (plus columns spanned by keys from
     /// previous rows via heightMultiplier) must equal this value.

--- a/wurstfingerKeyboard/Definition/Layout/GridLayoutSolver.swift
+++ b/wurstfingerKeyboard/Definition/Layout/GridLayoutSolver.swift
@@ -1,0 +1,82 @@
+//
+//  GridLayoutSolver.swift
+//  Wurstfinger
+//
+//  Resolves a GridArrangement into absolutely-positioned, spanning cells.
+//
+
+import Foundation
+
+/// A key placed at an absolute grid position with explicit column/row spans.
+struct SolvedCell: Equatable {
+    let keyId: String
+    let row: Int
+    let column: Int
+    let rowSpan: Int
+    let columnSpan: Int
+}
+
+/// Pure resolver that turns a `GridArrangement` — whose rows list placements in
+/// reading order and omit cells already covered by a span from an earlier row —
+/// into absolutely-positioned `SolvedCell`s.
+///
+/// This is what makes height-spanning keys (e.g. the landscape return key with
+/// `heightMultiplier == 2`) renderable: the geometry lives in a pure, testable
+/// function instead of being approximated in the SwiftUI tree. `KeyboardGridView`
+/// consumes the result to place each key, including across multiple rows — the
+/// case the old `Grid`-based renderer could not draw and trapped on.
+enum GridLayoutSolver {
+    /// Resolves an arrangement using first-fit, row-major placement: each
+    /// placement takes the next free column in its row, skipping cells already
+    /// occupied by a span descending from an earlier row.
+    static func solve(_ arrangement: GridArrangement) -> [SolvedCell] {
+        let columns = max(arrangement.columns, 1)
+        var occupied: [[Bool]] = []
+
+        func ensureRow(_ row: Int) {
+            while occupied.count <= row {
+                occupied.append(Array(repeating: false, count: columns))
+            }
+        }
+
+        var cells: [SolvedCell] = []
+        for (rowIndex, row) in arrangement.rows.enumerated() {
+            ensureRow(rowIndex)
+            var column = 0
+            for placement in row {
+                // Advance past cells already covered by a span from above.
+                while column < columns, occupied[rowIndex][column] {
+                    column += 1
+                }
+                guard column < columns else { break }
+
+                let columnSpan = min(max(placement.widthMultiplier, 1), columns - column)
+                let rowSpan = max(placement.heightMultiplier, 1)
+
+                for spanRow in rowIndex ..< (rowIndex + rowSpan) {
+                    ensureRow(spanRow)
+                    for spanColumn in column ..< (column + columnSpan) {
+                        occupied[spanRow][spanColumn] = true
+                    }
+                }
+
+                cells.append(
+                    SolvedCell(
+                        keyId: placement.keyId,
+                        row: rowIndex,
+                        column: column,
+                        rowSpan: rowSpan,
+                        columnSpan: columnSpan
+                    )
+                )
+                column += columnSpan
+            }
+        }
+        return cells
+    }
+
+    /// Total number of grid rows the arrangement occupies, accounting for spans.
+    static func rowCount(_ arrangement: GridArrangement) -> Int {
+        solve(arrangement).map { $0.row + $0.rowSpan }.max() ?? arrangement.rows.count
+    }
+}

--- a/wurstfingerKeyboard/Definition/Layout/GridLayoutSolver.swift
+++ b/wurstfingerKeyboard/Definition/Layout/GridLayoutSolver.swift
@@ -75,6 +75,21 @@ enum GridLayoutSolver {
         return cells
     }
 
+    /// Cache of solved arrangements. There are only a handful of distinct
+    /// arrangements (4 contexts × alpha/numeric), so this stays tiny and is
+    /// effectively permanent. Main-actor isolated because only the SwiftUI view
+    /// reads it; tests call the pure `solve(_:)` directly.
+    @MainActor private static var cache: [GridArrangement: [SolvedCell]] = [:]
+
+    /// `solve(_:)` memoised for the render path, avoiding the occupancy-matrix
+    /// and cell-array allocations on every `body` evaluation.
+    @MainActor static func solveCached(_ arrangement: GridArrangement) -> [SolvedCell] {
+        if let cached = cache[arrangement] { return cached }
+        let solved = solve(arrangement)
+        cache[arrangement] = solved
+        return solved
+    }
+
     /// Total number of grid rows the arrangement occupies, accounting for spans.
     static func rowCount(_ arrangement: GridArrangement) -> Int {
         solve(arrangement).map { $0.row + $0.rowSpan }.max() ?? arrangement.rows.count

--- a/wurstfingerKeyboard/Definition/Layout/KeyPlacement.swift
+++ b/wurstfingerKeyboard/Definition/Layout/KeyPlacement.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// References a key by ID and determines its size in the grid.
 /// The same key can be placed differently in different arrangements.
-struct KeyPlacement: Codable, Equatable {
+struct KeyPlacement: Codable, Equatable, Hashable {
     /// Reference to a KeyConfig.id
     let keyId: String
 

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -51,7 +51,11 @@ struct KeyView: View {
             label
             hintOverlay
         }
-        .frame(height: effectiveKeyHeight)
+        // Fill the cell frame imposed by KeyboardGridLayout. The layout sizes
+        // rows from the same effective key height, so single-row keys are
+        // unchanged while a spanning key (e.g. landscape return) grows to cover
+        // multiple rows.
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityIdentifier(key.id)

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -24,14 +24,14 @@ struct KeyView: View {
 
     @State private var isActive = false
 
-    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
-    private var keyboardStyle: KeyboardStyle = .classic
-
-    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
-    private var keyboardScale: Double = DeviceLayoutUtils.defaultKeyboardScale
-
-    @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
-    private var keyAspectRatio: Double = DeviceLayoutUtils.defaultKeyAspectRatio
+    /// Visual style, row height and aspect ratio are passed down from
+    /// `KeyboardGridView` rather than each key observing UserDefaults itself.
+    /// That collapses ~3 observers per key (dozens per keyboard) into one set of
+    /// observers on the parent, so a settings change re-renders the grid once
+    /// instead of fanning out across every key.
+    var keyboardStyle: KeyboardStyle = .classic
+    var rowHeight: CGFloat = KeyboardConstants.KeyDimensions.height
+    var aspectRatio: CGFloat = DeviceLayoutUtils.defaultKeyAspectRatio
 
     /// Maps emoji labels to SF Symbol names for utility keys.
     private static let sfSymbolMap: [String: String] = [
@@ -75,7 +75,7 @@ struct KeyView: View {
                     onGesture(key, classification.gesture, classification.isReturn)
                 },
                 onTouchDown: { onTouchDown?() },
-                aspectRatio: keyAspectRatio,
+                aspectRatio: aspectRatio,
                 isActive: $isActive
             ))
         }
@@ -115,22 +115,17 @@ struct KeyView: View {
         }
     }
 
-    /// Effective key height accounting for both keyboard scale and aspect ratio.
-    private var effectiveKeyHeight: CGFloat {
-        KeyboardConstants.Calculations.keyHeight(aspectRatio: keyAspectRatio) * keyboardScale
-    }
-
-    /// Scaled font size proportional to effective key height.
+    /// Scaled font size proportional to the row height.
     private var scaledFontSize: CGFloat {
         let base = Self.baseFontSize(for: key.style)
-        let scaled = base * (effectiveKeyHeight / KeyboardConstants.FontSizes.mainLabelReferenceHeight)
+        let scaled = base * (rowHeight / KeyboardConstants.FontSizes.mainLabelReferenceHeight)
         return min(max(scaled, KeyboardConstants.FontSizes.mainLabelMinSize), KeyboardConstants.FontSizes.mainLabelMaxSize)
     }
 
-    /// Scaled hint font size proportional to effective key height.
+    /// Scaled hint font size proportional to the row height.
     private var scaledHintFontSize: CGFloat {
         let base = KeyboardConstants.FontSizes.hintBaseSize
-        let scaled = base * (effectiveKeyHeight / KeyboardConstants.FontSizes.hintReferenceHeight)
+        let scaled = base * (rowHeight / KeyboardConstants.FontSizes.hintReferenceHeight)
         return min(max(scaled, KeyboardConstants.FontSizes.hintMinSize), KeyboardConstants.FontSizes.hintMaxSize)
     }
 

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridLayout.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridLayout.swift
@@ -1,0 +1,55 @@
+//
+//  KeyboardGridLayout.swift
+//  Wurstfinger
+//
+//  SwiftUI Layout that positions keys with both column and row spans.
+//
+
+import SwiftUI
+
+/// Positions keyboard keys on a fixed grid, honouring **both** column and row
+/// spans. SwiftUI's `Grid` only supports column spans (`gridCellColumns`), which
+/// is why a row-spanning key (e.g. the landscape return key) previously could
+/// not be drawn — the old renderer trapped on it instead.
+///
+/// Cells are pre-resolved by `GridLayoutSolver`; the subviews handed to the
+/// layout must be in the same order as `cells`. Each cell is given an explicit
+/// frame, so a key can span multiple rows and/or columns.
+struct KeyboardGridLayout: Layout {
+    let cells: [SolvedCell]
+    let columns: Int
+    let rowHeight: CGFloat
+    let horizontalSpacing: CGFloat
+    let verticalSpacing: CGFloat
+
+    private var rowCount: Int {
+        cells.map { $0.row + $0.rowSpan }.max() ?? 0
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews _: Subviews, cache _: inout ()) -> CGSize {
+        let width = proposal.width ?? 0
+        let rows = rowCount
+        let height = CGFloat(rows) * rowHeight + CGFloat(max(rows - 1, 0)) * verticalSpacing
+        return CGSize(width: width, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
+        guard columns > 0 else { return }
+        let totalHorizontalSpacing = CGFloat(columns - 1) * horizontalSpacing
+        let columnWidth = max((bounds.width - totalHorizontalSpacing) / CGFloat(columns), 0)
+
+        for (index, cell) in cells.enumerated() where index < subviews.count {
+            let originX = bounds.minX + CGFloat(cell.column) * (columnWidth + horizontalSpacing)
+            let originY = bounds.minY + CGFloat(cell.row) * (rowHeight + verticalSpacing)
+            let width = CGFloat(cell.columnSpan) * columnWidth
+                + CGFloat(cell.columnSpan - 1) * horizontalSpacing
+            let height = CGFloat(cell.rowSpan) * rowHeight
+                + CGFloat(cell.rowSpan - 1) * verticalSpacing
+            subviews[index].place(
+                at: CGPoint(x: originX, y: originY),
+                anchor: .topLeading,
+                proposal: ProposedViewSize(width: width, height: height)
+            )
+        }
+    }
+}

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -2,21 +2,18 @@
 //  KeyboardGridView.swift
 //  Wurstfinger
 //
-//  Generic SwiftUI Grid renderer for any GridArrangement + key pool.
+//  Generic SwiftUI grid renderer for any GridArrangement + key pool.
 //
 
 import SwiftUI
 
-/// Generic grid renderer that lays out a `GridArrangement` using SwiftUI's
-/// `Grid` view (iOS 16+). Width multipliers map directly onto
-/// `gridCellColumns`, so multi-column keys (e.g. space) are supported
-/// without hardcoding any positions.
+/// Generic grid renderer for a `GridArrangement` and key pool.
 ///
-/// **Height-spanning keys.** SwiftUI's `Grid` does not expose a built-in
-/// `gridCellRows` modifier. Multi-row placements (e.g. landscape return key)
-/// are tracked in the model via `KeyPlacement.heightMultiplier` but the
-/// rendering is not yet implemented here. Currently all placements fed to
-/// this view must have `heightMultiplier == 1`.
+/// Uses `GridLayoutSolver` to resolve the arrangement into absolutely
+/// positioned cells and `KeyboardGridLayout` to place them, so keys can span
+/// multiple columns **and** rows (e.g. the landscape return key with
+/// `heightMultiplier == 2`). Width/height multipliers map directly onto the
+/// cell's column/row span, without hardcoding any positions.
 struct KeyboardGridView: View {
     let arrangement: GridArrangement
     let keys: [String: KeyConfig]
@@ -24,45 +21,47 @@ struct KeyboardGridView: View {
     var onTouchDown: (() -> Void)?
     var onSlide: ((KeyConfig, SlidePhase) -> Void)?
 
+    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
+    private var keyboardScale: Double = DeviceLayoutUtils.defaultKeyboardScale
+
+    @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
+    private var keyAspectRatio: Double = DeviceLayoutUtils.defaultKeyAspectRatio
+
+    /// Height of a single grid row, matching `KeyView`'s effective key height so
+    /// portrait layouts are unchanged and a 2-row key is exactly twice as tall
+    /// (plus the inter-row spacing).
+    private var rowHeight: CGFloat {
+        KeyboardConstants.Calculations.keyHeight(aspectRatio: keyAspectRatio) * keyboardScale
+    }
+
     var body: some View {
-        Grid(
+        let cells = GridLayoutSolver.solve(arrangement)
+        KeyboardGridLayout(
+            cells: cells,
+            columns: arrangement.columns,
+            rowHeight: rowHeight,
             horizontalSpacing: KeyboardConstants.Layout.gridHorizontalSpacing,
             verticalSpacing: KeyboardConstants.Layout.gridVerticalSpacing
         ) {
-            ForEach(Array(arrangement.rows.enumerated()), id: \.offset) { _, row in
-                GridRow {
-                    ForEach(Array(row.enumerated()), id: \.offset) { _, placement in
-                        cell(for: placement)
-                    }
-                }
+            ForEach(Array(cells.enumerated()), id: \.offset) { _, cell in
+                cellContent(for: cell)
             }
         }
     }
 
-    private func cell(for placement: KeyPlacement) -> some View {
-        assert(
-            placement.heightMultiplier == 1,
-            "Multi-row rendering is not yet implemented in KeyboardGridView"
-        )
-        return cellContent(for: placement)
-    }
-
     @ViewBuilder
-    private func cellContent(for placement: KeyPlacement) -> some View {
-        if let key = keys[placement.keyId] {
+    private func cellContent(for cell: SolvedCell) -> some View {
+        if let key = keys[cell.keyId] {
             KeyView(
                 key: key,
                 onGesture: onGesture,
                 onTouchDown: onTouchDown,
                 onSlide: onSlide,
-                spanRatio: CGFloat(placement.widthMultiplier) / CGFloat(placement.heightMultiplier)
+                spanRatio: CGFloat(cell.columnSpan) / CGFloat(cell.rowSpan)
             )
-            .gridCellColumns(placement.widthMultiplier)
-            .gridCellAnchor(.top)
-            .id(placement.keyId)
+            .id(cell.keyId)
         } else {
             Color.clear
-                .gridCellColumns(placement.widthMultiplier)
         }
     }
 

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -27,6 +27,11 @@ struct KeyboardGridView: View {
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var keyAspectRatio: Double = DeviceLayoutUtils.defaultKeyAspectRatio
 
+    // Observed once for the whole grid and passed down to each KeyView, instead
+    // of every key observing this key itself.
+    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
+    private var keyboardStyle: KeyboardStyle = .classic
+
     /// Height of a single grid row, matching `KeyView`'s effective key height so
     /// portrait layouts are unchanged and a 2-row key is exactly twice as tall
     /// (plus the inter-row spacing).
@@ -35,7 +40,7 @@ struct KeyboardGridView: View {
     }
 
     var body: some View {
-        let cells = GridLayoutSolver.solve(arrangement)
+        let cells = GridLayoutSolver.solveCached(arrangement)
         KeyboardGridLayout(
             cells: cells,
             columns: arrangement.columns,
@@ -57,7 +62,10 @@ struct KeyboardGridView: View {
                 onGesture: onGesture,
                 onTouchDown: onTouchDown,
                 onSlide: onSlide,
-                spanRatio: CGFloat(cell.columnSpan) / CGFloat(cell.rowSpan)
+                spanRatio: CGFloat(cell.columnSpan) / CGFloat(cell.rowSpan),
+                keyboardStyle: keyboardStyle,
+                rowHeight: rowHeight,
+                aspectRatio: keyAspectRatio
             )
             .id(cell.keyId)
         } else {

--- a/wurstfingerTests/GridLayoutSolverTests.swift
+++ b/wurstfingerTests/GridLayoutSolverTests.swift
@@ -1,0 +1,98 @@
+//
+//  GridLayoutSolverTests.swift
+//  WurstfingerTests
+//
+//  Reproduces the landscape multi-row return-key crash and verifies the
+//  GridLayoutSolver resolves spans correctly.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct GridLayoutSolverReproTests {
+    /// Reproduces the *crash input*: the landscape arrangement feeds the
+    /// renderer a return key with `heightMultiplier == 2`. The old
+    /// `KeyboardGridView.cell(for:)` rejected that with
+    /// `assert(heightMultiplier == 1)`, trapping (EXC_BREAKPOINT) when the
+    /// keyboard laid out in landscape. (A literal trap can't be caught
+    /// in-process on the iOS simulator, so we pin the triggering data and
+    /// verify the solver now handles it below.)
+    @Test func landscapeArrangementContainsMultiRowReturnKey() {
+        let landscape = StandardArrangements.grid3x3[.landscape]
+        let placements = landscape?.rows.flatMap(\.self) ?? []
+        let returnPlacement = placements.first { $0.keyId == UtilitySlot.return }
+        #expect(returnPlacement?.heightMultiplier == 2)
+    }
+
+    /// The fix: the solver spans the return key across two rows at the correct
+    /// position, instead of trapping.
+    @Test func solverSpansLandscapeReturnKeyAcrossTwoRows() throws {
+        let landscape = try #require(StandardArrangements.grid3x3[.landscape])
+        let cells = GridLayoutSolver.solve(landscape)
+        let returnCell = try #require(cells.first { $0.keyId == UtilitySlot.return })
+        #expect(returnCell.rowSpan == 2)
+        // In the 5-column landscape grid the return key sits in row 1, column 4.
+        #expect(returnCell.row == 1)
+        #expect(returnCell.column == 4)
+    }
+
+    /// The row below the spanning key must skip the occupied column: the
+    /// bottom-row keys land in columns 0...3, never under the return key.
+    @Test func cellsBelowSpanSkipOccupiedColumn() throws {
+        let landscape = try #require(StandardArrangements.grid3x3[.landscape])
+        let cells = GridLayoutSolver.solve(landscape)
+        let returnCell = try #require(cells.first { $0.keyId == UtilitySlot.return })
+        let lastRow = returnCell.row + returnCell.rowSpan - 1
+        let cellsInLastRow = cells.filter { $0.row == lastRow && $0.keyId != UtilitySlot.return }
+        #expect(cellsInLastRow.allSatisfy { $0.column < returnCell.column })
+    }
+}
+
+/// A named arrangement so parameterised tests report which one failed.
+struct NamedArrangement: CustomStringConvertible {
+    let name: String
+    let arrangement: GridArrangement
+    var description: String {
+        name
+    }
+}
+
+struct GridLayoutSolverInvariantTests {
+    /// Every standard arrangement (all contexts, alpha + numeric) must resolve
+    /// to a fully tiled grid with no overlapping cells. This is the property the
+    /// old renderer violated; it guards every layout, not just the one that
+    /// happened to crash.
+    @Test(arguments: GridLayoutSolverInvariantTests.allArrangements)
+    func arrangementTilesWithoutOverlap(_ item: NamedArrangement) {
+        let name = item.name
+        let arrangement = item.arrangement
+        let cells = GridLayoutSolver.solve(arrangement)
+        let rows = GridLayoutSolver.rowCount(arrangement)
+        var covered = Set<[Int]>()
+        for cell in cells {
+            for row in cell.row ..< (cell.row + cell.rowSpan) {
+                for column in cell.column ..< (cell.column + cell.columnSpan) {
+                    let key = [row, column]
+                    #expect(!covered.contains(key), "\(name): overlap at \(key)")
+                    covered.insert(key)
+                }
+            }
+        }
+        // No cell escapes the declared column count.
+        #expect(cells.allSatisfy { $0.column + $0.columnSpan <= arrangement.columns }, "\(name): column overflow")
+        // Every grid slot is covered exactly once (full tiling).
+        #expect(covered.count == rows * arrangement.columns, "\(name): grid not fully tiled")
+    }
+
+    static let allArrangements: [NamedArrangement] = {
+        var result: [NamedArrangement] = []
+        for (context, arrangement) in StandardArrangements.grid3x3 {
+            result.append(NamedArrangement(name: "grid3x3.\(context)", arrangement: arrangement))
+        }
+        for (context, arrangement) in StandardArrangements.numeric3x3 {
+            result.append(NamedArrangement(name: "numeric3x3.\(context)", arrangement: arrangement))
+        }
+        return result
+    }()
+}


### PR DESCRIPTION
> ⚠️ **Stacked on #193** (`fix/landscape-multirow-crash`) — it depends on that PR's KeyView/KeyboardGridView/solver. Merge #193 first, then retarget this PR's base to `develop` before squash-merging #193.

Two behaviour-preserving render-path optimisations from a perf/memory pass over the hot paths. (The gesture path was already well-optimised — O(1) ring-buffer appends, classification only on touch-up — so nothing changed there.)

## 1. Stop every key from observing UserDefaults
`KeyView` read **three** `@AppStorage` keys (style, scale, aspect) — ~3 KVO observers *per key*, dozens per keyboard — so any settings change fanned a re-render out across every key. Now `KeyboardGridView` observes those once and passes `keyboardStyle`, `rowHeight` and `aspectRatio` down. Same values reach each key; the observer set collapses and the grid re-renders once.

## 2. Memoise the grid solve
`GridLayoutSolver.solveCached` caches the per-arrangement result, so the occupancy matrix + cell array aren't reallocated on every `body` evaluation (there are only a handful of distinct arrangements; cache is main-actor isolated, tests still use the pure `solve(_:)`). `GridArrangement`/`KeyPlacement` gain `Hashable` to key the cache.

## Deliberately NOT done (assessed, not worth it)
- **Caching `fromUserDefaults()` gesture config** — read only once per completed gesture (not per move); a cache needs invalidation on settings change → correctness risk for a sub-noise gain.
- **Caching `DeviceLayoutUtils.screenBounds`** — already a documented deliberate `UIScreen.main` choice (UIApplication.shared is unavailable in extensions); per-render cost is a cheap property access.

These are render-efficiency wins, not a memory silver bullet — the dominant footprint is the SwiftUI/UIHostingController runtime (see the on-device measurement follow-up).

## Verification
- Serial unit tests: **TEST SUCCEEDED**, 0 failures ✅
- SwiftFormat + SwiftLint `--strict` clean ✅
- Landscape/portrait simulator screenshots unchanged (behaviour-preserving) ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard layouts now support keys that span multiple rows and columns, improving support for larger special keys in landscape and compact layouts.
  * Keyboard appearance settings are now applied more consistently when the keyboard opens.

* **Bug Fixes**
  * Fixed layout issues that could cause overlapping or misplaced keys in certain grid-based keyboard configurations.
  * Improved keyboard sizing so keys fill their assigned space more reliably across different display settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->