### PR TITLE
Fix Auto-Capitalization Engagement and Mode Guards

### DIFF
--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -151,7 +151,6 @@ enum GridKeyboardFactory {
             defaultMode: ModeNames.main,
             settings: KeyboardDefinitionSettings(
                 autoCapitalize: true,
-                autoCapitalizers: [],
                 composeRuleOverrides: nil,
                 inputMethod: inputMethod
             ),

--- a/wurstfingerKeyboard/Definition/Language/KeyboardDefinition.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardDefinition.swift
@@ -105,9 +105,6 @@ struct KeyboardDefinitionSettings: Codable, Equatable {
     /// Auto-capitalization enabled
     let autoCapitalize: Bool
 
-    /// Language-specific auto-capitalizer rules (e.g. "i" → "I" in English)
-    let autoCapitalizers: [AutoCapitalizerRule]
-
     /// Language-specific compose rule overrides.
     /// Merged with global base rules at runtime.
     /// nil = only use global rules (sufficient for most languages).
@@ -119,22 +116,11 @@ struct KeyboardDefinitionSettings: Codable, Equatable {
 
     init(
         autoCapitalize: Bool,
-        autoCapitalizers: [AutoCapitalizerRule],
         composeRuleOverrides: ComposeRuleSet?,
         inputMethod: InputMethodKind = .direct
     ) {
         self.autoCapitalize = autoCapitalize
-        self.autoCapitalizers = autoCapitalizers
         self.composeRuleOverrides = composeRuleOverrides
         self.inputMethod = inputMethod
     }
-}
-
-/// A rule for automatic capitalization.
-struct AutoCapitalizerRule: Codable, Equatable {
-    /// Pattern recognized in text before cursor
-    let pattern: String
-
-    /// Replacement
-    let replacement: String
 }

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -88,6 +88,20 @@ final class KeyboardViewController: UIInputViewController {
         // keyboard was backgrounded — avoids rebuilding the pipeline every time.
         loadDefinitionIfNeeded()
         updateKeyboardHeight()
+        // Engage/release shift for the field's current context (e.g. start
+        // uppercase in an empty compose field). `textDidChange` usually also
+        // fires on appearance, but that is not guaranteed in every host app;
+        // the refresh is idempotent, so evaluating in both paths is safe.
+        viewModel.refreshAutoCapitalization()
+    }
+
+    override func textDidChange(_ textInput: UITextInput?) {
+        super.textDidChange(textInput)
+        // Fires when the host text or caret position changes outside our own
+        // key actions (field switch, caret relocation, external edits) — and
+        // on keyboard appearance. Re-evaluate so stale shift state is
+        // corrected (e.g. caret moved from a sentence start into a word).
+        viewModel.refreshAutoCapitalization()
     }
 
     /// Loads the keyboard definition only when the inputs that determine it

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -78,6 +78,10 @@ final class KeyboardViewModel: ObservableObject {
     var resolverChain: GestureResolverChain?
     var returnSwipeResolverChain: GestureResolverChain?
     var pipeline: ActionPipeline?
+    /// Whether the current `shifted` mode was engaged by auto-capitalization
+    /// (as opposed to a manual shift tap). Only auto-engaged shift may be
+    /// released by `refreshAutoCapitalization()`; cleared on any mode change.
+    var shiftEngagedByAutoCapitalization = false
     weak var textInputTarget: TextInputTarget?
     var onAdvanceToNextInputMode: (() -> Void)?
     var onDismissKeyboard: (() -> Void)?

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -169,9 +169,17 @@ extension KeyboardViewModel {
     /// `textDidChange` both firing on appearance) are harmless.
     func refreshAutoCapitalization() {
         switch evaluateAutoCapitalization() {
-        case .some(true): engageAutoCapitalization()
-        case .some(false): releaseAutoCapitalization()
-        case .none: break
+        case .some(true):
+            engageAutoCapitalization()
+        case .some(false):
+            // Outside the key pipeline only an *auto-engaged* shift may be
+            // released — a manually tapped shift must survive textDidChange
+            // firing for caret moves or field switches.
+            if shiftEngagedByAutoCapitalization {
+                releaseAutoCapitalization()
+            }
+        case .none:
+            break
         }
     }
 
@@ -193,6 +201,7 @@ extension KeyboardViewModel {
     func engageAutoCapitalization() {
         guard activeModeName == ModeNames.main else { return }
         switchToMode(ModeNames.shifted)
+        shiftEngagedByAutoCapitalization = activeModeName == ModeNames.shifted
     }
 
     /// Releases a pending auto-shift. Only fires from `shifted` so caps
@@ -283,6 +292,9 @@ extension KeyboardViewModel {
         else { return }
         activeModeName = modeName
         currentMode = definition.mode(modeName)
+        // Any mode change invalidates a pending auto-shift; the auto-cap
+        // engage path re-sets the flag right after switching.
+        shiftEngagedByAutoCapitalization = false
     }
 
     // MARK: - Slide Gesture Handling

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -143,23 +143,9 @@ extension KeyboardViewModel {
 
         // 7. Auto-capitalization
         middlewares.append(AutoCapitalizationMiddleware(
-            evaluate: { [weak self] in
-                guard let self,
-                      sharedDefaults.bool(forKey: SettingsKey.autoCapitalizeEnabled.rawValue)
-                else { return nil }
-                return AutoCapitalization.shouldCapitalize(
-                    context: textInputTarget?.documentContextBeforeInput
-                )
-            },
-            onCapitalize: { [weak self] in
-                self?.switchToMode(ModeNames.shifted)
-            },
-            onReleaseCapitalize: { [weak self] in
-                guard let self else { return }
-                if activeModeName == ModeNames.shifted {
-                    switchToMode(ModeNames.main)
-                }
-            }
+            evaluate: { [weak self] in self?.evaluateAutoCapitalization() },
+            onCapitalize: { [weak self] in self?.engageAutoCapitalization() },
+            onReleaseCapitalize: { [weak self] in self?.releaseAutoCapitalization() }
         ))
 
         // 8. Mode transitions (auto-transitions from key category)
@@ -171,6 +157,49 @@ extension KeyboardViewModel {
         ))
 
         pipeline = ActionPipeline(middlewares: middlewares)
+    }
+
+    // MARK: - Auto-Capitalization
+
+    /// Re-evaluates auto-capitalization outside the key-action pipeline.
+    /// Called from `KeyboardViewController` when the host text changes
+    /// (keyboard appearance, field switch, caret relocation) so the shift
+    /// state matches the new context. Idempotent: `switchToMode` ignores
+    /// same-mode switches, so overlapping calls (e.g. `viewWillAppear` and
+    /// `textDidChange` both firing on appearance) are harmless.
+    func refreshAutoCapitalization() {
+        switch evaluateAutoCapitalization() {
+        case .some(true): engageAutoCapitalization()
+        case .some(false): releaseAutoCapitalization()
+        case .none: break
+        }
+    }
+
+    /// Returns whether the next key should be capitalized, or `nil` when
+    /// auto-capitalization is inactive — either the definition does not
+    /// support it for this language or the user disabled it in settings.
+    func evaluateAutoCapitalization() -> Bool? {
+        guard currentDefinition?.settings.autoCapitalize == true,
+              sharedDefaults.bool(forKey: SettingsKey.autoCapitalizeEnabled.rawValue)
+        else { return nil }
+        return AutoCapitalization.shouldCapitalize(
+            context: textInputTarget?.documentContextBeforeInput
+        )
+    }
+
+    /// Engages the shifted layer for the next key. Only fires from `main`:
+    /// caps lock must survive sentence enders, and the numeric/symbol
+    /// layers must not be hijacked into the letter layers.
+    func engageAutoCapitalization() {
+        guard activeModeName == ModeNames.main else { return }
+        switchToMode(ModeNames.shifted)
+    }
+
+    /// Releases a pending auto-shift. Only fires from `shifted` so caps
+    /// lock and non-letter layers are never demoted.
+    func releaseAutoCapitalization() {
+        guard activeModeName == ModeNames.shifted else { return }
+        switchToMode(ModeNames.main)
     }
 
     // MARK: - Gesture Dispatch

--- a/wurstfingerTests/ActionPipelineTests.swift
+++ b/wurstfingerTests/ActionPipelineTests.swift
@@ -80,7 +80,6 @@ private enum PipelineFixtures {
             defaultMode: modes.first?.name ?? "main",
             settings: KeyboardDefinitionSettings(
                 autoCapitalize: true,
-                autoCapitalizers: [],
                 composeRuleOverrides: nil
             )
         )

--- a/wurstfingerTests/AutoCapitalizationTests.swift
+++ b/wurstfingerTests/AutoCapitalizationTests.swift
@@ -232,6 +232,35 @@ struct AutoCapitalizationTests {
         #expect(vm.activeModeName == ModeNames.shifted)
     }
 
+    @Test func refreshDoesNotReleaseManuallyTappedShift() {
+        let (vm, target) = makeAutoCapViewModel()
+        // Mid-sentence context: auto-capitalization evaluates to false.
+        target.documentContextBeforeInput = "Hello wor"
+
+        // User taps shift to type a proper noun mid-sentence…
+        vm.switchToMode(ModeNames.shifted)
+        // …then the host fires textDidChange (e.g. caret bookkeeping).
+        vm.refreshAutoCapitalization()
+
+        #expect(
+            vm.activeModeName == ModeNames.shifted,
+            "A manual shift must survive out-of-pipeline refreshes"
+        )
+    }
+
+    @Test func refreshStillReleasesAutoEngagedShiftAfterManualCheck() {
+        let (vm, target) = makeAutoCapViewModel()
+        // Auto-engage in an empty field, then the caret moves mid-sentence:
+        // the auto-engaged shift is stale and must be released.
+        target.documentContextBeforeInput = nil
+        vm.refreshAutoCapitalization()
+        #expect(vm.activeModeName == ModeNames.shifted)
+
+        target.documentContextBeforeInput = "Hello wor"
+        vm.refreshAutoCapitalization()
+        #expect(vm.activeModeName == ModeNames.main)
+    }
+
     // MARK: - Engagement through the pipeline (key actions)
 
     @Test func middlewareEngagesShiftAfterSentenceEnderFromMain() {

--- a/wurstfingerTests/AutoCapitalizationTests.swift
+++ b/wurstfingerTests/AutoCapitalizationTests.swift
@@ -175,4 +175,146 @@ struct AutoCapitalizationTests {
         vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
         #expect(vm.activeModeName == ModeNames.capsLock)
     }
+
+    // MARK: - Engagement outside the pipeline (textDidChange / appearance)
+
+    /// View model with the user's auto-capitalize setting enabled, as wired
+    /// by `KeyboardViewController` in production.
+    private func makeAutoCapViewModel() -> (KeyboardViewModel, MockTextTarget) {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+        vm.sharedDefaults.set(true, forKey: SettingsKey.autoCapitalizeEnabled.rawValue)
+        return (vm, target)
+    }
+
+    @Test func refreshEngagesShiftInEmptyField() {
+        let (vm, target) = makeAutoCapViewModel()
+        target.documentContextBeforeInput = nil
+
+        // Simulates textDidChange / keyboard appearance in an empty field.
+        vm.refreshAutoCapitalization()
+        #expect(vm.activeModeName == ModeNames.shifted)
+    }
+
+    @Test func refreshEngagesShiftAfterSentenceEnderAndSpace() {
+        let (vm, target) = makeAutoCapViewModel()
+        target.documentContextBeforeInput = "Hello. "
+
+        vm.refreshAutoCapitalization()
+        #expect(vm.activeModeName == ModeNames.shifted)
+    }
+
+    @Test func refreshReleasesStaleShiftWhenCaretMovesMidSentence() {
+        let (vm, target) = makeAutoCapViewModel()
+        target.documentContextBeforeInput = nil
+        vm.refreshAutoCapitalization()
+        #expect(vm.activeModeName == ModeNames.shifted)
+
+        // Caret relocated into the middle of a word (host-side change).
+        target.documentContextBeforeInput = "Hello wor"
+        vm.refreshAutoCapitalization()
+        #expect(vm.activeModeName == ModeNames.main)
+    }
+
+    @Test func refreshDoesNothingWhenUserSettingDisabled() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+        target.documentContextBeforeInput = nil
+
+        vm.refreshAutoCapitalization()
+        #expect(vm.activeModeName == ModeNames.main)
+    }
+
+    @Test func refreshIsIdempotentWhenAlreadyShifted() {
+        let (vm, target) = makeAutoCapViewModel()
+        target.documentContextBeforeInput = ""
+
+        vm.refreshAutoCapitalization()
+        vm.refreshAutoCapitalization()
+        #expect(vm.activeModeName == ModeNames.shifted)
+    }
+
+    // MARK: - Engagement through the pipeline (key actions)
+
+    @Test func middlewareEngagesShiftAfterSentenceEnderFromMain() {
+        let (vm, target) = makeAutoCapViewModel()
+        target.documentContextBeforeInput = "Hello"
+
+        vm.dispatchAction(.commitText(". "))
+        #expect(vm.activeModeName == ModeNames.shifted)
+    }
+
+    @Test func capsLockSurvivesSentenceEnder() {
+        let (vm, target) = makeAutoCapViewModel()
+
+        // Activate capsLock via double-tap shift.
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.capsLock)
+
+        // Typing "HELLO. " must not demote capsLock to shifted.
+        vm.dispatchAction(.commitText("HELLO. "))
+        #expect(vm.activeModeName == ModeNames.capsLock)
+        #expect(target.events.contains(.insertText("HELLO. ")))
+    }
+
+    @Test func capsLockNotDemotedByRefresh() {
+        let (vm, target) = makeAutoCapViewModel()
+
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.capsLock)
+
+        // Neither an engage (empty field) nor a release (mid-word) context
+        // may change the user's explicit capsLock.
+        target.documentContextBeforeInput = nil
+        vm.refreshAutoCapitalization()
+        #expect(vm.activeModeName == ModeNames.capsLock)
+
+        target.documentContextBeforeInput = "Hello wor"
+        vm.refreshAutoCapitalization()
+        #expect(vm.activeModeName == ModeNames.capsLock)
+    }
+
+    @Test func numericLayerStaysOnSentenceEnder() {
+        let (vm, target) = makeAutoCapViewModel()
+
+        vm.handleGesture(.tap, keyId: UtilitySlot.symbols, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.numeric)
+
+        // Typing ". " on the numeric layer must not teleport to shifted.
+        vm.dispatchAction(.commitText(". "))
+        #expect(vm.activeModeName == ModeNames.numeric)
+
+        // A host-side refresh must not either.
+        target.documentContextBeforeInput = "Hello. "
+        vm.refreshAutoCapitalization()
+        #expect(vm.activeModeName == ModeNames.numeric)
+    }
+
+    // MARK: - Definition-level enablement
+
+    @Test func definitionWithoutAutoCapitalizeDisablesEngagement() throws {
+        let (vm, target) = makeAutoCapViewModel()
+        let base = try #require(vm.currentDefinition)
+        vm.currentDefinition = KeyboardDefinition(
+            title: base.title,
+            id: base.id,
+            localeIdentifier: base.localeIdentifier,
+            modes: base.modes,
+            defaultMode: base.defaultMode,
+            settings: KeyboardDefinitionSettings(
+                autoCapitalize: false,
+                composeRuleOverrides: base.settings.composeRuleOverrides,
+                inputMethod: base.settings.inputMethod
+            ),
+            numericBackToAlphaLabel: base.numericBackToAlphaLabel
+        )
+
+        // User setting is on, but the definition opts out entirely.
+        target.documentContextBeforeInput = nil
+        vm.refreshAutoCapitalization()
+        #expect(vm.activeModeName == ModeNames.main)
+
+        vm.dispatchAction(.commitText("Hello. "))
+        #expect(vm.activeModeName == ModeNames.main)
+    }
 }

