### PR TITLE
Handle Touch Cancellation in Gesture Handlers

### DIFF
--- a/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
@@ -16,6 +16,55 @@ struct GestureClassification {
     let isReturn: Bool
 }
 
+/// Touch-sequence state backing `KeyGestureRecognizer`.
+///
+/// Extracted as a pure value type so sequence tracking and cancellation
+/// recovery can be unit-tested without rendering SwiftUI views.
+struct KeyGestureSequence {
+    private var positions: RingBuffer<CGPoint>
+
+    init(capacity: Int = KeyboardConstants.Gesture.positionBufferSize) {
+        positions = RingBuffer<CGPoint>(capacity: capacity)
+    }
+
+    /// Whether a touch sequence is currently being recorded.
+    var isTracking: Bool {
+        !positions.isEmpty
+    }
+
+    /// Records one `onChanged` sample. Returns true when this sample is the
+    /// first contact of a new sequence (touch down).
+    mutating func handleChanged(translation: CGSize) -> Bool {
+        let isTouchDown = positions.isEmpty
+        if isTouchDown {
+            positions.append(.zero)
+        }
+        positions.append(CGPoint(x: translation.width, y: translation.height))
+        return isTouchDown
+    }
+
+    /// Records the final sample and classifies the completed sequence.
+    mutating func handleEnded(translation: CGSize, aspectRatio: CGFloat) -> GestureClassification {
+        defer { positions.removeAll() }
+        if positions.isEmpty {
+            positions.append(.zero)
+        }
+        positions.append(CGPoint(x: translation.width, y: translation.height))
+        return KeyGestureRecognizer.classify(
+            positions: KeyGestureRecognizer.anchoringOrigin(positions.elements),
+            aspectRatio: aspectRatio
+        )
+    }
+
+    /// Discards the partial sequence after the system cancelled the touches
+    /// (`onEnded` is never called for cancelled gestures). Without this, the
+    /// next touch would skip touch-down handling and append onto the stale
+    /// path, misclassifying a tap as the previous gesture's swipe.
+    mutating func handleCancelled() {
+        positions.removeAll()
+    }
+}
+
 /// Reusable gesture recognition logic used by `KeyView`.
 ///
 /// Wraps the existing `GesturePreprocessor` + `GestureFeatures` pipeline and
