### PR TITLE
Fix Cursor Offsets for Emoji and Surrogate Pairs

### DIFF
--- a/wurstfingerKeyboard/Definition/Model/TextInputTarget.swift
+++ b/wurstfingerKeyboard/Definition/Model/TextInputTarget.swift
@@ -18,6 +18,11 @@ import Foundation
 protocol TextInputTarget: AnyObject {
     func insertText(_ text: String)
     func deleteBackward()
+
+    /// Moves the cursor by `offset` **UTF-16 code units**, matching the
+    /// observed behavior of `UITextDocumentProxy.adjustTextPosition` (despite
+    /// its parameter name). Callers must convert grapheme-cluster counts to
+    /// UTF-16 widths (`Character.utf16.count`) before calling.
     func adjustTextPosition(byCharacterOffset offset: Int)
 
     /// Text immediately before the cursor (up to the current paragraph start).

--- a/wurstfingerKeyboard/DocumentProxyTarget.swift
+++ b/wurstfingerKeyboard/DocumentProxyTarget.swift
@@ -35,6 +35,9 @@ final class DocumentProxyTarget: TextInputTarget {
     }
 
     func adjustTextPosition(byCharacterOffset offset: Int) {
+        // Forwarded unchanged: `offset` is already in UTF-16 code units, which
+        // is what `UITextDocumentProxy.adjustTextPosition` moves by in practice
+        // (its "character offset" naming notwithstanding).
         proxy?.adjustTextPosition(byCharacterOffset: offset)
     }
 

--- a/wurstfingerKeyboard/Runtime/Pipeline/AdvancedTextMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/AdvancedTextMiddleware.swift
@@ -51,8 +51,11 @@ struct AdvancedTextMiddleware: ActionMiddleware {
     // MARK: - Delete Forward
 
     private func deleteForward(target: TextInputTarget) {
-        guard let after = target.documentContextAfterInput, !after.isEmpty else { return }
-        target.adjustTextPosition(byCharacterOffset: 1)
+        guard let next = target.documentContextAfterInput?.first else { return }
+        // `adjustTextPosition` moves by UTF-16 code units, so cross the whole
+        // grapheme cluster (emoji can span 2+ units); a fixed +1 would land
+        // mid-surrogate and delete the wrong character.
+        target.adjustTextPosition(byCharacterOffset: next.utf16.count)
         target.deleteBackward()
     }
 

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -314,15 +314,29 @@ extension KeyboardViewModel {
     /// accumulated travel.
     private func stepContinuousCursor() {
         while spaceDragResidual <= -KeyboardConstants.SpaceGestures.dragStep {
-            dispatchAction(.moveCursor(offset: -1))
+            dispatchAction(.moveCursor(offset: singleGraphemeOffset(direction: -1)))
             feedbackDrag()
             spaceDragResidual += KeyboardConstants.SpaceGestures.dragStep
         }
         while spaceDragResidual >= KeyboardConstants.SpaceGestures.dragStep {
-            dispatchAction(.moveCursor(offset: 1))
+            dispatchAction(.moveCursor(offset: singleGraphemeOffset(direction: 1)))
             feedbackDrag()
             spaceDragResidual -= KeyboardConstants.SpaceGestures.dragStep
         }
+    }
+
+    /// UTF-16 offset that moves the cursor across exactly one grapheme cluster
+    /// in `direction` (+1 forward, -1 backward).
+    ///
+    /// `adjustTextPosition(byCharacterOffset:)` moves by UTF-16 code units, so
+    /// multi-unit clusters (emoji, surrogate pairs, ZWJ sequences) need their
+    /// full UTF-16 width; otherwise the caret lands inside the cluster. Falls
+    /// back to 1 when no document context is available.
+    private func singleGraphemeOffset(direction: Int) -> Int {
+        let cluster: Character? = direction > 0
+            ? textInputTarget?.documentContextAfterInput?.first
+            : textInputTarget?.documentContextBeforeInput?.last
+        return direction * (cluster?.utf16.count ?? 1)
     }
 
     /// Discrete (MessagEase) mode: classify the completed swipe.
@@ -339,13 +353,13 @@ extension KeyboardViewModel {
         if ratio < KeyboardConstants.SpaceGestures.returnSwipeThreshold {
             moveCursorByWord(direction: direction)
         } else {
-            dispatchAction(.moveCursor(offset: direction))
+            dispatchAction(.moveCursor(offset: singleGraphemeOffset(direction: direction)))
         }
         feedbackDrag()
     }
 
     /// Moves the cursor by one word in `direction` (+1 forward, -1 backward)
-    /// by computing the character offset to the nearest word boundary from the
+    /// by computing the UTF-16 offset to the nearest word boundary from the
     /// surrounding document context.
     private func moveCursorByWord(direction: Int) {
         let offset: Int = direction > 0
@@ -355,8 +369,9 @@ extension KeyboardViewModel {
         dispatchAction(.moveCursor(offset: offset))
     }
 
-    /// Characters from the cursor to the end of the next word: skip leading
-    /// whitespace, then the word itself.
+    /// UTF-16 code units from the cursor to the end of the next word: skip
+    /// leading whitespace, then the word itself. Iterates graphemes but sums
+    /// their UTF-16 widths, matching `adjustTextPosition`'s unit.
     static func forwardWordOffset(in text: String) -> Int {
         var count = 0
         var seenWord = false
@@ -366,13 +381,14 @@ extension KeyboardViewModel {
             } else {
                 seenWord = true
             }
-            count += 1
+            count += char.utf16.count
         }
         return count
     }
 
-    /// Characters from the cursor back to the start of the previous word: skip
-    /// trailing whitespace, then the word itself.
+    /// UTF-16 code units from the cursor back to the start of the previous
+    /// word: skip trailing whitespace, then the word itself. Iterates graphemes
+    /// but sums their UTF-16 widths, matching `adjustTextPosition`'s unit.
     static func backwardWordOffset(in text: String) -> Int {
         var count = 0
         var seenWord = false
@@ -382,7 +398,7 @@ extension KeyboardViewModel {
             } else {
                 seenWord = true
             }
-            count += 1
+            count += char.utf16.count
         }
         return count
     }

--- a/wurstfingerTests/AdvancedTextMiddlewareTests.swift
+++ b/wurstfingerTests/AdvancedTextMiddlewareTests.swift
@@ -129,6 +129,7 @@ struct AdvancedTextMiddlewareDeleteForwardTests {
         middleware.process(AdvancedTextFixtures.context(.deleteForward)) { _ in }
 
         #expect(target.events == [.adjustCursor(4), .deleteBackward])
+        #expect(target.documentContextBeforeInput == "")
         #expect(target.documentContextAfterInput == "abc")
     }
 
@@ -141,6 +142,7 @@ struct AdvancedTextMiddlewareDeleteForwardTests {
         middleware.process(AdvancedTextFixtures.context(.deleteForward)) { _ in }
 
         #expect(target.events == [.adjustCursor(11), .deleteBackward])
+        #expect(target.documentContextBeforeInput == "")
         #expect(target.documentContextAfterInput == "!")
     }
 }

--- a/wurstfingerTests/AdvancedTextMiddlewareTests.swift
+++ b/wurstfingerTests/AdvancedTextMiddlewareTests.swift
@@ -105,6 +105,44 @@ struct AdvancedTextMiddlewareDeleteForwardTests {
 
         #expect(target.events.isEmpty)
     }
+
+    @Test func deletesWholeSurrogatePairEmojiAfterCursor() {
+        let target = MockTextTarget()
+        // 👍 = surrogate pair = 2 UTF-16 units; a fixed +1 offset would land
+        // mid-pair and the deleteBackward would corrupt the emoji.
+        target.documentContextAfterInput = "👍abc"
+        let middleware = AdvancedTextFixtures.middleware(target: target)
+
+        middleware.process(AdvancedTextFixtures.context(.deleteForward)) { _ in }
+
+        #expect(target.events == [.adjustCursor(2), .deleteBackward])
+        #expect(target.documentContextBeforeInput == "")
+        #expect(target.documentContextAfterInput == "abc")
+    }
+
+    @Test func deletesWholeSkinToneEmojiAfterCursor() {
+        let target = MockTextTarget()
+        // 👍🏽 = thumbs up + skin-tone modifier = 4 UTF-16 units.
+        target.documentContextAfterInput = "👍🏽abc"
+        let middleware = AdvancedTextFixtures.middleware(target: target)
+
+        middleware.process(AdvancedTextFixtures.context(.deleteForward)) { _ in }
+
+        #expect(target.events == [.adjustCursor(4), .deleteBackward])
+        #expect(target.documentContextAfterInput == "abc")
+    }
+
+    @Test func deletesWholeZWJFamilyEmojiAfterCursor() {
+        let target = MockTextTarget()
+        // 👨‍👩‍👧‍👦 = ZWJ family sequence = 11 UTF-16 units.
+        target.documentContextAfterInput = "👨‍👩‍👧‍👦!"
+        let middleware = AdvancedTextFixtures.middleware(target: target)
+
+        middleware.process(AdvancedTextFixtures.context(.deleteForward)) { _ in }
+
+        #expect(target.events == [.adjustCursor(11), .deleteBackward])
+        #expect(target.documentContextAfterInput == "!")
+    }
 }
 
 // MARK: - Capitalize word

