### PR TITLE
Apply Expert Gesture Thresholds Only When Expert Mode Is On

### DIFF
--- a/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
@@ -118,8 +118,11 @@ struct GesturePreprocessorConfig {
 
     /// Loads config from SharedDefaults with fallback to defaults.
     /// Non-finite values (NaN, Inf) are replaced with defaults.
-    static func fromUserDefaults() -> GesturePreprocessorConfig {
-        let store = SharedDefaults.store
+    /// Custom values only apply while expert mode is enabled; when it is off,
+    /// the defaults are returned. The stored values are kept so they survive
+    /// toggling expert mode off and on again.
+    static func fromUserDefaults(store: UserDefaults = SharedDefaults.store) -> GesturePreprocessorConfig {
+        guard store.bool(forKey: SettingsKey.expertModeEnabled.rawValue) else { return .default }
         let jitter = finiteCGFloat(from: store, key: jitterThresholdKey, default: defaultJitterThreshold)
         let maxJump = finiteCGFloat(from: store, key: maxJumpDistanceKey, default: defaultMaxJumpDistance)
         return GesturePreprocessorConfig(
@@ -360,9 +363,12 @@ struct GestureClassificationThresholds {
         return value.isFinite ? value : defaultValue
     }
 
-    /// Loads thresholds from SharedDefaults with fallback to defaults
-    static func fromUserDefaults() -> GestureClassificationThresholds {
-        let store = SharedDefaults.store
+    /// Loads thresholds from SharedDefaults with fallback to defaults.
+    /// Custom values only apply while expert mode is enabled; when it is off,
+    /// the defaults are returned. The stored values are kept so they survive
+    /// toggling expert mode off and on again.
+    static func fromUserDefaults(store: UserDefaults = SharedDefaults.store) -> GestureClassificationThresholds {
+        guard store.bool(forKey: SettingsKey.expertModeEnabled.rawValue) else { return .default }
         let start = loadCGFloat(from: store, key: returnDisplacementStartKey, default: defaultReturnDisplacementStart)
         let end = loadCGFloat(from: store, key: returnDisplacementEndKey, default: defaultReturnDisplacementEnd)
         return GestureClassificationThresholds(

--- a/wurstfingerTests/GesturePreprocessorTests.swift
+++ b/wurstfingerTests/GesturePreprocessorTests.swift
@@ -395,3 +395,83 @@ struct GestureFeaturesTests {
         #expect(features.isClockwise) // CCW in math = positive angularSpan
     }
 }
+
+// MARK: - Expert Mode Gating Tests
+
+/// Custom `gesture.*` values must only govern gesture recognition while
+/// expert mode is enabled. When the user turns expert mode off (the obvious
+/// recovery action after breaking gesture recognition), the defaults apply
+/// again — but the stored values survive so re-enabling restores them.
+struct ExpertModeGatingTests {
+    private func storeWithCustomValues(expertModeEnabled: Bool) -> InMemoryUserDefaults {
+        let store = InMemoryUserDefaults()
+        store.set(expertModeEnabled, forKey: SettingsKey.expertModeEnabled.rawValue)
+        store.set(9.0, forKey: GesturePreprocessorConfig.jitterThresholdKey)
+        store.set(120.0, forKey: GesturePreprocessorConfig.maxJumpDistanceKey)
+        store.set(7, forKey: GesturePreprocessorConfig.smoothingWindowKey)
+        store.set(42.0, forKey: GestureClassificationThresholds.minSwipeLengthKey)
+        store.set(0.9, forKey: GestureClassificationThresholds.maxReturnRatioKey)
+        store.set(0.75, forKey: GestureClassificationThresholds.minCircularityKey)
+        return store
+    }
+
+    @Test func configIgnoresCustomValuesWhenExpertModeIsOff() {
+        let store = storeWithCustomValues(expertModeEnabled: false)
+
+        let config = GesturePreprocessorConfig.fromUserDefaults(store: store)
+
+        #expect(config.jitterThreshold == GesturePreprocessorConfig.defaultJitterThreshold)
+        #expect(config.maxJumpDistance == GesturePreprocessorConfig.defaultMaxJumpDistance)
+        #expect(config.smoothingWindow == GesturePreprocessorConfig.defaultSmoothingWindow)
+    }
+
+    @Test func configAppliesCustomValuesWhenExpertModeIsOn() {
+        let store = storeWithCustomValues(expertModeEnabled: true)
+
+        let config = GesturePreprocessorConfig.fromUserDefaults(store: store)
+
+        #expect(config.jitterThreshold == 9.0)
+        #expect(config.maxJumpDistance == 120.0)
+        #expect(config.smoothingWindow == 7)
+    }
+
+    @Test func configIgnoresCustomValuesWhenExpertModeKeyIsMissing() {
+        let store = storeWithCustomValues(expertModeEnabled: false)
+        store.removeObject(forKey: SettingsKey.expertModeEnabled.rawValue)
+
+        let config = GesturePreprocessorConfig.fromUserDefaults(store: store)
+
+        #expect(config.jitterThreshold == GesturePreprocessorConfig.defaultJitterThreshold)
+    }
+
+    @Test func thresholdsIgnoreCustomValuesWhenExpertModeIsOff() {
+        let store = storeWithCustomValues(expertModeEnabled: false)
+
+        let thresholds = GestureClassificationThresholds.fromUserDefaults(store: store)
+
+        #expect(thresholds.minSwipeLength == GestureClassificationThresholds.defaultMinSwipeLength)
+        #expect(thresholds.maxReturnRatio == GestureClassificationThresholds.defaultMaxReturnRatio)
+        #expect(thresholds.minCircularity == GestureClassificationThresholds.defaultMinCircularity)
+    }
+
+    @Test func thresholdsApplyCustomValuesWhenExpertModeIsOn() {
+        let store = storeWithCustomValues(expertModeEnabled: true)
+
+        let thresholds = GestureClassificationThresholds.fromUserDefaults(store: store)
+
+        #expect(thresholds.minSwipeLength == 42.0)
+        #expect(thresholds.maxReturnRatio == 0.9)
+        #expect(thresholds.minCircularity == 0.75)
+    }
+
+    @Test func customValuesSurviveExpertModeRoundTrip() {
+        let store = storeWithCustomValues(expertModeEnabled: true)
+
+        store.set(false, forKey: SettingsKey.expertModeEnabled.rawValue)
+        #expect(GestureClassificationThresholds.fromUserDefaults(store: store).minSwipeLength
+            == GestureClassificationThresholds.defaultMinSwipeLength)
+
+        store.set(true, forKey: SettingsKey.expertModeEnabled.rawValue)
+        #expect(GestureClassificationThresholds.fromUserDefaults(store: store).minSwipeLength == 42.0)
+    }
+}

--- a/wurstfingerTests/GesturePreprocessorTests.swift
+++ b/wurstfingerTests/GesturePreprocessorTests.swift
@@ -474,4 +474,16 @@ struct ExpertModeGatingTests {
         store.set(true, forKey: SettingsKey.expertModeEnabled.rawValue)
         #expect(GestureClassificationThresholds.fromUserDefaults(store: store).minSwipeLength == 42.0)
     }
+
+    @Test func configValuesSurviveExpertModeRoundTrip() {
+        let store = storeWithCustomValues(expertModeEnabled: true)
+
+        store.set(false, forKey: SettingsKey.expertModeEnabled.rawValue)
+        #expect(GesturePreprocessorConfig.fromUserDefaults(store: store).jitterThreshold
+            == GesturePreprocessorConfig.defaultJitterThreshold)
+
+        store.set(true, forKey: SettingsKey.expertModeEnabled.rawValue)
+        #expect(GesturePreprocessorConfig.fromUserDefaults(store: store).jitterThreshold == 9.0)
+        #expect(GesturePreprocessorConfig.fromUserDefaults(store: store).maxJumpDistance == 120.0)
+    }
 }


### PR DESCRIPTION
## Bug

The keyboard extension applied the custom `gesture.*` UserDefaults values (jitter threshold, max jump distance, smoothing window, and all classification thresholds) unconditionally on every gesture. `expertModeEnabled` was written by the app's expert settings screen but never read by the extension.

The expert screen warns that "Incorrect values can make the keyboard unusable" — yet turning the toggle off only hid the sliders. A user who broke gesture recognition and disabled expert mode (the obvious recovery action) still had a broken keyboard, and the reset button is only visible while expert mode is on. There was no working recovery path short of re-enabling expert mode and resetting.

## Fix

`GesturePreprocessorConfig.fromUserDefaults()` and `GestureClassificationThresholds.fromUserDefaults()` now gate on `SettingsKey.expertModeEnabled` (read from the same `SharedDefaults` store as the `gesture.*` keys) and return the built-in defaults while expert mode is off.

- **Gating instead of wiping:** the stored values are intentionally left untouched, so a user's tuning survives toggling expert mode off and on again. Disabling expert mode is a safe, reversible escape hatch.
- **Immediate effect:** both configs are loaded per gesture in `KeyGestureRecognizer.classify`, so the keyboard picks up the toggle change without any extra reload plumbing.
- Both loaders gained an injectable `store:` parameter (defaulting to `SharedDefaults.store`), which also gives the new tests proper isolation via `InMemoryUserDefaults`.

## Tests

New `ExpertModeGatingTests` suite (Swift Testing) covering:
- expert mode off → custom `gesture.*` values are ignored, defaults apply (config + thresholds)
- expert mode key missing → defaults apply
- expert mode on → custom values apply (config + thresholds)
- off/on round-trip → custom values are preserved and restored

Also re-ran `GesturePreprocessorTests`, `KeyGestureClassificationTests`, and `CircularGestureTests` — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gesture settings now respect expert mode: when expert mode is off, saved custom preprocessing and classification values are ignored and defaults are used.
  * If the expert mode setting is missing, the app safely falls back to default gesture parameters.
  * When expert mode is enabled again, previously saved custom gesture preprocessing and classification values are restored as expected.
* **Tests**
  * Added coverage to verify expert-mode gating behavior for both gesture preprocessing configuration and classification thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->