@@ -30,48 +79,46 @@ struct KeyGestureRecognizer: ViewModifier {
     /// Key aspect ratio forwarded to the preprocessor for normalization.
     let aspectRatio: CGFloat
 
-    @State private var positions = RingBuffer<CGPoint>(
-        capacity: KeyboardConstants.Gesture.positionBufferSize
-    )
+    @State private var sequence = KeyGestureSequence()
     @Binding var isActive: Bool
+
+    /// True while a touch sequence is in flight. Unlike `@State`, SwiftUI
+    /// guarantees `@GestureState` is reset when the system cancels the
+    /// touches (incoming call, edge swipe, keyboard dismissal), where
+    /// `onEnded` is never called — the reset is our cancellation signal.
+    @GestureState private var sequenceInFlight = false
 
     func body(content: Content) -> some View {
         content
             .gesture(
                 DragGesture(minimumDistance: 0)
+                    .updating($sequenceInFlight) { _, inFlight, _ in
+                        inFlight = true
+                    }
                     .onChanged { value in
-                        if positions.isEmpty {
+                        if sequence.handleChanged(translation: value.translation) {
                             onTouchDown()
-                            positions.append(.zero)
                         }
-                        let point = CGPoint(
-                            x: value.translation.width,
-                            y: value.translation.height
-                        )
-                        positions.append(point)
                         isActive = true
                     }
                     .onEnded { value in
-                        defer {
-                            positions.removeAll()
-                            isActive = false
-                        }
-                        if positions.isEmpty {
-                            positions.append(.zero)
-                        }
-                        positions.append(
-                            CGPoint(
-                                x: value.translation.width,
-                                y: value.translation.height
-                            )
-                        )
-                        let classification = Self.classify(
-                            positions: Self.anchoringOrigin(positions.elements),
+                        let classification = sequence.handleEnded(
+                            translation: value.translation,
                             aspectRatio: aspectRatio
                         )
+                        isActive = false
                         onGestureRecognized(classification)
                     }
             )
+            .onChange(of: sequenceInFlight) { _, inFlight in
+                // A normal end already cleared the sequence in `onEnded`; if
+                // the sequence stops while samples remain, the system
+                // cancelled the touches. Discard the partial gesture without
+                // classifying it.
+                guard !inFlight, sequence.isTracking else { return }
+                sequence.handleCancelled()
+                isActive = false
+            }
     }
 
     /// Guarantees the touch-down origin `(0,0)` is the first sample.

--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -10,7 +10,7 @@
 import SwiftUI
 
 /// Phase of a slide gesture lifecycle.
-enum SlidePhase {
+enum SlidePhase: Equatable {
     /// First drag movement detected beyond activation threshold.
     case began
     /// Continuous drag update with horizontal delta since last report.
@@ -19,6 +19,84 @@ enum SlidePhase {
     case ended
     /// Drag ended without exceeding the slide activation threshold → tap.
     case tap
+    /// Touch sequence was cancelled by the system (incoming call, edge
+    /// swipe, keyboard dismissal mid-drag). Consumers must discard drag
+    /// state without committing any input.
+    case cancelled
+}
+
+/// State machine backing `SlideGestureHandler`.
+///
+/// Extracted as a pure value type so tap/slide classification and
+/// cancellation recovery can be unit-tested without rendering SwiftUI views.
+struct SlideGestureState {
+    private(set) var dragStarted = false
+    private(set) var isSliding = false
+    private(set) var lastTranslationX: CGFloat = 0
+
+    /// Events produced by a single drag update.
+    struct Update: Equatable {
+        var isTouchDown = false
+        var phases: [SlidePhase] = []
+    }
+
+    /// Processes one `onChanged` sample.
+    mutating func handleChanged(translation: CGSize, activationThreshold: CGFloat) -> Update {
+        var update = Update()
+        if !dragStarted {
+            dragStarted = true
+            update.isTouchDown = true
+        }
+
+        let currentX = translation.width
+
+        if !isSliding, abs(currentX) >= activationThreshold {
+            isSliding = true
+            // Anchor at the threshold crossing (not the full translation) so
+            // the travel beyond the threshold is reported on the same tick
+            // instead of being dropped — otherwise the first `threshold`
+            // points are a dead zone.
+            lastTranslationX = currentX < 0 ? -activationThreshold : activationThreshold
+            update.phases.append(.began)
+        }
+
+        if isSliding {
+            let deltaX = currentX - lastTranslationX
+            if deltaX != 0 {
+                lastTranslationX = currentX
+                update.phases.append(.changed(deltaX: deltaX))
+            }
+        }
+
+        return update
+    }
+
+    /// Processes `onEnded`. Returns the phase to report, or nil when the
+    /// gesture qualifies as neither a slide nor a tap.
+    mutating func handleEnded(translation: CGSize, activationThreshold: CGFloat) -> SlidePhase? {
+        defer { reset() }
+        if isSliding { return .ended }
+        // A tap must stay near its origin on *both* axes. Gating on
+        // horizontal travel alone would classify a vertical flick (e.g.
+        // 80 pt up on the space bar) as a tap and commit its center action.
+        let displacement = hypot(translation.width, translation.height)
+        return displacement < activationThreshold ? .tap : nil
+    }
+
+    /// Processes a system cancellation of the touch sequence (`onEnded` is
+    /// never called for cancelled gestures). Resets all state so the next
+    /// touch starts a fresh sequence instead of computing deltas against a
+    /// stale anchor; returns `.cancelled` when a drag was in flight.
+    mutating func handleCancelled() -> SlidePhase? {
+        defer { reset() }
+        return dragStarted ? .cancelled : nil
+    }
+
+    private mutating func reset() {
+        dragStarted = false
+        isSliding = false
+        lastTranslationX = 0
+    }
 }
 
 /// Gesture handler for keys with `slideType != .none`.
@@ -33,56 +111,54 @@ struct SlideGestureHandler: ViewModifier {
     let onTouchDown: () -> Void
     @Binding var isActive: Bool
 
-    @State private var dragStarted = false
-    @State private var isSliding = false
-    @State private var lastTranslationX: CGFloat = 0
+    @State private var state = SlideGestureState()
+
+    /// True while a touch sequence is in flight. Unlike `@State`, SwiftUI
+    /// guarantees `@GestureState` is reset when the system cancels the
+    /// touches (incoming call, edge swipe, keyboard dismissal), where
+    /// `onEnded` is never called — the reset is our cancellation signal.
+    @GestureState private var sequenceInFlight = false
 
     func body(content: Content) -> some View {
         content
             .gesture(
                 DragGesture(minimumDistance: 0)
+                    .updating($sequenceInFlight) { _, inFlight, _ in
+                        inFlight = true
+                    }
                     .onChanged { value in
-                        if !dragStarted {
-                            dragStarted = true
+                        let update = state.handleChanged(
+                            translation: value.translation,
+                            activationThreshold: activationThreshold
+                        )
+                        if update.isTouchDown {
                             onTouchDown()
                         }
-
-                        let currentX = value.translation.width
-
-                        if !isSliding {
-                            let threshold = activationThreshold
-                            if abs(currentX) >= threshold {
-                                isSliding = true
-                                isActive = true
-                                // Anchor at the threshold crossing (not the full
-                                // translation) so the travel beyond the threshold
-                                // is reported on the same tick instead of being
-                                // dropped — otherwise the first `threshold` points
-                                // are a dead zone.
-                                lastTranslationX = currentX < 0 ? -threshold : threshold
-                                onSlide(.began)
-                            }
+                        for phase in update.phases {
+                            onSlide(phase)
                         }
-
-                        if isSliding {
-                            let deltaX = currentX - lastTranslationX
-                            if deltaX != 0 {
-                                lastTranslationX = currentX
-                                onSlide(.changed(deltaX: deltaX))
-                            }
-                        }
-
                         isActive = true
                     }
-                    .onEnded { _ in
-                        defer { reset() }
-                        if isSliding {
-                            onSlide(.ended)
-                        } else {
-                            onSlide(.tap)
+                    .onEnded { value in
+                        if let phase = state.handleEnded(
+                            translation: value.translation,
+                            activationThreshold: activationThreshold
+                        ) {
+                            onSlide(phase)
                         }
+                        isActive = false
                     }
             )
+            .onChange(of: sequenceInFlight) { _, inFlight in
+                // A normal end already reset the state machine in `onEnded`;
+                // if the sequence stops while a drag is still marked as in
+                // flight, the system cancelled the touches.
+                guard !inFlight else { return }
+                if let phase = state.handleCancelled() {
+                    onSlide(phase)
+                }
+                isActive = false
+            }
     }
 
     private var activationThreshold: CGFloat {
@@ -94,12 +170,5 @@ struct SlideGestureHandler: ViewModifier {
         case .none:
             .infinity
         }
-    }
-
-    private func reset() {
-        dragStarted = false
-        isSliding = false
-        lastTranslationX = 0
-        isActive = false
     }
 }

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -305,6 +305,12 @@ extension KeyboardViewModel {
             isSpaceDragging = false
             spaceDragResidual = 0
             spaceDragPeak = 0
+        case .cancelled:
+            // System cancelled the touches mid-drag: discard the drag state
+            // without committing a discrete move or a tap.
+            isSpaceDragging = false
+            spaceDragResidual = 0
+            spaceDragPeak = 0
         case .tap:
             handleGesture(.tap, keyId: key.id, isReturn: false)
         }
@@ -406,7 +412,7 @@ extension KeyboardViewModel {
                 feedbackDrag()
                 deleteDragResidual -= step
             }
-        case .ended:
+        case .ended, .cancelled:
             isDeleteDragging = false
             deleteDragResidual = 0
         case .tap:

--- a/wurstfingerTests/KeyGestureSequenceTests.swift
+++ b/wurstfingerTests/KeyGestureSequenceTests.swift
@@ -1,0 +1,76 @@
+//
+//  KeyGestureSequenceTests.swift
+//  WurstfingerTests
+//
+//  Tests for KeyGestureSequence, the touch-sequence state machine backing
+//  KeyGestureRecognizer: touch-down detection and recovery from system
+//  touch cancellation. These need no SwiftUI rendering.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct KeyGestureSequenceTests {
+    /// Feeds a horizontal rightward drag into the sequence.
+    private func feedRightwardSwipe(into sequence: inout KeyGestureSequence) {
+        for x in stride(from: 10, through: 60, by: 10) {
+            _ = sequence.handleChanged(translation: CGSize(width: CGFloat(x), height: 0))
+        }
+    }
+
+    @Test func firstChangeReportsTouchDown() {
+        var sequence = KeyGestureSequence()
+        let first = sequence.handleChanged(translation: CGSize(width: 1, height: 0))
+        let second = sequence.handleChanged(translation: CGSize(width: 2, height: 0))
+        #expect(first)
+        #expect(!second)
+        #expect(sequence.isTracking)
+    }
+
+    @Test func endedSwipeClassifiesAndClears() {
+        var sequence = KeyGestureSequence()
+        feedRightwardSwipe(into: &sequence)
+        let classification = sequence.handleEnded(
+            translation: CGSize(width: 60, height: 0), aspectRatio: 1.0
+        )
+        #expect(classification.gesture == .swipeRight)
+        #expect(!sequence.isTracking)
+    }
+
+    @Test func cancellationClearsSequence() {
+        var sequence = KeyGestureSequence()
+        feedRightwardSwipe(into: &sequence)
+        #expect(sequence.isTracking)
+        sequence.handleCancelled()
+        #expect(!sequence.isTracking)
+    }
+
+    @Test func touchAfterCancellationIsANewTouchDown() {
+        var sequence = KeyGestureSequence()
+        feedRightwardSwipe(into: &sequence)
+        sequence.handleCancelled()
+        // Without the reset, the next touch would skip touch-down handling
+        // (no haptic feedback) because samples were still buffered.
+        let isTouchDown = sequence.handleChanged(translation: CGSize(width: 1, height: 0))
+        #expect(isTouchDown)
+    }
+
+    @Test func tapAfterCancelledSwipeClassifiesAsTap() {
+        var sequence = KeyGestureSequence()
+        // A rightward swipe is cancelled by the system mid-gesture …
+        feedRightwardSwipe(into: &sequence)
+        sequence.handleCancelled()
+
+        // … then the user taps the key. With the stale path still buffered,
+        // the tap's samples would append onto the swipe and classify as a
+        // rightward swipe; a fresh sequence classifies it as a tap.
+        _ = sequence.handleChanged(translation: CGSize(width: 1, height: 1))
+        let classification = sequence.handleEnded(
+            translation: CGSize(width: 1, height: 1), aspectRatio: 1.0
+        )
+        #expect(classification.gesture == .tap)
+        #expect(!classification.isReturn)
+    }
+}

--- a/wurstfingerTests/SlideGestureStateTests.swift
+++ b/wurstfingerTests/SlideGestureStateTests.swift
@@ -1,0 +1,179 @@
+//
+//  SlideGestureStateTests.swift
+//  WurstfingerTests
+//
+//  Tests for the SlideGestureState machine backing SlideGestureHandler:
+//  tap/slide classification (including vertical drags) and recovery from
+//  system touch cancellation. These need no SwiftUI rendering.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct SlideGestureStateTests {
+    /// Space-bar activation threshold used throughout these tests.
+    private let threshold = KeyboardConstants.SpaceGestures.dragActivationThreshold
+
+    // MARK: - Basic classification
+
+    @Test func firstChangeReportsTouchDown() {
+        var state = SlideGestureState()
+        let update = state.handleChanged(
+            translation: CGSize(width: 1, height: 0), activationThreshold: threshold
+        )
+        #expect(update.isTouchDown)
+        let second = state.handleChanged(
+            translation: CGSize(width: 2, height: 0), activationThreshold: threshold
+        )
+        #expect(!second.isTouchDown)
+    }
+
+    @Test func smallMovementEndsAsTap() {
+        var state = SlideGestureState()
+        _ = state.handleChanged(
+            translation: CGSize(width: 2, height: 2), activationThreshold: threshold
+        )
+        let phase = state.handleEnded(
+            translation: CGSize(width: 2, height: 2), activationThreshold: threshold
+        )
+        #expect(phase == .tap)
+    }
+
+    @Test func horizontalDragBeyondThresholdSlides() {
+        var state = SlideGestureState()
+        let update = state.handleChanged(
+            translation: CGSize(width: threshold + 4, height: 0),
+            activationThreshold: threshold
+        )
+        // Anchored at the threshold crossing: the overshoot is reported
+        // immediately instead of being dropped.
+        #expect(update.phases == [.began, .changed(deltaX: 4)])
+        let phase = state.handleEnded(
+            translation: CGSize(width: threshold + 4, height: 0),
+            activationThreshold: threshold
+        )
+        #expect(phase == .ended)
+    }
+
+    // MARK: - Vertical drags are not taps (Bug 2)
+
+    @Test func verticalFlickIsNotATap() {
+        var state = SlideGestureState()
+        // 80 pt vertical flick with almost no horizontal travel: previously
+        // classified as a tap (space inserted / character deleted).
+        _ = state.handleChanged(
+            translation: CGSize(width: 2, height: 40), activationThreshold: threshold
+        )
+        _ = state.handleChanged(
+            translation: CGSize(width: 2, height: 80), activationThreshold: threshold
+        )
+        let phase = state.handleEnded(
+            translation: CGSize(width: 2, height: 80), activationThreshold: threshold
+        )
+        #expect(phase == nil)
+    }
+
+    @Test func diagonalDisplacementBeyondThresholdIsNotATap() {
+        var state = SlideGestureState()
+        // Horizontal travel alone is under the threshold, but the total
+        // displacement is not — this is a drag, not a tap.
+        let translation = CGSize(width: threshold * 0.75, height: threshold * 0.75)
+        _ = state.handleChanged(translation: translation, activationThreshold: threshold)
+        let phase = state.handleEnded(translation: translation, activationThreshold: threshold)
+        #expect(phase == nil)
+    }
+
+    // MARK: - Touch cancellation (Bug 1)
+
+    @Test func cancellationMidSlideReportsCancelled() {
+        var state = SlideGestureState()
+        _ = state.handleChanged(
+            translation: CGSize(width: threshold + 50, height: 0),
+            activationThreshold: threshold
+        )
+        #expect(state.handleCancelled() == .cancelled)
+    }
+
+    @Test func cancellationBeforeSlideReportsCancelled() {
+        var state = SlideGestureState()
+        _ = state.handleChanged(
+            translation: CGSize(width: 2, height: 0), activationThreshold: threshold
+        )
+        #expect(state.handleCancelled() == .cancelled)
+    }
+
+    @Test func cancellationWithoutTouchReportsNothing() {
+        var state = SlideGestureState()
+        #expect(state.handleCancelled() == nil)
+    }
+
+    @Test func sequenceAfterCancellationStartsFresh() {
+        var state = SlideGestureState()
+        // Drag far to the right, then get cancelled by the system.
+        _ = state.handleChanged(
+            translation: CGSize(width: 100, height: 0), activationThreshold: threshold
+        )
+        _ = state.handleCancelled()
+
+        // Next touch: a small movement must be a fresh touch-down with no
+        // phases — a stale anchor would replay a large negative delta here
+        // (burst of deletions on the delete key, cursor jump on space).
+        let update = state.handleChanged(
+            translation: CGSize(width: 2, height: 0), activationThreshold: threshold
+        )
+        #expect(update.isTouchDown)
+        #expect(update.phases.isEmpty)
+
+        // And crossing the threshold anchors at the threshold, not at the
+        // previous gesture's translation.
+        let sliding = state.handleChanged(
+            translation: CGSize(width: threshold + 2, height: 0),
+            activationThreshold: threshold
+        )
+        #expect(sliding.phases == [.began, .changed(deltaX: 2)])
+    }
+
+    @Test func sequenceAfterNormalEndStartsFresh() {
+        var state = SlideGestureState()
+        _ = state.handleChanged(
+            translation: CGSize(width: 100, height: 0), activationThreshold: threshold
+        )
+        _ = state.handleEnded(
+            translation: CGSize(width: 100, height: 0), activationThreshold: threshold
+        )
+
+        let update = state.handleChanged(
+            translation: CGSize(width: 2, height: 0), activationThreshold: threshold
+        )
+        #expect(update.isTouchDown)
+        #expect(update.phases.isEmpty)
+    }
+}
+
+// MARK: - ViewModel handling of .cancelled
+
+@Suite(.serialized)
+struct SlideCancellationPipelineTests {
+    @Test func cancelledSpaceSlideResetsDragStateWithoutInput() throws {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+        let spaceKey = try #require(vm.activeModeFromDefinition?.key(for: UtilitySlot.space))
+        vm.handleSlide(spaceKey, phase: .began)
+        #expect(vm.isSpaceDragging)
+        vm.handleSlide(spaceKey, phase: .cancelled)
+        #expect(!vm.isSpaceDragging)
+        #expect(target.events.isEmpty)
+    }
+
+    @Test func cancelledDeleteSlideResetsDragStateWithoutInput() throws {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+        target.documentContextBeforeInput = "hello"
+        let deleteKey = try #require(vm.activeModeFromDefinition?.key(for: UtilitySlot.delete))
+        vm.handleSlide(deleteKey, phase: .began)
+        #expect(vm.isDeleteDragging)
+        vm.handleSlide(deleteKey, phase: .cancelled)
+        #expect(!vm.isDeleteDragging)
+        #expect(target.events.isEmpty)
+    }
+}


### PR DESCRIPTION
## Bugs

**1. No touch-cancellation handling in gesture handlers (major).**
SwiftUI's `DragGesture` never calls `.onEnded` when the system cancels the touch sequence (incoming call, control-center edge swipe, keyboard dismissal mid-drag). Both gesture handlers only reset their state in `.onEnded`, so after a cancellation:

- `SlideGestureHandler` kept a stale drag anchor (`lastTranslationX`) and stale `dragStarted`/`isSliding`. The next touch on the delete key computed its first delta against that stale anchor and replayed a burst of deletions (data loss); on the space bar it produced a cursor jump. The view model's `isSpaceDragging`/`isDeleteDragging` flags also stuck `true`.
- `KeyGestureRecognizer` never cleared its `positions` ring buffer and `isActive` stuck `true` (key stayed highlighted). The next touch skipped `onTouchDown` (no haptic) and appended onto the old path, so a plain tap could misclassify as a swipe in the previous gesture's direction.

**2. Vertical drags on space/delete misclassified as taps (minor).**
Tap classification looked only at `translation.width`. An 80 pt vertical flick on the space bar (<8 pt horizontal) inserted a space; on the delete key it deleted a character.

## Fix

- Cancellation is detected with `@GestureState`, which SwiftUI guarantees to reset when a sequence ends without `.onEnded`. An `onChange` on that flag discards the partial gesture: `SlideGestureHandler` reports a new `SlidePhase.cancelled` (the view model resets its drag flags and residuals without committing a discrete move or tap), and `KeyGestureRecognizer` drops the buffered path without classifying it. Both handlers also reset `isActive` so keys don't stay highlighted.
- Slide-key taps are now classified by total displacement (`hypot(width, height)`) instead of horizontal travel alone; a drag that ends beyond the threshold without ever activating the slide is ignored rather than committed as a tap.
- Both handlers' state machines are extracted into pure value types (`SlideGestureState`, `KeyGestureSequence`) so this behavior is unit-testable without rendering SwiftUI views. The gesture wiring in `KeyView`/`DataDrivenKeyboardRootView` is unchanged.

## Tests

New Swift Testing suites, all passing on iPhone 17 Pro simulator:

- `SlideGestureStateTests` — tap vs. slide classification, threshold anchoring, vertical flick is not a tap, diagonal displacement is not a tap, `.cancelled` reporting, fresh sequence after cancellation (no stale-anchor delta burst) and after normal end.
- `SlideCancellationPipelineTests` — `.cancelled` resets `isSpaceDragging`/`isDeleteDragging` without emitting any text-input events.
- `KeyGestureSequenceTests` — touch-down detection, classification on end, sequence cleared on cancellation, tap after a cancelled swipe classifies as a tap (not the stale swipe direction).

Existing gesture/cursor suites (`CursorMovementPipelineTests`, `DiscreteCursorMovementTests`, `KeyGestureClassificationTests`, `OriginAnchoringTests`) still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more reliable gesture handling for keyboard swipes and taps, including better cancellation awareness.
  * Swipe actions now track in-progress movement more consistently for smoother interactions.

* **Bug Fixes**
  * Fixed cases where cancelled drags could leave gestures stuck or trigger unintended actions.
  * Improved tap detection so vertical or diagonal movement is less likely to be misread as a tap.
  * Reset drag state correctly after cancellations for space and delete gestures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->