--- a/wurstfingerTests/CursorMovementTests.swift
+++ b/wurstfingerTests/CursorMovementTests.swift
@@ -74,6 +74,37 @@ struct CursorMovementPipelineTests {
         vm.handleSlide(deleteKey, phase: .ended)
         #expect(target.events.contains(.deleteBackward))
     }
+
+    @Test func continuousSlideForwardCrossesWholeEmojiCluster() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+        // 👍🏽 = thumbs up + skin-tone modifier = 4 UTF-16 code units.
+        target.documentContextAfterInput = "👍🏽x"
+        guard let spaceKey = vm.activeModeFromDefinition?.key(for: UtilitySlot.space) else {
+            Issue.record("Space key not found in definition")
+            return
+        }
+        vm.handleSlide(spaceKey, phase: .began)
+        vm.handleSlide(spaceKey, phase: .changed(deltaX: KeyboardConstants.SpaceGestures.dragStep))
+        vm.handleSlide(spaceKey, phase: .ended)
+        // One step must cross the whole cluster, not get stuck inside it.
+        #expect(target.events == [.adjustCursor(4)])
+        #expect(target.documentContextAfterInput == "x")
+    }
+
+    @Test func continuousSlideBackwardCrossesWholeEmojiCluster() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+        target.documentContextBeforeInput = "x👍"
+        guard let spaceKey = vm.activeModeFromDefinition?.key(for: UtilitySlot.space) else {
+            Issue.record("Space key not found in definition")
+            return
+        }
+        vm.handleSlide(spaceKey, phase: .began)
+        vm.handleSlide(spaceKey, phase: .changed(deltaX: -KeyboardConstants.SpaceGestures.dragStep))
+        vm.handleSlide(spaceKey, phase: .ended)
+        // 👍 is a surrogate pair = 2 UTF-16 code units.
+        #expect(target.events == [.adjustCursor(-2)])
+        #expect(target.documentContextBeforeInput == "x")
+    }
 }
 
 // MARK: - Discrete cursor movement (one swipe = char, return swipe = word)
