### PR TITLE
Guarantee the Keyboard Always Renders a Layout

### DIFF
--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -20,29 +20,29 @@ final class KeyboardViewController: UIInputViewController {
     /// `viewWillAppear` when nothing that affects the definition changed.
     private var loadedDefinitionSignature: String?
 
+    /// The language selected in the host app, normalised to an id that is
+    /// guaranteed to exist in the registry (falling back to the system language,
+    /// then English). Determines which definition is loaded.
+    private var selectedLanguageId: String {
+        LanguageSettings.resolvedLanguageId(
+            SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue)
+        )
+    }
+
     /// Reports the active keyboard language to iOS (shown in Settings > Keyboards).
     /// Reads directly from SharedDefaults to pick up language changes made in the host app,
     /// since the LanguageSettings singleton may hold a stale value from its init.
     override var primaryLanguage: String? {
         get {
-            // `resolvedLanguage` reads lightweight registry/config metadata only
-            // (it never builds a layout), so it is safe for iOS to query eagerly.
-            resolvedLanguage.locale.identifier
+            // Resolve the locale from lightweight registry metadata only. iOS may
+            // query this eagerly/repeatedly, so it must never build a layout.
+            let id = selectedLanguageId
+            return (KeyboardRegistry.available.first { $0.id == id }?.localeIdentifier)
+                ?? LanguageConfig.english.locale.identifier
         }
         set {
             super.primaryLanguage = newValue
         }
-    }
-
-    /// The active language, resolved identically for both `primaryLanguage`
-    /// (reported to iOS) and definition loading. Reads the selected id, falls
-    /// back to the detected system language, then to English for an unknown id —
-    /// so the rendered layout and the locale shown by iOS never diverge.
-    private var resolvedLanguage: LanguageConfig {
-        let requestedId = SharedDefaults.store.string(
-            forKey: SettingsKey.selectedLanguageId.rawValue
-        ) ?? LanguageSettings.detectSystemLanguage()
-        return LanguageConfig.language(withId: requestedId) ?? .english
     }
 
     override func viewDidLoad() {
@@ -91,7 +91,7 @@ final class KeyboardViewController: UIInputViewController {
         // Resolve via the shared helper so a stale/invalid persisted id falls
         // back the same way `primaryLanguage` does (system language, then
         // English) instead of leaving loadDefinition a no-op.
-        let languageId = resolvedLanguage.id
+        let languageId = selectedLanguageId
         let numpadStyle = SharedDefaults.store.string(
             forKey: SettingsKey.numpadStyle.rawValue
         ) ?? ""
@@ -109,7 +109,7 @@ final class KeyboardViewController: UIInputViewController {
         // Free cached layouts for languages other than the active one. The
         // active definition stays resident (the view model holds a strong
         // reference) and remains cached for fast reuse.
-        KeyboardRegistry.evictAll(except: resolvedLanguage.id)
+        KeyboardRegistry.evictAll(except: selectedLanguageId)
     }
 
     private func updateKeyboardHeight() {

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -15,7 +15,12 @@ extension KeyboardViewModel {
     /// Loads a keyboard definition by ID from the registry and sets up the
     /// resolver chain and action pipeline.
     func loadDefinition(for id: String) {
-        guard let base = KeyboardRegistry.load(id: id) else { return }
+        // Fall back to English if the requested language can't be resolved (e.g.
+        // a stale stored id for a language removed in a later version) so the
+        // keyboard always renders a layout instead of coming up blank.
+        guard let base = KeyboardRegistry.load(id: id)
+            ?? KeyboardRegistry.load(id: LanguageConfig.english.id)
+        else { return }
         let definition = applyNumpadStyle(to: base)
         currentDefinition = definition
         activeModeName = definition.defaultMode

--- a/wurstfingerKeyboard/Settings/LanguageSettings.swift
+++ b/wurstfingerKeyboard/Settings/LanguageSettings.swift
@@ -23,9 +23,11 @@ class LanguageSettings: ObservableObject {
     private init() {
         userDefaults = SharedDefaults.store
 
-        // Load saved language or detect from system, then normalize
-        let storedLanguageId = userDefaults.string(forKey: languageKey) ?? Self.detectSystemLanguage()
-        let resolvedLanguageId = LanguageConfig.language(withId: storedLanguageId)?.id ?? LanguageConfig.english.id
+        // Normalize the saved language through the shared resolver (stale/nil →
+        // system language → English) so the host app and the keyboard extension
+        // always resolve the same active language.
+        let storedLanguageId = userDefaults.string(forKey: languageKey)
+        let resolvedLanguageId = Self.resolvedLanguageId(storedLanguageId)
         selectedLanguageId = resolvedLanguageId
 
         // Persist the resolved ID so other readers (e.g. KeyboardViewModel.reloadLanguage)

--- a/wurstfingerKeyboard/Settings/LanguageSettings.swift
+++ b/wurstfingerKeyboard/Settings/LanguageSettings.swift
@@ -35,6 +35,18 @@ class LanguageSettings: ObservableObject {
         }
     }
 
+    /// Resolves a raw/stored language id to one guaranteed to exist in the
+    /// registry. If the stored value is missing or stale (e.g. a language
+    /// removed in a later version), falls back to the detected system language
+    /// — which itself falls back to English. Callers therefore always receive a
+    /// renderable language id, so the keyboard never comes up blank.
+    static func resolvedLanguageId(_ storedId: String?) -> String {
+        if let storedId, LanguageConfig.language(withId: storedId) != nil {
+            return storedId
+        }
+        return detectSystemLanguage()
+    }
+
     /// Detects the system language and returns matching language ID, or English as fallback
     static func detectSystemLanguage(preferredLanguages: [String]? = nil) -> String {
         let preferredLanguages = preferredLanguages ?? Locale.preferredLanguages

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -298,14 +298,12 @@ struct ResolvedLanguageIdTests {
 
     @Test("Falls back for a stale/unknown id")
     func fallsBackForUnknownId() {
-        let resolved = LanguageSettings.resolvedLanguageId("xx_XX")
-        // Must resolve to a language that actually exists in the registry.
-        #expect(LanguageConfig.language(withId: resolved) != nil)
+        // Contract: stale/unknown → detected system language (not just "any valid id").
+        #expect(LanguageSettings.resolvedLanguageId("xx_XX") == LanguageSettings.detectSystemLanguage())
     }
 
     @Test("Falls back for nil")
     func fallsBackForNil() {
-        let resolved = LanguageSettings.resolvedLanguageId(nil)
-        #expect(LanguageConfig.language(withId: resolved) != nil)
+        #expect(LanguageSettings.resolvedLanguageId(nil) == LanguageSettings.detectSystemLanguage())
     }
 }

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -287,3 +287,25 @@ struct InfoPlistLanguageTests {
         )
     }
 }
+
+// MARK: - resolvedLanguageId
+
+struct ResolvedLanguageIdTests {
+    @Test("Keeps a valid stored id")
+    func keepsValidId() {
+        #expect(LanguageSettings.resolvedLanguageId("de_DE") == "de_DE")
+    }
+
+    @Test("Falls back for a stale/unknown id")
+    func fallsBackForUnknownId() {
+        let resolved = LanguageSettings.resolvedLanguageId("xx_XX")
+        // Must resolve to a language that actually exists in the registry.
+        #expect(LanguageConfig.language(withId: resolved) != nil)
+    }
+
+    @Test("Falls back for nil")
+    func fallsBackForNil() {
+        let resolved = LanguageSettings.resolvedLanguageId(nil)
+        #expect(LanguageConfig.language(withId: resolved) != nil)
+    }
+}

--- a/wurstfingerTests/ViewModelPipelineTests.swift
+++ b/wurstfingerTests/ViewModelPipelineTests.swift
@@ -273,12 +273,14 @@ struct ViewModelDefinitionTests {
         #expect(vm.currentArrangement != nil)
     }
 
-    @Test func unknownLanguageIdDoesNotCrash() throws {
+    @Test func unknownLanguageIdFallsBackToEnglish() throws {
         let defaults = try #require(UserDefaults(suiteName: "test.\(UUID().uuidString)"))
         let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
         vm.loadDefinition(for: "nonexistent_XX")
-        #expect(vm.currentDefinition == nil)
-        #expect(vm.activeModeFromDefinition == nil)
+        // Must never leave the keyboard blank — falls back to a renderable layout.
+        #expect(vm.currentDefinition != nil)
+        #expect(vm.currentDefinition?.id == LanguageConfig.english.id)
+        #expect(vm.activeModeFromDefinition != nil)
     }
 
     @Test func allLanguagesLoadSuccessfully() {


### PR DESCRIPTION
Re-targets and supersedes #191, which GitHub auto-closed when its stacked base branch (`harden/keyboard-memory`, #190) was merged & deleted. Rebased onto `develop` via `rebase --onto` so only this PR's own commit remains.

## Problem

Follow-up hardening in the same "keyboard comes up blank" class as #190. Two residual gaps where a **stale stored language id** (a language removed/renamed in a later app version) could leave the keyboard blank:

1. `loadDefinition(for:)` did `guard let base = KeyboardRegistry.load(id:) else { return }` — an unresolvable id silently left `currentDefinition` nil → empty keyboard.
2. The controller read the raw stored language id at two sites, bypassing normalisation.

## Change

- `loadDefinition(for:)` falls back to English when the requested id can't be resolved, so a layout always renders.
- Centralised `LanguageSettings.resolvedLanguageId(_:)` (stored id → system language → English) and the controller now uses it consistently (`selectedLanguageId`), replacing the controller-local resolver from #176/#190 while keeping their signature-based reload caching and memory-warning eviction.

Verified: 675 unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard language selection now falls back more gracefully to a usable language when the saved choice is missing or no longer available.
  * Unknown language selections now load the English keyboard instead of leaving the keyboard without a definition.

* **Bug Fixes**
  * Improved keyboard layout reloading and cache handling so the active language stays consistent after settings changes or memory warnings.
  * Better handling of stale or blank saved language IDs to avoid empty or non-renderable keyboard states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->