### PR TITLE
Add Label Visibility Settings (re-port of #164)

### DIFF
--- a/wurstfinger/LabelVisibilitySettingsView.swift
+++ b/wurstfinger/LabelVisibilitySettingsView.swift
@@ -1,0 +1,65 @@
+//
+//  LabelVisibilitySettingsView.swift
+//  wurstfinger
+//
+//  Lets the user hide categories of key labels to practice the keyboard layout
+//  from memory.
+//
+
+import SwiftUI
+
+struct LabelVisibilitySettingsView: View {
+    @AppStorage(SettingsKey.hideLetters.rawValue, store: SharedDefaults.store)
+    private var hideLetters = false
+
+    @AppStorage(SettingsKey.hideStandardSymbols.rawValue, store: SharedDefaults.store)
+    private var hideStandardSymbols = false
+
+    @AppStorage(SettingsKey.hideExtraSymbols.rawValue, store: SharedDefaults.store)
+    private var hideExtraSymbols = false
+
+    @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
+    private var previewAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
+
+    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
+    private var previewScale = DeviceLayoutUtils.defaultKeyboardScale
+
+    @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
+    private var previewPosition = DeviceLayoutUtils.defaultKeyboardPosition
+
+    var body: some View {
+        VStack(spacing: 16) {
+            InteractiveKeyboardPreview(aspectRatio: $previewAspectRatio, scale: $previewScale, position: $previewPosition)
+                .padding(.horizontal, 16)
+
+            Form {
+                Section {
+                    Toggle("Show Letters", isOn: Binding(
+                        get: { !hideLetters },
+                        set: { hideLetters = !$0 }
+                    ))
+
+                    Toggle("Show Standard Symbols", isOn: Binding(
+                        get: { !hideStandardSymbols },
+                        set: { hideStandardSymbols = !$0 }
+                    ))
+
+                    Toggle("Show Extra Symbols", isOn: Binding(
+                        get: { !hideExtraSymbols },
+                        set: { hideExtraSymbols = !$0 }
+                    ))
+                } footer: {
+                    Text("Hide labels to practice the layout from memory. Numbers and control keys are always visible.")
+                }
+            }
+        }
+        .navigationTitle("Label Visibility")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        LabelVisibilitySettingsView()
+    }
+}

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -45,6 +45,15 @@ struct SettingsView: View {
     @AppStorage(SettingsKey.expertModeEnabled.rawValue, store: SharedDefaults.store)
     private var expertModeEnabled = false
 
+    @AppStorage(SettingsKey.hideLetters.rawValue, store: SharedDefaults.store)
+    private var hideLetters = false
+
+    @AppStorage(SettingsKey.hideStandardSymbols.rawValue, store: SharedDefaults.store)
+    private var hideStandardSymbols = false
+
+    @AppStorage(SettingsKey.hideExtraSymbols.rawValue, store: SharedDefaults.store)
+    private var hideExtraSymbols = false
+
     var body: some View {
         NavigationStack {
             Form {
@@ -101,6 +110,14 @@ struct SettingsView: View {
         Section {
             NavigationLink(destination: StyleSettingsView()) {
                 SettingsRow(icon: "paintbrush", color: .cyan, title: "Style", subtitle: keyboardStyleDescription)
+            }
+
+            NavigationLink(destination: LabelVisibilitySettingsView()) {
+                SettingsRow(
+                    icon: "eye.slash", color: .indigo,
+                    title: "Label Visibility",
+                    subtitle: labelVisibilityDescription
+                )
             }
 
             NavigationLink(destination: AspectRatioSettingsView(aspectRatio: $keyAspectRatio)) {
@@ -207,6 +224,15 @@ struct SettingsView: View {
     private var keyboardStyleDescription: String {
         let style = KeyboardStyle(rawValue: keyboardStyleRaw) ?? .classic
         return style.displayName
+    }
+
+    private var labelVisibilityDescription: String {
+        let hidden = [
+            hideLetters ? "letters" : nil,
+            hideStandardSymbols ? "standard symbols" : nil,
+            hideExtraSymbols ? "extra symbols" : nil,
+        ].compactMap(\.self)
+        return hidden.isEmpty ? "All labels visible" : "Hiding " + hidden.joined(separator: ", ")
     }
 
     private var cursorMovementStyleDescription: String {

--- a/wurstfingerKeyboard/Definition/Model/LabelCategory.swift
+++ b/wurstfingerKeyboard/Definition/Model/LabelCategory.swift
@@ -62,8 +62,9 @@ extension LabelCategory {
         switch binding.resolvedCategory {
         case .letter: .letter
         case .digit: .number
-        case .compose: .extraSymbol
-        case .modifier, .utility, .whitespace: .functional
+        // Compose/accent triggers are treated like other control keys (shift,
+        // symbols toggle): always visible, never hidden by the toggles.
+        case .modifier, .utility, .whitespace, .compose: .functional
         case .symbol: classify(binding.label)
         }
     }

--- a/wurstfingerKeyboard/Definition/Model/LabelCategory.swift
+++ b/wurstfingerKeyboard/Definition/Model/LabelCategory.swift
@@ -1,0 +1,81 @@
+//
+//  LabelCategory.swift
+//  Wurstfinger
+//
+//  Display classification of a key label, used to hide categories of labels so
+//  the layout can be practiced from memory. This is a *visual* classification
+//  (by character content), distinct from `KeyCategory`, which describes a
+//  binding's *behaviour* (auto-shift, haptics, hint styling).
+//
+
+import Foundation
+
+/// Classifies a key label for visibility toggling. Letters, standard symbols,
+/// and extra symbols can each be hidden independently; numbers and functional
+/// labels are always visible.
+enum LabelCategory {
+    /// Alphabetic characters (a–z, ä, ö, ß, …).
+    case letter
+    /// Common everyday punctuation (`. , ! ? - + / = ( ) @ * " ' : ; & ° € %`).
+    case standardSymbol
+    /// Technical/rare symbols (`$ ^ ~ \ { } [ ] | _ < > #`, accents, …).
+    case extraSymbol
+    /// Digits (0–9) — never hidden.
+    case number
+    /// Control keys (shift, symbols toggle, capitalize, …) — never hidden.
+    case functional
+
+    /// Whether this category participates in user-controlled visibility toggling.
+    var isHideable: Bool {
+        switch self {
+        case .letter, .standardSymbol, .extraSymbol: true
+        case .number, .functional: false
+        }
+    }
+}
+
+extension LabelCategory {
+    /// Characters classified as "standard" everyday punctuation. Everything else
+    /// that is not a letter or digit is treated as `.extraSymbol`.
+    private static let standardSymbolCharacters: Set<Character> = [
+        ".", ",", "!", "?", "-", "+", "/", "=",
+        "(", ")", "@", "*", "\"", "'", ":", ";",
+        "&", "°", "€", "%",
+    ]
+
+    /// Classifies a plain text label by its first character. Letters and digits
+    /// are recognised via Unicode properties; symbols fall back to an explicit
+    /// standard set.
+    static func classify(_ text: String) -> LabelCategory {
+        guard let first = text.first else { return .extraSymbol }
+        if first.isLetter { return .letter }
+        if first.isNumber { return .number }
+        if standardSymbolCharacters.contains(first) { return .standardSymbol }
+        return .extraSymbol
+    }
+
+    /// Display category for a binding. The binding's semantic `KeyCategory`
+    /// identifies the never-hidden buckets (modifiers, utility, whitespace,
+    /// digits) and compose triggers; letters and symbols are then classified by
+    /// their label text so the standard/extra split applies.
+    static func of(_ binding: KeyBinding) -> LabelCategory {
+        switch binding.resolvedCategory {
+        case .letter: .letter
+        case .digit: .number
+        case .compose: .extraSymbol
+        case .modifier, .utility, .whitespace: .functional
+        case .symbol: classify(binding.label)
+        }
+    }
+
+    /// Whether a label of this category should be shown given the user's
+    /// hide toggles. Numbers and functional labels are always visible.
+    func isVisible(hideLetters: Bool, hideStandardSymbols: Bool, hideExtraSymbols: Bool) -> Bool {
+        switch self {
+        case .letter: !hideLetters
+        case .standardSymbol: !hideStandardSymbols
+        case .extraSymbol: !hideExtraSymbols
+        case .number, .functional: true
+        }
+    }
+}

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -39,6 +39,25 @@ struct KeyView: View {
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var keyAspectRatio: Double = DeviceLayoutUtils.defaultKeyAspectRatio
 
+    @AppStorage(SettingsKey.hideLetters.rawValue, store: SharedDefaults.store)
+    private var hideLetters = false
+
+    @AppStorage(SettingsKey.hideStandardSymbols.rawValue, store: SharedDefaults.store)
+    private var hideStandardSymbols = false
+
+    @AppStorage(SettingsKey.hideExtraSymbols.rawValue, store: SharedDefaults.store)
+    private var hideExtraSymbols = false
+
+    /// Whether the label of `binding` should be drawn, honouring the user's
+    /// label-visibility toggles (numbers and functional keys always show).
+    private func isLabelVisible(_ binding: KeyBinding) -> Bool {
+        LabelCategory.of(binding).isVisible(
+            hideLetters: hideLetters,
+            hideStandardSymbols: hideStandardSymbols,
+            hideExtraSymbols: hideExtraSymbols
+        )
+    }
+
     /// Maps emoji labels to SF Symbol names for utility keys.
     private static let sfSymbolMap: [String: String] = [
         "🌐": "globe",
@@ -191,6 +210,9 @@ struct KeyView: View {
         if key.style == .spacebar {
             // Spacebar renders blank — label is purely for accessibility.
             EmptyView()
+        } else if let tap = key.bindings[.tap], !isLabelVisible(tap) {
+            // The centre label is hidden by the label-visibility setting.
+            EmptyView()
         } else {
             let font = Font.system(size: scaledFontSize, weight: .semibold, design: .rounded)
             if let sfName = Self.sfSymbolMap[primaryLabel] {
@@ -276,6 +298,7 @@ struct KeyView: View {
                 // hide them entirely.
                 if let binding = key.bindings[gesture],
                    !binding.label.isEmpty || Self.hintIcon(for: binding.action) != nil,
+                   isLabelVisible(binding),
                    let alignment = Self.hintAlignments[gesture] {
                     hintContent(for: binding)
                         .fixedSize()

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -29,6 +29,9 @@ enum SettingsKey: String {
     case keyboardStyle
     case keyboardFullAccess
     case cursorMovementStyle
+    case hideLetters
+    case hideStandardSymbols
+    case hideExtraSymbols
 }
 
 // MARK: - Haptic Settings

--- a/wurstfingerTests/LabelCategoryTests.swift
+++ b/wurstfingerTests/LabelCategoryTests.swift
@@ -52,14 +52,12 @@ struct LabelCategoryTests {
         #expect(LabelCategory.of(binding("$", .commitText("$"))) == .extraSymbol)
     }
 
-    @Test func mapsComposeToExtraSymbol() {
-        #expect(LabelCategory.of(binding("´", .compose(trigger: "´"))) == .extraSymbol)
-    }
-
     @Test func mapsControlKeysToFunctional() {
         #expect(LabelCategory.of(binding("", .switchMode("symbols"))) == .functional) // modifier
         #expect(LabelCategory.of(binding("⌫", .deleteBackward)) == .functional) // utility
         #expect(LabelCategory.of(binding(" ", .space)) == .functional) // whitespace
+        // Compose/accent triggers stay visible like other control keys.
+        #expect(LabelCategory.of(binding("´", .compose(trigger: "´"))) == .functional)
     }
 
     // MARK: - isVisible(...)

--- a/wurstfingerTests/LabelCategoryTests.swift
+++ b/wurstfingerTests/LabelCategoryTests.swift
@@ -1,0 +1,82 @@
+//
+//  LabelCategoryTests.swift
+//  wurstfingerTests
+//
+//  Covers the label-visibility classification: character classification,
+//  binding → display-category mapping, and the per-category visibility rule.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct LabelCategoryTests {
+    private func binding(_ label: String, _ action: KeyAction, category: KeyCategory? = nil) -> KeyBinding {
+        KeyBinding(label: label, action: action, category: category, returnAction: nil, accessibilityLabel: nil)
+    }
+
+    // MARK: - classify(_:)
+
+    @Test func classifyRecognisesLetters() {
+        #expect(LabelCategory.classify("a") == .letter)
+        #expect(LabelCategory.classify("ä") == .letter)
+        #expect(LabelCategory.classify("ß") == .letter)
+    }
+
+    @Test func classifyRecognisesDigits() {
+        #expect(LabelCategory.classify("5") == .number)
+    }
+
+    @Test func classifyRecognisesStandardSymbols() {
+        for symbol in [".", ",", "!", "?", "@", "%", "€", "("] {
+            #expect(LabelCategory.classify(symbol) == .standardSymbol, "\(symbol) should be a standard symbol")
+        }
+    }
+
+    @Test func classifyTreatsRareSymbolsAsExtra() {
+        for symbol in ["$", "^", "#", "\\", "{", "~", "<", "|"] {
+            #expect(LabelCategory.classify(symbol) == .extraSymbol, "\(symbol) should be an extra symbol")
+        }
+    }
+
+    @Test func classifyEmptyStringIsExtra() {
+        #expect(LabelCategory.classify("") == .extraSymbol)
+    }
+
+    // MARK: - of(_ binding:)
+
+    @Test func mapsTextBindingsByCharacter() {
+        #expect(LabelCategory.of(binding("a", .commitText("a"))) == .letter)
+        #expect(LabelCategory.of(binding("5", .commitText("5"))) == .number)
+        #expect(LabelCategory.of(binding(".", .commitText("."))) == .standardSymbol)
+        #expect(LabelCategory.of(binding("$", .commitText("$"))) == .extraSymbol)
+    }
+
+    @Test func mapsComposeToExtraSymbol() {
+        #expect(LabelCategory.of(binding("´", .compose(trigger: "´"))) == .extraSymbol)
+    }
+
+    @Test func mapsControlKeysToFunctional() {
+        #expect(LabelCategory.of(binding("", .switchMode("symbols"))) == .functional) // modifier
+        #expect(LabelCategory.of(binding("⌫", .deleteBackward)) == .functional) // utility
+        #expect(LabelCategory.of(binding(" ", .space)) == .functional) // whitespace
+    }
+
+    // MARK: - isVisible(...)
+
+    @Test func eachHideableCategoryTogglesIndependently() {
+        #expect(LabelCategory.letter.isVisible(hideLetters: false, hideStandardSymbols: true, hideExtraSymbols: true))
+        #expect(!LabelCategory.letter.isVisible(hideLetters: true, hideStandardSymbols: false, hideExtraSymbols: false))
+
+        #expect(LabelCategory.standardSymbol.isVisible(hideLetters: true, hideStandardSymbols: false, hideExtraSymbols: true))
+        #expect(!LabelCategory.standardSymbol.isVisible(hideLetters: false, hideStandardSymbols: true, hideExtraSymbols: false))
+
+        #expect(LabelCategory.extraSymbol.isVisible(hideLetters: true, hideStandardSymbols: true, hideExtraSymbols: false))
+        #expect(!LabelCategory.extraSymbol.isVisible(hideLetters: false, hideStandardSymbols: false, hideExtraSymbols: true))
+    }
+
+    @Test func numbersAndFunctionalAreAlwaysVisible() {
+        #expect(LabelCategory.number.isVisible(hideLetters: true, hideStandardSymbols: true, hideExtraSymbols: true))
+        #expect(LabelCategory.functional.isVisible(hideLetters: true, hideStandardSymbols: true, hideExtraSymbols: true))
+    }
+}


### PR DESCRIPTION
Re-implements #164 (Add Label Visibility Settings, #87) on the current data-driven architecture. #164 predated the Definition/Runtime/Settings refactor, so it couldn't be merged as-is. **Supersedes #164.**

## What it adds
Independent toggles to hide **letters**, **standard symbols**, and **extra symbols** on the keyboard, so users can practice the layout from memory. Numbers and control keys always stay visible.

## Design
Per discussion, the display classification is kept **separate** from the behavioural `KeyCategory`:

- **`LabelCategory`** (`Definition/Model/`) — a character-based display classifier: `letter / standardSymbol / extraSymbol / number / functional`.
  - `classify(_:)` splits symbols into standard (`. , ! ? - + / = ( ) @ * " ' : ; & ° € %`) vs extra (everything else).
  - `of(_ binding:)` uses the binding's semantic `KeyCategory` to pick the never-hide buckets (modifier/utility/whitespace/digit, plus compose → extra), and classifies letters/symbols by label text for the standard/extra split.
  - `isVisible(hideLetters:hideStandardSymbols:hideExtraSymbols:)` is the single visibility rule.
- **`KeyView`** reads the three flags via `@AppStorage` and gates both the centre label and the directional hints. Icon/functional hints (globe, copy/cut/paste) are never hidden.
- **Host app** — `LabelVisibilitySettingsView` with a live `InteractiveKeyboardPreview`, linked from the Appearance section of Settings.

## Tests
`LabelCategoryTests` — classification, binding → category mapping, and the per-category visibility rule (green). Broader rendering/factory/pipeline suites green (no regression; flags default to false = everything visible).

## Dropped vs #164
The old pre-refactor edits (`KeyHintOverlay`/`KeyboardRootView`, the `project.pbxproj` entry — synchronized groups auto-include files) are not needed; the equivalent logic lives in the new `KeyView`. The unused settings ObservableObject was folded into `LabelCategory` (KeyView + host view both read `@AppStorage` directly).

## Note
Reproduces only the visual hiding; verified via unit tests and host-app compile. A quick manual check in the simulator/host-app preview (toggle → labels disappear) is recommended before merge.

Original work: #164 (@cl445).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new settings screen for controlling which key labels are shown during practice.
  * Keyboard labels can now be hidden independently for letters, standard symbols, and extra symbols.
  * Key previews and on-key hints now respect these visibility preferences.

* **Bug Fixes**
  * Improved label handling so numbers and functional keys remain visible while other label types can be hidden consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->