--- a/wurstfingerTests/AutoCapitalizationTests.swift
+++ b/wurstfingerTests/AutoCapitalizationTests.swift
@@ -248,19 +248,6 @@ struct AutoCapitalizationTests {
         )
     }
 
-    @Test func refreshStillReleasesAutoEngagedShiftAfterManualCheck() {
-        let (vm, target) = makeAutoCapViewModel()
-        // Auto-engage in an empty field, then the caret moves mid-sentence:
-        // the auto-engaged shift is stale and must be released.
-        target.documentContextBeforeInput = nil
-        vm.refreshAutoCapitalization()
-        #expect(vm.activeModeName == ModeNames.shifted)
-
-        target.documentContextBeforeInput = "Hello wor"
-        vm.refreshAutoCapitalization()
-        #expect(vm.activeModeName == ModeNames.main)
-    }
-
     // MARK: - Engagement through the pipeline (key actions)
 
     @Test func middlewareEngagesShiftAfterSentenceEnderFromMain() {

--- a/wurstfingerTests/ModeDefinitionValidationTests.swift
+++ b/wurstfingerTests/ModeDefinitionValidationTests.swift
@@ -64,7 +64,7 @@ private func minimalDefinition(
         title: "Test", id: "test", localeIdentifier: "en_US",
         modes: modes ?? defaultModes,
         defaultMode: defaultMode,
-        settings: KeyboardDefinitionSettings(autoCapitalize: true, autoCapitalizers: [], composeRuleOverrides: nil)
+        settings: KeyboardDefinitionSettings(autoCapitalize: true, composeRuleOverrides: nil)
     )
 }
 
