### PR TITLE
Make KeyboardRegistry Cache Thread-Safe

### DIFF
--- a/wurstfingerKeyboard/Definition/Language/KeyboardRegistry.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardRegistry.swift
@@ -26,11 +26,19 @@ enum KeyboardRegistry {
 
     /// Cache for loaded definitions. Only languages actually loaded via
     /// `load(id:)` are built and held here.
+    ///
+    /// Guarded by `cacheLock`: the extension only touches the registry from
+    /// the main thread, but tests (and any future background use) may call it
+    /// concurrently — an unsynchronized dictionary crashes with SIGSEGV in
+    /// `Dictionary._Variant.setValue` under parallel access.
     private static var cache: [String: KeyboardDefinition] = [:]
+    private static let cacheLock = NSLock()
 
     /// Loads the full definition for a keyboard ID, building it lazily on first
     /// use and caching the result.
     static func load(id: String) -> KeyboardDefinition? {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
         if let cached = cache[id] { return cached }
         guard let descriptor = descriptorsByID[id] else {
             return nil
@@ -42,23 +50,31 @@ enum KeyboardRegistry {
 
     /// Removes a cached definition (e.g. on memory warning).
     static func evict(id: String) {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
         cache.removeValue(forKey: id)
     }
 
     /// Clears the entire cache. Active definitions are rebuilt lazily on next
     /// `load(id:)`.
     static func evictAll() {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
         cache.removeAll()
     }
 
     /// Evicts every cached definition except the given id. Used on memory
     /// warnings to free inactive layouts while keeping the active one resident.
     static func evictAll(except keepID: String) {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
         cache = cache.filter { $0.key == keepID }
     }
 
     /// Whether a definition is currently cached (for testing).
     static func isCached(id: String) -> Bool {
-        cache[id] != nil
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        return cache[id] != nil
     }
 }

--- a/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
@@ -91,18 +91,30 @@ struct KeyGestureRecognizer: ViewModifier {
 
     // MARK: - Classification (Pure Function)
 
-    /// Classifies a sequence of touch positions into a `GestureType`.
-    ///
-    /// This is a pure function so it can be unit-tested without rendering
-    /// any SwiftUI views.
+    /// Classifies a sequence of touch positions into a `GestureType`, reading
+    /// preprocessor config and thresholds from `SharedDefaults`.
     static func classify(
         positions: [CGPoint],
         aspectRatio: CGFloat = 1.0
     ) -> GestureClassification {
-        let config = GesturePreprocessorConfig.fromUserDefaults()
-            .with(aspectRatio: aspectRatio)
+        classify(
+            positions: positions,
+            config: GesturePreprocessorConfig.fromUserDefaults()
+                .with(aspectRatio: aspectRatio),
+            thresholds: GestureClassificationThresholds.fromUserDefaults()
+        )
+    }
+
+    /// Classifies a sequence of touch positions with explicit configuration.
+    ///
+    /// This is a pure function so it can be unit-tested without rendering
+    /// any SwiftUI views and without depending on the shared defaults store.
+    static func classify(
+        positions: [CGPoint],
+        config: GesturePreprocessorConfig,
+        thresholds: GestureClassificationThresholds
+    ) -> GestureClassification {
         let preprocessor = GesturePreprocessor(config: config)
-        let thresholds = GestureClassificationThresholds.fromUserDefaults()
         let processed = preprocessor.preprocess(positions)
         let features = GestureFeatures.extract(from: processed, thresholds: thresholds)
 

--- a/wurstfingerTests/GesturePreprocessorRobustnessTests.swift
+++ b/wurstfingerTests/GesturePreprocessorRobustnessTests.swift
@@ -14,7 +14,9 @@ import Testing
 
 struct GesturePreprocessorRobustnessTests {
     private func classify(_ points: [CGPoint]) -> GestureType {
-        KeyGestureRecognizer.classify(positions: points).gesture
+        // Explicit configs keep the test hermetic — independent of whatever
+        // is in the shared defaults store on the test host.
+        KeyGestureRecognizer.classify(positions: points, config: .default, thresholds: .default).gesture
     }
 
     @Test func emptyInputClassifiesAsTap() {

--- a/wurstfingerTests/KeyboardRegistryTests.swift
+++ b/wurstfingerTests/KeyboardRegistryTests.swift
@@ -76,6 +76,32 @@ struct KeyboardRegistryTests {
         #expect(reloaded != nil)
     }
 
+    /// Regression test: the registry cache used to be an unsynchronized
+    /// `static var` dictionary, which crashed with SIGSEGV in
+    /// `Dictionary._Variant.setValue` when parallel test suites called
+    /// `load(id:)` concurrently. Hammering the cache from multiple tasks
+    /// documents the thread-safety contract (and trips TSan without the lock).
+    @Test func concurrentLoadEvictAndQueryDoesNotCrash() async {
+        KeyboardRegistry.evictAll()
+        let ids = KeyboardRegistry.available.map(\.id)
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 4 {
+                for id in ids {
+                    group.addTask {
+                        _ = KeyboardRegistry.load(id: id)
+                        _ = KeyboardRegistry.isCached(id: id)
+                    }
+                    group.addTask {
+                        KeyboardRegistry.evict(id: id)
+                    }
+                }
+            }
+        }
+        for id in ids {
+            #expect(KeyboardRegistry.load(id: id) != nil, "Failed to load \(id) after concurrent access")
+        }
+    }
+
     @Test func evictAllClearsCache() {
         // Load a few definitions
         _ = KeyboardRegistry.load(id: LanguageDefinitions.german.id)

--- a/wurstfingerTests/KeyboardSettingsTests.swift
+++ b/wurstfingerTests/KeyboardSettingsTests.swift
@@ -12,8 +12,7 @@ import Testing
 struct HapticSettingsTests {
     // Helper to create isolated UserDefaults for testing
     private func createTestDefaults() -> UserDefaults {
-        let suiteName = "test.haptic.\(UUID().uuidString)"
-        return UserDefaults(suiteName: suiteName)!
+        InMemoryUserDefaults()
     }
 
     // MARK: - Initialization Tests
@@ -140,8 +139,7 @@ struct HapticSettingsTests {
 
 struct LayoutSettingsTests {
     private func createTestDefaults() -> UserDefaults {
-        let suiteName = "test.layout.\(UUID().uuidString)"
-        return UserDefaults(suiteName: suiteName)!
+        InMemoryUserDefaults()
     }
 
     // MARK: - Initialization Tests

--- a/wurstfingerTests/OriginAnchoringTests.swift
+++ b/wurstfingerTests/OriginAnchoringTests.swift
@@ -50,7 +50,11 @@ struct OriginAnchoringTests {
         // rightward return swipe again — checked through the production
         // classify(positions:) pipeline rather than a hand-rolled extraction.
         let anchored = KeyGestureRecognizer.anchoringOrigin(evicted)
-        let classification = KeyGestureRecognizer.classify(positions: anchored)
+        let classification = KeyGestureRecognizer.classify(
+            positions: anchored,
+            config: .default,
+            thresholds: .default
+        )
         #expect(classification.isReturn)
         #expect(classification.gesture == .swipeRight)
     }

--- a/wurstfingerTests/ViewModelPipelineTests.swift
+++ b/wurstfingerTests/ViewModelPipelineTests.swift
@@ -273,8 +273,8 @@ struct ViewModelDefinitionTests {
         #expect(vm.currentArrangement != nil)
     }
 
-    @Test func unknownLanguageIdFallsBackToEnglish() throws {
-        let defaults = try #require(UserDefaults(suiteName: "test.\(UUID().uuidString)"))
+    @Test func unknownLanguageIdFallsBackToEnglish() {
+        let defaults = InMemoryUserDefaults()
         let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
         vm.loadDefinition(for: "nonexistent_XX")
         // Must never leave the keyboard blank — falls back to a renderable layout.
@@ -311,7 +311,7 @@ struct ViewModelVCActionTests {
 @Suite(.serialized)
 struct ViewModelNumpadStyleTests {
     private func loadedNumericTopLeftDigit(numpadStyle: String?) -> String? {
-        let defaults = UserDefaults(suiteName: "test.\(UUID().uuidString)")!
+        let defaults = InMemoryUserDefaults()
         if let numpadStyle {
             defaults.set(numpadStyle, forKey: SettingsKey.numpadStyle.rawValue)
         }


### PR DESCRIPTION
## Problem

`KeyboardRegistry.cache` is a `private static var` dictionary read and written by `load`, `evict`, `evictAll`, and `isCached` with no synchronization. Swift Testing runs suites in parallel, and an intermittent SIGSEGV was reproduced on clean `develop` in `KeyboardRegistry.load(id:)` (`Dictionary._Variant.setValue`, KeyboardRegistry.swift:39) when `MultiLanguageTypingTests` ran concurrently with other suites calling `load`. This likely also explains the known `LanguageDefinitionValidationTests` flakiness, and the unsynchronized global would not compile under strict Swift 6 concurrency.

## Fix

Guard all cache access with an `NSLock` (matches the existing locking style in `InMemoryUserDefaults`; `OSAllocatedUnfairLock.withLock` would require `Sendable` state or the unchecked variants). The registry is only called from the main thread in the extension, so lock overhead is irrelevant; the public API stays synchronous and unchanged.

Added a regression test (`concurrentLoadEvictAndQueryDoesNotCrash`) that hammers `load`/`evict`/`isCached` for all language ids from a `TaskGroup` — it documents the thread-safety contract and trips TSan/crashes without the lock. Runs in ~6 ms.

## Test-hygiene fixes (same review)

- **On-disk `UserDefaults(suiteName:)!` in tests:** `KeyboardSettingsTests` and `ViewModelPipelineTests` had reintroduced the fresh on-disk defaults-domain pattern with force-unwraps and no `removePersistentDomain` — exactly what `TestHelpers.InMemoryUserDefaults` was added to replace (under parallel execution `UserDefaults(suiteName:)` can return `nil` and crash on the force-unwrap). Switched those call sites to `InMemoryUserDefaults`.
- **`classify(positions:)` reads the shared defaults store:** the documented-as-pure classification path pulled preprocessor config and thresholds from `SharedDefaults.store`, so unit test outcomes depended on the test host's app-group defaults (e.g. leftover expert-mode values). Added a `classify(positions:config:thresholds:)` overload; the defaults-reading variant now delegates to it. `GesturePreprocessorRobustnessTests` and `OriginAnchoringTests` pass explicit `.default` configs (`KeyGestureClassificationTests` was already hermetic via `classify(features:)` with pinned thresholds).

## Testing

- Build: `xcodebuild -scheme Wurstfinger … build` succeeds.
- Targeted suites all pass: KeyboardRegistryTests (incl. new concurrency test), KeyboardInfoTests, HapticSettingsTests, LayoutSettingsTests, SettingsKeyTests, KeyGestureClassificationTests, GesturePreprocessorRobustnessTests, OriginAnchoringTests, ViewModelDefinitionTests, ViewModelVCActionTests, ViewModelNumpadStyleTests, and MultiLanguageTypingTests (the previously crashing suite).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard stability during rapid background activity, reducing crashes when loading, removing, or checking keyboard data at the same time.
  * Gesture recognition now handles inputs more reliably with clearer handling of default settings.
* **Tests**
  * Added regression coverage for concurrent keyboard loading and removal.
  * Updated gesture and settings tests to use more isolated test data storage for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->