### PR TITLE
Fix Outlier Filter Cascade Discarding Fast Swipes

### DIFF
--- a/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
@@ -41,8 +41,10 @@
 //  1. **Jitter Filter**: Removes points too close together (< jitterThreshold)
 //     - Prevents noise from finger micro-movements
 //
-//  2. **Outlier Filter**: Removes impossible jumps (> maxJumpDistance)
+//  2. **Outlier Filter**: Removes isolated impossible jumps (> maxJumpDistance)
 //     - Handles touch glitches and multitouch interference
+//     - Keeps points consistent with a raw neighbor, so a single dropped-frame
+//       gap cannot cascade and discard the rest of a genuine fast swipe
 //
 //  3. **Aspect Ratio Normalization**: Divides X by aspect ratio
 //     - Makes horizontal and vertical movements comparable on non-square keys
@@ -212,7 +214,16 @@ struct GesturePreprocessor {
 
     // MARK: - Step 2: Outlier Filter
 
-    /// Removes points with physically impossible jumps
+    /// Removes points with physically impossible jumps.
+    ///
+    /// A point is an outlier only when it is farther than `maxJumpDistance`
+    /// from the last accepted point AND from both of its raw neighbors.
+    /// Comparing solely against the last accepted point would cascade: one
+    /// dropped-frame gap leaves the anchor stuck before the gap, so every
+    /// later sample of a genuine fast swipe (or of a re-anchored long drag
+    /// whose retained window sits far from the origin) would be discarded
+    /// too. Consistency with a raw neighbor proves real motion, so only
+    /// isolated glitch points are removed.
     func filterOutliers(_ points: [CGPoint]) -> [CGPoint] {
         guard points.count >= 2 else { return points }
 
@@ -220,15 +231,18 @@ struct GesturePreprocessor {
 
         for i in 1 ..< points.count {
             // Safe: filtered always has at least one element (initialized with points[0])
-            guard let prev = filtered.last else { continue }
+            guard let lastAccepted = filtered.last else { continue }
             let current = points[i]
 
-            let distance = current.distance(to: prev)
+            let nearAccepted = current.distance(to: lastAccepted) <= config.maxJumpDistance
+            let nearRawPrevious = current.distance(to: points[i - 1]) <= config.maxJumpDistance
+            let nearRawNext = i + 1 < points.count &&
+                current.distance(to: points[i + 1]) <= config.maxJumpDistance
 
-            if distance <= config.maxJumpDistance {
+            if nearAccepted || nearRawPrevious || nearRawNext {
                 filtered.append(current)
             }
-            // Outlier: skip this point
+            // Isolated outlier (far from accepted path and both raw neighbors): skip
         }
 
         return filtered

--- a/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
@@ -247,9 +247,9 @@ struct GesturePreprocessor {
             // a sustained run of mutually consistent samples (a re-anchored
             // long drag or a genuine post-gap tail keeps moving; a ghost
             // cluster does not).
-            let ceiling = config.maxJumpDistance * 3
+            let ceiling = config.maxJumpDistance * Self.plausibilityCeilingFactor
             let supportIsPlausible = distanceToAccepted <= ceiling
-                || consistentRunLength(in: points, at: i) >= 3
+                || consistentRunLength(in: points, at: i) >= Self.sustainedRunMinimumLength
 
             if nearAccepted || ((nearRawPrevious || nearRawNext) && supportIsPlausible) {
                 filtered.append(current)
@@ -259,6 +259,15 @@ struct GesturePreprocessor {
 
         return filtered
     }
+
+    /// Raw-neighbor support only counts within this multiple of
+    /// `maxJumpDistance` from the accepted path; farther points need a
+    /// sustained run instead.
+    private static let plausibilityCeilingFactor: CGFloat = 3
+
+    /// A run of at least this many mutually consistent samples counts as
+    /// sustained real motion regardless of distance from the accepted path.
+    private static let sustainedRunMinimumLength = 3
 
     /// Length of the run of mutually consistent raw samples containing
     /// index `i` (consecutive neighbors within `maxJumpDistance`).

--- a/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
@@ -234,18 +234,49 @@ struct GesturePreprocessor {
             guard let lastAccepted = filtered.last else { continue }
             let current = points[i]
 
-            let nearAccepted = current.distance(to: lastAccepted) <= config.maxJumpDistance
+            let distanceToAccepted = current.distance(to: lastAccepted)
+            let nearAccepted = distanceToAccepted <= config.maxJumpDistance
             let nearRawPrevious = current.distance(to: points[i - 1]) <= config.maxJumpDistance
             let nearRawNext = i + 1 < points.count &&
                 current.distance(to: points[i + 1]) <= config.maxJumpDistance
 
-            if nearAccepted || nearRawPrevious || nearRawNext {
+            // Raw-neighbor support alone can be bootstrapped by a clustered
+            // glitch burst: two mutually close ghost points admit each other.
+            // Support therefore only counts while the point stays within a
+            // plausibility ceiling of the accepted path, unless it belongs to
+            // a sustained run of mutually consistent samples (a re-anchored
+            // long drag or a genuine post-gap tail keeps moving; a ghost
+            // cluster does not).
+            let ceiling = config.maxJumpDistance * 3
+            let supportIsPlausible = distanceToAccepted <= ceiling
+                || consistentRunLength(in: points, at: i) >= 3
+
+            if nearAccepted || ((nearRawPrevious || nearRawNext) && supportIsPlausible) {
                 filtered.append(current)
             }
-            // Isolated outlier (far from accepted path and both raw neighbors): skip
+            // Isolated or clustered outlier: skip
         }
 
         return filtered
+    }
+
+    /// Length of the run of mutually consistent raw samples containing
+    /// index `i` (consecutive neighbors within `maxJumpDistance`).
+    private func consistentRunLength(in points: [CGPoint], at i: Int) -> Int {
+        var length = 1
+        var backward = i
+        while backward > 0,
+              points[backward].distance(to: points[backward - 1]) <= config.maxJumpDistance {
+            length += 1
+            backward -= 1
+        }
+        var forward = i
+        while forward + 1 < points.count,
+              points[forward].distance(to: points[forward + 1]) <= config.maxJumpDistance {
+            length += 1
+            forward += 1
+        }
+        return length
     }
 
     // MARK: - Step 3: Aspect Ratio Normalization

--- a/wurstfingerTests/GesturePreprocessorRobustnessTests.swift
+++ b/wurstfingerTests/GesturePreprocessorRobustnessTests.swift
@@ -51,6 +51,20 @@ struct GesturePreprocessorRobustnessTests {
         #expect(GestureType.allCases.contains(classify(points)))
     }
 
+    @Test func fastSwipeWithDroppedFrameGapClassifiesAsSwipe() {
+        // One inter-sample gap > maxJumpDistance (50pt default, e.g. from a
+        // dropped frame) must not discard the tail of a genuine fast flick
+        // and demote it to a tap.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 10, y: 0),
+            CGPoint(x: 20, y: 0),
+            CGPoint(x: 80, y: 0),
+            CGPoint(x: 95, y: 0),
+        ]
+        #expect(classify(points) == .swipeRight)
+    }
+
     @Test func pathLongerThanPositionBufferStaysClassifiable() {
         // More samples than KeyboardConstants.Gesture.positionBufferSize (60),
         // a straight rightward drag — must still classify as a right swipe.

--- a/wurstfingerTests/GesturePreprocessorTests.swift
+++ b/wurstfingerTests/GesturePreprocessorTests.swift
@@ -82,6 +82,50 @@ struct GesturePreprocessorTests {
         #expect(!filtered.contains(CGPoint(x: 100, y: 0)))
     }
 
+    @Test func outlierFilterRemovesTrailingGlitchPoint() {
+        let config = GesturePreprocessorConfig(
+            jitterThreshold: 3.0,
+            maxJumpDistance: 30.0,
+            smoothingWindow: 5,
+            smoothingOrder: 2,
+            aspectRatio: 1.0
+        )
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // A glitch as the final sample has no raw successor and must
+        // still be removed.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 10, y: 0),
+            CGPoint(x: 20, y: 0),
+            CGPoint(x: 150, y: 0) // trailing outlier: jump of 130pt
+        ]
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(filtered == Array(points.prefix(3)))
+    }
+
+    @Test func outlierFilterKeepsTailAfterDroppedFrameGap() {
+        let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // A dropped frame under main-thread load creates one inter-sample
+        // gap > maxJumpDistance in a genuine fast swipe. The points after
+        // the gap are mutually consistent and must not cascade away.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 10, y: 0),
+            CGPoint(x: 20, y: 0),
+            CGPoint(x: 80, y: 0), // 60pt gap: dropped frame, real motion
+            CGPoint(x: 95, y: 0)
+        ]
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(filtered == points)
+    }
+
     // MARK: - Aspect Ratio Normalization Tests
 
     @Test func aspectRatioNormalizationDividesX() {

--- a/wurstfingerTests/GesturePreprocessorTests.swift
+++ b/wurstfingerTests/GesturePreprocessorTests.swift
@@ -126,6 +126,47 @@ struct GesturePreprocessorTests {
         #expect(filtered == points)
     }
 
+    @Test func outlierFilterRemovesClusteredGlitchPair() {
+        let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // Two mutually close ghost points far from the path must not admit
+        // each other via raw-neighbor support: the run is short (2) and the
+        // cluster sits beyond the 3x plausibility ceiling.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 10, y: 0),
+            CGPoint(x: 200, y: 5), // ghost pair, ~190pt off the path
+            CGPoint(x: 205, y: 0),
+            CGPoint(x: 20, y: 0), // real motion resumes
+            CGPoint(x: 30, y: 0)
+        ]
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(filtered == [points[0], points[1], points[4], points[5]])
+    }
+
+    @Test func outlierFilterKeepsSustainedFarRun() {
+        let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // A run of >= 3 mutually consistent samples beyond the ceiling is
+        // sustained real motion (re-anchored long drag), not a ghost cluster.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 10, y: 0),
+            CGPoint(x: 200, y: 0), // far window, but the motion continues
+            CGPoint(x: 210, y: 0),
+            CGPoint(x: 220, y: 0),
+            CGPoint(x: 230, y: 0)
+        ]
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(filtered == points)
+    }
+
     // MARK: - Aspect Ratio Normalization Tests
 
     @Test func aspectRatioNormalizationDividesX() {

--- a/wurstfingerTests/OriginAnchoringTests.swift
+++ b/wurstfingerTests/OriginAnchoringTests.swift
@@ -54,4 +54,21 @@ struct OriginAnchoringTests {
         #expect(classification.isReturn)
         #expect(classification.gesture == .swipeRight)
     }
+
+    @Test func longDragWithFarOutRetainedWindowClassifiesAsSwipe() {
+        // A long slow drag overflowed the ring buffer and the retained
+        // window sits entirely beyond maxJumpDistance (50pt) from the
+        // origin. The synthetic (0,0) → first-sample jump must not make
+        // the outlier filter discard the whole gesture (which would
+        // classify the drag as a tap).
+        var evicted: [CGPoint] = []
+        for x in stride(from: 100, through: 160, by: 4) {
+            evicted.append(CGPoint(x: CGFloat(x), y: 0))
+        }
+
+        let anchored = KeyGestureRecognizer.anchoringOrigin(evicted)
+        let classification = KeyGestureRecognizer.classify(positions: anchored)
+        #expect(classification.gesture == .swipeRight)
+        #expect(!classification.isReturn)
+    }
 }


### PR DESCRIPTION
## Problem

`GesturePreprocessor.filterOutliers` compared every sample against the **last accepted** point, and that anchor never advanced past a rejected sample. This caused two real failure scenarios:

1. **Dropped-frame cascade**: One inter-sample gap > `maxJumpDistance` (default 50pt, e.g. a dropped frame under main-thread load during a fast flick) left the anchor stuck before the gap. Every subsequent point of the genuine swipe was then also > 50pt from the stale anchor and got discarded. Example: `[(0,0), (10,0), (20,0), (80,0), (95,0)]` lost everything after `(20,0)` → `maxDisplacement` 20 < `minSwipeLength` → the flick was classified as a **tap** and committed the wrong character.

2. **Ring-buffer re-anchoring interaction**: After buffer overflow (> 60 samples), `KeyGestureRecognizer.anchoringOrigin` prepends a synthetic `(0,0)`. If the retained window sits entirely > 50pt from the origin (any long slow drag), the synthetic `zero → first` jump exceeded the threshold and the cascade discarded the **entire gesture** — a long swipe classified as a tap.

## Fix

`filterOutliers` now treats a point as an outlier only when it is farther than `maxJumpDistance` from the last accepted point **and** from both of its raw neighbors. Consistency with a raw neighbor proves real motion, so:

- A genuine isolated glitch (far from both neighbors) is still removed — the existing `outlierFilterRemovesLargeJumps` test passes unchanged.
- After a dropped-frame gap, the tail of a fast swipe is mutually consistent and fully retained.
- The first retained sample after the synthetic re-anchored origin is consistent with its raw successor, so the whole gesture survives. No change to `KeyGestureRecognizer` was needed, keeping this branch conflict-free with concurrent work there.

## Test Coverage

- `outlierFilterKeepsTailAfterDroppedFrameGap` — filter-level: a 60pt gap in a fast swipe keeps all points.
- `outlierFilterRemovesTrailingGlitchPoint` — filter-level: a trailing glitch (no raw successor) is still removed.
- `fastSwipeWithDroppedFrameGapClassifiesAsSwipe` — end-to-end: the review's example path classifies as `.swipeRight`, not `.tap`.
- `longDragWithFarOutRetainedWindowClassifiesAsSwipe` — end-to-end: overflowed buffer with retained window at x = 100–160 plus re-anchored origin classifies as `.swipeRight`, not `.tap`.

All existing gesture suites (`GesturePreprocessorTests`, `GestureFeaturesTests`, `GesturePreprocessorRobustnessTests`, `OriginAnchoringTests`, `AngleToGestureTypeTests`, `KeyGestureClassifyFeaturesTests`, `CircularGestureTests`, `GestureCalculationsTests`) pass on iPhone 17 Pro simulator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gesture outlier rejection so dropped-frame gaps no longer cause later valid fast-swipe samples to be discarded.
  * Reduced cases where fast swipes were incorrectly classified as taps.
* **Documentation**
  * Clarified how outliers are evaluated using compatibility with recent accepted points and their immediate neighbors.
* **Tests**
  * Added unit and end-to-end coverage for dropped-frame swipes, trailing outliers, clustered glitches, and long-drag sequences that should still classify as swipes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->