@@ -415,7 +415,6 @@ struct ValidationTests {
             defaultMode: "wrong_key",
             settings: KeyboardDefinitionSettings(
                 autoCapitalize: false,
-                autoCapitalizers: [],
                 composeRuleOverrides: nil
             )
         )
@@ -435,13 +434,6 @@ struct SupportingTypeTests {
         let data = try JSONEncoder().encode(rules)
         let decoded = try JSONDecoder().decode(ComposeRuleSet.self, from: data)
         #expect(decoded == rules)
-    }
-
-    @Test func autoCapitalizerRuleCodable() throws {
-        let rule = AutoCapitalizerRule(pattern: " i ", replacement: " I ")
-        let data = try JSONEncoder().encode(rule)
-        let decoded = try JSONDecoder().decode(AutoCapitalizerRule.self, from: data)
-        #expect(decoded == rule)
     }
 
     @Test func modeNamesConstants() {


### PR DESCRIPTION
## Issues

### 1. Auto-capitalization never engages on keyboard appearance, field switch, or caret relocation (major)

`KeyboardViewController` had no `textDidChange(_:)` override, and `AutoCapitalizationMiddleware` only re-evaluates after a key action is processed (`affectsCapitalization` excludes `.moveCursor`). Concrete failures with auto-capitalize enabled:

- Opening the keyboard in an empty compose field started on the lowercase layer — the first letter of every message was lowercase.
- Switching to another text field kept whatever shift state was left over from the previous field.
- Moving the caret into/out of a sentence start left stale shift state (e.g. shift stayed engaged after relocating mid-word).

**Fix:** `KeyboardViewController` now overrides `textDidChange(_:)` and also evaluates once in `viewWillAppear`, both forwarding to `KeyboardViewModel.refreshAutoCapitalization()`, which runs the exact evaluate/engage/release logic the middleware uses (the middleware closures now call the same methods). The refresh is idempotent (`switchToMode` ignores same-mode switches), so `textDidChange` also firing on appearance causes no double transition. The user's auto-capitalize setting is respected in `evaluateAutoCapitalization()`.

### 2. Engage callback hijacks caps lock and the numeric layer (major)

The middleware's `onCapitalize` callback unconditionally called `switchToMode(ModeNames.shifted)`:

- With caps lock active, typing `HELLO. ` demoted capsLock → shifted, and the next letter auto-transitioned to main — the user's explicit caps lock was silently dropped (contradicting the intent pinned by `capsLockDoesNotAutoTransitionAfterLetter`).
- Typing `. ` on the numeric layer teleported the user to the shifted letters layer.

**Fix:** the engage path (`engageAutoCapitalization`) is guarded with `activeModeName == ModeNames.main`, mirroring the shifted-only guard the release path already had.

### 3. Dead definition fields (cleanup)

`KeyboardDefinitionSettings.autoCapitalize` and `autoCapitalizers` were consumed by nothing: `GridKeyboardFactory` hardcoded them and the middleware read only the UserDefaults key.

**Fix:** `settings.autoCapitalize` is now wired into the middleware enablement — the definition says whether the language supports auto-capitalization at all, the user setting toggles it (`definitionAllows && userEnabled`). The never-implemented `autoCapitalizers` field and the `AutoCapitalizerRule` type are removed entirely (including the hardcoded `[]` in the factory and the obsolete Codable test). `composeRuleOverrides` is untouched.

## Test coverage

New tests in `AutoCapitalizationTests`:

- `refreshEngagesShiftInEmptyField` / `refreshEngagesShiftAfterSentenceEnderAndSpace` — engage on the textDidChange/appearance path.
- `refreshReleasesStaleShiftWhenCaretMovesMidSentence` — stale shift released when the caret relocates mid-word.
- `refreshDoesNothingWhenUserSettingDisabled`, `refreshIsIdempotentWhenAlreadyShifted`.
- `middlewareEngagesShiftAfterSentenceEnderFromMain` — pipeline path still engages from main.
- `capsLockSurvivesSentenceEnder`, `capsLockNotDemotedByRefresh` — `HELLO. ` keeps capsLock on both paths.
- `numericLayerStaysOnSentenceEnder` — `. ` on the numeric layer stays numeric on both paths.
- `definitionWithoutAutoCapitalizeDisablesEngagement` — definition-level `autoCapitalize: false` disables the middleware regardless of the user setting.

All `AutoCapitalizationTests`, `ActionPipelineTests`, `KeyboardDefinitionTests`, `KeyboardModeTests`, and `SupportingTypeTests` pass locally. Note: `MultiLanguageTypingTests` crashes intermittently under parallel test execution due to an unsynchronized static cache in `KeyboardRegistry.load(id:)` — verified to reproduce identically on unmodified `develop`, so it is pre-existing and unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-capitalization now refreshes more reliably when the keyboard appears and as the cursor/context changes in the host text.
* **Bug Fixes**
  * Stale shifted/capitalization state is corrected: auto-engaged shifts release when the caret moves mid-sentence, while manually tapped shift stays active.
  * Auto-capitalization now properly follows the keyboard definition’s `autoCapitalize` setting, preserving caps lock behavior and keeping numeric mode numeric.
* **Tests**
  * Added and expanded coverage for engagement/release/idempotency across typing, caret movement, caps lock, and numeric mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->