@@ -162,5 +193,75 @@ struct DiscreteCursorMovementTests {
         #expect(KeyboardViewModel.backwardWordOffset(in: "foo bar  ") == 5)
         #expect(KeyboardViewModel.backwardWordOffset(in: "foo") == 3)
         #expect(KeyboardViewModel.backwardWordOffset(in: "") == 0)
+    }
+
+    // MARK: - UTF-16 offsets for emoji and surrogate pairs
+
+    @Test func forwardWordOffsetCountsUTF16UnitsForEmoji() {
+        // 👍 = surrogate pair = 2 UTF-16 units; leading space adds 1.
+        #expect(KeyboardViewModel.forwardWordOffset(in: " 👍 bar") == 3)
+        // 👍🏽 = thumbs up + skin-tone modifier = 4 units.
+        #expect(KeyboardViewModel.forwardWordOffset(in: "👍🏽 bar") == 4)
+        // 👨‍👩‍👧‍👦 = ZWJ family sequence = 11 units.
+        #expect(KeyboardViewModel.forwardWordOffset(in: "👨‍👩‍👧‍👦 x") == 11)
+    }
+
+    @Test func backwardWordOffsetCountsUTF16UnitsForEmoji() {
+        #expect(KeyboardViewModel.backwardWordOffset(in: "bar 👍 ") == 3)
+        #expect(KeyboardViewModel.backwardWordOffset(in: "foo 👍🏽") == 4)
+        #expect(KeyboardViewModel.backwardWordOffset(in: "x 👨‍👩‍👧‍👦") == 11)
+    }
+
+    @Test func returnSwipeForwardAcrossEmojiLandsOnClusterBoundary() throws {
+        let (vm, target) = makeDiscreteViewModel()
+        let key = try spaceKey(vm)
+        target.documentContextAfterInput = "👍🏽 bar"
+        vm.handleSlide(key, phase: .began)
+        vm.handleSlide(key, phase: .changed(deltaX: 40))
+        vm.handleSlide(key, phase: .changed(deltaX: -36))
+        vm.handleSlide(key, phase: .ended)
+        // Word jump must cover the emoji's full 4 UTF-16 units.
+        #expect(target.events == [.adjustCursor(4)])
+        #expect(target.documentContextBeforeInput == "👍🏽")
+        #expect(target.documentContextAfterInput == " bar")
+    }
+
+    @Test func returnSwipeBackwardAcrossEmojiLandsOnClusterBoundary() throws {
+        let (vm, target) = makeDiscreteViewModel()
+        let key = try spaceKey(vm)
+        target.documentContextBeforeInput = "foo 👍🏽"
+        vm.handleSlide(key, phase: .began)
+        vm.handleSlide(key, phase: .changed(deltaX: -40))
+        vm.handleSlide(key, phase: .changed(deltaX: 36))
+        vm.handleSlide(key, phase: .ended)
+        #expect(target.events == [.adjustCursor(-4)])
+        #expect(target.documentContextBeforeInput == "foo ")
+        #expect(target.documentContextAfterInput == "👍🏽")
+    }
+
+    @Test func regularSwipeForwardCrossesWholeEmojiCluster() throws {
+        let (vm, target) = makeDiscreteViewModel()
+        let key = try spaceKey(vm)
+        target.documentContextAfterInput = "👍 bar"
+        let step = KeyboardConstants.SpaceGestures.dragStep
+        vm.handleSlide(key, phase: .began)
+        vm.handleSlide(key, phase: .changed(deltaX: step * 2))
+        vm.handleSlide(key, phase: .ended)
+        // One discrete step = one grapheme = 2 UTF-16 units for 👍.
+        #expect(target.events == [.adjustCursor(2)])
+        #expect(target.documentContextAfterInput == " bar")
+    }
+
+    @Test func regularSwipeBackwardCrossesZWJSequence() throws {
+        let (vm, target) = makeDiscreteViewModel()
+        let key = try spaceKey(vm)
+        target.documentContextBeforeInput = "x👨‍👩‍👧‍👦"
+        let step = KeyboardConstants.SpaceGestures.dragStep
+        vm.handleSlide(key, phase: .began)
+        vm.handleSlide(key, phase: .changed(deltaX: -step * 2))
+        vm.handleSlide(key, phase: .ended)
+        // The whole family emoji (11 UTF-16 units) is a single step.
+        #expect(target.events == [.adjustCursor(-11)])
+        #expect(target.documentContextBeforeInput == "x")
     }
 }

