### PR TITLE
In-Keyboard Language Switching (rebased #135)

### DIFF
--- a/wurstfinger/LanguageSelectionView.swift
+++ b/wurstfinger/LanguageSelectionView.swift
@@ -58,35 +58,37 @@ private struct LanguageRow: View {
     let onToggle: () -> Void
 
     var body: some View {
-        Button(action: onTap) {
-            HStack {
-                Button(action: onToggle) {
-                    Image(systemName: isEnabled ? "checkmark.circle.fill" : "circle")
-                        .foregroundColor(isEnabled ? .accentColor : .secondary)
-                        .imageScale(.large)
-                }
-                .buttonStyle(.plain)
+        HStack {
+            Button(action: onToggle) {
+                Image(systemName: isEnabled ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(isEnabled ? .accentColor : .secondary)
+                    .imageScale(.large)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(isEnabled ? "Disable" : "Enable") \(language.name)")
+            .accessibilityValue(isEnabled ? "Enabled" : "Disabled")
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(language.name)
-                        .font(.body)
-                        .foregroundColor(.primary)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(language.name)
+                    .font(.body)
+                    .foregroundColor(.primary)
 
-                    Text("MessagEase Layout")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
+                Text("MessagEase Layout")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
 
-                Spacer()
+            Spacer()
 
-                if isActive {
-                    Text("Active")
-                        .font(.caption)
-                        .foregroundColor(.accentColor)
-                        .fontWeight(.medium)
-                }
+            if isActive {
+                Text("Active")
+                    .font(.caption)
+                    .foregroundColor(.accentColor)
+                    .fontWeight(.medium)
             }
         }
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
     }
 }
 

--- a/wurstfinger/LanguageSelectionView.swift
+++ b/wurstfinger/LanguageSelectionView.swift
@@ -9,36 +9,84 @@ import SwiftUI
 
 struct LanguageSelectionView: View {
     @StateObject private var languageSettings = LanguageSettings.shared
-    @Environment(\.dismiss) private var dismiss
+    @State private var showLastLanguageAlert = false
 
     var body: some View {
-        List(LanguageConfig.allLanguages) { language in
-            Button {
-                languageSettings.selectLanguage(language)
-                dismiss()
-            } label: {
-                HStack {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(language.name)
-                            .font(.body)
-                            .foregroundColor(.primary)
-
-                        Text("MessagEase Layout")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-
-                    Spacer()
-
-                    if languageSettings.selectedLanguageId == language.id {
-                        Image(systemName: "checkmark")
-                            .foregroundColor(.accentColor)
-                    }
+        List {
+            Section {
+                ForEach(LanguageConfig.allLanguages) { language in
+                    LanguageRow(
+                        language: language,
+                        isEnabled: languageSettings.isLanguageEnabled(language),
+                        isActive: languageSettings.selectedLanguageId == language.id,
+                        onTap: {
+                            if languageSettings.isLanguageEnabled(language) {
+                                languageSettings.selectLanguage(language)
+                            } else {
+                                languageSettings.toggleLanguage(language)
+                                languageSettings.selectLanguage(language)
+                            }
+                        },
+                        onToggle: {
+                            if !languageSettings.toggleLanguage(language) {
+                                showLastLanguageAlert = true
+                            }
+                        }
+                    )
+                }
+            } footer: {
+                if languageSettings.hasMultipleLanguages {
+                    Text("Swipe right on the globe key to switch languages.")
                 }
             }
         }
-        .navigationTitle("Keyboard Language")
+        .navigationTitle("Languages")
         .navigationBarTitleDisplayMode(.inline)
+        .alert("Cannot Disable", isPresented: $showLastLanguageAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("At least one language must be enabled.")
+        }
+    }
+}
+
+private struct LanguageRow: View {
+    let language: LanguageConfig
+    let isEnabled: Bool
+    let isActive: Bool
+    let onTap: () -> Void
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack {
+                Button(action: onToggle) {
+                    Image(systemName: isEnabled ? "checkmark.circle.fill" : "circle")
+                        .foregroundColor(isEnabled ? .accentColor : .secondary)
+                        .imageScale(.large)
+                }
+                .buttonStyle(.plain)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(language.name)
+                        .font(.body)
+                        .foregroundColor(.primary)
+
+                    Text("MessagEase Layout")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                if isActive {
+                    Text("Active")
+                        .font(.caption)
+                        .foregroundColor(.accentColor)
+                        .fontWeight(.medium)
+                }
+            }
+        }
     }
 }
 

--- a/wurstfinger/LanguageSelectionView.swift
+++ b/wurstfinger/LanguageSelectionView.swift
@@ -18,13 +18,13 @@ struct LanguageSelectionView: View {
                     LanguageRow(
                         language: language,
                         isEnabled: languageSettings.isLanguageEnabled(language),
-                        isActive: languageSettings.selectedLanguageId == language.id,
+                        isDefault: languageSettings.pinnedLanguageId == language.id,
                         onTap: {
                             if languageSettings.isLanguageEnabled(language) {
-                                languageSettings.selectLanguage(language)
+                                languageSettings.pinLanguage(language)
                             } else {
                                 languageSettings.toggleLanguage(language)
-                                languageSettings.selectLanguage(language)
+                                languageSettings.pinLanguage(language)
                             }
                         },
                         onToggle: {
@@ -36,7 +36,7 @@ struct LanguageSelectionView: View {
                 }
             } footer: {
                 if languageSettings.hasMultipleLanguages {
-                    Text("Swipe right on the globe key to switch languages.")
+                    Text("Swipe right on the globe key to switch languages. Tap a language to set it as the default startup language.")
                 }
             }
         }
@@ -53,7 +53,7 @@ struct LanguageSelectionView: View {
 private struct LanguageRow: View {
     let language: LanguageConfig
     let isEnabled: Bool
-    let isActive: Bool
+    let isDefault: Bool
     let onTap: () -> Void
     let onToggle: () -> Void
 
@@ -80,8 +80,8 @@ private struct LanguageRow: View {
 
             Spacer()
 
-            if isActive {
-                Text("Active")
+            if isDefault {
+                Text("Default")
                     .font(.caption)
                     .foregroundColor(.accentColor)
                     .fontWeight(.medium)

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -206,10 +206,15 @@ struct SettingsView: View {
 
     private var enabledLanguagesSummary: String {
         let names = languageSettings.enabledLanguages.map(\.name)
-        if names.count <= 2 {
-            return names.joined(separator: ", ")
+        let list = if names.count <= 2 {
+            names.joined(separator: ", ")
+        } else {
+            "\(names[0]) + \(names.count - 1) more"
         }
-        return "\(names[0]) + \(names.count - 1) more"
+        if let pinned = languageSettings.pinnedLanguage {
+            return "\(list) (default: \(pinned.name))"
+        }
+        return list
     }
 
     private var keyboardStyleDescription: String {

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -63,7 +63,7 @@ struct SettingsView: View {
     private var generalSection: some View {
         Section {
             NavigationLink(destination: LanguageSelectionView()) {
-                SettingsRow(icon: "globe", color: .blue, title: "Language", subtitle: languageSettings.selectedLanguage.name)
+                SettingsRow(icon: "globe", color: .blue, title: "Languages", subtitle: enabledLanguagesSummary)
             }
 
             Toggle(isOn: $utilityColumnLeading) {
@@ -203,6 +203,14 @@ struct SettingsView: View {
     }
 
     // MARK: - Helpers
+
+    private var enabledLanguagesSummary: String {
+        let names = languageSettings.enabledLanguages.map(\.name)
+        if names.count <= 2 {
+            return names.joined(separator: ", ")
+        }
+        return "\(names[0]) + \(names.count - 1) more"
+    }
 
     private var keyboardStyleDescription: String {
         let style = KeyboardStyle(rawValue: keyboardStyleRaw) ?? .classic

--- a/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
+++ b/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
@@ -28,6 +28,10 @@ enum CommonKeys {
             category: .utility, returnAction: nil,
             accessibilityLabel: "Tastatur ausblenden"
         )
+        bindings[.swipeRight] = KeyBinding(
+            label: "", action: .switchToNextLanguage,
+            category: .utility, returnAction: nil, accessibilityLabel: nil
+        )
         return KeyConfig(
             id: UtilitySlot.globe, bindings: bindings,
             swipeMode: .fourWayCross, slideType: .none,

--- a/wurstfingerKeyboard/Definition/Language/LanguageConfig.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageConfig.swift
@@ -30,6 +30,14 @@ extension LanguageConfig {
         id: "en_US", name: "English", locale: Locale(identifier: "en_US")
     )
 
+    static let german = LanguageConfig(
+        id: "de_DE", name: "Deutsch", locale: Locale(identifier: "de_DE")
+    )
+
+    static let russian = LanguageConfig(
+        id: "ru_RU", name: "Русский", locale: Locale(identifier: "ru_RU")
+    )
+
     /// All supported languages, derived from `KeyboardRegistry.available` and
     /// sorted alphabetically by name. This is the single source of truth --
     /// adding a new `KeyboardDefinition` to `LanguageDefinitions.all`

--- a/wurstfingerKeyboard/Definition/Model/KeyAction.swift
+++ b/wurstfingerKeyboard/Definition/Model/KeyAction.swift
@@ -31,6 +31,9 @@ enum KeyAction: Codable, Equatable {
     /// Dismiss keyboard
     case dismissKeyboard
 
+    /// Switch to the next enabled language
+    case switchToNextLanguage
+
     /// Delete backward
     case deleteBackward
 

--- a/wurstfingerKeyboard/Definition/Model/KeyCategory.swift
+++ b/wurstfingerKeyboard/Definition/Model/KeyCategory.swift
@@ -35,7 +35,7 @@ extension KeyAction {
         case .capitalizeWord: return .modifier
         case .space, .newline: return .whitespace
         case .deleteBackward, .deleteForward, .moveCursor,
-             .advanceToNextInputMode, .dismissKeyboard:
+             .advanceToNextInputMode, .dismissKeyboard, .switchToNextLanguage:
             return .utility
         case .copy, .paste, .cut: return .utility
         case .none: return .utility

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -61,6 +61,11 @@ final class KeyboardViewController: UIInputViewController {
             dismissKeyboard: { [weak self] in self?.dismissKeyboard() }
         )
 
+        // Honor a pinned startup language on cold start so the keyboard always
+        // opens with it. In-keyboard cycling afterwards updates the selection
+        // normally (subsequent reloads follow selectedLanguageId, not the pin).
+        LanguageSettings(userDefaults: SharedDefaults.store).applyStartupLanguage()
+
         // Load the keyboard definition for the selected language
         loadDefinitionIfNeeded()
 

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -75,7 +75,10 @@ final class KeyboardViewModel: ObservableObject {
     var onDismissKeyboard: (() -> Void)?
     /// Locale used by the pipeline (set from the keyboard definition).
     var pipelineLocale: Locale?
-    private var enabledLanguageIds: [String] = []
+    /// Published so the globe hint (`hasMultipleLanguages`) re-renders when the
+    /// enabled-language set changes in Settings without the active language
+    /// changing. `private(set)` keeps the normalisation invariants intact.
+    @Published private(set) var enabledLanguageIds: [String] = []
 
     // MARK: - Settings (delegated to extracted classes)
 
@@ -151,8 +154,7 @@ final class KeyboardViewModel: ObservableObject {
         layoutSettings = LayoutSettings(defaults: defaults, shouldPersist: shouldPersistSettings)
         hapticManager = HapticFeedbackManager(settings: hapticSettings)
 
-        enabledLanguageIds = LanguageSettings.loadEnabledLanguageIds(from: defaults)
-            ?? [SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue) ?? "en_US"]
+        enabledLanguageIds = LanguageSettings.normalizedEnabledLanguageIds(from: defaults)
 
         // Forward settings changes to trigger objectWillChange on this ViewModel
         hapticSettings.objectWillChange
@@ -222,15 +224,18 @@ final class KeyboardViewModel: ObservableObject {
         hapticSettings.reload()
         layoutSettings.reload()
 
-        enabledLanguageIds = LanguageSettings.loadEnabledLanguageIds(from: sharedDefaults)
-            ?? enabledLanguageIds
+        enabledLanguageIds = LanguageSettings.normalizedEnabledLanguageIds(from: sharedDefaults)
     }
 
     func switchToNextLanguage() {
         guard enabledLanguageIds.count > 1 else { return }
 
-        let currentId = sharedDefaults.string(forKey: SettingsKey.selectedLanguageId.rawValue)
-            ?? currentDefinition?.id
+        // Cycle from the layout that is actually on screen. Startup can load a
+        // pinned language whose id differs from the stored selection, so the
+        // active definition — not shared defaults — is the source of truth;
+        // otherwise the first swipe would just reload the current layout.
+        let currentId = currentDefinition?.id
+            ?? sharedDefaults.string(forKey: SettingsKey.selectedLanguageId.rawValue)
             ?? "en_US"
         let nextId = LanguageSettings(userDefaults: sharedDefaults).nextLanguageId(after: currentId)
 
@@ -245,8 +250,8 @@ final class KeyboardViewModel: ObservableObject {
     }
 
     var currentLanguageLabel: String {
-        let lang = pipelineLocale?.language.languageCode?.identifier ?? ""
-        return lang.uppercased()
+        guard let locale = pipelineLocale else { return "" }
+        return LanguageSettings.label(for: locale)
     }
 
     // MARK: - Haptic Feedback (delegated to HapticFeedbackManager)

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -153,7 +153,6 @@ final class KeyboardViewModel: ObservableObject {
         enabledLanguageIds = LanguageSettings.loadEnabledLanguageIds(from: defaults)
             ?? [SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue) ?? "en_US"]
 
-
         // Forward settings changes to trigger objectWillChange on this ViewModel
         hapticSettings.objectWillChange
             .sink { [weak self] _ in self?.objectWillChange.send() }

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -153,6 +153,7 @@ final class KeyboardViewModel: ObservableObject {
         enabledLanguageIds = LanguageSettings.loadEnabledLanguageIds(from: defaults)
             ?? [SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue) ?? "en_US"]
 
+
         // Forward settings changes to trigger objectWillChange on this ViewModel
         hapticSettings.objectWillChange
             .sink { [weak self] _ in self?.objectWillChange.send() }

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -80,6 +80,7 @@ final class KeyboardViewModel: ObservableObject {
     var onDismissKeyboard: (() -> Void)?
     /// Locale used by the pipeline (set from the keyboard definition).
     var pipelineLocale: Locale?
+    private var enabledLanguageIds: [String] = []
 
     // MARK: - Settings (delegated to extracted classes)
 
@@ -148,6 +149,9 @@ final class KeyboardViewModel: ObservableObject {
         hapticSettings = HapticSettings(defaults: defaults, shouldPersist: shouldPersistSettings)
         layoutSettings = LayoutSettings(defaults: defaults, shouldPersist: shouldPersistSettings)
         hapticManager = HapticFeedbackManager(settings: hapticSettings)
+
+        enabledLanguageIds = LanguageSettings.loadEnabledLanguageIds(from: defaults)
+            ?? [SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue) ?? "en_US"]
 
         // Forward settings changes to trigger objectWillChange on this ViewModel
         hapticSettings.objectWillChange
@@ -225,6 +229,32 @@ final class KeyboardViewModel: ObservableObject {
         // Delegate to extracted settings classes - eliminates duplicate code
         hapticSettings.reload()
         layoutSettings.reload()
+
+        enabledLanguageIds = LanguageSettings.loadEnabledLanguageIds(from: sharedDefaults)
+            ?? enabledLanguageIds
+    }
+
+    func switchToNextLanguage() {
+        guard enabledLanguageIds.count > 1 else { return }
+
+        let currentId = sharedDefaults.string(forKey: SettingsKey.selectedLanguageId.rawValue)
+            ?? currentDefinition?.id
+            ?? "en_US"
+        let nextId = LanguageSettings(userDefaults: sharedDefaults).nextLanguageId(after: currentId)
+
+        if nextId != currentId {
+            sharedDefaults.set(nextId, forKey: SettingsKey.selectedLanguageId.rawValue)
+            loadDefinition(for: nextId)
+        }
+    }
+
+    var hasMultipleLanguages: Bool {
+        enabledLanguageIds.count > 1
+    }
+
+    var currentLanguageLabel: String {
+        let lang = pipelineLocale?.language.languageCode?.identifier ?? ""
+        return lang.uppercased()
     }
 
     // MARK: - Haptic Feedback (delegated to HapticFeedbackManager)

--- a/wurstfingerKeyboard/Runtime/Pipeline/AutoCapitalizationMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/AutoCapitalizationMiddleware.swift
@@ -44,7 +44,7 @@ struct AutoCapitalizationMiddleware: ActionMiddleware {
              .compose, .cycleAccents, .paste, .cut:
             true
         case .moveCursor, .switchMode, .capitalizeWord, .advanceToNextInputMode,
-             .dismissKeyboard, .copy, .none:
+             .dismissKeyboard, .copy, .none, .switchToNextLanguage:
             false
         }
     }

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -174,6 +174,11 @@ extension KeyboardViewModel {
             return
         }
 
+        if case .switchToNextLanguage = binding.action {
+            switchToNextLanguage()
+            return
+        }
+
         let context = ActionContext(
             action: binding.action,
             binding: binding,

--- a/wurstfingerKeyboard/Runtime/Pipeline/TextInputMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/TextInputMiddleware.swift
@@ -50,7 +50,7 @@ struct TextInputMiddleware: ActionMiddleware {
             target.adjustTextPosition(byCharacterOffset: offset)
         case .compose, .cycleAccents, .switchMode, .capitalizeWord,
              .advanceToNextInputMode, .dismissKeyboard, .deleteForward,
-             .copy, .paste, .cut, .none:
+             .copy, .paste, .cut, .none, .switchToNextLanguage:
             break
         }
     }

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -47,7 +47,9 @@ struct DataDrivenKeyboardRootView: View {
                     },
                     onSlide: { key, phase in
                         viewModel.handleSlide(key, phase: phase)
-                    }
+                    },
+                    languageLabel: viewModel.currentLanguageLabel,
+                    showLanguageLabel: viewModel.hasMultipleLanguages
                 )
                 .padding(.horizontal, KeyboardConstants.Layout.horizontalPadding)
                 .padding(.top, KeyboardConstants.Layout.verticalPaddingTop)

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -39,18 +39,13 @@ struct KeyView: View {
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var keyAspectRatio: Double = DeviceLayoutUtils.defaultKeyAspectRatio
 
-    @AppStorage(SettingsKey.selectedLanguageId.rawValue, store: SharedDefaults.store)
-    private var selectedLanguageId: String = "en_US"
-
-    private var languageLabel: String {
-        let locale = Locale(identifier: selectedLanguageId)
-        return locale.language.languageCode?.identifier.uppercased() ?? ""
-    }
-
-    private var hasMultipleLanguages: Bool {
-        let ids = SharedDefaults.store.stringArray(forKey: SettingsKey.enabledLanguageIds.rawValue)
-        return (ids?.count ?? 0) > 1
-    }
+    /// Short language label (e.g. "DE") shown on the switch key, and whether to
+    /// show it. Driven by the active keyboard locale via `KeyboardViewModel`
+    /// (threaded through `KeyboardGridView`) rather than re-derived from shared
+    /// defaults, so the hint stays correct even when startup loads a pinned
+    /// language whose id differs from the stored selection.
+    var languageLabel: String = ""
+    var showLanguageLabel: Bool = false
 
     /// Maps emoji labels to SF Symbol names for utility keys.
     private static let sfSymbolMap: [String: String] = [
@@ -290,7 +285,7 @@ struct KeyView: View {
                 if let binding = key.bindings[gesture],
                    let alignment = Self.hintAlignments[gesture] {
                     if binding.action == .switchToNextLanguage {
-                        if hasMultipleLanguages {
+                        if showLanguageLabel {
                             Text(languageLabel)
                                 .font(.system(size: scaledHintFontSize * 0.75, weight: .semibold, design: .rounded))
                                 .foregroundStyle(Color.primary.opacity(0.5))

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -33,6 +33,19 @@ struct KeyView: View {
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var keyAspectRatio: Double = DeviceLayoutUtils.defaultKeyAspectRatio
 
+    @AppStorage(SettingsKey.selectedLanguageId.rawValue, store: SharedDefaults.store)
+    private var selectedLanguageId: String = "en_US"
+
+    private var languageLabel: String {
+        let locale = Locale(identifier: selectedLanguageId)
+        return locale.language.languageCode?.identifier.uppercased() ?? ""
+    }
+
+    private var hasMultipleLanguages: Bool {
+        let ids = SharedDefaults.store.stringArray(forKey: SettingsKey.enabledLanguageIds.rawValue)
+        return (ids?.count ?? 0) > 1
+    }
+
     /// Maps emoji labels to SF Symbol names for utility keys.
     private static let sfSymbolMap: [String: String] = [
         "🌐": "globe",
@@ -250,16 +263,30 @@ struct KeyView: View {
 
             ForEach(Array(key.bindings.keys), id: \.self) { gesture in
                 if let binding = key.bindings[gesture],
-                   !binding.label.isEmpty,
                    let alignment = Self.hintAlignments[gesture] {
-                    hintContent(for: binding)
-                        .fixedSize()
-                        .padding(Self.hintEdgePadding(for: gesture, horizontal: hPad, vertical: vPad))
-                        .frame(
-                            width: size.width,
-                            height: size.height,
-                            alignment: alignment
-                        )
+                    if binding.action == .switchToNextLanguage {
+                        if hasMultipleLanguages {
+                            Text(languageLabel)
+                                .font(.system(size: scaledHintFontSize * 0.75, weight: .semibold, design: .rounded))
+                                .foregroundStyle(Color.primary.opacity(0.5))
+                                .fixedSize()
+                                .padding(Self.hintEdgePadding(for: gesture, horizontal: hPad, vertical: vPad))
+                                .frame(
+                                    width: size.width,
+                                    height: size.height,
+                                    alignment: alignment
+                                )
+                        }
+                    } else if !binding.label.isEmpty {
+                        hintContent(for: binding)
+                            .fixedSize()
+                            .padding(Self.hintEdgePadding(for: gesture, horizontal: hPad, vertical: vPad))
+                            .frame(
+                                width: size.width,
+                                height: size.height,
+                                alignment: alignment
+                            )
+                    }
                 }
             }
         }

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -20,6 +20,10 @@ struct KeyboardGridView: View {
     let onGesture: (KeyConfig, GestureType, Bool) -> Void
     var onTouchDown: (() -> Void)?
     var onSlide: ((KeyConfig, SlidePhase) -> Void)?
+    /// Active-language hint for the switch key, supplied by `KeyboardViewModel`
+    /// so it reflects the loaded definition rather than re-derived storage.
+    var languageLabel: String = ""
+    var showLanguageLabel: Bool = false
 
     @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
     private var keyboardScale: Double = DeviceLayoutUtils.defaultKeyboardScale
@@ -59,7 +63,9 @@ struct KeyboardGridView: View {
                 onTouchDown: onTouchDown,
                 onSlide: onSlide,
                 spanRatio: CGFloat(cell.columnSpan) / CGFloat(cell.rowSpan),
-                visualInset: visualInset(for: cell, totalRows: totalRows)
+                visualInset: visualInset(for: cell, totalRows: totalRows),
+                languageLabel: languageLabel,
+                showLanguageLabel: showLanguageLabel
             )
             .id(cell.keyId)
         } else {

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -24,6 +24,7 @@ enum SettingsKey: String {
     case keyboardHorizontalPosition
     case numpadStyle
     case selectedLanguageId
+    case enabledLanguageIds
     case autoCapitalizeEnabled
     case expertModeEnabled
     case keyboardStyle

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -25,6 +25,7 @@ enum SettingsKey: String {
     case numpadStyle
     case selectedLanguageId
     case enabledLanguageIds
+    case pinnedLanguageId
     case autoCapitalizeEnabled
     case expertModeEnabled
     case keyboardStyle

--- a/wurstfingerKeyboard/Settings/LanguageSettings.swift
+++ b/wurstfingerKeyboard/Settings/LanguageSettings.swift
@@ -30,7 +30,9 @@ class LanguageSettings: ObservableObject {
 
     /// Optional pinned default language. When set, the keyboard always opens
     /// with this language. When nil, it opens with the last-used language.
-    @Published var pinnedLanguageId: String? {
+    /// `private(set)` so writes funnel through `pinLanguage(_:)`, preserving the
+    /// "pin implies enabled" invariant.
+    @Published private(set) var pinnedLanguageId: String? {
         didSet {
             userDefaults.set(pinnedLanguageId, forKey: SettingsKey.pinnedLanguageId.rawValue)
         }
@@ -87,6 +89,12 @@ class LanguageSettings: ObservableObject {
             defaults.set(resolvedLanguageId, forKey: SettingsKey.selectedLanguageId.rawValue)
         }
         Self.saveEnabledLanguageIds(enabledLanguageIds, to: defaults)
+        // Clearing a stale pin above happened inside `init`, where `didSet` does
+        // not fire — so remove the now-invalid key from storage explicitly,
+        // otherwise it would be re-read on the next launch.
+        if pinnedLanguageId == nil {
+            defaults.removeObject(forKey: SettingsKey.pinnedLanguageId.rawValue)
+        }
     }
 
     /// Resolves a raw/stored language id to one guaranteed to exist in the
@@ -142,8 +150,16 @@ class LanguageSettings: ObservableObject {
 
     /// Short uppercase label for the current language, e.g. "EN", "RU", "DE"
     var currentLanguageLabel: String {
-        let lang = selectedLanguage.locale.language.languageCode?.identifier ?? selectedLanguageId
-        return lang.uppercased(with: selectedLanguage.locale)
+        Self.label(for: selectedLanguage.locale, fallback: selectedLanguageId)
+    }
+
+    /// Locale-aware short uppercase label (e.g. "EN", "DE") for a locale.
+    /// Centralised so every call site uses the same casing rules (German de_DE,
+    /// Turkish dotted/dotless i, …) instead of recreating the casing drift that
+    /// caused the original label bug.
+    static func label(for locale: Locale, fallback: String = "") -> String {
+        let lang = locale.language.languageCode?.identifier ?? fallback
+        return lang.uppercased(with: locale)
     }
 
     var pinnedLanguage: LanguageConfig? {
@@ -158,6 +174,16 @@ class LanguageSettings: ObservableObject {
             return pinned
         }
         return selectedLanguageId
+    }
+
+    /// Applies the startup language preference to the active selection. The
+    /// keyboard extension calls this on cold start so a pinned language always
+    /// wins; in-keyboard cycling afterwards updates the selection normally.
+    func applyStartupLanguage() {
+        let startup = startupLanguageId
+        if startup != selectedLanguageId {
+            selectedLanguageId = startup
+        }
     }
 
     /// Pin a language as the default startup language. If already pinned, unpin it.
@@ -233,5 +259,19 @@ class LanguageSettings: ObservableObject {
 
     static func loadEnabledLanguageIds(from defaults: UserDefaults) -> [String]? {
         defaults.stringArray(forKey: SettingsKey.enabledLanguageIds.rawValue)
+    }
+
+    /// Returns the enabled language IDs filtered to known languages, guaranteed
+    /// non-empty and with the active language included — mirroring the
+    /// normalisation the initializer performs, but **without persisting**. Safe
+    /// to call repeatedly (e.g. from the keyboard extension's `reloadSettings`)
+    /// so a stale or empty stored list can never leave the runtime cycling to an
+    /// unknown id.
+    static func normalizedEnabledLanguageIds(from defaults: UserDefaults) -> [String] {
+        let selected = resolvedLanguageId(defaults.string(forKey: SettingsKey.selectedLanguageId.rawValue))
+        let stored = loadEnabledLanguageIds(from: defaults) ?? []
+        let valid = stored.filter { LanguageConfig.language(withId: $0) != nil }
+        if valid.isEmpty { return [selected] }
+        return valid.contains(selected) ? valid : [selected] + valid
     }
 }

--- a/wurstfingerKeyboard/Settings/LanguageSettings.swift
+++ b/wurstfingerKeyboard/Settings/LanguageSettings.swift
@@ -22,6 +22,17 @@ class LanguageSettings: ObservableObject {
     @Published private(set) var enabledLanguageIds: [String] {
         didSet {
             saveEnabledLanguages()
+            if let pinned = pinnedLanguageId, !enabledLanguageIds.contains(pinned) {
+                pinnedLanguageId = nil
+            }
+        }
+    }
+
+    /// Optional pinned default language. When set, the keyboard always opens
+    /// with this language. When nil, it opens with the last-used language.
+    @Published var pinnedLanguageId: String? {
+        didSet {
+            userDefaults.set(pinnedLanguageId, forKey: SettingsKey.pinnedLanguageId.rawValue)
         }
     }
 
@@ -51,12 +62,23 @@ class LanguageSettings: ObservableObject {
             resolvedEnabled = [resolvedLanguageId]
         }
 
+        // Load pinned language (before enabledLanguageIds didSet can fire)
+        let storedPinned = defaults.string(forKey: SettingsKey.pinnedLanguageId.rawValue)
+
         selectedLanguageId = resolvedLanguageId
         enabledLanguageIds = resolvedEnabled
+        pinnedLanguageId = storedPinned
 
         // Ensure selected language is in the enabled list
         if !resolvedEnabled.contains(resolvedLanguageId) {
             enabledLanguageIds.insert(resolvedLanguageId, at: 0)
+        }
+
+        // Clear stale pinned ID
+        if let pinned = pinnedLanguageId {
+            if !enabledLanguageIds.contains(pinned) || LanguageConfig.language(withId: pinned) == nil {
+                pinnedLanguageId = nil
+            }
         }
 
         // Persist normalized values
@@ -109,6 +131,32 @@ class LanguageSettings: ObservableObject {
     var currentLanguageLabel: String {
         let lang = selectedLanguage.locale.language.languageCode?.identifier ?? selectedLanguageId
         return lang.uppercased(with: selectedLanguage.locale)
+    }
+
+    var pinnedLanguage: LanguageConfig? {
+        pinnedLanguageId.flatMap { LanguageConfig.language(withId: $0) }
+    }
+
+    /// Returns the language the keyboard should open with: pinned if set and
+    /// valid, otherwise the last-used selected language.
+    var startupLanguageId: String {
+        if let pinned = pinnedLanguageId, enabledLanguageIds.contains(pinned),
+           LanguageConfig.language(withId: pinned) != nil {
+            return pinned
+        }
+        return selectedLanguageId
+    }
+
+    /// Pin a language as the default startup language. If already pinned, unpin it.
+    func pinLanguage(_ language: LanguageConfig) {
+        if pinnedLanguageId == language.id {
+            pinnedLanguageId = nil
+        } else {
+            if !enabledLanguageIds.contains(language.id) {
+                enabledLanguageIds.append(language.id)
+            }
+            pinnedLanguageId = language.id
+        }
     }
 
     func selectLanguage(_ language: LanguageConfig) {

--- a/wurstfingerKeyboard/Settings/LanguageSettings.swift
+++ b/wurstfingerKeyboard/Settings/LanguageSettings.swift
@@ -5,6 +5,7 @@
 //  Created by Claas Flint on 06.11.25.
 //
 
+import Combine
 import Foundation
 
 /// Manages keyboard language settings shared between host app and keyboard extension.
@@ -107,14 +108,14 @@ class LanguageSettings: ObservableObject {
     /// Short uppercase label for the current language, e.g. "EN", "RU", "DE"
     var currentLanguageLabel: String {
         let lang = selectedLanguage.locale.language.languageCode?.identifier ?? selectedLanguageId
-        return lang.uppercased()
+        return lang.uppercased(with: selectedLanguage.locale)
     }
 
     func selectLanguage(_ language: LanguageConfig) {
-        selectedLanguageId = language.id
         if !enabledLanguageIds.contains(language.id) {
             enabledLanguageIds.append(language.id)
         }
+        selectedLanguageId = language.id
     }
 
     /// Toggle a language on/off in the enabled list. Returns false if trying to
@@ -123,11 +124,11 @@ class LanguageSettings: ObservableObject {
     func toggleLanguage(_ language: LanguageConfig) -> Bool {
         if let index = enabledLanguageIds.firstIndex(of: language.id) {
             guard enabledLanguageIds.count > 1 else { return false }
-            enabledLanguageIds.remove(at: index)
-            // If the removed language was selected, switch to the first enabled
             if selectedLanguageId == language.id {
-                selectedLanguageId = enabledLanguageIds[0]
+                let fallbackId = enabledLanguageIds[index == 0 ? 1 : 0]
+                selectedLanguageId = fallbackId
             }
+            enabledLanguageIds.remove(at: index)
         } else {
             enabledLanguageIds.append(language.id)
         }

--- a/wurstfingerKeyboard/Settings/LanguageSettings.swift
+++ b/wurstfingerKeyboard/Settings/LanguageSettings.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-/// Manages keyboard language settings shared between host app and keyboard extension
+/// Manages keyboard language settings shared between host app and keyboard extension.
+/// Supports multiple enabled languages with in-keyboard cycling.
 class LanguageSettings: ObservableObject {
     static let shared = LanguageSettings()
 
@@ -17,42 +18,69 @@ class LanguageSettings: ObservableObject {
         }
     }
 
-    private let userDefaults: UserDefaults
-    private let languageKey = SettingsKey.selectedLanguageId.rawValue
-
-    private init() {
-        userDefaults = SharedDefaults.store
-
-        // Load saved language or detect from system, then normalize
-        let storedLanguageId = userDefaults.string(forKey: languageKey) ?? Self.detectSystemLanguage()
-        let resolvedLanguageId = LanguageConfig.language(withId: storedLanguageId)?.id ?? LanguageConfig.english.id
-        selectedLanguageId = resolvedLanguageId
-
-        // Persist the resolved ID so other readers (e.g. KeyboardViewModel.reloadLanguage)
-        // see the same normalized value
-        if resolvedLanguageId != storedLanguageId {
-            userDefaults.set(resolvedLanguageId, forKey: languageKey)
+    @Published var enabledLanguageIds: [String] {
+        didSet {
+            saveEnabledLanguages()
         }
     }
+
+    private let userDefaults: UserDefaults
+    private let languageKey = SettingsKey.selectedLanguageId.rawValue
+    private let enabledKey = SettingsKey.enabledLanguageIds.rawValue
+
+    init(userDefaults: UserDefaults? = nil) {
+        let defaults = userDefaults ?? SharedDefaults.store
+        self.userDefaults = defaults
+
+        // Load saved language or detect from system, then normalize
+        let storedLanguageId = defaults.string(forKey: SettingsKey.selectedLanguageId.rawValue)
+            ?? Self.detectSystemLanguage()
+        let resolvedLanguageId = LanguageConfig.language(withId: storedLanguageId)?.id
+            ?? LanguageConfig.english.id
+
+        // Load enabled languages, migrating from single-language if needed
+        let storedEnabled = Self.loadEnabledLanguageIds(from: defaults)
+        let resolvedEnabled: [String]
+        if let stored = storedEnabled, !stored.isEmpty {
+            // Filter out any stale/unknown IDs
+            let valid = stored.filter { LanguageConfig.language(withId: $0) != nil }
+            resolvedEnabled = valid.isEmpty ? [resolvedLanguageId] : valid
+        } else {
+            // Migration: no enabled list stored yet, seed with current selection
+            resolvedEnabled = [resolvedLanguageId]
+        }
+
+        selectedLanguageId = resolvedLanguageId
+        enabledLanguageIds = resolvedEnabled
+
+        // Ensure selected language is in the enabled list
+        if !resolvedEnabled.contains(resolvedLanguageId) {
+            enabledLanguageIds.insert(resolvedLanguageId, at: 0)
+        }
+
+        // Persist normalized values
+        if resolvedLanguageId != storedLanguageId {
+            defaults.set(resolvedLanguageId, forKey: SettingsKey.selectedLanguageId.rawValue)
+        }
+        Self.saveEnabledLanguageIds(enabledLanguageIds, to: defaults)
+    }
+
+    // MARK: - Public API
 
     /// Detects the system language and returns matching language ID, or English as fallback
     static func detectSystemLanguage(preferredLanguages: [String]? = nil) -> String {
         let preferredLanguages = preferredLanguages ?? Locale.preferredLanguages
 
-        // Try to find a matching language config for the user's preferred languages
         for languageCode in preferredLanguages {
-            // Extract language and region (e.g., "de-DE", "en-US", "fr")
             let locale = Locale(identifier: languageCode)
             let language = locale.language.languageCode?.identifier ?? ""
             let region = locale.region?.identifier ?? ""
 
-            // Try exact match first (e.g., "de_DE")
             let exactId = "\(language)_\(region)"
             if let match = LanguageConfig.allLanguages.first(where: { $0.id == exactId }) {
                 return match.id
             }
 
-            // Try language-only match (e.g., any German variant for "de")
             if let match = LanguageConfig.allLanguages.first(where: {
                 $0.locale.language.languageCode?.identifier == language
             }) {
@@ -60,7 +88,6 @@ class LanguageSettings: ObservableObject {
             }
         }
 
-        // Fallback to English
         return LanguageConfig.english.id
     }
 
@@ -68,11 +95,87 @@ class LanguageSettings: ObservableObject {
         LanguageConfig.language(withId: selectedLanguageId) ?? .english
     }
 
+    /// Resolved LanguageConfig objects for enabled IDs, preserving order
+    var enabledLanguages: [LanguageConfig] {
+        enabledLanguageIds.compactMap { LanguageConfig.language(withId: $0) }
+    }
+
+    var hasMultipleLanguages: Bool {
+        enabledLanguageIds.count > 1
+    }
+
+    /// Short uppercase label for the current language, e.g. "EN", "RU", "DE"
+    var currentLanguageLabel: String {
+        let lang = selectedLanguage.locale.language.languageCode?.identifier ?? selectedLanguageId
+        return lang.uppercased()
+    }
+
     func selectLanguage(_ language: LanguageConfig) {
         selectedLanguageId = language.id
+        if !enabledLanguageIds.contains(language.id) {
+            enabledLanguageIds.append(language.id)
+        }
     }
+
+    /// Toggle a language on/off in the enabled list. Returns false if trying to
+    /// disable the last remaining language (operation is rejected).
+    @discardableResult
+    func toggleLanguage(_ language: LanguageConfig) -> Bool {
+        if let index = enabledLanguageIds.firstIndex(of: language.id) {
+            guard enabledLanguageIds.count > 1 else { return false }
+            enabledLanguageIds.remove(at: index)
+            // If the removed language was selected, switch to the first enabled
+            if selectedLanguageId == language.id {
+                selectedLanguageId = enabledLanguageIds[0]
+            }
+        } else {
+            enabledLanguageIds.append(language.id)
+        }
+        return true
+    }
+
+    func isLanguageEnabled(_ language: LanguageConfig) -> Bool {
+        enabledLanguageIds.contains(language.id)
+    }
+
+    /// Returns the next language ID after the current one, wrapping around.
+    /// If only one language is enabled, returns that same language.
+    func nextLanguageId(after currentId: String) -> String {
+        guard enabledLanguageIds.count > 1 else {
+            return enabledLanguageIds.first ?? currentId
+        }
+        guard let currentIndex = enabledLanguageIds.firstIndex(of: currentId) else {
+            return enabledLanguageIds[0]
+        }
+        let nextIndex = (currentIndex + 1) % enabledLanguageIds.count
+        return enabledLanguageIds[nextIndex]
+    }
+
+    // MARK: - Persistence
 
     private func save() {
         userDefaults.set(selectedLanguageId, forKey: languageKey)
+    }
+
+    private func saveEnabledLanguages() {
+        Self.saveEnabledLanguageIds(enabledLanguageIds, to: userDefaults)
+    }
+
+    /// Encodes the enabled language IDs as a JSON array string for UserDefaults storage.
+    /// Using JSON rather than NSArray ensures clean cross-process serialization.
+    static func saveEnabledLanguageIds(_ ids: [String], to defaults: UserDefaults) {
+        guard let data = try? JSONEncoder().encode(ids),
+              let json = String(data: data, encoding: .utf8) else { return }
+        defaults.set(json, forKey: SettingsKey.enabledLanguageIds.rawValue)
+    }
+
+    static func loadEnabledLanguageIds(from defaults: UserDefaults) -> [String]? {
+        guard let json = defaults.string(forKey: SettingsKey.enabledLanguageIds.rawValue),
+              let data = json.data(using: .utf8),
+              let ids = try? JSONDecoder().decode([String].self, from: data)
+        else {
+            return nil
+        }
+        return ids
     }
 }

--- a/wurstfingerKeyboard/Settings/LanguageSettings.swift
+++ b/wurstfingerKeyboard/Settings/LanguageSettings.swift
@@ -18,7 +18,7 @@ class LanguageSettings: ObservableObject {
         }
     }
 
-    @Published var enabledLanguageIds: [String] {
+    @Published private(set) var enabledLanguageIds: [String] {
         didSet {
             saveEnabledLanguages()
         }
@@ -141,14 +141,18 @@ class LanguageSettings: ObservableObject {
     /// Returns the next language ID after the current one, wrapping around.
     /// If only one language is enabled, returns that same language.
     func nextLanguageId(after currentId: String) -> String {
-        guard enabledLanguageIds.count > 1 else {
-            return enabledLanguageIds.first ?? currentId
+        Self.nextLanguageId(after: currentId, in: enabledLanguageIds)
+    }
+
+    static func nextLanguageId(after currentId: String, in enabledIds: [String]) -> String {
+        guard enabledIds.count > 1 else {
+            return enabledIds.first ?? currentId
         }
-        guard let currentIndex = enabledLanguageIds.firstIndex(of: currentId) else {
-            return enabledLanguageIds[0]
+        guard let currentIndex = enabledIds.firstIndex(of: currentId) else {
+            return enabledIds[0]
         }
-        let nextIndex = (currentIndex + 1) % enabledLanguageIds.count
-        return enabledLanguageIds[nextIndex]
+        let nextIndex = (currentIndex + 1) % enabledIds.count
+        return enabledIds[nextIndex]
     }
 
     // MARK: - Persistence
@@ -161,21 +165,11 @@ class LanguageSettings: ObservableObject {
         Self.saveEnabledLanguageIds(enabledLanguageIds, to: userDefaults)
     }
 
-    /// Encodes the enabled language IDs as a JSON array string for UserDefaults storage.
-    /// Using JSON rather than NSArray ensures clean cross-process serialization.
     static func saveEnabledLanguageIds(_ ids: [String], to defaults: UserDefaults) {
-        guard let data = try? JSONEncoder().encode(ids),
-              let json = String(data: data, encoding: .utf8) else { return }
-        defaults.set(json, forKey: SettingsKey.enabledLanguageIds.rawValue)
+        defaults.set(ids, forKey: SettingsKey.enabledLanguageIds.rawValue)
     }
 
     static func loadEnabledLanguageIds(from defaults: UserDefaults) -> [String]? {
-        guard let json = defaults.string(forKey: SettingsKey.enabledLanguageIds.rawValue),
-              let data = json.data(using: .utf8),
-              let ids = try? JSONDecoder().decode([String].self, from: data)
-        else {
-            return nil
-        }
-        return ids
+        defaults.stringArray(forKey: SettingsKey.enabledLanguageIds.rawValue)
     }
 }

--- a/wurstfingerTests/CommonKeysFactoryTests.swift
+++ b/wurstfingerTests/CommonKeysFactoryTests.swift
@@ -28,6 +28,8 @@ struct CommonKeysTests {
         // Switching the input method lives on swipe-left; tap is intentionally inert.
         #expect(globe.bindings[.tap]?.action == KeyAction.none)
         #expect(globe.bindings[.swipeLeft]?.action == .advanceToNextInputMode)
+        // Cycling the in-keyboard language lives on swipe-right.
+        #expect(globe.bindings[.swipeRight]?.action == .switchToNextLanguage)
         #expect(globe.style == .utility)
     }
 

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -579,6 +579,31 @@ struct PinnedLanguageTests {
         #expect(settings.startupLanguageId == "en_US")
     }
 
+    @Test("applyStartupLanguage makes the pinned language the active selection")
+    func applyStartupHonorsPin() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
+        settings.applyStartupLanguage()
+
+        // The cold-start selection — and the persisted value the extension reads —
+        // now reflect the pin, so the keyboard boots in the pinned language.
+        #expect(settings.selectedLanguageId == "ru_RU")
+        #expect(defaults.string(forKey: SettingsKey.selectedLanguageId.rawValue) == "ru_RU")
+    }
+
+    @Test("applyStartupLanguage leaves the selection unchanged when no pin")
+    func applyStartupNoPinKeepsSelection() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
+        settings.applyStartupLanguage()
+
+        #expect(settings.selectedLanguageId == "en_US")
+    }
+
     @Test("Stale pinned ID is cleared on load")
     func stalePinnedIdCleared() {
         let (defaults, suite) = createTestDefaults()
@@ -702,5 +727,52 @@ struct ResolvedLanguageIdTests {
     @Test("Falls back for nil")
     func fallsBackForNil() {
         #expect(LanguageSettings.resolvedLanguageId(nil) == LanguageSettings.detectSystemLanguage())
+    }
+}
+
+// MARK: - normalizedEnabledLanguageIds
+
+struct NormalizedEnabledLanguageIdsTests {
+    private func makeDefaults(selected: String, enabled: [String]?) -> (UserDefaults, String) {
+        let suite = "test.normalized.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.set(selected, forKey: SettingsKey.selectedLanguageId.rawValue)
+        if let enabled {
+            LanguageSettings.saveEnabledLanguageIds(enabled, to: defaults)
+        }
+        return (defaults, suite)
+    }
+
+    @Test("Filters out stale/unknown enabled IDs")
+    func filtersStaleIds() {
+        let (defaults, suite) = makeDefaults(selected: "de_DE", enabled: ["de_DE", "zz_ZZ", "en_US"])
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        #expect(LanguageSettings.normalizedEnabledLanguageIds(from: defaults) == ["de_DE", "en_US"])
+    }
+
+    @Test("Falls back to the selected language when the stored list is empty")
+    func emptyFallsBackToSelected() {
+        let (defaults, suite) = makeDefaults(selected: "ru_RU", enabled: [])
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        #expect(LanguageSettings.normalizedEnabledLanguageIds(from: defaults) == ["ru_RU"])
+    }
+
+    @Test("Includes the selected language even when missing from the stored list")
+    func includesSelectedWhenAbsent() {
+        let (defaults, suite) = makeDefaults(selected: "de_DE", enabled: ["en_US"])
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        #expect(LanguageSettings.normalizedEnabledLanguageIds(from: defaults) == ["de_DE", "en_US"])
+    }
+
+    @Test("Does not persist — leaves the stored list untouched")
+    func doesNotPersist() {
+        let (defaults, suite) = makeDefaults(selected: "de_DE", enabled: ["de_DE", "zz_ZZ"])
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        _ = LanguageSettings.normalizedEnabledLanguageIds(from: defaults)
+        #expect(LanguageSettings.loadEnabledLanguageIds(from: defaults) == ["de_DE", "zz_ZZ"])
     }
 }

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -264,6 +264,232 @@ struct PrimaryLanguageResolutionTests {
     }
 }
 
+// MARK: - Multi-Language Settings Tests
+
+struct MultiLanguageSettingsTests {
+    private func createTestDefaults() -> (UserDefaults, String) {
+        let suiteName = "test.multiLang.\(UUID().uuidString)"
+        return (UserDefaults(suiteName: suiteName)!, suiteName)
+    }
+
+    private func createSettings(defaults: UserDefaults, selectedId: String = "en_US", enabledIds: [String]? = nil) -> LanguageSettings {
+        defaults.set(selectedId, forKey: SettingsKey.selectedLanguageId.rawValue)
+        if let enabledIds {
+            LanguageSettings.saveEnabledLanguageIds(enabledIds, to: defaults)
+        }
+        return LanguageSettings(userDefaults: defaults)
+    }
+
+    @Test("Migration: no enabled list seeds from selected language")
+    func migrationSeedsFromSelected() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "de_DE")
+        #expect(settings.enabledLanguageIds == ["de_DE"])
+        #expect(settings.selectedLanguageId == "de_DE")
+    }
+
+    @Test("Loads existing enabled list from UserDefaults")
+    func loadsEnabledList() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU", "de_DE"])
+        #expect(settings.enabledLanguageIds == ["en_US", "ru_RU", "de_DE"])
+    }
+
+    @Test("Toggle enables a language")
+    func toggleEnablesLanguage() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
+        settings.toggleLanguage(.russian)
+        #expect(settings.enabledLanguageIds.contains("ru_RU"))
+        #expect(settings.enabledLanguageIds.count == 2)
+    }
+
+    @Test("Toggle disables an enabled language")
+    func toggleDisablesLanguage() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU", "de_DE"])
+        let result = settings.toggleLanguage(.russian)
+        #expect(result == true)
+        #expect(!settings.enabledLanguageIds.contains("ru_RU"))
+        #expect(settings.enabledLanguageIds.count == 2)
+    }
+
+    @Test("Cannot disable last remaining language")
+    func cannotDisableLastLanguage() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
+        let result = settings.toggleLanguage(.english)
+        #expect(result == false)
+        #expect(settings.enabledLanguageIds == ["en_US"])
+    }
+
+    @Test("Disabling selected language switches to first enabled")
+    func disablingSelectedSwitchesToFirst() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "ru_RU", enabledIds: ["en_US", "ru_RU", "de_DE"])
+        settings.toggleLanguage(.russian)
+        #expect(settings.selectedLanguageId == "en_US")
+    }
+
+    @Test("Selecting a language adds it to enabled if not present")
+    func selectAddsToEnabled() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
+        settings.selectLanguage(.russian)
+        #expect(settings.selectedLanguageId == "ru_RU")
+        #expect(settings.enabledLanguageIds.contains("ru_RU"))
+    }
+
+    @Test("Next language cycles through enabled list with 2 languages")
+    func nextLanguageCyclesTwoLanguages() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
+        #expect(settings.nextLanguageId(after: "en_US") == "ru_RU")
+        #expect(settings.nextLanguageId(after: "ru_RU") == "en_US")
+    }
+
+    @Test("Next language cycles through enabled list with 3 languages")
+    func nextLanguageCyclesThreeLanguages() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU", "de_DE"])
+        #expect(settings.nextLanguageId(after: "en_US") == "ru_RU")
+        #expect(settings.nextLanguageId(after: "ru_RU") == "de_DE")
+        #expect(settings.nextLanguageId(after: "de_DE") == "en_US")
+    }
+
+    @Test("Next language cycles through many enabled languages")
+    func nextLanguageCyclesManyLanguages() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let ids = ["en_US", "ru_RU", "de_DE", "fr_FR", "es_ES"]
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ids)
+        for i in 0 ..< ids.count {
+            let next = settings.nextLanguageId(after: ids[i])
+            let expectedIndex = (i + 1) % ids.count
+            #expect(next == ids[expectedIndex], "After \(ids[i]) expected \(ids[expectedIndex]), got \(next)")
+        }
+    }
+
+    @Test("Next language returns same when only one enabled")
+    func nextLanguageSingleLanguage() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
+        #expect(settings.nextLanguageId(after: "en_US") == "en_US")
+    }
+
+    @Test("Next language falls back to first when current not in list")
+    func nextLanguageFallsBackWhenNotInList() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
+        #expect(settings.nextLanguageId(after: "de_DE") == "en_US")
+    }
+
+    @Test("hasMultipleLanguages reflects enabled count")
+    func hasMultipleLanguagesFlag() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let single = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
+        #expect(single.hasMultipleLanguages == false)
+
+        let multi = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
+        #expect(multi.hasMultipleLanguages == true)
+    }
+
+    @Test("currentLanguageLabel returns uppercase language code")
+    func languageLabelUppercase() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let enSettings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
+        #expect(enSettings.currentLanguageLabel == "EN")
+
+        let ruSettings = createSettings(defaults: defaults, selectedId: "ru_RU", enabledIds: ["ru_RU"])
+        #expect(ruSettings.currentLanguageLabel == "RU")
+
+        let deSettings = createSettings(defaults: defaults, selectedId: "de_DE", enabledIds: ["de_DE"])
+        #expect(deSettings.currentLanguageLabel == "DE")
+    }
+
+    @Test("enabledLanguages returns resolved LanguageConfig objects")
+    func enabledLanguagesResolved() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU", "de_DE"])
+        let configs = settings.enabledLanguages
+        #expect(configs.count == 3)
+        #expect(configs[0].id == "en_US")
+        #expect(configs[1].id == "ru_RU")
+        #expect(configs[2].id == "de_DE")
+    }
+
+    @Test("Stale IDs in enabled list are filtered out on load")
+    func staleIdsFiltered() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "zz_ZZ", "ru_RU"])
+        #expect(settings.enabledLanguageIds == ["en_US", "ru_RU"])
+    }
+
+    @Test("Selected language always in enabled list after init")
+    func selectedAlwaysInEnabled() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        // Selected is ru_RU but enabled list only has en_US
+        let settings = createSettings(defaults: defaults, selectedId: "ru_RU", enabledIds: ["en_US"])
+        #expect(settings.enabledLanguageIds.contains("ru_RU"))
+        #expect(settings.enabledLanguageIds.contains("en_US"))
+    }
+
+    @Test("Enabled list persistence round-trips through JSON")
+    func enabledListPersistence() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let ids = ["en_US", "ru_RU", "de_DE", "fr_FR"]
+        LanguageSettings.saveEnabledLanguageIds(ids, to: defaults)
+        let loaded = LanguageSettings.loadEnabledLanguageIds(from: defaults)
+        #expect(loaded == ids)
+    }
+
+    @Test("isLanguageEnabled reflects enabled state")
+    func isLanguageEnabledCheck() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
+        #expect(settings.isLanguageEnabled(.english) == true)
+        #expect(settings.isLanguageEnabled(.russian) == true)
+        #expect(settings.isLanguageEnabled(.german) == false)
+    }
+}
+
 // MARK: - Info.plist PrimaryLanguage Tests
 
 struct InfoPlistLanguageTests {

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -636,6 +636,24 @@ struct PinnedLanguageTests {
         let stored = defaults.string(forKey: SettingsKey.pinnedLanguageId.rawValue)
         #expect(stored == nil)
     }
+
+    @Test("KeyboardViewModel boots with pinned language, not selected")
+    func viewModelBootsWithPinnedLanguage() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set("en_US", forKey: SettingsKey.selectedLanguageId.rawValue)
+        LanguageSettings.saveEnabledLanguageIds(["en_US", "ru_RU"], to: defaults)
+        defaults.set("ru_RU", forKey: SettingsKey.pinnedLanguageId.rawValue)
+
+        let viewModel = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
+        viewModel.bindActionHandler { _ in }
+
+        #expect(
+            viewModel.currentLocale().identifier == "ru_RU",
+            "ViewModel should boot with pinned language ru_RU, not selected en_US"
+        )
+    }
 }
 
 // MARK: - Info.plist PrimaryLanguage Tests

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -647,10 +647,15 @@ struct PinnedLanguageTests {
         defaults.set("ru_RU", forKey: SettingsKey.pinnedLanguageId.rawValue)
 
         let viewModel = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
-        viewModel.bindActionHandler { _ in }
+        let target = MockTextTarget()
+        viewModel.bindTextInputTarget(target)
+        viewModel.bindViewControllerActions(advanceToNextInputMode: {}, dismissKeyboard: {})
+
+        let startupId = LanguageSettings(userDefaults: defaults).startupLanguageId
+        viewModel.loadDefinition(for: startupId)
 
         #expect(
-            viewModel.currentLocale().identifier == "ru_RU",
+            viewModel.pipelineLocale?.identifier == "ru_RU",
             "ViewModel should boot with pinned language ru_RU, not selected en_US"
         )
     }

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -490,6 +490,154 @@ struct MultiLanguageSettingsTests {
     }
 }
 
+// MARK: - Pinned Default Language Tests
+
+struct PinnedLanguageTests {
+    private func createTestDefaults() -> (UserDefaults, String) {
+        let suiteName = "test.pinned.\(UUID().uuidString)"
+        return (UserDefaults(suiteName: suiteName)!, suiteName)
+    }
+
+    private func createSettings(
+        defaults: UserDefaults,
+        selectedId: String = "en_US",
+        enabledIds: [String],
+        pinnedId: String? = nil
+    ) -> LanguageSettings {
+        defaults.set(selectedId, forKey: SettingsKey.selectedLanguageId.rawValue)
+        LanguageSettings.saveEnabledLanguageIds(enabledIds, to: defaults)
+        defaults.set(pinnedId, forKey: SettingsKey.pinnedLanguageId.rawValue)
+        return LanguageSettings(userDefaults: defaults)
+    }
+
+    @Test("Pin a language sets pinnedLanguageId")
+    func pinSetsId() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"])
+        settings.pinLanguage(.russian)
+        #expect(settings.pinnedLanguageId == "ru_RU")
+    }
+
+    @Test("Unpin by tapping the same language")
+    func unpinSameLanguage() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
+        settings.pinLanguage(.russian)
+        #expect(settings.pinnedLanguageId == nil)
+    }
+
+    @Test("Pin a different language replaces the previous pin")
+    func pinDifferentLanguage() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "en_US")
+        settings.pinLanguage(.russian)
+        #expect(settings.pinnedLanguageId == "ru_RU")
+    }
+
+    @Test("Pinning a disabled language enables it first")
+    func pinDisabledLanguageEnablesIt() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US"])
+        settings.pinLanguage(.russian)
+        #expect(settings.pinnedLanguageId == "ru_RU")
+        #expect(settings.enabledLanguageIds.contains("ru_RU"))
+    }
+
+    @Test("Disabling the pinned language clears the pin")
+    func disablingPinnedLanguageClearsPin() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
+        settings.toggleLanguage(.russian)
+        #expect(settings.pinnedLanguageId == nil)
+    }
+
+    @Test("startupLanguageId returns pinned when set")
+    func startupReturnsPinned() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
+        #expect(settings.startupLanguageId == "ru_RU")
+    }
+
+    @Test("startupLanguageId returns selectedLanguageId when no pin")
+    func startupReturnsSelectedWhenNoPin() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
+        #expect(settings.startupLanguageId == "en_US")
+    }
+
+    @Test("Stale pinned ID is cleared on load")
+    func stalePinnedIdCleared() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "zz_ZZ")
+        #expect(settings.pinnedLanguageId == nil)
+    }
+
+    @Test("Pinned ID not in enabled list is cleared on load")
+    func pinnedNotInEnabledCleared() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US"], pinnedId: "ru_RU")
+        #expect(settings.pinnedLanguageId == nil)
+    }
+
+    @Test("pinnedLanguage returns resolved LanguageConfig")
+    func pinnedLanguageResolved() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
+        #expect(settings.pinnedLanguage?.id == "ru_RU")
+    }
+
+    @Test("pinnedLanguage is nil when no pin")
+    func pinnedLanguageNilWhenNoPin() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"])
+        #expect(settings.pinnedLanguage == nil)
+    }
+
+    @Test("Pin persists to UserDefaults")
+    func pinPersists() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"])
+        settings.pinLanguage(.russian)
+        let stored = defaults.string(forKey: SettingsKey.pinnedLanguageId.rawValue)
+        #expect(stored == "ru_RU")
+    }
+
+    @Test("Unpin persists nil to UserDefaults")
+    func unpinPersistsNil() {
+        let (defaults, suite) = createTestDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
+        settings.pinLanguage(.russian)
+        let stored = defaults.string(forKey: SettingsKey.pinnedLanguageId.rawValue)
+        #expect(stored == nil)
+    }
+}
+
 // MARK: - Info.plist PrimaryLanguage Tests
 
 struct InfoPlistLanguageTests {

--- a/wurstfingerTests/LanguageSwitchingTests.swift
+++ b/wurstfingerTests/LanguageSwitchingTests.swift
@@ -1,0 +1,65 @@
+//
+//  LanguageSwitchingTests.swift
+//  wurstfingerTests
+//
+//  Integration tests for in-keyboard language switching: pressing the language
+//  key (globe, swipe-right → `.switchToNextLanguage`) must cycle the active
+//  definition through the enabled languages, honour the count > 1 guard, and
+//  emit no text. The `LanguageSettings` model itself — detection, enabled list,
+//  pinning, the pure cycling logic — is covered by `LanguageSettingsTests`.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+@Suite(.serialized)
+struct LanguageSwitchingTests {
+    /// A view model whose shared defaults already list `enabled` languages with
+    /// `selected` active — the view model loads the enabled list at init, so the
+    /// seeding must happen before construction.
+    private func makeViewModel(enabled: [String], selected: String) -> (KeyboardViewModel, MockTextTarget) {
+        let defaults = InMemoryUserDefaults()
+        LanguageSettings.saveEnabledLanguageIds(enabled, to: defaults)
+        defaults.set(selected, forKey: SettingsKey.selectedLanguageId.rawValue)
+        let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
+        let target = MockTextTarget()
+        vm.bindTextInputTarget(target)
+        vm.loadDefinition(for: selected)
+        return (vm, target)
+    }
+
+    @Test("Language key cycles the active definition to the next enabled language")
+    func switchKeyCyclesToNextLanguage() {
+        let (vm, target) = makeViewModel(enabled: ["de_DE", "en_US"], selected: "de_DE")
+        #expect(vm.currentDefinition?.id == "de_DE")
+
+        vm.handleGesture(.swipeRight, keyId: UtilitySlot.globe, isReturn: false)
+
+        // The active definition advanced to the next enabled language…
+        #expect(vm.currentDefinition?.id == "en_US")
+        // …and the selection was persisted so the next launch resumes there.
+        #expect(vm.sharedDefaults.string(forKey: SettingsKey.selectedLanguageId.rawValue) == "en_US")
+        // Switching languages must never type anything.
+        #expect(target.events.isEmpty)
+    }
+
+    @Test("Language key wraps from the last enabled language back to the first")
+    func switchKeyWrapsAround() {
+        let (vm, _) = makeViewModel(enabled: ["de_DE", "en_US"], selected: "en_US")
+
+        vm.handleGesture(.swipeRight, keyId: UtilitySlot.globe, isReturn: false)
+
+        #expect(vm.currentDefinition?.id == "de_DE")
+    }
+
+    @Test("Language key is inert when only one language is enabled")
+    func switchKeyNoOpWithSingleLanguage() {
+        let (vm, target) = makeViewModel(enabled: ["de_DE"], selected: "de_DE")
+
+        vm.handleGesture(.swipeRight, keyId: UtilitySlot.globe, isReturn: false)
+
+        #expect(vm.currentDefinition?.id == "de_DE")
+        #expect(target.events.isEmpty)
+    }
+}

--- a/wurstfingerTests/LanguageSwitchingTests.swift
+++ b/wurstfingerTests/LanguageSwitchingTests.swift
@@ -9,6 +9,7 @@
 //  pinning, the pure cycling logic — is covered by `LanguageSettingsTests`.
 //
 
+import Combine
 import Foundation
 import Testing
 @testable import WurstfingerApp
@@ -61,5 +62,40 @@ struct LanguageSwitchingTests {
 
         #expect(vm.currentDefinition?.id == "de_DE")
         #expect(target.events.isEmpty)
+    }
+
+    @Test("Disabling a language in the host app updates the globe-hint state")
+    func enabledSetChangeReflectedAfterReload() {
+        let (vm, _) = makeViewModel(enabled: ["de_DE", "en_US"], selected: "de_DE")
+        #expect(vm.hasMultipleLanguages)
+
+        // `enabledLanguageIds` is @Published, so a SwiftUI view observing the
+        // view model re-renders when the set changes — assert the emission fires.
+        var emitted = false
+        let cancellable = vm.objectWillChange.sink { emitted = true }
+        defer { cancellable.cancel() }
+
+        // Simulate the host app disabling the second language, then the
+        // viewWillAppear → reloadSettings path the extension runs on re-entry.
+        LanguageSettings.saveEnabledLanguageIds(["de_DE"], to: vm.sharedDefaults)
+        vm.reloadSettings()
+
+        #expect(!vm.hasMultipleLanguages)
+        #expect(emitted)
+    }
+
+    @Test("reloadSettings drops stale enabled IDs instead of cycling to them")
+    func reloadNormalizesStaleEnabledIds() {
+        let (vm, _) = makeViewModel(enabled: ["de_DE", "en_US"], selected: "de_DE")
+
+        // A language removed in a later version lingers in stored defaults.
+        LanguageSettings.saveEnabledLanguageIds(["de_DE", "zz_ZZ"], to: vm.sharedDefaults)
+        vm.reloadSettings()
+
+        // Only the valid language remains, so the globe is correctly inert.
+        #expect(!vm.hasMultipleLanguages)
+
+        vm.handleGesture(.swipeRight, keyId: UtilitySlot.globe, isReturn: false)
+        #expect(vm.currentDefinition?.id == "de_DE")
     }
 }


### PR DESCRIPTION
Brings @kiensh's in-keyboard language switching (#135) up to date with the current `develop`.

#135 was already ported to the data-driven architecture but had drifted behind ~50 commits of `develop`. This branch replays its 6 commits on top of current `develop` and resolves the two conflicts. **Supersedes #135** (cannot push to the fork's branch directly).

## What it adds
- Multiple enabled languages with in-keyboard cycling (`enabledLanguageIds`), an optional pinned default language (`pinnedLanguageId`), and a `.switchToNextLanguage` `KeyAction` wired through the data-driven pipeline.
- Host-app language selection UI and a dynamic language-label hint on the switch key.

## Conflicts resolved
- **`LanguageSettings.swift`** — combined develop's `resolvedLanguageId(_:)` resolver (used by `KeyboardViewController` for the "never blank" normalization) with #135's multi-language state + testable `init(userDefaults:)`. The merged init normalizes the selected language through `resolvedLanguageId`.
- **`KeyView.swift`** — the hint-rendering block diverged: develop added a gate so empty-label icon hints (globe, copy/cut/paste) still show; #135 restructured it for the `.switchToNextLanguage` label. Merged so the language hint renders **and** develop's icon-hint fix is preserved (gate moved into the per-binding `else if`).

## Tests
- `LanguageSettingsTests` (48), `KeyboardGridRenderingTests`, `CommonKeysTests` — green.
- Pipeline / middleware / viewmodel / gesture suites — green.

Credit: original work by @kiensh in #135.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline language management in Settings, including enabling/disabling languages and setting a default language.
  * Added swipe-right on the globe key to switch to the next enabled language.
  * Expanded the available language list with German and Russian.
  * Language rows and keyboard hints now show clearer status and default-language indicators.

* **Bug Fixes**
  * Prevented disabling the last remaining enabled language.
  * Improved startup language selection so pinned language preferences are respected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->