### PR TITLE
Prevent Stale Language Settings From Re-Enabling Disabled Languages

### DIFF
--- a/wurstfinger/wurstfingerApp.swift
+++ b/wurstfinger/wurstfingerApp.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 @main
 struct wurstfingerApp: App {
+    @Environment(\.scenePhase) private var scenePhase
+
     private let screenshotMode: ScreenshotMode
 
     private enum ScreenshotMode {
@@ -38,13 +40,24 @@ struct wurstfingerApp: App {
 
     var body: some Scene {
         WindowGroup {
-            switch screenshotMode {
-            case .appStore:
-                AppStoreScreenshotView()
-            case .keyboardOnly:
-                KeyboardShowcaseView()
-            case .none:
-                ContentView()
+            Group {
+                switch screenshotMode {
+                case .appStore:
+                    AppStoreScreenshotView()
+                case .keyboardOnly:
+                    KeyboardShowcaseView()
+                case .none:
+                    ContentView()
+                }
+            }
+            .onChange(of: scenePhase) { _, newPhase in
+                // The keyboard extension writes the language selection while
+                // the app is backgrounded (globe-key cycling). Refresh the
+                // shared singleton on foreground so the settings UI never acts
+                // on stale state.
+                if newPhase == .active {
+                    LanguageSettings.shared.reloadFromStore()
+                }
             }
         }
     }

--- a/wurstfingerKeyboard/Settings/LanguageSettings.swift
+++ b/wurstfingerKeyboard/Settings/LanguageSettings.swift
@@ -46,54 +46,79 @@ class LanguageSettings: ObservableObject {
         let defaults = userDefaults ?? SharedDefaults.store
         self.userDefaults = defaults
 
+        let state = Self.loadNormalizedState(from: defaults)
+        selectedLanguageId = state.selected
+        enabledLanguageIds = state.enabled
+        pinnedLanguageId = state.pinned
+
+        // `didSet` does not fire inside `init`, so persist the normalized
+        // values explicitly — otherwise a corrected inconsistency (e.g. a
+        // reselected language) would be re-read in its broken form next launch.
+        if state.selected != defaults.string(forKey: SettingsKey.selectedLanguageId.rawValue) {
+            defaults.set(state.selected, forKey: SettingsKey.selectedLanguageId.rawValue)
+        }
+        Self.saveEnabledLanguageIds(state.enabled, to: defaults)
+        if state.pinned == nil {
+            defaults.removeObject(forKey: SettingsKey.pinnedLanguageId.rawValue)
+        }
+    }
+
+    /// Snapshot of the persisted language state after normalization.
+    private struct NormalizedState {
+        let selected: String
+        let enabled: [String]
+        let pinned: String?
+    }
+
+    /// Reads and normalizes the persisted language state.
+    ///
+    /// Invariant: the selected language is always a member of the non-empty,
+    /// known-languages-only enabled list. When the stored selection is not in
+    /// the enabled list — e.g. the keyboard extension cycled to a language that
+    /// the host app subsequently disabled — the selection falls back to the
+    /// first enabled language instead of re-inserting the disabled one, so an
+    /// explicit disable is never silently undone.
+    private static func loadNormalizedState(from defaults: UserDefaults) -> NormalizedState {
         // Normalize the saved language through the shared resolver (stale/nil →
         // system language → English) so the host app and the keyboard extension
         // always resolve the same active language.
-        let resolvedLanguageId = Self.resolvedLanguageId(
+        let resolvedSelected = resolvedLanguageId(
             defaults.string(forKey: SettingsKey.selectedLanguageId.rawValue)
         )
 
-        // Load enabled languages, migrating from a single-language setup if needed
-        let storedEnabled = Self.loadEnabledLanguageIds(from: defaults)
-        let resolvedEnabled: [String]
-        if let stored = storedEnabled, !stored.isEmpty {
-            // Filter out any stale/unknown IDs
-            let valid = stored.filter { LanguageConfig.language(withId: $0) != nil }
-            resolvedEnabled = valid.isEmpty ? [resolvedLanguageId] : valid
-        } else {
-            // Migration: no enabled list stored yet, seed with current selection
-            resolvedEnabled = [resolvedLanguageId]
-        }
+        // Load enabled languages (filtering stale/unknown IDs), migrating from
+        // a single-language setup by seeding with the current selection.
+        let stored = loadEnabledLanguageIds(from: defaults) ?? []
+        let valid = stored.filter { LanguageConfig.language(withId: $0) != nil }
+        let enabled = valid.isEmpty ? [resolvedSelected] : valid
 
-        // Load pinned language (before enabledLanguageIds didSet can fire)
+        let selected = enabled.contains(resolvedSelected) ? resolvedSelected : enabled[0]
+
+        // A pin is only valid while its language is enabled and known.
         let storedPinned = defaults.string(forKey: SettingsKey.pinnedLanguageId.rawValue)
-
-        selectedLanguageId = resolvedLanguageId
-        enabledLanguageIds = resolvedEnabled
-        pinnedLanguageId = storedPinned
-
-        // Ensure selected language is in the enabled list
-        if !resolvedEnabled.contains(resolvedLanguageId) {
-            enabledLanguageIds.insert(resolvedLanguageId, at: 0)
+        let pinned = storedPinned.flatMap { pin in
+            enabled.contains(pin) && LanguageConfig.language(withId: pin) != nil ? pin : nil
         }
 
-        // Clear stale pinned ID
-        if let pinned = pinnedLanguageId {
-            if !enabledLanguageIds.contains(pinned) || LanguageConfig.language(withId: pinned) == nil {
-                pinnedLanguageId = nil
-            }
-        }
+        return NormalizedState(selected: selected, enabled: enabled, pinned: pinned)
+    }
 
-        // Persist normalized values
-        if resolvedLanguageId != defaults.string(forKey: SettingsKey.selectedLanguageId.rawValue) {
-            defaults.set(resolvedLanguageId, forKey: SettingsKey.selectedLanguageId.rawValue)
+    /// Re-reads the language state from the backing store, resolving
+    /// cross-process drift: the keyboard extension persists `selectedLanguageId`
+    /// on every in-keyboard language cycle, so a long-lived instance (the host
+    /// app singleton) must refresh before acting on its in-memory copy. Called
+    /// automatically before every mutating API and when the app foregrounds.
+    func reloadFromStore() {
+        let state = Self.loadNormalizedState(from: userDefaults)
+        // Only reassign on change so @Published does not emit spurious updates.
+        if enabledLanguageIds != state.enabled {
+            enabledLanguageIds = state.enabled
         }
-        Self.saveEnabledLanguageIds(enabledLanguageIds, to: defaults)
-        // Clearing a stale pin above happened inside `init`, where `didSet` does
-        // not fire — so remove the now-invalid key from storage explicitly,
-        // otherwise it would be re-read on the next launch.
-        if pinnedLanguageId == nil {
-            defaults.removeObject(forKey: SettingsKey.pinnedLanguageId.rawValue)
+        if selectedLanguageId != state.selected {
+            selectedLanguageId = state.selected
+        }
+        if pinnedLanguageId != state.pinned {
+            pinnedLanguageId = state.pinned
         }
     }
 
@@ -188,6 +213,7 @@ class LanguageSettings: ObservableObject {
 
     /// Pin a language as the default startup language. If already pinned, unpin it.
     func pinLanguage(_ language: LanguageConfig) {
+        reloadFromStore()
         if pinnedLanguageId == language.id {
             pinnedLanguageId = nil
         } else {
@@ -199,6 +225,7 @@ class LanguageSettings: ObservableObject {
     }
 
     func selectLanguage(_ language: LanguageConfig) {
+        reloadFromStore()
         if !enabledLanguageIds.contains(language.id) {
             enabledLanguageIds.append(language.id)
         }
@@ -209,6 +236,7 @@ class LanguageSettings: ObservableObject {
     /// disable the last remaining language (operation is rejected).
     @discardableResult
     func toggleLanguage(_ language: LanguageConfig) -> Bool {
+        reloadFromStore()
         if let index = enabledLanguageIds.firstIndex(of: language.id) {
             guard enabledLanguageIds.count > 1 else { return false }
             if selectedLanguageId == language.id {
@@ -262,16 +290,14 @@ class LanguageSettings: ObservableObject {
     }
 
     /// Returns the enabled language IDs filtered to known languages, guaranteed
-    /// non-empty and with the active language included — mirroring the
-    /// normalisation the initializer performs, but **without persisting**. Safe
-    /// to call repeatedly (e.g. from the keyboard extension's `reloadSettings`)
-    /// so a stale or empty stored list can never leave the runtime cycling to an
-    /// unknown id.
+    /// non-empty — mirroring the normalisation the initializer performs, but
+    /// **without persisting**. Safe to call repeatedly (e.g. from the keyboard
+    /// extension's `reloadSettings`) so a stale or empty stored list can never
+    /// leave the runtime cycling to an unknown id. A stored selection that is
+    /// not in the enabled list is deliberately **not** added back: that state
+    /// means the host app disabled the language after the keyboard selected it,
+    /// and re-adding it would resurrect a language the user turned off.
     static func normalizedEnabledLanguageIds(from defaults: UserDefaults) -> [String] {
-        let selected = resolvedLanguageId(defaults.string(forKey: SettingsKey.selectedLanguageId.rawValue))
-        let stored = loadEnabledLanguageIds(from: defaults) ?? []
-        let valid = stored.filter { LanguageConfig.language(withId: $0) != nil }
-        if valid.isEmpty { return [selected] }
-        return valid.contains(selected) ? valid : [selected] + valid
+        loadNormalizedState(from: defaults).enabled
     }
 }

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -858,4 +858,19 @@ struct LanguageSettingsStalenessTests {
         #expect(settings.selectedLanguageId == "de_DE")
         #expect(settings.enabledLanguageIds == ["en_US", "de_DE"])
     }
+
+    @Test("Pinning an externally-disabled language re-enables and pins it")
+    func pinReEnablesExternallyDisabledLanguage() {
+        // Deliberate asymmetry to the disable-wins invariant above: a pin is
+        // an explicit "use this language" request, so pin implies enabled —
+        // even when another process disabled the language in the meantime.
+        let defaults = makeStore()
+        let settings = LanguageSettings(userDefaults: defaults)
+
+        LanguageSettings.saveEnabledLanguageIds(["en_US"], to: defaults)
+        settings.pinLanguage(.german)
+
+        #expect(settings.enabledLanguageIds.contains("de_DE"))
+        #expect(settings.pinnedLanguageId == "de_DE")
+    }
 }

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -456,15 +456,19 @@ struct MultiLanguageSettingsTests {
         #expect(settings.enabledLanguageIds == ["en_US", "ru_RU"])
     }
 
-    @Test("Selected language always in enabled list after init")
-    func selectedAlwaysInEnabled() {
+    @Test("Init reselects the first enabled language when selected is not enabled")
+    func selectedNotEnabledReselectsFirstEnabled() {
         let (defaults, suite) = createTestDefaults()
         defer { defaults.removePersistentDomain(forName: suite) }
 
-        // Selected is ru_RU but enabled list only has en_US
+        // Selected is ru_RU but enabled list only has en_US — this state arises
+        // when the language was disabled elsewhere; the disable must win, so the
+        // selection falls back instead of re-enabling ru_RU.
         let settings = createSettings(defaults: defaults, selectedId: "ru_RU", enabledIds: ["en_US"])
-        #expect(settings.enabledLanguageIds.contains("ru_RU"))
-        #expect(settings.enabledLanguageIds.contains("en_US"))
+        #expect(settings.selectedLanguageId == "en_US")
+        #expect(settings.enabledLanguageIds == ["en_US"])
+        // The corrected selection is persisted for the keyboard extension.
+        #expect(defaults.string(forKey: SettingsKey.selectedLanguageId.rawValue) == "en_US")
     }
 
     @Test("Enabled list persistence round-trips through JSON")
@@ -759,12 +763,15 @@ struct NormalizedEnabledLanguageIdsTests {
         #expect(LanguageSettings.normalizedEnabledLanguageIds(from: defaults) == ["ru_RU"])
     }
 
-    @Test("Includes the selected language even when missing from the stored list")
-    func includesSelectedWhenAbsent() {
+    @Test("Does not re-add a selected language missing from the stored list")
+    func doesNotReAddSelectedWhenAbsent() {
+        // selected = de_DE with de_DE absent from the enabled list means the
+        // host app disabled German after the keyboard selected it — treating it
+        // as enabled again would resurrect a language the user turned off.
         let (defaults, suite) = makeDefaults(selected: "de_DE", enabled: ["en_US"])
         defer { defaults.removePersistentDomain(forName: suite) }
 
-        #expect(LanguageSettings.normalizedEnabledLanguageIds(from: defaults) == ["de_DE", "en_US"])
+        #expect(LanguageSettings.normalizedEnabledLanguageIds(from: defaults) == ["en_US"])
     }
 
     @Test("Does not persist — leaves the stored list untouched")
@@ -774,5 +781,81 @@ struct NormalizedEnabledLanguageIdsTests {
 
         _ = LanguageSettings.normalizedEnabledLanguageIds(from: defaults)
         #expect(LanguageSettings.loadEnabledLanguageIds(from: defaults) == ["de_DE", "zz_ZZ"])
+    }
+}
+
+// MARK: - Cross-Process Staleness
+
+/// The host app holds `LanguageSettings.shared` for its whole lifetime while
+/// the keyboard extension writes `selectedLanguageId` on every globe-key
+/// language cycle. These tests simulate that cross-process drift by writing to
+/// the injected in-memory store externally between init and the mutating call.
+struct LanguageSettingsStalenessTests {
+    /// Store seeded with `selected = en_US`, `enabled = [en_US, de_DE]`.
+    private func makeStore() -> InMemoryUserDefaults {
+        let defaults = InMemoryUserDefaults()
+        defaults.set("en_US", forKey: SettingsKey.selectedLanguageId.rawValue)
+        LanguageSettings.saveEnabledLanguageIds(["en_US", "de_DE"], to: defaults)
+        return defaults
+    }
+
+    @Test("Disabling the externally-selected language reselects a remaining one")
+    func toggleRefreshesBeforeDisabling() {
+        let defaults = makeStore()
+        let settings = LanguageSettings(userDefaults: defaults)
+
+        // The keyboard extension cycles to German while the app is backgrounded.
+        defaults.set("de_DE", forKey: SettingsKey.selectedLanguageId.rawValue)
+
+        // Back in the app, the user disables German.
+        let result = settings.toggleLanguage(.german)
+
+        #expect(result == true)
+        #expect(settings.selectedLanguageId == "en_US")
+        #expect(settings.enabledLanguageIds == ["en_US"])
+        // The store ends consistent: the selection is enabled, German is gone.
+        #expect(defaults.string(forKey: SettingsKey.selectedLanguageId.rawValue) == "en_US")
+        #expect(LanguageSettings.loadEnabledLanguageIds(from: defaults) == ["en_US"])
+    }
+
+    @Test("A disabled language stays disabled across a fresh init")
+    func disabledLanguageDoesNotResurrect() {
+        let defaults = makeStore()
+        let settings = LanguageSettings(userDefaults: defaults)
+
+        defaults.set("de_DE", forKey: SettingsKey.selectedLanguageId.rawValue)
+        settings.toggleLanguage(.german)
+
+        // The next app launch re-reads the store — German must not come back.
+        let relaunched = LanguageSettings(userDefaults: defaults)
+        #expect(relaunched.enabledLanguageIds == ["en_US"])
+        #expect(relaunched.selectedLanguageId == "en_US")
+    }
+
+    @Test("Init with an inconsistent store reselects the first enabled language")
+    func initNormalizesInconsistentStore() {
+        // selected = de_DE while de_DE is not enabled: the state an external
+        // writer (or the pre-fix toggle path) can leave behind.
+        let defaults = InMemoryUserDefaults()
+        defaults.set("de_DE", forKey: SettingsKey.selectedLanguageId.rawValue)
+        LanguageSettings.saveEnabledLanguageIds(["en_US"], to: defaults)
+
+        let settings = LanguageSettings(userDefaults: defaults)
+
+        #expect(settings.selectedLanguageId == "en_US")
+        #expect(settings.enabledLanguageIds == ["en_US"])
+        #expect(defaults.string(forKey: SettingsKey.selectedLanguageId.rawValue) == "en_US")
+    }
+
+    @Test("reloadFromStore picks up an external language cycle")
+    func reloadPicksUpExternalSelection() {
+        let defaults = makeStore()
+        let settings = LanguageSettings(userDefaults: defaults)
+
+        defaults.set("de_DE", forKey: SettingsKey.selectedLanguageId.rawValue)
+        settings.reloadFromStore()
+
+        #expect(settings.selectedLanguageId == "de_DE")
+        #expect(settings.enabledLanguageIds == ["en_US", "de_DE"])
     }
 }


### PR DESCRIPTION
## Problem

The host app's `LanguageSettings` singleton read the shared app-group defaults once at init and never refreshed, while the keyboard extension persists `selectedLanguageId` on every in-keyboard (globe key) language cycle.

Concrete failure sequence:
1. App is backgrounded with `selected = en_US` in its in-memory singleton.
2. User cycles the keyboard to `de_DE` — the store now has `selected = de_DE`.
3. User returns to the app and disables German in Settings. `toggleLanguage` consults its stale `selectedLanguageId == en_US`, so it removes `de_DE` from the enabled list **without reselecting** — the store ends inconsistent (`selected = de_DE`, `enabled = [en_US]`).
4. The extension's normalization treats German as still enabled, and on next app launch init re-inserted the selected language into the enabled list: **the language the user explicitly disabled reappears enabled and active.**

## Fix (two layers)

- **Refresh before mutate:** `toggleLanguage`, `pinLanguage`, and `selectLanguage` reload state from the store before applying their logic, so decisions are made against fresh cross-process state.
- **Refresh on foreground:** the app reloads the shared singleton whenever the scene becomes active (`scenePhase` observation in `wurstfingerApp`).

## Normalization invariant

Normalization is now centralized in `loadNormalizedState` with one rule: **the selection must be a member of the enabled list.** When it is not, the selection falls back to the first enabled language instead of re-enabling the selected one — an explicit disable is never silently undone. `normalizedEnabledLanguageIds` follows the same rule, so the extension no longer treats a disabled language as enabled.

## Tests

New Swift Testing cases in `LanguageSettingsTests` simulate the cross-process scenario with an injected in-memory store: external `selectedLanguageId` write between init and `toggleLanguage` → disabling the externally-selected language reselects a remaining enabled language and leaves the store consistent; init with an inconsistent store normalizes per the invariant above. `LanguageSettingsTests` and `LanguageSwitchingTests` are green.

Found by a full-codebase review; part of a series of fixes (#205–#212).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - App state now refreshes shared language settings more reliably when the app returns to the foreground.
  - Language settings are normalized on load and store reload to prevent inconsistent saved state.
  - Disabled or unknown languages no longer reappear in enabled/selection or cycling behavior.
  - Settings changes made elsewhere are applied more consistently, reducing cross-process stale state.
- **Tests**
  - Updated and expanded language settings tests to cover new normalization and drift scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->