### PR TITLE
Add Hebrew Final Letters via Return Swipes

### DIFF
--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -83,6 +83,11 @@ enum GridKeyboardFactory {
                 // uppercasing is the identity, e.g. Hebrew final forms (כ → ך).
                 if let returns = returnOverrides[slotId] {
                     for (gesture, text) in returns {
+                        guard gesture.isSwipe else {
+                            preconditionFailure(
+                                "returnOverrides[\(slotId)][\(gesture)] must target a swipe gesture"
+                            )
+                        }
                         guard let base = bindings[gesture] else {
                             preconditionFailure(
                                 "returnOverrides[\(slotId)][\(gesture)] has no base binding"

--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -19,6 +19,10 @@ enum GridKeyboardFactory {
     ///   - localeIdentifier: Locale string for uppercasing (e.g. "de_DE")
     ///   - centerCharacters: 3x3 grid of center tap characters
     ///   - directionalOverrides: Per-slot overrides that replace CommonKeys defaults
+    ///   - returnOverrides: Per-slot return-swipe outputs that replace the
+    ///     auto-generated uppercase return action (e.g. Hebrew final forms:
+    ///     a return swipe on כ produces ך). Each entry must target a gesture
+    ///     that already has a binding on that slot.
     ///   - numericBackToAlphaLabel: Label shown on the symbols key in numeric
     ///     mode that switches back to the main (alphabetic) layer. Defaults to
     ///     the Latin "abc"; non-Latin layouts (Hebrew, Russian, …) should
@@ -32,6 +36,7 @@ enum GridKeyboardFactory {
         localeIdentifier: String,
         centerCharacters: [[String]],
         directionalOverrides: [String: [GestureType: String]] = [:],
+        returnOverrides: [String: [GestureType: String]] = [:],
         numericBackToAlphaLabel: String = NumericLayouts.defaultBackToAlphaLabel,
         inputMethod: InputMethodKind = .direct
     ) -> KeyboardDefinition {
@@ -72,6 +77,24 @@ enum GridKeyboardFactory {
                     label: char, action: .commitText(char),
                     category: nil, returnAction: nil, accessibilityLabel: nil
                 )
+
+                // Apply explicit return-swipe outputs (replace the auto-generated
+                // uppercase return action). Needed for caseless scripts where
+                // uppercasing is the identity, e.g. Hebrew final forms (כ → ך).
+                if let returns = returnOverrides[slotId] {
+                    for (gesture, text) in returns {
+                        guard let base = bindings[gesture] else {
+                            preconditionFailure(
+                                "returnOverrides[\(slotId)][\(gesture)] has no base binding"
+                            )
+                        }
+                        bindings[gesture] = KeyBinding(
+                            label: base.label, action: base.action,
+                            category: base.category, returnAction: .commitText(text),
+                            accessibilityLabel: base.accessibilityLabel
+                        )
+                    }
+                }
 
                 letterKeys[slotId] = KeyConfig(
                     id: slotId, bindings: bindings, swipeMode: .eightWay,

--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
@@ -248,6 +248,14 @@ enum LanguageDefinitions {
                 GridSlot.bottomCenter: [.swipeUp: "ס"],
                 GridSlot.bottomRight: [.swipeUpLeft: "ט"],
             ],
+            // MessagEase convention: a return swipe on a base letter produces
+            // its final form (ן/ם additionally keep their dedicated swipes).
+            returnOverrides: [
+                GridSlot.topRight: [.swipeDownLeft: "ץ"],
+                GridSlot.center: [
+                    .swipeUpRight: "ף", .swipeDown: "ן", .swipeDownLeft: "ך",
+                ],
+            ],
             numericBackToAlphaLabel: "אבג"
         )
     }

--- a/wurstfingerTests/ReturnSwipeLanguageTests.swift
+++ b/wurstfingerTests/ReturnSwipeLanguageTests.swift
@@ -28,6 +28,9 @@ struct ReturnSwipeLanguageTests {
 
     /// Regression guard: for every language, the center key's return swipe overrides
     /// for letter bindings should match the uppercased version of the regular swipe output.
+    /// Caseless letters (uppercasing is the identity) are exempt — there the return
+    /// swipe may carry an explicit `returnOverrides` output instead (e.g. Hebrew
+    /// final forms: return swipe on כ produces ך).
     @Test func centerKeyReturnSwipeMatchesUppercasedSwipeForAllLanguages() {
         for info in KeyboardRegistry.available {
             guard let definition = KeyboardRegistry.load(id: info.id) else {
@@ -65,11 +68,74 @@ struct ReturnSwipeLanguageTests {
                 else { continue }
 
                 let expected = swipeText.uppercased(with: locale)
+
+                // Caseless letters have no meaningful uppercase — explicit
+                // return overrides (final forms) are legitimate there.
+                guard expected != swipeText else { continue }
                 #expect(
                     returnText == expected,
                     "[\(info.id)] center key return swipe \(gesture): expected '\(expected)', got '\(returnText)'"
                 )
             }
         }
+    }
+}
+
+// MARK: - Hebrew Final Letters
+
+/// The Hebrew layout must be able to produce all five final letters
+/// (ך ם ן ף ץ). Following the MessagEase convention, a return swipe on a
+/// base letter produces its final form; ן and ם additionally keep their
+/// dedicated directional swipes.
+@Suite(.serialized)
+struct HebrewFinalLetterTests {
+    static let hebrew = LanguageDefinitions.hebrew.makeDefinition()
+
+    @Test func returnSwipeBindingsProduceFinalForms() throws {
+        let main = try #require(Self.hebrew.modes[ModeNames.main])
+        let center = try #require(main.keys[GridSlot.center])
+        let topRight = try #require(main.keys[GridSlot.topRight])
+
+        // Base letters stay on the regular swipe…
+        #expect(center.bindings[.swipeDownLeft]?.action == .commitText("כ"))
+        #expect(center.bindings[.swipeUpRight]?.action == .commitText("פ"))
+        #expect(center.bindings[.swipeDown]?.action == .commitText("נ"))
+        #expect(topRight.bindings[.swipeDownLeft]?.action == .commitText("צ"))
+
+        // …while the return swipe yields the final form.
+        #expect(center.bindings[.swipeDownLeft]?.returnAction == .commitText("ך"))
+        #expect(center.bindings[.swipeUpRight]?.returnAction == .commitText("ף"))
+        #expect(center.bindings[.swipeDown]?.returnAction == .commitText("ן"))
+        #expect(topRight.bindings[.swipeDownLeft]?.returnAction == .commitText("ץ"))
+    }
+
+    @Test func dedicatedSwipesForFinalNunAndMemArePreserved() throws {
+        let main = try #require(Self.hebrew.modes[ModeNames.main])
+        #expect(main.keys[GridSlot.topLeft]?.bindings[.swipeDownRight]?.action == .commitText("ן"))
+        #expect(main.keys[GridSlot.midLeft]?.bindings[.swipeRight]?.action == .commitText("ם"))
+    }
+
+    @Test func allFiveFinalLettersAreTypableThroughThePipeline() {
+        let (vm, target) = makeViewModel(languageId: "he_IL")
+
+        vm.handleGesture(.swipeDownLeft, keyId: GridSlot.center, isReturn: true) // ך
+        vm.handleGesture(.swipeRight, keyId: GridSlot.midLeft, isReturn: false) // ם
+        vm.handleGesture(.swipeDown, keyId: GridSlot.center, isReturn: true) // ן
+        vm.handleGesture(.swipeUpRight, keyId: GridSlot.center, isReturn: true) // ף
+        vm.handleGesture(.swipeDownLeft, keyId: GridSlot.topRight, isReturn: true) // ץ
+
+        let inserts = target.events.compactMap { if case let .insertText(t) = $0 { t } else { nil } }
+        #expect(inserts == ["ך", "ם", "ן", "ף", "ץ"])
+    }
+
+    @Test func returnSwipeOverridesDoNotChangeRegularSwipeOutput() {
+        let (vm, target) = makeViewModel(languageId: "he_IL")
+
+        vm.handleGesture(.swipeDownLeft, keyId: GridSlot.center, isReturn: false) // כ
+        vm.handleGesture(.swipeUpRight, keyId: GridSlot.center, isReturn: false) // פ
+        vm.handleGesture(.swipeDownLeft, keyId: GridSlot.topRight, isReturn: false) // צ
+
+        let inserts = target.events.compactMap { if case let .insertText(t) = $0 { t } else { nil } }
+        #expect(inserts == ["כ", "פ", "צ"])
     }
 }


### PR DESCRIPTION
## Bug

The Hebrew layout could not type three of the five final letters: **ך** (final kaf), **ף** (final pe), and **ץ** (final tsadi). Common words like דרך, כסף, ארץ, or סוף were impossible to write. Only ן and ם were reachable via dedicated directional swipes (topLeft ↘ and midLeft →).

## Why the finals were unreachable

- **Return swipes:** `GridKeyboardFactory.layout` auto-generates `returnAction = .commitText(text.keyboardUppercased(with: locale))` for letter overrides. Hebrew is caseless, so uppercasing is the identity — a return swipe on כ/פ/צ just re-committed the same base letter.
- **Shifted layer:** `KeyboardMode.generateShifted` uppercases letter bindings, which is also the identity for Hebrew, so the `shifted`/`capsLock` modes are byte-identical copies of `main` and offer no alternate layer either.

## Fix

Following the MessagEase convention, a return swipe on a base letter now produces its final form. This is implemented as a generic, data-driven mechanism:

- `GridKeyboardFactory.layout` gains an optional `returnOverrides: [String: [GestureType: String]]` parameter (per slot, per gesture) that replaces the auto-generated uppercase return action with an explicit output. A precondition guards against overrides that target a gesture without a base binding. Other caseless scripts can reuse this directly.
- The Hebrew definition maps:
  - כ (center ↙) return swipe → **ך**
  - פ (center ↗) return swipe → **ף**
  - נ (center ↓) return swipe → **ן**
  - צ (topRight ↙) return swipe → **ץ**
- The existing dedicated swipes for ן (topLeft ↘) and ם (midLeft →) are kept unchanged — nothing is removed. ם has no return-swipe variant because מ is a tap (center character), and return swipes only exist for swipe gestures.

## Tests

- New `HebrewFinalLetterTests` suite:
  - definition-level: the four return-swipe bindings carry the final forms while the regular swipe output stays the base letter
  - the dedicated ן/ם swipes are preserved
  - pipeline-level: all five final letters (ך ם ן ף ץ) are typable end-to-end through `KeyboardViewModel` → `ActionPipeline` → mock `TextInputTarget`
- `ReturnSwipeLanguageTests.centerKeyReturnSwipeMatchesUppercasedSwipeForAllLanguages` regression guard updated: it now skips caseless letters (where uppercasing is the identity), so explicit final-form overrides are legitimate there while the uppercase rule stays enforced for all cased languages.
- Verified green: `ReturnSwipeLanguageTests`, `HebrewFinalLetterTests`, `LanguageDefinitionValidationTests`, `GermanLayoutTests`, `NumericLayoutTests`, `SlotFactoryShiftedTests`, `LayoutValidationTests`, `KeyboardModeTests`, `KeyboardDefinitionTests`, `ValidationTests`, `CommonKeysFactoryTests`.

**Note (pre-existing, unrelated):** `MultiLanguageTypingTests` intermittently crashes with SIGSEGV in `KeyboardRegistry.load(id:)` (`Dictionary._Variant.setValue`) under parallel test execution — the unsynchronized static `cache` is written concurrently by parallel Swift Testing tasks. Reproduced identically on clean `origin/develop` (and visible in test logs from 2026-06-30), so it is not caused by this change. Worth a follow-up (e.g. a lock around the registry cache).

## Follow-up idea (not included)

For caseless scripts, the `shifted`/`capsLock` modes are byte-identical copies of `main` — two redundant modes per non-cased language (wasted memory in the jetsam-constrained extension). Skipping their generation touches the shift-key bindings and mode-transition validation, so it was left out of this focused fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added language-specific return-swipe overrides for Hebrew to support correct final-form characters, including explicit handling for specific slots and swipe directions.

* **Bug Fixes**
  * Adjusted return-swipe logic so default uppercase-style behavior no longer replaces valid final-form return outputs.
  * Ensured return-swipe overrides do not change normal (non-return) swipe output.

* **Tests**
  * Added and updated Hebrew return-swipe test coverage, including cases for final letters and exempt caseless letter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->