### PR TITLE
Add 1.3.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## Unreleased
 
+## v1.3.0 — 2026-06-30
+
+### Added
+
+- In-keyboard language switching — cycle through enabled languages with a swipe on the globe key (#199, #135)
+- Label visibility practice mode — independently hide letters, standard symbols, and extra symbols to learn the layout from memory (#200)
+- App localization in 12 languages (#189)
+- Vietnamese Telex input method (#134)
+- Cursor movement style setting — continuous or step-by-step, with word-wise movement (#173)
+- Numpad style setting — phone or classic layout (#172)
+- Extensive new test coverage: gesture classification, action pipeline, middlewares, compose integrity, accessibility, and end-to-end typing UI tests (#181, #182, #183, #186, #188)
+
+### Fixed
+
+- Fix Liquid Glass inter-key dead zones — taps in the gaps between keys now register in the real keyboard extension (#198)
+- Fix landscape keyboard crash with multi-row key rendering (#193)
+- Guarantee the keyboard always renders a layout and never comes up blank (#196)
+- Harden the keyboard extension against memory jetsam so it opens more reliably (#190)
+- Restore missing utility-key hint icons (globe, dismiss, clipboard) (#184)
+- Re-anchor the gesture origin on ring-buffer overflow for reliable long gestures (#174)
+- Fix auto-capitalization whitespace handling, layout validation, and force-unwrap risks (#177)
+- Harden settings loading against UserDefaults suite crashes (#185)
+
+### Changed
+
+- Restructure the keyboard extension into a data-driven architecture (Definition/Runtime/Settings): layouts are declared as data and executed by a generic runtime (#169, plus the #155–#168 series)
+- Keep the portrait key arrangement in landscape orientation (#197)
+- Gesture tuning: delete-step, turn angle, and slide dead-zone thresholds (#175)
+- Settings robustness: pipeline cache and text-field input clamps (#176)
+- Run CI unit tests serially to avoid flaky simulator-clone failures (#192)
+
 ## v1.2.0 — 2026-04-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Added
 
 - In-keyboard language switching — cycle through enabled languages with a swipe on the globe key (#199, #135)
-- Label visibility practice mode — independently hide letters, standard symbols, and extra symbols to learn the layout from memory (#200)
+- Label visibility — hide letters, standard symbols, or extra symbols independently to choose which labels appear on the keys (#200)
 - App localization in 12 languages (#189)
 - Vietnamese Telex input method (#134)
 - Cursor movement style setting — continuous or step-by-step, with word-wise movement (#173)
@@ -20,7 +20,6 @@
 - Fix landscape keyboard crash with multi-row key rendering (#193)
 - Guarantee the keyboard always renders a layout and never comes up blank (#196)
 - Harden the keyboard extension against memory jetsam so it opens more reliably (#190)
-- Restore missing utility-key hint icons (globe, dismiss, clipboard) (#184)
 - Re-anchor the gesture origin on ring-buffer overflow for reliable long gestures (#174)
 - Fix auto-capitalization whitespace handling, layout validation, and force-unwrap risks (#177)
 - Harden settings loading against UserDefaults suite crashes (#185)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,14 @@
 - App localization in 12 languages (#189)
 - Vietnamese Telex input method (#134)
 - Cursor movement style setting — continuous or step-by-step, with word-wise movement (#173)
-- Numpad style setting — phone or classic layout (#172)
 - Extensive new test coverage: gesture classification, action pipeline, middlewares, compose integrity, accessibility, and end-to-end typing UI tests (#181, #182, #183, #186, #188)
 
 ### Fixed
 
 - Fix Liquid Glass inter-key dead zones — taps in the gaps between keys now register in the real keyboard extension (#198)
-- Fix landscape keyboard crash with multi-row key rendering (#193)
-- Guarantee the keyboard always renders a layout and never comes up blank (#196)
 - Harden the keyboard extension against memory jetsam so it opens more reliably (#190)
 - Re-anchor the gesture origin on ring-buffer overflow for reliable long gestures (#174)
 - Fix auto-capitalization whitespace handling, layout validation, and force-unwrap risks (#177)
-- Harden settings loading against UserDefaults suite crashes (#185)
 
 ### Changed
 

--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -2,11 +2,11 @@ Version 1.3.0
 
 Neu:
 • Sprache direkt auf der Tastatur wechseln — mit einem Wisch über die Globus-Taste durch deine aktivierten Sprachen
+• Cursor-Steuerung — wählen, wie sich der Cursor per Leertaste bewegt: stufenlos oder schrittweise, auch wortweise
 • Label-Sichtbarkeit — Buchstaben, Standard- oder Extra-Symbole einzeln ausblenden
 • Die App ist jetzt in 12 Sprachen verfügbar
 • Neue vietnamesische Telex-Eingabe
 
 Zuverlässigkeit:
 • Die Tastatur öffnet jetzt zuverlässiger
-• Absturz beim Drehen ins Querformat behoben
 • Tote Bereiche zwischen den Tasten im Liquid-Glass-Stil behoben

--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,13 +1,14 @@
-Version 1.2.0
+Version 1.3.0
 
 Highlights:
-• Keine toten Bereiche mehr — jeder Pixel der Tastatur reagiert jetzt auf Berührungen
-• Schnelleres haptisches Feedback — Vibration bereits beim Antippen statt erst nach der Aktion
-• Tastatur bleibt nach Drehen im Hintergrund korrekt ausgerichtet
+• Sprache direkt auf der Tastatur wechseln — mit einem Wisch über die Globus-Taste durch deine aktivierten Sprachen
+• Neuer Übungsmodus — Buchstaben oder Symbole ausblenden, um das Layout auswendig zu lernen
+• Die App ist jetzt in 12 Sprachen verfügbar
+• Neue vietnamesische Telex-Eingabe
 
-Fehlerbehebungen:
-• Französisches Layout: Return-Swipe auf Mitteltaste korrigiert
-• Auto-Großschreibung nach Löschen funktioniert wieder korrekt
-• Apostroph löst keinen Akzent-Modus mehr aus
-• iOS zeigt jetzt die korrekte Tastatursprache an
-• Diverse weitere Korrekturen bei Gesten und Einstellungen
+Zuverlässigkeit:
+• Absturz beim Drehen ins Querformat behoben
+• Tote Bereiche zwischen den Tasten im Liquid-Glass-Stil behoben
+• Die Tastatur öffnet jetzt zuverlässiger und kommt nicht mehr leer hoch
+• Fehlende Symbole auf Globus-, Ausblenden- und Zwischenablage-Tasten wiederhergestellt
+• Viele Verbesserungen bei Gesten und Einstellungen unter der Haube

--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,14 +1,12 @@
 Version 1.3.0
 
-Highlights:
+Neu:
 • Sprache direkt auf der Tastatur wechseln — mit einem Wisch über die Globus-Taste durch deine aktivierten Sprachen
-• Neuer Übungsmodus — Buchstaben oder Symbole ausblenden, um das Layout auswendig zu lernen
+• Label-Sichtbarkeit — Buchstaben, Standard- oder Extra-Symbole einzeln ausblenden
 • Die App ist jetzt in 12 Sprachen verfügbar
 • Neue vietnamesische Telex-Eingabe
 
 Zuverlässigkeit:
+• Die Tastatur öffnet jetzt zuverlässiger
 • Absturz beim Drehen ins Querformat behoben
 • Tote Bereiche zwischen den Tasten im Liquid-Glass-Stil behoben
-• Die Tastatur öffnet jetzt zuverlässiger und kommt nicht mehr leer hoch
-• Fehlende Symbole auf Globus-, Ausblenden- und Zwischenablage-Tasten wiederhergestellt
-• Viele Verbesserungen bei Gesten und Einstellungen unter der Haube

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,14 +1,12 @@
 Version 1.3.0
 
-Highlights:
+New:
 • Switch languages right from the keyboard — cycle through your enabled languages with a swipe on the globe key
-• New practice mode — hide letters or symbols to learn the layout from memory
+• Label visibility — hide letters, standard symbols, or extra symbols independently
 • The app is now available in 12 languages
 • New Vietnamese Telex input
 
 Reliability:
+• The keyboard now opens more reliably
 • Fixed a crash when rotating to landscape
 • Fixed dead zones between keys in the Liquid Glass style
-• The keyboard now opens more reliably and no longer comes up blank
-• Restored missing icons on the globe, dismiss, and clipboard keys
-• Many gesture and settings improvements under the hood

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,13 +1,14 @@
-Version 1.2.0
+Version 1.3.0
 
 Highlights:
-• No more dead zones — every pixel on the keyboard now responds to touch
-• Snappier haptic feedback — vibration fires on touch-down instead of after the action
-• Keyboard stays correctly aligned after rotating while backgrounded
+• Switch languages right from the keyboard — cycle through your enabled languages with a swipe on the globe key
+• New practice mode — hide letters or symbols to learn the layout from memory
+• The app is now available in 12 languages
+• New Vietnamese Telex input
 
-Bug fixes:
-• French layout: fixed return swipe on center key
-• Auto-capitalization after delete works correctly again
-• Apostrophe no longer triggers accent/compose mode
-• iOS now reports the correct keyboard language
-• Various other fixes for gestures and settings
+Reliability:
+• Fixed a crash when rotating to landscape
+• Fixed dead zones between keys in the Liquid Glass style
+• The keyboard now opens more reliably and no longer comes up blank
+• Restored missing icons on the globe, dismiss, and clipboard keys
+• Many gesture and settings improvements under the hood

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -2,11 +2,11 @@ Version 1.3.0
 
 New:
 • Switch languages right from the keyboard — cycle through your enabled languages with a swipe on the globe key
+• Cursor control — choose how the space-bar cursor moves: continuous drag or step-by-step, including word-by-word
 • Label visibility — hide letters, standard symbols, or extra symbols independently
 • The app is now available in 12 languages
 • New Vietnamese Telex input
 
 Reliability:
 • The keyboard now opens more reliably
-• Fixed a crash when rotating to landscape
 • Fixed dead zones between keys in the Liquid Glass style


### PR DESCRIPTION
Release notes for the upcoming **1.3.0** release (companion to the version bump in #202).

Per `RELEASE.md`:
- **`CHANGELOG.md`** — renamed `Unreleased` → `v1.3.0 — 2026-06-30` with Added / Fixed / Changed sections (PR-referenced), and kept an empty `Unreleased` section on top.
- **`fastlane/metadata/en-US/release_notes.txt`** and **`fastlane/metadata/de-DE/release_notes.txt`** — App Store "What's New" for 1.3.0 (well under the 4000-char limit).

Highlights surfaced to users: in-keyboard language switching (#199), label-visibility practice mode (#200), 12-language app localization (#189), Vietnamese Telex (#134), plus the crash/reliability fixes from 1.2.0 (#190, #193, #196, #198).

Note: Liquid Glass already shipped in 1.2.0, so it is presented as a **fix** (dead zones), not a new feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release notes to version **1.3.0** in **English** and **German**, outlining the latest keyboard features and reliability improvements.

* **New Features**
  * Added **swipe-based language switching** from the keyboard (globe key).
  * Improved **practice mode** with granular label visibility (letters and symbols).
  * Expanded language support to **12 languages**, including **Vietnamese Telex**.

* **Bug Fixes**
  * Improved **keyboard opening reliability** and addressed a **landscape rotation crash**.
  * Removed **dead touch areas** (Liquid-Glass style) and refined gesture stability; hint icons were restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->