--- a/wurstfingerTests/TestHelpers.swift
+++ b/wurstfingerTests/TestHelpers.swift
@@ -38,6 +38,23 @@ final class MockTextTarget: TextInputTarget {
 
     func adjustTextPosition(byCharacterOffset offset: Int) {
         events.append(.adjustCursor(offset))
+        // Mirror UIKit: `adjustTextPosition(byCharacterOffset:)` moves by
+        // UTF-16 code units, so apply the offset over the UTF-16 view of the
+        // buffer. Landing inside a surrogate pair produces U+FFFD replacement
+        // characters, which makes unit mismatches visible in test assertions.
+        var before = Array((documentContextBeforeInput ?? "").utf16)
+        var after = Array((documentContextAfterInput ?? "").utf16)
+        if offset > 0 {
+            let moved = min(offset, after.count)
+            before.append(contentsOf: after.prefix(moved))
+            after.removeFirst(moved)
+        } else if offset < 0 {
+            let moved = min(-offset, before.count)
+            after.insert(contentsOf: before.suffix(moved), at: 0)
+            before.removeLast(moved)
+        }
+        documentContextBeforeInput = String(decoding: before, as: UTF16.self)
+        documentContextAfterInput = String(decoding: after, as: UTF16.self)
     }
 }
 


