### PR TITLE
Switch imprint to operating company (Akator GmbH)

### DIFF
--- a/fastlane/metadata/copyright.txt
+++ b/fastlane/metadata/copyright.txt
@@ -1,1 +1,1 @@
-2025 Akator GmbH
+2026 Akator GmbH

--- a/wurstfinger/ImprintView.swift
+++ b/wurstfinger/ImprintView.swift
@@ -12,22 +12,31 @@ struct ImprintView: View {
         List {
             Section {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Claas Flint")
+                    Text("Akator GmbH")
                         .font(.headline)
                     Text("Mozartstr. 13")
                     Text("49740 Haselünne")
                     Text("Germany")
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Managing directors: Claas Flint, Dr. Sven Willner")
+                        Text("Register court: Amtsgericht Osnabrück · HRB 220235")
+                        Text("VAT ID (§ 27a UStG): DE367322752")
+                    }
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                    .padding(.top, 4)
                 }
                 .padding(.vertical, 4)
             } header: {
-                Text("Information according to § 5 TMG")
+                Text("Information according to § 5 DDG")
             }
 
             Section {
-                Link(destination: URL(string: "mailto:claas.flint@gmail.com")!) {
+                Link(destination: URL(string: "mailto:info@akator.de")!) {
                     HStack {
                         Image(systemName: "envelope")
-                        Text("claas.flint@gmail.com")
+                        Text("info@akator.de")
                     }
                 }
             } header: {

--- a/wurstfinger/ImprintView.swift
+++ b/wurstfinger/ImprintView.swift
@@ -24,10 +24,10 @@ struct ImprintView: View {
             }
 
             Section {
-                Link(destination: URL(string: "mailto:claas.fling@gmail.com")!) {
+                Link(destination: URL(string: "mailto:claas.flint@gmail.com")!) {
                     HStack {
                         Image(systemName: "envelope")
-                        Text("claas.fling@gmail.com")
+                        Text("claas.flint@gmail.com")
                     }
                 }
             } header: {


### PR DESCRIPTION
The app is operated commercially by **Akator GmbH**, so the imprint must identify the company (§ 5 DDG), not a private person — the previous private-person imprint was inconsistent with the App Store seller and the copyright (both Akator GmbH).

Updates `ImprintView`:
- Company: **Akator GmbH**, Mozartstr. 13, 49740 Haselünne
- Managing directors: Claas Flint, Dr. Sven Willner
- Register court: Amtsgericht Osnabrück · HRB 220235
- VAT ID (§ 27a UStG): DE367322752
- Contact: **info@akator.de** (company address; replaces the private gmail — also resolves the earlier `claas.fling` typo)
- Updated the outdated **§ 5 TMG** reference to **§ 5 DDG** (TMG was replaced by the Digitale-Dienste-Gesetz in 2024)

Data taken verbatim from the company imprint at akator.de. Supersedes the initial email-only fix.