### PR TITLE
Keep Portrait Layout in Landscape Orientation

### DIFF
--- a/wurstfinger/KeyboardShowcaseView.swift
+++ b/wurstfinger/KeyboardShowcaseView.swift
@@ -125,13 +125,6 @@ struct KeyboardShowcaseView: View {
                 viewModel.bindTextInputTarget(actionTarget)
             }
 
-            // Force orientation if specified (for landscape screenshots / UI tests).
-            // The host app never drives orientation into the view model the way the
-            // keyboard extension does, so without this the showcase is always portrait.
-            if ProcessInfo.processInfo.environment["FORCE_ORIENTATION"] == "landscape" {
-                viewModel.updateOrientation(isLandscape: true)
-            }
-
             // Load definition
             viewModel.loadDefinition(for: languageSettings.selectedLanguageId)
 

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -134,21 +134,6 @@ final class KeyboardViewController: UIInputViewController {
         // Update viewModel with current width so SwiftUI re-renders after
         // orientation changes that happen while the keyboard is backgrounded.
         viewModel.updateViewWidth(view.bounds.width)
-        viewModel.updateOrientation(isLandscape: detectIsLandscape())
-    }
-
-    /// Determines whether the host app is currently in a landscape orientation.
-    ///
-    /// On iPhone, `verticalSizeClass == .compact` is the canonical signal.
-    /// On iPad, `verticalSizeClass` stays `.regular` in both orientations,
-    /// so we fall back to the window scene's `interfaceOrientation`. The
-    /// keyboard's own bounds are always shorter than tall and cannot be
-    /// used as a substitute.
-    private func detectIsLandscape() -> Bool {
-        if traitCollection.userInterfaceIdiom == .pad {
-            return view.window?.windowScene?.interfaceOrientation.isLandscape ?? false
-        }
-        return traitCollection.verticalSizeClass == .compact
     }
 
     override var needsInputModeSwitchKey: Bool {

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -59,11 +59,6 @@ final class KeyboardViewModel: ObservableObject {
     /// Updated by the controller in `viewWillLayoutSubviews()` so that
     /// SwiftUI re-evaluates layout after orientation changes.
     @Published private(set) var viewWidth: CGFloat = UIScreen.main.bounds.width
-    /// Whether the device is currently in a landscape orientation.
-    /// Driven by the controller via `updateOrientation(isLandscape:)`, since
-    /// the keyboard's own bounds are always shorter than tall and cannot
-    /// reliably distinguish portrait from landscape on their own.
-    @Published private(set) var isLandscape: Bool = false
     /// The currently active keyboard mode.
     @Published var currentMode: KeyboardMode?
     /// Name of the currently active mode in the data-driven definition.
@@ -189,26 +184,17 @@ final class KeyboardViewModel: ObservableObject {
         viewWidth = width
     }
 
-    /// Updates the tracked orientation. Called by the controller from
-    /// `viewWillLayoutSubviews()` (which inspects its `traitCollection`) so
-    /// `currentContext` can pick portrait/landscape arrangements correctly.
-    func updateOrientation(isLandscape: Bool) {
-        guard isLandscape != self.isLandscape else { return }
-        self.isLandscape = isLandscape
-    }
-
     // MARK: - Arrangement Selection
 
-    /// Determines the active arrangement context based on orientation and
-    /// the user's utility-column preference.
+    /// Determines the active arrangement context from the user's utility-column
+    /// preference.
+    ///
+    /// The keyboard intentionally keeps the portrait arrangement in **all**
+    /// orientations so the key positions stay constant when the device rotates
+    /// (muscle memory). The data model still defines dedicated `.landscape`
+    /// arrangements, but the runtime does not select them.
     var currentContext: ArrangementContext {
-        let utilityLeft = layoutSettings.utilityColumnLeading
-        switch (isLandscape, utilityLeft) {
-        case (false, false): return .portrait
-        case (false, true): return .portraitUtilityLeft
-        case (true, false): return .landscape
-        case (true, true): return .landscapeUtilityLeft
-        }
+        layoutSettings.utilityColumnLeading ? .portraitUtilityLeft : .portrait
     }
 
     /// The grid arrangement for `currentMode` and `currentContext`.

--- a/wurstfingerTests/KeyboardGridRenderingTests.swift
+++ b/wurstfingerTests/KeyboardGridRenderingTests.swift
@@ -15,51 +15,40 @@ import Testing
 
 @Suite(.serialized)
 struct KeyboardViewModelContextTests {
-    /// Builds a ViewModel with a deterministic orientation and utility-column
-    /// setting. We use an in-memory UserDefaults so the suite never touches
-    /// the shared store.
-    private func makeViewModel(isLandscape: Bool, utilityLeft: Bool) -> KeyboardViewModel {
+    /// Builds a ViewModel with a deterministic utility-column setting. We use an
+    /// in-memory UserDefaults so the suite never touches the shared store.
+    private func makeViewModel(utilityLeft: Bool) -> KeyboardViewModel {
         let defaults = UserDefaults(suiteName: "test.\(UUID().uuidString)")!
         let viewModel = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
         viewModel.utilityColumnLeading = utilityLeft
-        viewModel.updateOrientation(isLandscape: isLandscape)
         return viewModel
     }
 
-    @Test func portraitUtilityRight() {
-        let viewModel = makeViewModel(isLandscape: false, utilityLeft: false)
+    @Test func utilityRightSelectsPortrait() {
+        let viewModel = makeViewModel(utilityLeft: false)
         #expect(viewModel.currentContext == .portrait)
     }
 
-    @Test func portraitUtilityLeft() {
-        let viewModel = makeViewModel(isLandscape: false, utilityLeft: true)
+    @Test func utilityLeftSelectsPortraitUtilityLeft() {
+        let viewModel = makeViewModel(utilityLeft: true)
         #expect(viewModel.currentContext == .portraitUtilityLeft)
     }
 
-    @Test func landscapeUtilityRight() {
-        let viewModel = makeViewModel(isLandscape: true, utilityLeft: false)
-        #expect(viewModel.currentContext == .landscape)
-    }
-
-    @Test func landscapeUtilityLeft() {
-        let viewModel = makeViewModel(isLandscape: true, utilityLeft: true)
-        #expect(viewModel.currentContext == .landscapeUtilityLeft)
-    }
-
     @Test func currentArrangementIsNilWithoutMode() {
-        let viewModel = makeViewModel(isLandscape: false, utilityLeft: false)
+        let viewModel = makeViewModel(utilityLeft: false)
         #expect(viewModel.currentMode == nil)
         #expect(viewModel.currentArrangement == nil)
     }
 
     @Test func currentArrangementUsesContextLookup() {
         // Build a minimal mode with distinct arrangements per context so
-        // we can verify currentArrangement chases the right one.
-        let portraitArrangement = GridArrangement(
+        // we can verify currentArrangement chases the right one as the
+        // utility-column preference changes.
+        let utilityRightArrangement = GridArrangement(
             columns: 1,
             rows: [[KeyPlacement(keyId: "a")]]
         )
-        let landscapeArrangement = GridArrangement(
+        let utilityLeftArrangement = GridArrangement(
             columns: 2,
             rows: [[KeyPlacement(keyId: "a"), KeyPlacement(keyId: "a")]]
         )
@@ -80,18 +69,18 @@ struct KeyboardViewModelContextTests {
                 tapCycleActions: nil
             )],
             arrangements: [
-                .portrait: portraitArrangement,
-                .landscape: landscapeArrangement,
+                .portrait: utilityRightArrangement,
+                .portraitUtilityLeft: utilityLeftArrangement,
             ],
             autoTransitions: [:],
             doubleTapMode: nil
         )
 
-        let viewModel = makeViewModel(isLandscape: false, utilityLeft: false)
+        let viewModel = makeViewModel(utilityLeft: false)
         viewModel.currentMode = mode
         #expect(viewModel.currentArrangement?.columns == 1)
 
-        viewModel.updateOrientation(isLandscape: true)
+        viewModel.utilityColumnLeading = true
         #expect(viewModel.currentArrangement?.columns == 2)
     }
 }


### PR DESCRIPTION
## Problem

Beim Drehen ins Querformat wechselte die Tastatur auf eine eigene 5-Spalten-Landscape-Anordnung. Die Tasten waren dadurch verschoben und kollidierten zusätzlich mit der auf Hochformat ausgelegten Container-Geometrie (Breite auf `screenShortestSide` geklemmt, Höhe für `totalRows = 4`), was zu gequetschten Spalten führte.

## Lösung

`KeyboardViewModel.currentContext` wählt jetzt **immer** die Portrait-Variante — die Tastenpositionen bleiben über alle Orientierungen konstant (Muscle Memory). Das danach tote Orientierungs-Plumbing wurde entfernt.

| Datei | Änderung |
|---|---|
| `KeyboardViewModel.swift` | `currentContext` nur noch von `utilityColumnLeading` abhängig; `isLandscape` + `updateOrientation` entfernt |
| `KeyboardViewController.swift` | `detectIsLandscape()` + Aufruf in `viewWillLayoutSubviews` entfernt (`updateViewWidth` bleibt) |
| `KeyboardShowcaseView.swift` | Ungenutzten `FORCE_ORIENTATION=landscape`-Zweig entfernt |
| `KeyboardGridRenderingTests.swift` | Context-Tests auf neue Auswahllogik umgestellt |

Die `.landscape`-Arrangements im Datenmodell (`StandardArrangements`, `ArrangementContext.landscape`) bleiben erhalten — sie sind eigenständig getestet und repräsentieren weiterhin eine Fähigkeit des Datenmodells; nur die Laufzeit wählt sie nicht mehr aus.

## Verifikation

- ✅ Build über alle Targets (App, Keyboard-Extension, Tests, UI-Tests)
- ✅ `KeyboardViewModelContextTests` — 4/4 grün
- ✅ SwiftFormat `--lint` & SwiftLint `--strict` clean

## Hinweis

Im Querformat bleibt die Tastatur nun auf Hochformat-Breite zentriert. Falls sie im Querformat die volle Bildschirmbreite nutzen soll, wäre das eine separate, bewusste Erweiterung.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Keyboard layout selection now follows the utility-column setting consistently, instead of switching based on device orientation.
  * The keyboard view no longer changes layout state during appearance or resize events, which should make arrangement behavior more predictable.

* **Tests**
  * Updated keyboard layout tests to match the simplified arrangement selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->