### PR DESCRIPTION
## Problem

`UITextDocumentProxy.adjustTextPosition(byCharacterOffset:)` moves the cursor by **UTF-16 code units** in practice, despite its parameter name. The pipeline was passing offsets counted in Swift `Character`s (grapheme clusters), so every offset was too small whenever the surrounding text contained non-BMP characters:

- **Word jumps** (discrete space-bar return swipe): `forwardWordOffset` / `backwardWordOffset` counted graphemes. Jumping across `foo 👍🏽 bar` under-moved and landed the caret inside a word or in the middle of the emoji cluster (👍🏽 = 4 UTF-16 units, counted as 1).
- **±1 cursor steps** (continuous and discrete space-bar slide): each step passed `±1`, so the caret got stuck at or half-crossed an emoji (👍 = 2 units, family ZWJ sequence 👨‍👩‍👧‍👦 = 11 units).
- **`deleteForward`** (`AdvancedTextMiddleware`): adjusted by a fixed `+1` and then called `deleteBackward`, landing mid-surrogate-pair before an emoji and deleting the wrong character.

## Fix

Pipeline reasoning stays in graphemes (reading `documentContextBefore/AfterInput`); conversion to UTF-16 happens where offsets are produced:

- `forwardWordOffset` / `backwardWordOffset` still iterate graphemes for whitespace/word classification but sum `char.utf16.count` (`KeyboardViewModel+Pipeline.swift`).
- New `singleGraphemeOffset(direction:)` helper reads the grapheme cluster adjacent to the cursor and returns its full UTF-16 width (falls back to 1 with no context). Used by continuous stepping and the discrete single-character swipe.
- `deleteForward` adjusts by the UTF-16 width of the next grapheme instead of a fixed `+1`.
- `TextInputTarget.adjustTextPosition` is now documented as taking UTF-16 code units; `DocumentProxyTarget` forwards unchanged (offsets already converted upstream).

## Mock change

`MockTextTarget.adjustTextPosition` previously only recorded the offset as an opaque `Int`, so tests could not catch unit mismatches. It now applies the offset over the UTF-16 view of its before/after buffer, mirroring UIKit behavior. Landing inside a surrogate pair produces U+FFFD replacement characters, making wrong offsets visible in assertions.

## Tests

New Swift Testing cases (all existing ASCII tests unchanged and passing):

- Word offsets: surrogate pair (👍 = 2), skin-tone modifier (👍🏽 = 4), ZWJ family sequence (👨‍👩‍👧‍👦 = 11)
- Discrete return swipe (word jump) across emoji, forward and backward, verifying the caret lands exactly on the cluster boundary
- Discrete ±1 swipe and continuous slide crossing a whole emoji cluster in one step
- `deleteForward` before surrogate-pair, skin-tone, and ZWJ emoji, verifying the emoji is deleted cleanly

## Verification note

`adjustTextPosition`'s UTF-16 behavior is under-documented (the API name says "character offset", but it moves by UTF-16 code units in practice). On-device verification with emoji content (word jumps, cursor slide, delete-forward in a real text field) is recommended before release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cursor movement, deletion, and swipe/slide gestures now correctly account for emoji and other multi-code-unit characters, preventing cursor landing mid-character and ensuring deletion targets the right range.
  * Space-bar dragging and word-based navigation now move by grapheme-cluster boundaries using UTF-16 unit offsets.
* **Documentation**
  * Updated inline guidance for text-position adjustments to clarify offsets are interpreted in UTF-16 code units.
* **Tests**
  * Expanded coverage for surrogate-pair, skin-tone modifier, and ZWJ family emoji sequences, including updated mock behavior and cursor/deletion assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->