### PR TITLE
WIP: Add App Store Metadata for 13 Additional Locales

### DIFF
--- a/fastlane/metadata/cs-CZ/description.txt
+++ b/fastlane/metadata/cs-CZ/description.txt
@@ -1,6 +1,6 @@
 Wurstfinger: klávesnice pro silné prsty
 
-Unaveni překlepy? Wurstfinger je klávesnice ohleduplná k soukromí s velkými klávesami a gesty přejetí. Vychází z osvědčeného rozložení MessagEase a nahrazuje stísněnou mřížku QWERTY rozložením 3x3 optimalizovaným pro psaní palci.
+Unaveni překlepy? Wurstfinger je klávesnice ohleduplná k soukromí s velkými klávesami a gesty přejetí. Nahrazuje stísněnou mřížku QWERTY osvědčeným rozložením 3x3 optimalizovaným pro psaní palci.
 
 Na rozdíl od běžných klávesnic se Wurstfinger nespoléhá na invazivní predikci slov – přesnosti dosahuje ergonomickým návrhem. Velké a dobře rozmístěné klávesy znamenají méně chybných doteků a systém gest umožňuje přístup ke všem znakům bez hledání drobných tlačítek.
 

--- a/fastlane/metadata/cs-CZ/description.txt
+++ b/fastlane/metadata/cs-CZ/description.txt
@@ -1,0 +1,27 @@
+Wurstfinger: klávesnice pro silné prsty
+
+Unaveni překlepy? Wurstfinger je klávesnice ohleduplná k soukromí s velkými klávesami a gesty přejetí. Vychází z osvědčeného rozložení MessagEase a nahrazuje stísněnou mřížku QWERTY rozložením 3x3 optimalizovaným pro psaní palci.
+
+Na rozdíl od běžných klávesnic se Wurstfinger nespoléhá na invazivní predikci slov – přesnosti dosahuje ergonomickým návrhem. Velké a dobře rozmístěné klávesy znamenají méně chybných doteků a systém gest umožňuje přístup ke všem znakům bez hledání drobných tlačítek.
+
+FUNKCE:
+
+• Mřížka kláves 3x3 – navržená pro palce, ne pro přesné ukazovátko
+• Gesta přejetí – přístup k 8 dalším znakům na klávesu přejetím
+• 15 jazyků – katalánština, chorvatština, angličtina, estonsko-finská, finština, francouzština, němčina, hebrejština, italština, polština, ruština, španělština, švédština, tagalog a vietnamština (se vstupem Telex)
+• Pravidla skládání – vytvářejte akcenty kombinacemi (např. ' + a = á)
+• Kruhová gesta – nakreslete kruh pro velká písmena
+• Ovládání kurzoru – tažením po mezerníku posunete kurzor; podržením vyberete text
+• Haptická odezva – nastavitelná intenzita vibrací
+• Plně nastavitelné – upravte velikost klávesnice podle svých představ
+
+SOUKROMÍ NA PRVNÍM MÍSTĚ:
+
+• Žádný sběr dat
+• Žádný přístup k síti
+• Žádné sledování pomocí predikce slov
+• Veškeré zpracování probíhá lokálně ve vašem zařízení
+
+Wurstfinger vyžaduje trénink – počítejte s několika dny na vybudování svalové paměti. Jakmile ale tento práh překonáte, nebudete se chtít vrátit k běžné klávesnici. Gesta vám přejdou do krve a budete psát rychleji a s menším počtem chyb než kdy dřív.
+
+Vaše prsty vám poděkují!

--- a/fastlane/metadata/cs-CZ/keywords.txt
+++ b/fastlane/metadata/cs-CZ/keywords.txt
@@ -1,1 +1,1 @@
-klávesnice,MessagEase,ThumbKey,psaní,přejetí,palec,ergonomická,soukromí,gesta,velké klávesy
+klávesnice,ThumbKey,psaní,přejetí,palec,ergonomická,soukromí,gesta,velké klávesy

--- a/fastlane/metadata/cs-CZ/keywords.txt
+++ b/fastlane/metadata/cs-CZ/keywords.txt
@@ -1,0 +1,1 @@
+klávesnice,MessagEase,ThumbKey,psaní,přejetí,palec,ergonomická,soukromí,gesta,velké klávesy

--- a/fastlane/metadata/cs-CZ/name.txt
+++ b/fastlane/metadata/cs-CZ/name.txt
@@ -1,0 +1,1 @@
+Wurstfinger

--- a/fastlane/metadata/cs-CZ/privacy_url.txt
+++ b/fastlane/metadata/cs-CZ/privacy_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

--- a/fastlane/metadata/cs-CZ/promotional_text.txt
+++ b/fastlane/metadata/cs-CZ/promotional_text.txt
@@ -1,0 +1,1 @@
+Dokonalá klávesnice pro velké palce – pište rychleji a přesněji díky intuitivním gestům přejetí!

--- a/fastlane/metadata/cs-CZ/release_notes.txt
+++ b/fastlane/metadata/cs-CZ/release_notes.txt
@@ -1,0 +1,13 @@
+Verze 1.2.0
+
+Hlavní novinky:
+• Konec mrtvých zón – každý pixel klávesnice nyní reaguje na dotek
+• Svižnější haptická odezva – vibrace se spustí při doteku, ne až po akci
+• Klávesnice zůstává správně zarovnaná po otočení na pozadí
+
+Opravy:
+• Francouzské rozložení: opraveno návratové přejetí na prostřední klávese
+• Automatická velká písmena po smazání opět fungují
+• Apostrof už nespouští režim akcentů/skládání
+• iOS nyní hlásí správný jazyk klávesnice
+• Různé další opravy gest a nastavení

--- a/fastlane/metadata/cs-CZ/subtitle.txt
+++ b/fastlane/metadata/cs-CZ/subtitle.txt
@@ -1,0 +1,1 @@
+Klávesnice pro silné prsty

--- a/fastlane/metadata/cs-CZ/support_url.txt
+++ b/fastlane/metadata/cs-CZ/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/issues

--- a/fastlane/metadata/da-DK/description.txt
+++ b/fastlane/metadata/da-DK/description.txt
@@ -1,0 +1,27 @@
+Wurstfinger: tastaturet til tykke fingre
+
+Træt af tastefejl? Wurstfinger er et privatlivsvenligt tastatur med store taster og strygebevægelser. Baseret på det gennemprøvede MessagEase-layout erstatter det det trange QWERTY-gitter med et 3x3-layout optimeret til at skrive med tommelfingrene.
+
+I modsætning til almindelige tastaturer bygger Wurstfinger ikke på påtrængende ordforslag – det opnår præcision gennem ergonomisk design. Store taster med god afstand giver færre fejltryk, og bevægelsessystemet giver adgang til alle tegn uden at lede efter bittesmå knapper.
+
+FUNKTIONER:
+
+• 3x3-tastegitter – lavet til tommelfingre, ikke til præcisionspegere
+• Strygebevægelser – få adgang til 8 ekstra tegn pr. tast ved at stryge
+• 15 sprog – catalansk, kroatisk, engelsk, estisk-finsk, finsk, fransk, tysk, hebraisk, italiensk, polsk, russisk, spansk, svensk, tagalog og vietnamesisk (med Telex-input)
+• Sammensætningsregler – lav accenter via kombinationer (f.eks. ' + a = á)
+• Cirkelbevægelser – tegn en cirkel for store bogstaver
+• Markørstyring – træk på mellemrumstasten for at flytte markøren; hold nede for at markere tekst
+• Haptisk feedback – justerbar vibrationsstyrke
+• Fuldt justerbart – skalér tastaturets størrelse efter ønske
+
+PRIVATLIV FØRST:
+
+• Ingen dataindsamling
+• Ingen netværksadgang
+• Ingen sporing via ordforslag
+• Al behandling sker lokalt på din enhed
+
+Wurstfinger kræver træning – regn med et par dage til at opbygge muskelhukommelse. Men når du først er over den tærskel, vil du aldrig tilbage til et almindeligt tastatur. Bevægelserne bliver en anden natur, og du skriver hurtigere og med færre fejl end nogensinde.
+
+Dine fingre vil takke dig!

--- a/fastlane/metadata/da-DK/description.txt
+++ b/fastlane/metadata/da-DK/description.txt
@@ -1,6 +1,6 @@
 Wurstfinger: tastaturet til tykke fingre
 
-Træt af tastefejl? Wurstfinger er et privatlivsvenligt tastatur med store taster og strygebevægelser. Baseret på det gennemprøvede MessagEase-layout erstatter det det trange QWERTY-gitter med et 3x3-layout optimeret til at skrive med tommelfingrene.
+Træt af tastefejl? Wurstfinger er et privatlivsvenligt tastatur med store taster og strygebevægelser. Det erstatter det trange QWERTY-gitter med et gennemprøvet 3x3-layout optimeret til at skrive med tommelfingrene.
 
 I modsætning til almindelige tastaturer bygger Wurstfinger ikke på påtrængende ordforslag – det opnår præcision gennem ergonomisk design. Store taster med god afstand giver færre fejltryk, og bevægelsessystemet giver adgang til alle tegn uden at lede efter bittesmå knapper.
 

--- a/fastlane/metadata/da-DK/keywords.txt
+++ b/fastlane/metadata/da-DK/keywords.txt
@@ -1,1 +1,1 @@
-tastatur,MessagEase,ThumbKey,skrive,stryge,tommel,ergonomisk,privatliv,bevægelser,store taster
+tastatur,ThumbKey,skrive,stryge,tommel,ergonomisk,privatliv,bevægelser,store taster

--- a/fastlane/metadata/da-DK/keywords.txt
+++ b/fastlane/metadata/da-DK/keywords.txt
@@ -1,0 +1,1 @@
+tastatur,MessagEase,ThumbKey,skrive,stryge,tommel,ergonomisk,privatliv,bevægelser,store taster

--- a/fastlane/metadata/da-DK/name.txt
+++ b/fastlane/metadata/da-DK/name.txt
@@ -1,0 +1,1 @@
+Wurstfinger

--- a/fastlane/metadata/da-DK/privacy_url.txt
+++ b/fastlane/metadata/da-DK/privacy_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

--- a/fastlane/metadata/da-DK/promotional_text.txt
+++ b/fastlane/metadata/da-DK/promotional_text.txt
@@ -1,0 +1,1 @@
+Det perfekte tastatur til store tommelfingre – skriv hurtigere og mere præcist med intuitive strygebevægelser!

--- a/fastlane/metadata/da-DK/release_notes.txt
+++ b/fastlane/metadata/da-DK/release_notes.txt
@@ -1,0 +1,13 @@
+Version 1.2.0
+
+Højdepunkter:
+• Slut med døde zoner – hver pixel på tastaturet reagerer nu på berøring
+• Hurtigere haptisk feedback – vibrationen udløses ved berøring i stedet for efter handlingen
+• Tastaturet forbliver korrekt justeret efter rotation i baggrunden
+
+Rettelser:
+• Fransk layout: rettet retur-strygning på midtertasten
+• Automatisk stort begyndelsesbogstav efter sletning virker igen
+• Apostroffen udløser ikke længere accent-/sammensætningstilstand
+• iOS rapporterer nu det korrekte tastatursprog
+• Diverse andre rettelser til bevægelser og indstillinger

--- a/fastlane/metadata/da-DK/subtitle.txt
+++ b/fastlane/metadata/da-DK/subtitle.txt
@@ -1,0 +1,1 @@
+Tastatur til tykke fingre

--- a/fastlane/metadata/da-DK/support_url.txt
+++ b/fastlane/metadata/da-DK/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/issues

--- a/fastlane/metadata/es-ES/description.txt
+++ b/fastlane/metadata/es-ES/description.txt
@@ -1,6 +1,6 @@
 Wurstfinger: el teclado para dedos gordos
 
-¿Cansado de erratas? Wurstfinger es un teclado respetuoso con la privacidad, con teclas grandes y gestos de deslizamiento. Basado en el probado diseño MessagEase, sustituye la apretada cuadrícula QWERTY por una disposición de 3x3 optimizada para escribir con los pulgares.
+¿Cansado de erratas? Wurstfinger es un teclado respetuoso con la privacidad, con teclas grandes y gestos de deslizamiento. Sustituye la apretada cuadrícula QWERTY por una probada disposición de 3x3 optimizada para escribir con los pulgares.
 
 A diferencia de los teclados convencionales, Wurstfinger no depende de una predicción de palabras invasiva, sino que logra la precisión mediante un diseño ergonómico. Las teclas grandes y bien espaciadas reducen los toques fallidos, y el sistema de gestos te da acceso a todos los caracteres sin buscar botones diminutos.
 

--- a/fastlane/metadata/es-ES/description.txt
+++ b/fastlane/metadata/es-ES/description.txt
@@ -1,0 +1,27 @@
+Wurstfinger: el teclado para dedos gordos
+
+¿Cansado de erratas? Wurstfinger es un teclado respetuoso con la privacidad, con teclas grandes y gestos de deslizamiento. Basado en el probado diseño MessagEase, sustituye la apretada cuadrícula QWERTY por una disposición de 3x3 optimizada para escribir con los pulgares.
+
+A diferencia de los teclados convencionales, Wurstfinger no depende de una predicción de palabras invasiva, sino que logra la precisión mediante un diseño ergonómico. Las teclas grandes y bien espaciadas reducen los toques fallidos, y el sistema de gestos te da acceso a todos los caracteres sin buscar botones diminutos.
+
+FUNCIONES:
+
+• Cuadrícula de teclas 3x3 — pensada para los pulgares, no para la puntería
+• Gestos de deslizamiento — accede a 8 caracteres adicionales por tecla deslizando
+• 15 idiomas — catalán, croata, inglés, estonio-finés, finés, francés, alemán, hebreo, italiano, polaco, ruso, español, sueco, tagalo y vietnamita (con entrada Telex)
+• Reglas de composición — crea acentos mediante combinaciones (p. ej. ' + a = á)
+• Gestos circulares — dibuja un círculo para las mayúsculas
+• Control del cursor — arrastra sobre la barra espaciadora para mover el cursor; mantén pulsado para seleccionar texto
+• Respuesta háptica — intensidad de vibración personalizable
+• Totalmente ajustable — adapta el tamaño del teclado a tu gusto
+
+LA PRIVACIDAD ANTE TODO:
+
+• Sin recopilación de datos
+• Sin acceso a la red
+• Sin seguimiento por predicción de palabras
+• Todo el procesamiento ocurre localmente en tu dispositivo
+
+Wurstfinger requiere práctica: cuenta con unos días para crear memoria muscular. Pero una vez superado ese umbral, no querrás volver a un teclado estándar. Los gestos se vuelven naturales y escribirás más rápido y con menos errores que nunca.
+
+¡Tus dedos te lo agradecerán!

--- a/fastlane/metadata/es-ES/keywords.txt
+++ b/fastlane/metadata/es-ES/keywords.txt
@@ -1,1 +1,1 @@
-teclado,MessagEase,ThumbKey,escribir,deslizar,pulgar,ergonómico,privacidad,gestos,teclas grandes
+teclado,ThumbKey,escribir,deslizar,pulgar,ergonómico,privacidad,gestos,teclas grandes

--- a/fastlane/metadata/es-ES/keywords.txt
+++ b/fastlane/metadata/es-ES/keywords.txt
@@ -1,0 +1,1 @@
+teclado,MessagEase,ThumbKey,escribir,deslizar,pulgar,ergonómico,privacidad,gestos,teclas grandes

--- a/fastlane/metadata/es-ES/name.txt
+++ b/fastlane/metadata/es-ES/name.txt
@@ -1,0 +1,1 @@
+Wurstfinger

--- a/fastlane/metadata/es-ES/privacy_url.txt
+++ b/fastlane/metadata/es-ES/privacy_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

--- a/fastlane/metadata/es-ES/promotional_text.txt
+++ b/fastlane/metadata/es-ES/promotional_text.txt
@@ -1,0 +1,1 @@
+¡El teclado perfecto para pulgares grandes: escribe más rápido y con más precisión gracias a gestos de deslizamiento intuitivos!

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -1,0 +1,13 @@
+Versión 1.2.0
+
+Novedades:
+• Se acabaron las zonas muertas: ahora cada píxel del teclado responde al tacto
+• Respuesta háptica más ágil: la vibración se activa al tocar, no después de la acción
+• El teclado permanece bien alineado tras girar el dispositivo en segundo plano
+
+Correcciones:
+• Distribución francesa: corregido el deslizamiento de retorno en la tecla central
+• El uso de mayúsculas automático tras borrar vuelve a funcionar
+• El apóstrofo ya no activa el modo de acentos/composición
+• iOS ahora informa correctamente del idioma del teclado
+• Varias correcciones adicionales en gestos y ajustes

--- a/fastlane/metadata/es-ES/subtitle.txt
+++ b/fastlane/metadata/es-ES/subtitle.txt
@@ -1,0 +1,1 @@
+El teclado para dedos gordos

--- a/fastlane/metadata/es-ES/support_url.txt
+++ b/fastlane/metadata/es-ES/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/issues

--- a/fastlane/metadata/fi-FI/description.txt
+++ b/fastlane/metadata/fi-FI/description.txt
@@ -1,0 +1,27 @@
+Wurstfinger: näppäimistö paksuille sormille
+
+Väsynyt kirjoitusvirheisiin? Wurstfinger on yksityisyyttä kunnioittava näppäimistö, jossa on isot näppäimet ja pyyhkäisyeleet. Se perustuu hyväksi havaittuun MessagEase-asetteluun ja korvaa ahtaan QWERTY-ruudukon 3x3-asettelulla, joka on optimoitu peukaloilla kirjoittamiseen.
+
+Toisin kuin tavalliset näppäimistöt, Wurstfinger ei nojaa tungettelevaan sanaennustukseen – se saavuttaa tarkkuuden ergonomisella suunnittelulla. Isot ja väljästi sijoitellut näppäimet vähentävät ohi menneitä painalluksia, ja elejärjestelmä antaa pääsyn kaikkiin merkkeihin ilman pikkuruisten painikkeiden etsimistä.
+
+OMINAISUUDET:
+
+• 3x3-näppäinruudukko – tehty peukaloille, ei tarkkuusosoittimille
+• Pyyhkäisyeleet – käytä 8:aa lisämerkkiä näppäintä kohden pyyhkäisemällä
+• 15 kieltä – katalaani, kroatia, englanti, viro-suomi, suomi, ranska, saksa, heprea, italia, puola, venäjä, espanja, ruotsi, tagalog ja vietnam (Telex-syöttö)
+• Yhdistämissäännöt – luo aksentteja yhdistelmillä (esim. ' + a = á)
+• Ympyräeleet – piirrä ympyrä isoja kirjaimia varten
+• Kohdistimen hallinta – vedä välilyöntinäppäintä siirtääksesi kohdistinta; pidä painettuna valitaksesi tekstiä
+• Haptinen palaute – säädettävä värinän voimakkuus
+• Täysin säädettävä – skaalaa näppäimistön koko mieleiseksesi
+
+YKSITYISYYS ENSIN:
+
+• Ei tiedonkeruuta
+• Ei verkkoyhteyttä
+• Ei seurantaa sanaennustuksen kautta
+• Kaikki käsittely tapahtuu paikallisesti laitteellasi
+
+Wurstfinger vaatii harjoittelua – varaa muutama päivä lihasmuistin rakentamiseen. Mutta kun olet ylittänyt sen kynnyksen, et halua enää takaisin tavalliseen näppäimistöön. Eleistä tulee selkäytimestä lähteviä, ja kirjoitat nopeammin ja vähemmin virhein kuin koskaan.
+
+Sormesi kiittävät sinua!

--- a/fastlane/metadata/fi-FI/description.txt
+++ b/fastlane/metadata/fi-FI/description.txt
@@ -1,6 +1,6 @@
 Wurstfinger: näppäimistö paksuille sormille
 
-Väsynyt kirjoitusvirheisiin? Wurstfinger on yksityisyyttä kunnioittava näppäimistö, jossa on isot näppäimet ja pyyhkäisyeleet. Se perustuu hyväksi havaittuun MessagEase-asetteluun ja korvaa ahtaan QWERTY-ruudukon 3x3-asettelulla, joka on optimoitu peukaloilla kirjoittamiseen.
+Väsynyt kirjoitusvirheisiin? Wurstfinger on yksityisyyttä kunnioittava näppäimistö, jossa on isot näppäimet ja pyyhkäisyeleet. Se korvaa ahtaan QWERTY-ruudukon hyväksi havaitulla 3x3-asettelulla, joka on optimoitu peukaloilla kirjoittamiseen.
 
 Toisin kuin tavalliset näppäimistöt, Wurstfinger ei nojaa tungettelevaan sanaennustukseen – se saavuttaa tarkkuuden ergonomisella suunnittelulla. Isot ja väljästi sijoitellut näppäimet vähentävät ohi menneitä painalluksia, ja elejärjestelmä antaa pääsyn kaikkiin merkkeihin ilman pikkuruisten painikkeiden etsimistä.
 

--- a/fastlane/metadata/fi-FI/keywords.txt
+++ b/fastlane/metadata/fi-FI/keywords.txt
@@ -1,1 +1,1 @@
-näppäimistö,MessagEase,ThumbKey,kirjoittaa,pyyhkäisy,peukalo,ergonominen,yksityisyys,eleet
+näppäimistö,ThumbKey,kirjoittaa,pyyhkäisy,peukalo,ergonominen,yksityisyys,eleet

--- a/fastlane/metadata/fi-FI/keywords.txt
+++ b/fastlane/metadata/fi-FI/keywords.txt
@@ -1,0 +1,1 @@
+näppäimistö,MessagEase,ThumbKey,kirjoittaa,pyyhkäisy,peukalo,ergonominen,yksityisyys,eleet

--- a/fastlane/metadata/fi-FI/name.txt
+++ b/fastlane/metadata/fi-FI/name.txt
@@ -1,0 +1,1 @@
+Wurstfinger

--- a/fastlane/metadata/fi-FI/privacy_url.txt
+++ b/fastlane/metadata/fi-FI/privacy_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

--- a/fastlane/metadata/fi-FI/promotional_text.txt
+++ b/fastlane/metadata/fi-FI/promotional_text.txt
@@ -1,0 +1,1 @@
+Täydellinen näppäimistö isoille peukaloille – kirjoita nopeammin ja tarkemmin intuitiivisilla pyyhkäisyeleillä!

--- a/fastlane/metadata/fi-FI/release_notes.txt
+++ b/fastlane/metadata/fi-FI/release_notes.txt
@@ -1,0 +1,13 @@
+Versio 1.2.0
+
+Kohokohdat:
+• Ei enää katvealueita – jokainen näppäimistön pikseli reagoi nyt kosketukseen
+• Nopeampi haptinen palaute – värinä laukeaa kosketuksesta eikä toiminnon jälkeen
+• Näppäimistö pysyy oikein kohdistettuna, kun laitetta käännetään taustalla
+
+Korjaukset:
+• Ranskalainen asettelu: korjattu keskinäppäimen paluupyyhkäisy
+• Automaattinen isojen alkukirjainten käyttö poiston jälkeen toimii taas
+• Heittomerkki ei enää käynnistä aksentti-/yhdistämistilaa
+• iOS ilmoittaa nyt oikean näppäimistön kielen
+• Useita muita korjauksia eleisiin ja asetuksiin

--- a/fastlane/metadata/fi-FI/subtitle.txt
+++ b/fastlane/metadata/fi-FI/subtitle.txt
@@ -1,0 +1,1 @@
+Isojen sormien näppäimistö

--- a/fastlane/metadata/fi-FI/support_url.txt
+++ b/fastlane/metadata/fi-FI/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/issues

--- a/fastlane/metadata/fr-FR/description.txt
+++ b/fastlane/metadata/fr-FR/description.txt
@@ -1,0 +1,27 @@
+Wurstfinger : le clavier pour gros doigts
+
+Fatigué des fautes de frappe ? Wurstfinger est un clavier respectueux de la vie privée, doté de grandes touches et de gestes de glissement. Basé sur la disposition éprouvée MessagEase, il remplace la grille QWERTY exiguë par une disposition 3x3 optimisée pour la saisie au pouce.
+
+Contrairement aux claviers classiques, Wurstfinger ne repose pas sur une prédiction de mots intrusive : il atteint la précision grâce à une conception ergonomique. Des touches grandes et bien espacées réduisent les fautes de frappe, et le système de gestes donne accès à tous les caractères sans chercher de minuscules boutons.
+
+FONCTIONNALITÉS :
+
+• Grille de touches 3x3 — pensée pour les pouces, pas pour la précision d'un stylet
+• Gestes de glissement — accédez à 8 caractères supplémentaires par touche en glissant
+• 15 langues — catalan, croate, anglais, estonien-finnois, finnois, français, allemand, hébreu, italien, polonais, russe, espagnol, suédois, tagalog et vietnamien (saisie Telex)
+• Règles de composition — créez des accents par combinaisons (p. ex. ' + a = á)
+• Gestes circulaires — dessinez un cercle pour les majuscules
+• Contrôle du curseur — glissez sur la barre d'espace pour déplacer le curseur, appui long pour sélectionner du texte
+• Retour haptique — intensité de vibration personnalisable
+• Entièrement réglable — ajustez la taille du clavier selon vos préférences
+
+LA CONFIDENTIALITÉ AVANT TOUT :
+
+• Aucune collecte de données
+• Aucun accès au réseau
+• Aucun suivi par prédiction de mots
+• Tout le traitement se fait localement sur votre appareil
+
+Wurstfinger demande un peu d'entraînement : comptez quelques jours pour acquérir des automatismes. Mais une fois ce cap franchi, vous ne voudrez plus revenir à un clavier classique. Les gestes deviennent une seconde nature et vous taperez plus vite et avec moins d'erreurs que jamais.
+
+Vos doigts vous remercieront !

--- a/fastlane/metadata/fr-FR/description.txt
+++ b/fastlane/metadata/fr-FR/description.txt
@@ -1,6 +1,6 @@
 Wurstfinger : le clavier pour gros doigts
 
-Fatigué des fautes de frappe ? Wurstfinger est un clavier respectueux de la vie privée, doté de grandes touches et de gestes de glissement. Basé sur la disposition éprouvée MessagEase, il remplace la grille QWERTY exiguë par une disposition 3x3 optimisée pour la saisie au pouce.
+Fatigué des fautes de frappe ? Wurstfinger est un clavier respectueux de la vie privée, doté de grandes touches et de gestes de glissement. Il remplace la grille QWERTY exiguë par une disposition 3x3 éprouvée, optimisée pour la saisie au pouce.
 
 Contrairement aux claviers classiques, Wurstfinger ne repose pas sur une prédiction de mots intrusive : il atteint la précision grâce à une conception ergonomique. Des touches grandes et bien espacées réduisent les fautes de frappe, et le système de gestes donne accès à tous les caractères sans chercher de minuscules boutons.
 

--- a/fastlane/metadata/fr-FR/keywords.txt
+++ b/fastlane/metadata/fr-FR/keywords.txt
@@ -1,1 +1,1 @@
-clavier,MessagEase,ThumbKey,saisie,glisser,pouce,ergonomique,confidentialité,gestes,grandes touches
+clavier,ThumbKey,saisie,glisser,pouce,ergonomique,confidentialité,gestes,grandes touches

--- a/fastlane/metadata/fr-FR/keywords.txt
+++ b/fastlane/metadata/fr-FR/keywords.txt
@@ -1,0 +1,1 @@
+clavier,MessagEase,ThumbKey,saisie,glisser,pouce,ergonomique,confidentialité,gestes,grandes touches

--- a/fastlane/metadata/fr-FR/name.txt
+++ b/fastlane/metadata/fr-FR/name.txt
@@ -1,0 +1,1 @@
+Wurstfinger

--- a/fastlane/metadata/fr-FR/privacy_url.txt
+++ b/fastlane/metadata/fr-FR/privacy_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

--- a/fastlane/metadata/fr-FR/promotional_text.txt
+++ b/fastlane/metadata/fr-FR/promotional_text.txt
@@ -1,0 +1,1 @@
+Le clavier parfait pour les gros pouces : tapez plus vite et avec plus de précision grâce à des gestes de glissement intuitifs !

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,0 +1,13 @@
+Version 1.2.0
+
+Nouveautés :
+• Fini les zones mortes — chaque pixel du clavier réagit désormais au toucher
+• Retour haptique plus réactif — la vibration se déclenche au contact, plus après l'action
+• Le clavier reste bien aligné après une rotation en arrière-plan
+
+Corrections :
+• Disposition française : correction du glissement de retour sur la touche centrale
+• La majuscule automatique après suppression fonctionne de nouveau
+• L'apostrophe ne déclenche plus le mode accent/composition
+• iOS indique désormais correctement la langue du clavier
+• Diverses autres corrections pour les gestes et les réglages

--- a/fastlane/metadata/fr-FR/subtitle.txt
+++ b/fastlane/metadata/fr-FR/subtitle.txt
@@ -1,0 +1,1 @@
+Le clavier pour gros doigts

--- a/fastlane/metadata/fr-FR/support_url.txt
+++ b/fastlane/metadata/fr-FR/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/issues

--- a/fastlane/metadata/it-IT/description.txt
+++ b/fastlane/metadata/it-IT/description.txt
@@ -1,0 +1,27 @@
+Wurstfinger: la tastiera per dita grosse
+
+Stanco di errori di battitura? Wurstfinger è una tastiera attenta alla privacy, con tasti grandi e gesti di scorrimento. Basata sul collaudato schema MessagEase, sostituisce la stretta griglia QWERTY con una disposizione 3x3 ottimizzata per la digitazione con i pollici.
+
+A differenza delle tastiere tradizionali, Wurstfinger non si affida a una predizione delle parole invasiva: ottiene la precisione grazie a un design ergonomico. Tasti grandi e ben distanziati riducono i tocchi mancati e il sistema di gesti consente di accedere a tutti i caratteri senza cercare minuscoli pulsanti.
+
+FUNZIONI:
+
+• Griglia di tasti 3x3 — pensata per i pollici, non per la precisione di un pennino
+• Gesti di scorrimento — accedi a 8 caratteri aggiuntivi per tasto scorrendo
+• 15 lingue — catalano, croato, inglese, estone-finlandese, finlandese, francese, tedesco, ebraico, italiano, polacco, russo, spagnolo, svedese, tagalog e vietnamita (con input Telex)
+• Regole di composizione — crea accenti tramite combinazioni (es. ' + a = á)
+• Gesti circolari — disegna un cerchio per le maiuscole
+• Controllo del cursore — trascina sulla barra spaziatrice per spostare il cursore, tieni premuto per selezionare il testo
+• Feedback aptico — intensità della vibrazione personalizzabile
+• Completamente regolabile — adatta le dimensioni della tastiera alle tue preferenze
+
+PRIMA DI TUTTO LA PRIVACY:
+
+• Nessuna raccolta di dati
+• Nessun accesso alla rete
+• Nessun tracciamento tramite predizione delle parole
+• Tutta l'elaborazione avviene localmente sul tuo dispositivo
+
+Wurstfinger richiede un po' di pratica: metti in conto qualche giorno per costruire la memoria muscolare. Ma una volta superata quella soglia, non vorrai più tornare a una tastiera standard. I gesti diventano naturali e digiterai più velocemente e con meno errori che mai.
+
+Le tue dita ti ringrazieranno!

--- a/fastlane/metadata/it-IT/description.txt
+++ b/fastlane/metadata/it-IT/description.txt
@@ -1,6 +1,6 @@
 Wurstfinger: la tastiera per dita grosse
 
-Stanco di errori di battitura? Wurstfinger è una tastiera attenta alla privacy, con tasti grandi e gesti di scorrimento. Basata sul collaudato schema MessagEase, sostituisce la stretta griglia QWERTY con una disposizione 3x3 ottimizzata per la digitazione con i pollici.
+Stanco di errori di battitura? Wurstfinger è una tastiera attenta alla privacy, con tasti grandi e gesti di scorrimento. Sostituisce la stretta griglia QWERTY con una collaudata disposizione 3x3 ottimizzata per la digitazione con i pollici.
 
 A differenza delle tastiere tradizionali, Wurstfinger non si affida a una predizione delle parole invasiva: ottiene la precisione grazie a un design ergonomico. Tasti grandi e ben distanziati riducono i tocchi mancati e il sistema di gesti consente di accedere a tutti i caratteri senza cercare minuscoli pulsanti.
 

--- a/fastlane/metadata/it-IT/keywords.txt
+++ b/fastlane/metadata/it-IT/keywords.txt
@@ -1,0 +1,1 @@
+tastiera,MessagEase,ThumbKey,digitare,scorrere,pollice,ergonomica,privacy,gesti,tasti grandi

--- a/fastlane/metadata/it-IT/keywords.txt
+++ b/fastlane/metadata/it-IT/keywords.txt
@@ -1,1 +1,1 @@
-tastiera,MessagEase,ThumbKey,digitare,scorrere,pollice,ergonomica,privacy,gesti,tasti grandi
+tastiera,ThumbKey,digitare,scorrere,pollice,ergonomica,privacy,gesti,tasti grandi

--- a/fastlane/metadata/it-IT/name.txt
+++ b/fastlane/metadata/it-IT/name.txt
@@ -1,0 +1,1 @@
+Wurstfinger

--- a/fastlane/metadata/it-IT/privacy_url.txt
+++ b/fastlane/metadata/it-IT/privacy_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

--- a/fastlane/metadata/it-IT/promotional_text.txt
+++ b/fastlane/metadata/it-IT/promotional_text.txt
@@ -1,0 +1,1 @@
+La tastiera perfetta per i pollici grandi: digita più velocemente e con maggiore precisione grazie a gesti di scorrimento intuitivi!

--- a/fastlane/metadata/it-IT/release_notes.txt
+++ b/fastlane/metadata/it-IT/release_notes.txt
@@ -1,0 +1,13 @@
+Versione 1.2.0
+
+Novità:
+• Niente più zone morte: ora ogni pixel della tastiera risponde al tocco
+• Feedback aptico più reattivo: la vibrazione scatta al tocco, non dopo l'azione
+• La tastiera resta allineata correttamente dopo una rotazione in background
+
+Correzioni:
+• Layout francese: corretto lo scorrimento di ritorno sul tasto centrale
+• Le maiuscole automatiche dopo la cancellazione funzionano di nuovo
+• L'apostrofo non attiva più la modalità accenti/composizione
+• iOS ora segnala correttamente la lingua della tastiera
+• Varie altre correzioni per gesti e impostazioni

--- a/fastlane/metadata/it-IT/subtitle.txt
+++ b/fastlane/metadata/it-IT/subtitle.txt
@@ -1,0 +1,1 @@
+La tastiera per dita grosse

--- a/fastlane/metadata/it-IT/support_url.txt
+++ b/fastlane/metadata/it-IT/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/issues

--- a/fastlane/metadata/nb-NO/description.txt
+++ b/fastlane/metadata/nb-NO/description.txt
@@ -1,6 +1,6 @@
 Wurstfinger: tastaturet for tjukke fingre
 
-Lei av skrivefeil? Wurstfinger er et personvernvennlig tastatur med store taster og sveipebevegelser. Basert på den velprøvde MessagEase-oppsettet erstatter det det trange QWERTY-rutenettet med et 3x3-oppsett optimalisert for skriving med tomlene.
+Lei av skrivefeil? Wurstfinger er et personvernvennlig tastatur med store taster og sveipebevegelser. Det erstatter det trange QWERTY-rutenettet med et velprøvd 3x3-oppsett optimalisert for skriving med tomlene.
 
 I motsetning til vanlige tastaturer baserer ikke Wurstfinger seg på påtrengende ordforslag – det oppnår nøyaktighet gjennom ergonomisk design. Store taster med god avstand gir færre bomtrykk, og bevegelsessystemet gir tilgang til alle tegn uten å lete etter bittesmå knapper.
 

--- a/fastlane/metadata/nb-NO/description.txt
+++ b/fastlane/metadata/nb-NO/description.txt
@@ -1,0 +1,27 @@
+Wurstfinger: tastaturet for tjukke fingre
+
+Lei av skrivefeil? Wurstfinger er et personvernvennlig tastatur med store taster og sveipebevegelser. Basert på den velprøvde MessagEase-oppsettet erstatter det det trange QWERTY-rutenettet med et 3x3-oppsett optimalisert for skriving med tomlene.
+
+I motsetning til vanlige tastaturer baserer ikke Wurstfinger seg på påtrengende ordforslag – det oppnår nøyaktighet gjennom ergonomisk design. Store taster med god avstand gir færre bomtrykk, og bevegelsessystemet gir tilgang til alle tegn uten å lete etter bittesmå knapper.
+
+FUNKSJONER:
+
+• 3x3-rutenett med taster – laget for tomler, ikke for presisjonspekere
+• Sveipebevegelser – få tilgang til 8 ekstra tegn per tast ved å sveipe
+• 15 språk – katalansk, kroatisk, engelsk, estisk-finsk, finsk, fransk, tysk, hebraisk, italiensk, polsk, russisk, spansk, svensk, tagalog og vietnamesisk (med Telex-inntasting)
+• Komposisjonsregler – lag aksenter via kombinasjoner (f.eks. ' + a = á)
+• Sirkelbevegelser – tegn en sirkel for store bokstaver
+• Markørkontroll – dra på mellomromstasten for å flytte markøren; hold inne for å markere tekst
+• Haptisk tilbakemelding – justerbar vibrasjonsstyrke
+• Fullt justerbart – skaler tastaturstørrelsen slik du vil
+
+PERSONVERN FØRST:
+
+• Ingen datainnsamling
+• Ingen nettverkstilgang
+• Ingen sporing via ordforslag
+• All behandling skjer lokalt på enheten din
+
+Wurstfinger krever øving – regn med noen dager for å bygge muskelminne. Men når du først har passert den terskelen, vil du aldri tilbake til et vanlig tastatur. Bevegelsene blir en andre natur, og du skriver raskere og med færre feil enn noen gang.
+
+Fingrene dine vil takke deg!

--- a/fastlane/metadata/nb-NO/keywords.txt
+++ b/fastlane/metadata/nb-NO/keywords.txt
@@ -1,0 +1,1 @@
+tastatur,MessagEase,ThumbKey,skrive,sveipe,tommel,ergonomisk,personvern,bevegelser,store taster

--- a/fastlane/metadata/nb-NO/keywords.txt
+++ b/fastlane/metadata/nb-NO/keywords.txt
@@ -1,1 +1,1 @@
-tastatur,MessagEase,ThumbKey,skrive,sveipe,tommel,ergonomisk,personvern,bevegelser,store taster
+tastatur,ThumbKey,skrive,sveipe,tommel,ergonomisk,personvern,bevegelser,store taster

--- a/fastlane/metadata/nb-NO/name.txt
+++ b/fastlane/metadata/nb-NO/name.txt
@@ -1,0 +1,1 @@
+Wurstfinger

--- a/fastlane/metadata/nb-NO/privacy_url.txt
+++ b/fastlane/metadata/nb-NO/privacy_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

--- a/fastlane/metadata/nb-NO/promotional_text.txt
+++ b/fastlane/metadata/nb-NO/promotional_text.txt
@@ -1,0 +1,1 @@
+Det perfekte tastaturet for store tomler – skriv raskere og mer nøyaktig med intuitive sveipebevegelser!

--- a/fastlane/metadata/nb-NO/release_notes.txt
+++ b/fastlane/metadata/nb-NO/release_notes.txt
@@ -1,0 +1,13 @@
+Versjon 1.2.0
+
+Høydepunkter:
+• Slutt på døde soner – hver piksel på tastaturet reagerer nå på berøring
+• Raskere haptisk tilbakemelding – vibrasjonen utløses ved berøring i stedet for etter handlingen
+• Tastaturet holder seg riktig justert etter rotering i bakgrunnen
+
+Rettelser:
+• Fransk oppsett: rettet retursveip på midttasten
+• Automatisk stor forbokstav etter sletting virker igjen
+• Apostrofen utløser ikke lenger aksent-/komposisjonsmodus
+• iOS rapporterer nå riktig tastaturspråk
+• Diverse andre rettelser for bevegelser og innstillinger

--- a/fastlane/metadata/nb-NO/subtitle.txt
+++ b/fastlane/metadata/nb-NO/subtitle.txt
@@ -1,0 +1,1 @@
+Tastatur for store tommer

--- a/fastlane/metadata/nb-NO/support_url.txt
+++ b/fastlane/metadata/nb-NO/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/issues

--- a/fastlane/metadata/nl-NL/description.txt
+++ b/fastlane/metadata/nl-NL/description.txt
@@ -1,0 +1,27 @@
+Wurstfinger: het toetsenbord voor dikke vingers
+
+Moe van typfouten? Wurstfinger is een privacyvriendelijk toetsenbord met grote toetsen en veeggebaren. Gebaseerd op de beproefde MessagEase-indeling vervangt het het krappe QWERTY-raster door een 3x3-indeling die is geoptimaliseerd voor typen met de duimen.
+
+Anders dan gangbare toetsenborden leunt Wurstfinger niet op opdringerige woordvoorspelling, maar bereikt het nauwkeurigheid via ergonomisch ontwerp. Grote toetsen met ruime tussenruimte zorgen voor minder misslagen, en het gebarensysteem geeft toegang tot alle tekens zonder te zoeken naar minuscule knopjes.
+
+FUNCTIES:
+
+• 3x3-toetsenraster — gemaakt voor duimen, niet voor precisieaanwijzers
+• Veeggebaren — bereik 8 extra tekens per toets door te vegen
+• 15 talen — Catalaans, Kroatisch, Engels, Estisch-Fins, Fins, Frans, Duits, Hebreeuws, Italiaans, Pools, Russisch, Spaans, Zweeds, Tagalog en Vietnamees (met Telex-invoer)
+• Samenstelregels — maak accenten via combinaties (bijv. ' + a = á)
+• Cirkelgebaren — teken een cirkel voor hoofdletters
+• Cursorbesturing — sleep over de spatiebalk om de cursor te verplaatsen; houd ingedrukt om tekst te selecteren
+• Haptische feedback — instelbare trilsterkte
+• Volledig aanpasbaar — schaal de toetsenbordgrootte naar wens
+
+PRIVACY VOOROP:
+
+• Geen gegevensverzameling
+• Geen netwerktoegang
+• Geen tracking via woordvoorspelling
+• Alle verwerking gebeurt lokaal op je apparaat
+
+Wurstfinger vraagt oefening: reken op een paar dagen om spiergeheugen op te bouwen. Maar zodra je die drempel over bent, wil je nooit meer terug naar een standaardtoetsenbord. De gebaren worden een tweede natuur en je typt sneller en met minder fouten dan ooit.
+
+Je vingers zullen je dankbaar zijn!

--- a/fastlane/metadata/nl-NL/description.txt
+++ b/fastlane/metadata/nl-NL/description.txt
@@ -1,6 +1,6 @@
 Wurstfinger: het toetsenbord voor dikke vingers
 
-Moe van typfouten? Wurstfinger is een privacyvriendelijk toetsenbord met grote toetsen en veeggebaren. Gebaseerd op de beproefde MessagEase-indeling vervangt het het krappe QWERTY-raster door een 3x3-indeling die is geoptimaliseerd voor typen met de duimen.
+Moe van typfouten? Wurstfinger is een privacyvriendelijk toetsenbord met grote toetsen en veeggebaren. Het vervangt het krappe QWERTY-raster door een beproefde 3x3-indeling die is geoptimaliseerd voor typen met de duimen.
 
 Anders dan gangbare toetsenborden leunt Wurstfinger niet op opdringerige woordvoorspelling, maar bereikt het nauwkeurigheid via ergonomisch ontwerp. Grote toetsen met ruime tussenruimte zorgen voor minder misslagen, en het gebarensysteem geeft toegang tot alle tekens zonder te zoeken naar minuscule knopjes.
 

--- a/fastlane/metadata/nl-NL/keywords.txt
+++ b/fastlane/metadata/nl-NL/keywords.txt
@@ -1,0 +1,1 @@
+toetsenbord,MessagEase,ThumbKey,typen,vegen,duim,ergonomisch,privacy,gebaren,grote toetsen

--- a/fastlane/metadata/nl-NL/keywords.txt
+++ b/fastlane/metadata/nl-NL/keywords.txt
@@ -1,1 +1,1 @@
-toetsenbord,MessagEase,ThumbKey,typen,vegen,duim,ergonomisch,privacy,gebaren,grote toetsen
+toetsenbord,ThumbKey,typen,vegen,duim,ergonomisch,privacy,gebaren,grote toetsen

--- a/fastlane/metadata/nl-NL/name.txt
+++ b/fastlane/metadata/nl-NL/name.txt
@@ -1,0 +1,1 @@
+Wurstfinger

--- a/fastlane/metadata/nl-NL/privacy_url.txt
+++ b/fastlane/metadata/nl-NL/privacy_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

--- a/fastlane/metadata/nl-NL/promotional_text.txt
+++ b/fastlane/metadata/nl-NL/promotional_text.txt
@@ -1,0 +1,1 @@
+Het perfecte toetsenbord voor grote duimen: typ sneller en nauwkeuriger met intuïtieve veeggebaren!

--- a/fastlane/metadata/nl-NL/release_notes.txt
+++ b/fastlane/metadata/nl-NL/release_notes.txt
@@ -1,0 +1,13 @@
+Versie 1.2.0
+
+Hoogtepunten:
+• Geen dode zones meer: elke pixel van het toetsenbord reageert nu op aanraking
+• Snellere haptische feedback: de trilling komt bij aanraken, niet na de actie
+• Het toetsenbord blijft correct uitgelijnd na draaien op de achtergrond
+
+Opgelost:
+• Franse indeling: terugveeg op de middelste toets gecorrigeerd
+• Automatische hoofdletters na verwijderen werkt weer
+• De apostrof activeert niet langer de accent-/samenstelmodus
+• iOS meldt nu de juiste toetsenbordtaal
+• Diverse andere correcties voor gebaren en instellingen

--- a/fastlane/metadata/nl-NL/subtitle.txt
+++ b/fastlane/metadata/nl-NL/subtitle.txt
@@ -1,0 +1,1 @@
+Toetsenbord voor grote duimen

--- a/fastlane/metadata/nl-NL/support_url.txt
+++ b/fastlane/metadata/nl-NL/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/issues

--- a/fastlane/metadata/pl-PL/description.txt
+++ b/fastlane/metadata/pl-PL/description.txt
@@ -1,0 +1,27 @@
+Wurstfinger: klawiatura dla grubych palców
+
+Masz dość literówek? Wurstfinger to dbająca o prywatność klawiatura z dużymi klawiszami i gestami przesuwania. Oparta na sprawdzonym układzie MessagEase zastępuje ciasną siatkę QWERTY układem 3x3 zoptymalizowanym do pisania kciukami.
+
+W przeciwieństwie do popularnych klawiatur Wurstfinger nie opiera się na inwazyjnym przewidywaniu słów – precyzję osiąga dzięki ergonomicznej konstrukcji. Duże, dobrze rozmieszczone klawisze ograniczają chybione dotknięcia, a system gestów daje dostęp do wszystkich znaków bez szukania maleńkich przycisków.
+
+FUNKCJE:
+
+• Siatka klawiszy 3x3 – stworzona dla kciuków, nie dla precyzyjnych wskaźników
+• Gesty przesuwania – uzyskaj dostęp do 8 dodatkowych znaków na klawisz, przesuwając
+• 15 języków – kataloński, chorwacki, angielski, estońsko-fiński, fiński, francuski, niemiecki, hebrajski, włoski, polski, rosyjski, hiszpański, szwedzki, tagalski i wietnamski (z wprowadzaniem Telex)
+• Reguły składania – twórz znaki diakrytyczne przez kombinacje (np. ' + a = á)
+• Gesty kołowe – narysuj okrąg, aby uzyskać wielkie litery
+• Sterowanie kursorem – przeciągnij po spacji, aby przesunąć kursor; przytrzymaj, aby zaznaczyć tekst
+• Sprzężenie haptyczne – regulowana siła wibracji
+• W pełni konfigurowalna – dostosuj rozmiar klawiatury do swoich preferencji
+
+PRYWATNOŚĆ PRZEDE WSZYSTKIM:
+
+• Brak zbierania danych
+• Brak dostępu do sieci
+• Brak śledzenia przez przewidywanie słów
+• Całe przetwarzanie odbywa się lokalnie na Twoim urządzeniu
+
+Wurstfinger wymaga treningu – licz się z kilkoma dniami na zbudowanie pamięci mięśniowej. Ale gdy już przekroczysz ten próg, nie zechcesz wracać do zwykłej klawiatury. Gesty wchodzą w nawyk, a Ty piszesz szybciej i z mniejszą liczbą błędów niż kiedykolwiek.
+
+Twoje palce Ci podziękują!

--- a/fastlane/metadata/pl-PL/description.txt
+++ b/fastlane/metadata/pl-PL/description.txt
@@ -1,6 +1,6 @@
 Wurstfinger: klawiatura dla grubych palców
 
-Masz dość literówek? Wurstfinger to dbająca o prywatność klawiatura z dużymi klawiszami i gestami przesuwania. Oparta na sprawdzonym układzie MessagEase zastępuje ciasną siatkę QWERTY układem 3x3 zoptymalizowanym do pisania kciukami.
+Masz dość literówek? Wurstfinger to dbająca o prywatność klawiatura z dużymi klawiszami i gestami przesuwania. Zastępuje ciasną siatkę QWERTY sprawdzonym układem 3x3 zoptymalizowanym do pisania kciukami.
 
 W przeciwieństwie do popularnych klawiatur Wurstfinger nie opiera się na inwazyjnym przewidywaniu słów – precyzję osiąga dzięki ergonomicznej konstrukcji. Duże, dobrze rozmieszczone klawisze ograniczają chybione dotknięcia, a system gestów daje dostęp do wszystkich znaków bez szukania maleńkich przycisków.
 

--- a/fastlane/metadata/pl-PL/keywords.txt
+++ b/fastlane/metadata/pl-PL/keywords.txt
@@ -1,0 +1,1 @@
+klawiatura,MessagEase,ThumbKey,pisanie,przesuwanie,kciuk,ergonomiczna,prywatność,gesty

--- a/fastlane/metadata/pl-PL/keywords.txt
+++ b/fastlane/metadata/pl-PL/keywords.txt
@@ -1,1 +1,1 @@
-klawiatura,MessagEase,ThumbKey,pisanie,przesuwanie,kciuk,ergonomiczna,prywatność,gesty
+klawiatura,ThumbKey,pisanie,przesuwanie,kciuk,ergonomiczna,prywatność,gesty

--- a/fastlane/metadata/pl-PL/name.txt
+++ b/fastlane/metadata/pl-PL/name.txt
@@ -1,0 +1,1 @@
+Wurstfinger

--- a/fastlane/metadata/pl-PL/privacy_url.txt
+++ b/fastlane/metadata/pl-PL/privacy_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

--- a/fastlane/metadata/pl-PL/promotional_text.txt
+++ b/fastlane/metadata/pl-PL/promotional_text.txt
@@ -1,0 +1,1 @@
+Idealna klawiatura dla dużych kciuków – pisz szybciej i dokładniej dzięki intuicyjnym gestom przesuwania!

--- a/fastlane/metadata/pl-PL/release_notes.txt
+++ b/fastlane/metadata/pl-PL/release_notes.txt
@@ -1,0 +1,13 @@
+Wersja 1.2.0
+
+Najważniejsze zmiany:
+• Koniec z martwymi strefami – każdy piksel klawiatury reaguje teraz na dotyk
+• Szybsze sprzężenie haptyczne – wibracja uruchamia się przy dotknięciu, a nie po akcji
+• Klawiatura pozostaje prawidłowo wyrównana po obróceniu w tle
+
+Poprawki:
+• Układ francuski: naprawiono gest powrotny na klawiszu środkowym
+• Automatyczne wielkie litery po usunięciu znów działają
+• Apostrof nie uruchamia już trybu akcentów/składania
+• iOS zgłasza teraz poprawny język klawiatury
+• Różne inne poprawki gestów i ustawień

--- a/fastlane/metadata/pl-PL/subtitle.txt
+++ b/fastlane/metadata/pl-PL/subtitle.txt
@@ -1,0 +1,1 @@
+Klawiatura dla grubych palców

--- a/fastlane/metadata/pl-PL/support_url.txt
+++ b/fastlane/metadata/pl-PL/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/issues

--- a/fastlane/metadata/pt-BR/description.txt
+++ b/fastlane/metadata/pt-BR/description.txt
@@ -1,0 +1,27 @@
+Wurstfinger: o teclado para dedos grandes
+
+Cansado de erros de digitação? O Wurstfinger é um teclado que respeita a privacidade, com teclas grandes e gestos de deslizar. Baseado no consagrado layout MessagEase, ele substitui a apertada grade QWERTY por uma disposição 3x3 otimizada para digitar com os polegares.
+
+Diferente dos teclados convencionais, o Wurstfinger não depende de previsão de palavras invasiva: ele alcança precisão por meio de um design ergonômico. Teclas grandes e bem espaçadas reduzem os toques errados, e o sistema de gestos dá acesso a todos os caracteres sem precisar caçar botões minúsculos.
+
+RECURSOS:
+
+• Grade de teclas 3x3 — pensada para os polegares, não para a mira precisa
+• Gestos de deslizar — acesse 8 caracteres adicionais por tecla deslizando
+• 15 idiomas — catalão, croata, inglês, estoniano-finlandês, finlandês, francês, alemão, hebraico, italiano, polonês, russo, espanhol, sueco, tagalo e vietnamita (com entrada Telex)
+• Regras de composição — crie acentos por combinações (ex.: ' + a = á)
+• Gestos circulares — desenhe um círculo para letras maiúsculas
+• Controle do cursor — arraste na barra de espaço para mover o cursor; pressione e segure para selecionar texto
+• Resposta tátil — intensidade de vibração personalizável
+• Totalmente ajustável — adapte o tamanho do teclado à sua preferência
+
+PRIVACIDADE EM PRIMEIRO LUGAR:
+
+• Sem coleta de dados
+• Sem acesso à rede
+• Sem rastreamento por previsão de palavras
+• Todo o processamento acontece localmente no seu dispositivo
+
+O Wurstfinger exige prática: reserve alguns dias para criar memória muscular. Mas, depois de passar dessa fase, você não vai querer voltar a um teclado comum. Os gestos se tornam naturais e você vai digitar mais rápido e com menos erros do que nunca.
+
+Seus dedos vão agradecer!

--- a/fastlane/metadata/pt-BR/description.txt
+++ b/fastlane/metadata/pt-BR/description.txt
@@ -1,6 +1,6 @@
 Wurstfinger: o teclado para dedos grandes
 
-Cansado de erros de digitação? O Wurstfinger é um teclado que respeita a privacidade, com teclas grandes e gestos de deslizar. Baseado no consagrado layout MessagEase, ele substitui a apertada grade QWERTY por uma disposição 3x3 otimizada para digitar com os polegares.
+Cansado de erros de digitação? O Wurstfinger é um teclado que respeita a privacidade, com teclas grandes e gestos de deslizar. Ele substitui a apertada grade QWERTY por uma consagrada disposição 3x3 otimizada para digitar com os polegares.
 
 Diferente dos teclados convencionais, o Wurstfinger não depende de previsão de palavras invasiva: ele alcança precisão por meio de um design ergonômico. Teclas grandes e bem espaçadas reduzem os toques errados, e o sistema de gestos dá acesso a todos os caracteres sem precisar caçar botões minúsculos.
 

--- a/fastlane/metadata/pt-BR/keywords.txt
+++ b/fastlane/metadata/pt-BR/keywords.txt
@@ -1,1 +1,1 @@
-teclado,MessagEase,ThumbKey,digitar,deslizar,polegar,ergonômico,privacidade,gestos,teclas grandes
+teclado,ThumbKey,digitar,deslizar,polegar,ergonômico,privacidade,gestos,teclas grandes

--- a/fastlane/metadata/pt-BR/keywords.txt
+++ b/fastlane/metadata/pt-BR/keywords.txt
@@ -1,0 +1,1 @@
+teclado,MessagEase,ThumbKey,digitar,deslizar,polegar,ergonômico,privacidade,gestos,teclas grandes

--- a/fastlane/metadata/pt-BR/name.txt
+++ b/fastlane/metadata/pt-BR/name.txt
@@ -1,0 +1,1 @@
+Wurstfinger

--- a/fastlane/metadata/pt-BR/privacy_url.txt
+++ b/fastlane/metadata/pt-BR/privacy_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

--- a/fastlane/metadata/pt-BR/promotional_text.txt
+++ b/fastlane/metadata/pt-BR/promotional_text.txt
@@ -1,0 +1,1 @@
+O teclado perfeito para polegares grandes: digite mais rápido e com mais precisão usando gestos de deslizar intuitivos!

--- a/fastlane/metadata/pt-BR/release_notes.txt
+++ b/fastlane/metadata/pt-BR/release_notes.txt
@@ -1,0 +1,13 @@
+Versão 1.2.0
+
+Destaques:
+• Acabaram as zonas mortas: agora cada pixel do teclado responde ao toque
+• Resposta tátil mais ágil: a vibração ocorre ao tocar, não depois da ação
+• O teclado continua alinhado corretamente após girar o aparelho em segundo plano
+
+Correções:
+• Layout francês: corrigido o deslizar de retorno na tecla central
+• A capitalização automática após apagar volta a funcionar
+• O apóstrofo não ativa mais o modo de acento/composição
+• O iOS agora informa corretamente o idioma do teclado
+• Diversas outras correções em gestos e ajustes

--- a/fastlane/metadata/pt-BR/subtitle.txt
+++ b/fastlane/metadata/pt-BR/subtitle.txt
@@ -1,0 +1,1 @@
+O teclado para dedos grandes

--- a/fastlane/metadata/pt-BR/support_url.txt
+++ b/fastlane/metadata/pt-BR/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/issues

--- a/fastlane/metadata/pt-PT/description.txt
+++ b/fastlane/metadata/pt-PT/description.txt
@@ -1,0 +1,27 @@
+Wurstfinger: o teclado para dedos grandes
+
+Farto de erros ao escrever? O Wurstfinger é um teclado que respeita a privacidade, com teclas grandes e gestos de deslize. Baseado no comprovado esquema MessagEase, substitui a apertada grelha QWERTY por uma disposição 3x3 otimizada para escrever com os polegares.
+
+Ao contrário dos teclados convencionais, o Wurstfinger não depende de previsão de palavras invasiva: alcança precisão através de um design ergonómico. Teclas grandes e bem espaçadas reduzem os toques falhados, e o sistema de gestos dá acesso a todos os caracteres sem procurar botões minúsculos.
+
+FUNCIONALIDADES:
+
+• Grelha de teclas 3x3 — pensada para os polegares, não para a pontaria precisa
+• Gestos de deslize — aceda a 8 caracteres adicionais por tecla ao deslizar
+• 15 idiomas — catalão, croata, inglês, estónio-finlandês, finlandês, francês, alemão, hebraico, italiano, polaco, russo, espanhol, sueco, tagalo e vietnamita (com entrada Telex)
+• Regras de composição — crie acentos através de combinações (ex.: ' + a = á)
+• Gestos circulares — desenhe um círculo para letras maiúsculas
+• Controlo do cursor — arraste na barra de espaços para mover o cursor; mantenha premido para selecionar texto
+• Resposta tátil — intensidade de vibração personalizável
+• Totalmente ajustável — adapte o tamanho do teclado à sua preferência
+
+PRIVACIDADE EM PRIMEIRO LUGAR:
+
+• Sem recolha de dados
+• Sem acesso à rede
+• Sem rastreio por previsão de palavras
+• Todo o processamento acontece localmente no seu dispositivo
+
+O Wurstfinger exige prática: conte com alguns dias para criar memória muscular. Mas, depois de ultrapassar esse limite, não vai querer voltar a um teclado normal. Os gestos tornam-se naturais e vai escrever mais depressa e com menos erros do que nunca.
+
+Os seus dedos vão agradecer!

--- a/fastlane/metadata/pt-PT/description.txt
+++ b/fastlane/metadata/pt-PT/description.txt
@@ -1,6 +1,6 @@
 Wurstfinger: o teclado para dedos grandes
 
-Farto de erros ao escrever? O Wurstfinger é um teclado que respeita a privacidade, com teclas grandes e gestos de deslize. Baseado no comprovado esquema MessagEase, substitui a apertada grelha QWERTY por uma disposição 3x3 otimizada para escrever com os polegares.
+Farto de erros ao escrever? O Wurstfinger é um teclado que respeita a privacidade, com teclas grandes e gestos de deslize. Substitui a apertada grelha QWERTY por uma comprovada disposição 3x3 otimizada para escrever com os polegares.
 
 Ao contrário dos teclados convencionais, o Wurstfinger não depende de previsão de palavras invasiva: alcança precisão através de um design ergonómico. Teclas grandes e bem espaçadas reduzem os toques falhados, e o sistema de gestos dá acesso a todos os caracteres sem procurar botões minúsculos.
 

--- a/fastlane/metadata/pt-PT/keywords.txt
+++ b/fastlane/metadata/pt-PT/keywords.txt
@@ -1,1 +1,1 @@
-teclado,MessagEase,ThumbKey,escrever,deslizar,polegar,ergonómico,privacidade,gestos,teclas grandes
+teclado,ThumbKey,escrever,deslizar,polegar,ergonómico,privacidade,gestos,teclas grandes

--- a/fastlane/metadata/pt-PT/keywords.txt
+++ b/fastlane/metadata/pt-PT/keywords.txt
@@ -1,0 +1,1 @@
+teclado,MessagEase,ThumbKey,escrever,deslizar,polegar,ergonómico,privacidade,gestos,teclas grandes

--- a/fastlane/metadata/pt-PT/name.txt
+++ b/fastlane/metadata/pt-PT/name.txt
@@ -1,0 +1,1 @@
+Wurstfinger

--- a/fastlane/metadata/pt-PT/privacy_url.txt
+++ b/fastlane/metadata/pt-PT/privacy_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

--- a/fastlane/metadata/pt-PT/promotional_text.txt
+++ b/fastlane/metadata/pt-PT/promotional_text.txt
@@ -1,0 +1,1 @@
+O teclado perfeito para polegares grandes: escreva mais depressa e com mais precisão através de gestos de deslize intuitivos!

--- a/fastlane/metadata/pt-PT/release_notes.txt
+++ b/fastlane/metadata/pt-PT/release_notes.txt
@@ -1,0 +1,13 @@
+Versão 1.2.0
+
+Destaques:
+• Adeus zonas mortas: agora cada pixel do teclado responde ao toque
+• Resposta tátil mais ágil: a vibração ocorre ao tocar, não depois da ação
+• O teclado mantém-se alinhado corretamente após rodar o dispositivo em segundo plano
+
+Correções:
+• Esquema francês: corrigido o deslize de retorno na tecla central
+• A capitalização automática após apagar voltou a funcionar
+• O apóstrofo já não ativa o modo de acentos/composição
+• O iOS indica agora corretamente o idioma do teclado
+• Várias outras correções em gestos e definições

--- a/fastlane/metadata/pt-PT/subtitle.txt
+++ b/fastlane/metadata/pt-PT/subtitle.txt
@@ -1,0 +1,1 @@
+O teclado para dedos grandes

--- a/fastlane/metadata/pt-PT/support_url.txt
+++ b/fastlane/metadata/pt-PT/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/issues

--- a/fastlane/metadata/sv-SE/description.txt
+++ b/fastlane/metadata/sv-SE/description.txt
@@ -1,0 +1,27 @@
+Wurstfinger: tangentbordet för tjocka fingrar
+
+Trött på skrivfel? Wurstfinger är ett integritetsvänligt tangentbord med stora tangenter och svepgester. Baserat på den beprövade MessagEase-layouten ersätter det det trånga QWERTY-rutnätet med en 3x3-layout optimerad för att skriva med tummarna.
+
+Till skillnad från vanliga tangentbord förlitar sig Wurstfinger inte på påträngande ordprediktion – det uppnår precision genom ergonomisk design. Stora, väl åtskilda tangenter ger färre felträffar, och gestsystemet ger åtkomst till alla tecken utan att leta efter pyttesmå knappar.
+
+FUNKTIONER:
+
+• 3x3-rutnät med tangenter – gjort för tummar, inte för precisionspekare
+• Svepgester – kom åt 8 extra tecken per tangent genom att svepa
+• 15 språk – katalanska, kroatiska, engelska, estnisk-finska, finska, franska, tyska, hebreiska, italienska, polska, ryska, spanska, svenska, tagalog och vietnamesiska (med Telex-inmatning)
+• Kompositionsregler – skapa accenter via kombinationer (t.ex. ' + a = á)
+• Cirkelgester – rita en cirkel för versaler
+• Markörkontroll – dra på mellanslagstangenten för att flytta markören; håll in för att markera text
+• Haptisk respons – justerbar vibrationsstyrka
+• Helt justerbart – skala tangentbordets storlek efter eget tycke
+
+INTEGRITET FÖRST:
+
+• Ingen datainsamling
+• Ingen nätverksåtkomst
+• Ingen spårning via ordprediktion
+• All bearbetning sker lokalt på din enhet
+
+Wurstfinger kräver träning – räkna med några dagar för att bygga muskelminne. Men när du väl passerat den tröskeln vill du aldrig tillbaka till ett vanligt tangentbord. Gesterna blir en andra natur och du skriver snabbare och med färre fel än någonsin.
+
+Dina fingrar kommer att tacka dig!

--- a/fastlane/metadata/sv-SE/description.txt
+++ b/fastlane/metadata/sv-SE/description.txt
@@ -1,6 +1,6 @@
 Wurstfinger: tangentbordet för tjocka fingrar
 
-Trött på skrivfel? Wurstfinger är ett integritetsvänligt tangentbord med stora tangenter och svepgester. Baserat på den beprövade MessagEase-layouten ersätter det det trånga QWERTY-rutnätet med en 3x3-layout optimerad för att skriva med tummarna.
+Trött på skrivfel? Wurstfinger är ett integritetsvänligt tangentbord med stora tangenter och svepgester. Det ersätter det trånga QWERTY-rutnätet med en beprövad 3x3-layout optimerad för att skriva med tummarna.
 
 Till skillnad från vanliga tangentbord förlitar sig Wurstfinger inte på påträngande ordprediktion – det uppnår precision genom ergonomisk design. Stora, väl åtskilda tangenter ger färre felträffar, och gestsystemet ger åtkomst till alla tecken utan att leta efter pyttesmå knappar.
 

--- a/fastlane/metadata/sv-SE/keywords.txt
+++ b/fastlane/metadata/sv-SE/keywords.txt
@@ -1,0 +1,1 @@
+tangentbord,MessagEase,ThumbKey,skriva,svepa,tumme,ergonomiskt,integritet,gester,stora tangenter

--- a/fastlane/metadata/sv-SE/keywords.txt
+++ b/fastlane/metadata/sv-SE/keywords.txt
@@ -1,1 +1,1 @@
-tangentbord,MessagEase,ThumbKey,skriva,svepa,tumme,ergonomiskt,integritet,gester,stora tangenter
+tangentbord,ThumbKey,skriva,svepa,tumme,ergonomiskt,integritet,gester,stora tangenter

--- a/fastlane/metadata/sv-SE/name.txt
+++ b/fastlane/metadata/sv-SE/name.txt
@@ -1,0 +1,1 @@
+Wurstfinger

--- a/fastlane/metadata/sv-SE/privacy_url.txt
+++ b/fastlane/metadata/sv-SE/privacy_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

--- a/fastlane/metadata/sv-SE/promotional_text.txt
+++ b/fastlane/metadata/sv-SE/promotional_text.txt
@@ -1,0 +1,1 @@
+Det perfekta tangentbordet för stora tummar – skriv snabbare och mer exakt med intuitiva svepgester!

--- a/fastlane/metadata/sv-SE/release_notes.txt
+++ b/fastlane/metadata/sv-SE/release_notes.txt
@@ -1,0 +1,13 @@
+Version 1.2.0
+
+Höjdpunkter:
+• Inga fler döda zoner – varje pixel på tangentbordet reagerar nu på beröring
+• Snabbare haptisk respons – vibrationen utlöses vid beröring i stället för efter åtgärden
+• Tangentbordet förblir korrekt justerat efter rotation i bakgrunden
+
+Rättningar:
+• Fransk layout: åtgärdat retursvep på mittentangenten
+• Automatisk versalisering efter radering fungerar igen
+• Apostrofen utlöser inte längre accent-/kompositionsläget
+• iOS rapporterar nu rätt tangentbordsspråk
+• Diverse andra rättningar för gester och inställningar

--- a/fastlane/metadata/sv-SE/subtitle.txt
+++ b/fastlane/metadata/sv-SE/subtitle.txt
@@ -1,0 +1,1 @@
+Tangentbord för stora tummar

--- a/fastlane/metadata/sv-SE/support_url.txt
+++ b/fastlane/metadata/sv-SE/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/issues

--- a/fastlane/metadata/vi-VN/description.txt
+++ b/fastlane/metadata/vi-VN/description.txt
@@ -1,0 +1,27 @@
+Wurstfinger: bàn phím cho ngón tay to
+
+Mệt mỏi vì gõ sai? Wurstfinger là bàn phím tôn trọng quyền riêng tư với các phím lớn và cử chỉ vuốt. Dựa trên bố cục MessagEase đã được kiểm chứng, nó thay lưới QWERTY chật chội bằng bố cục 3x3 tối ưu cho việc gõ bằng ngón cái.
+
+Khác với các bàn phím phổ thông, Wurstfinger không dựa vào dự đoán từ xâm phạm – nó đạt độ chính xác nhờ thiết kế công thái học. Các phím lớn, cách nhau hợp lý giúp giảm chạm hụt, và hệ thống cử chỉ cho phép truy cập mọi ký tự mà không phải dò tìm những nút bé xíu.
+
+TÍNH NĂNG:
+
+• Lưới phím 3x3 – tạo cho ngón cái, không phải để chỉ chính xác
+• Cử chỉ vuốt – truy cập thêm 8 ký tự cho mỗi phím bằng cách vuốt
+• 15 ngôn ngữ – Catalan, Croatia, Anh, Estonia-Phần Lan, Phần Lan, Pháp, Đức, Do Thái, Ý, Ba Lan, Nga, Tây Ban Nha, Thụy Điển, Tagalog và Việt (nhập Telex)
+• Quy tắc ghép – tạo dấu qua tổ hợp (ví dụ: ' + a = á)
+• Cử chỉ vòng tròn – vẽ một vòng tròn để viết hoa
+• Điều khiển con trỏ – kéo trên thanh dấu cách để di chuyển con trỏ; nhấn giữ để chọn văn bản
+• Phản hồi rung – cường độ rung tùy chỉnh
+• Tùy chỉnh hoàn toàn – chỉnh kích thước bàn phím theo ý bạn
+
+QUYỀN RIÊNG TƯ LÀ TRÊN HẾT:
+
+• Không thu thập dữ liệu
+• Không truy cập mạng
+• Không theo dõi qua dự đoán từ
+• Mọi xử lý diễn ra cục bộ trên thiết bị của bạn
+
+Wurstfinger cần luyện tập – hãy dành vài ngày để hình thành trí nhớ cơ. Nhưng khi đã vượt qua ngưỡng đó, bạn sẽ không muốn quay lại bàn phím thông thường. Các cử chỉ trở thành bản năng, và bạn sẽ gõ nhanh hơn, ít lỗi hơn bao giờ hết.
+
+Những ngón tay của bạn sẽ cảm ơn bạn!

--- a/fastlane/metadata/vi-VN/description.txt
+++ b/fastlane/metadata/vi-VN/description.txt
@@ -1,6 +1,6 @@
 Wurstfinger: bàn phím cho ngón tay to
 
-Mệt mỏi vì gõ sai? Wurstfinger là bàn phím tôn trọng quyền riêng tư với các phím lớn và cử chỉ vuốt. Dựa trên bố cục MessagEase đã được kiểm chứng, nó thay lưới QWERTY chật chội bằng bố cục 3x3 tối ưu cho việc gõ bằng ngón cái.
+Mệt mỏi vì gõ sai? Wurstfinger là bàn phím tôn trọng quyền riêng tư với các phím lớn và cử chỉ vuốt. Nó thay lưới QWERTY chật chội bằng bố cục 3x3 đã được kiểm chứng, tối ưu cho việc gõ bằng ngón cái.
 
 Khác với các bàn phím phổ thông, Wurstfinger không dựa vào dự đoán từ xâm phạm – nó đạt độ chính xác nhờ thiết kế công thái học. Các phím lớn, cách nhau hợp lý giúp giảm chạm hụt, và hệ thống cử chỉ cho phép truy cập mọi ký tự mà không phải dò tìm những nút bé xíu.
 

--- a/fastlane/metadata/vi-VN/keywords.txt
+++ b/fastlane/metadata/vi-VN/keywords.txt
@@ -1,1 +1,1 @@
-bàn phím,MessagEase,ThumbKey,gõ,vuốt,ngón cái,công thái học,riêng tư,cử chỉ,phím lớn
+bàn phím,ThumbKey,gõ,vuốt,ngón cái,công thái học,riêng tư,cử chỉ,phím lớn

--- a/fastlane/metadata/vi-VN/keywords.txt
+++ b/fastlane/metadata/vi-VN/keywords.txt
@@ -1,0 +1,1 @@
+bàn phím,MessagEase,ThumbKey,gõ,vuốt,ngón cái,công thái học,riêng tư,cử chỉ,phím lớn

--- a/fastlane/metadata/vi-VN/name.txt
+++ b/fastlane/metadata/vi-VN/name.txt
@@ -1,0 +1,1 @@
+Wurstfinger

--- a/fastlane/metadata/vi-VN/privacy_url.txt
+++ b/fastlane/metadata/vi-VN/privacy_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/blob/develop/PRIVACY.md

--- a/fastlane/metadata/vi-VN/promotional_text.txt
+++ b/fastlane/metadata/vi-VN/promotional_text.txt
@@ -1,0 +1,1 @@
+Bàn phím hoàn hảo cho ngón cái to – gõ nhanh hơn và chính xác hơn với các cử chỉ vuốt trực quan!

--- a/fastlane/metadata/vi-VN/release_notes.txt
+++ b/fastlane/metadata/vi-VN/release_notes.txt
@@ -1,0 +1,13 @@
+Phiên bản 1.2.0
+
+Điểm nổi bật:
+• Không còn vùng chết – giờ đây mọi điểm ảnh trên bàn phím đều phản hồi khi chạm
+• Phản hồi rung nhanh hơn – rung kích hoạt ngay khi chạm thay vì sau hành động
+• Bàn phím vẫn căn chỉnh đúng sau khi xoay máy ở chế độ nền
+
+Sửa lỗi:
+• Bố cục tiếng Pháp: sửa cử chỉ vuốt quay lại trên phím giữa
+• Tự động viết hoa sau khi xóa hoạt động trở lại
+• Dấu nháy đơn không còn kích hoạt chế độ dấu/ghép
+• iOS giờ báo đúng ngôn ngữ bàn phím
+• Nhiều sửa lỗi khác cho cử chỉ và cài đặt

--- a/fastlane/metadata/vi-VN/subtitle.txt
+++ b/fastlane/metadata/vi-VN/subtitle.txt
@@ -1,0 +1,1 @@
+Bàn phím cho ngón tay to

--- a/fastlane/metadata/vi-VN/support_url.txt
+++ b/fastlane/metadata/vi-VN/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/cl445/wurstfinger/issues


### PR DESCRIPTION
Closes #51.

App Store listing metadata previously existed only for **en-US** and **de-DE**. This adds the full per-locale metadata set for the remaining store languages the keyboard targets.

## Locales added (13)
es-ES, fr-FR, pt-BR, pt-PT, it-IT, nl-NL, sv-SE, nb-NO, da-DK, fi-FI, pl-PL, cs-CZ, vi-VN

## What's in each
`name`, `subtitle`, `promotional_text`, `keywords`, `description`, `release_notes`, `privacy_url`, `support_url` — matching the file set of the existing locales.

- `name` keeps the brand "Wurstfinger"; privacy/support URLs are identical to en-US/de-DE.
- Everything else is translated from the en-US source, mirroring the de-DE tone.
- All fields respect App Store limits (subtitle ≤ 30, promotional_text ≤ 170, keywords ≤ 100, description ≤ 4000 chars) — verified per locale.
- `upload_to_app_store` discovers these locales automatically from the metadata directory, so the release lane (`fastlane/Fastfile`) needs **no changes**.

## Out of scope
- **Per-locale screenshots** — the existing generation covers en/de; App Store falls back to the primary locale's screenshots for the new languages. Per-language screenshots can follow separately.

## Note on translations
Translations are AI-assisted. Native-speaker review via follow-up PRs is welcome, in keeping with the project's open-source localization approach (same philosophy as the in-app localization in #189).