### PR TITLE
Wire Compose Rule Overrides Into the Pipeline

### DIFF
--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -23,6 +23,9 @@ enum GridKeyboardFactory {
     ///     auto-generated uppercase return action (e.g. Hebrew final forms:
     ///     a return swipe on כ produces ך). Each entry must target a gesture
     ///     that already has a binding on that slot.
+    ///   - composeRuleOverrides: Language-specific compose rules merged over the
+    ///     global base rules at runtime (override wins for the same trigger +
+    ///     base character). Defaults to nil (global rules only).
     ///   - numericBackToAlphaLabel: Label shown on the symbols key in numeric
     ///     mode that switches back to the main (alphabetic) layer. Defaults to
     ///     the Latin "abc"; non-Latin layouts (Hebrew, Russian, …) should
@@ -37,6 +40,7 @@ enum GridKeyboardFactory {
         centerCharacters: [[String]],
         directionalOverrides: [String: [GestureType: String]] = [:],
         returnOverrides: [String: [GestureType: String]] = [:],
+        composeRuleOverrides: ComposeRuleSet? = nil,
         numericBackToAlphaLabel: String = NumericLayouts.defaultBackToAlphaLabel,
         inputMethod: InputMethodKind = .direct
     ) -> KeyboardDefinition {
@@ -151,7 +155,7 @@ enum GridKeyboardFactory {
             defaultMode: ModeNames.main,
             settings: KeyboardDefinitionSettings(
                 autoCapitalize: true,
-                composeRuleOverrides: nil,
+                composeRuleOverrides: composeRuleOverrides,
                 inputMethod: inputMethod
             ),
             numericBackToAlphaLabel: numericBackToAlphaLabel

--- a/wurstfingerKeyboard/Definition/Language/KeyboardDefinition.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardDefinition.swift
@@ -106,7 +106,9 @@ struct KeyboardDefinitionSettings: Codable, Equatable {
     let autoCapitalize: Bool
 
     /// Language-specific compose rule overrides.
-    /// Merged with global base rules at runtime.
+    /// Merged with global base rules at runtime: an override wins over the
+    /// global rule for the same trigger + base character; all other global
+    /// rules stay available.
     /// nil = only use global rules (sufficient for most languages).
     let composeRuleOverrides: ComposeRuleSet?
 

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -90,13 +90,16 @@ extension KeyboardViewModel {
             self?.triggerHapticTap()
         }))
 
-        // 2. Compose + Cycle Accents
+        // 2. Compose + Cycle Accents — per-definition engine so language-specific
+        // compose rule overrides are honored (rebuilt on every definition load).
+        let composeEngine = definition.settings.composeRuleOverrides
+            .map { ComposeEngine.withGlobalRules(overrides: $0) } ?? .shared
         middlewares.append(ComposeMiddleware(
             compose: { previous, trigger in
-                ComposeEngine.compose(previous: previous, trigger: trigger)
+                composeEngine.compose(previous: previous, trigger: trigger)
             },
             cycleAccent: { character in
-                ComposeEngine.cycleAccent(for: character)
+                composeEngine.cycleAccent(for: character)
             },
             previousCharacter: { [weak self] in
                 self?.textInputTarget?.documentContextBeforeInput?.last.map(String.init) ?? ""

--- a/wurstfingerTests/ComposeOverrideWiringTests.swift
+++ b/wurstfingerTests/ComposeOverrideWiringTests.swift
@@ -1,0 +1,107 @@
+//
+//  ComposeOverrideWiringTests.swift
+//  WurstfingerTests
+//
+//  End-to-end tests for language-specific compose rule overrides:
+//  factory → definition settings → pipeline → ComposeMiddleware.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+/// Builds a view model whose loaded definition comes from
+/// `GridKeyboardFactory.layout` with the given compose rule overrides.
+private func makeOverrideViewModel(
+    composeRuleOverrides: ComposeRuleSet?
+) -> (KeyboardViewModel, MockTextTarget) {
+    let vm = KeyboardViewModel(userDefaults: InMemoryUserDefaults(), shouldPersistSettings: false)
+    let target = MockTextTarget()
+    vm.bindTextInputTarget(target)
+    let definition = GridKeyboardFactory.layout(
+        id: "test_compose_overrides",
+        title: "Test Compose Overrides",
+        localeIdentifier: "de_DE",
+        centerCharacters: [
+            ["a", "n", "i"],
+            ["h", "d", "r"],
+            ["t", "e", "s"],
+        ],
+        composeRuleOverrides: composeRuleOverrides
+    )
+    vm.currentDefinition = definition
+    vm.activeModeName = definition.defaultMode
+    vm.currentMode = definition.mode(definition.defaultMode)
+    vm.rebuildResolverChain()
+    vm.rebuildPipeline()
+    return (vm, target)
+}
+
+@Suite(.serialized)
+struct ComposeOverrideWiringTests {
+    private let overrides = ComposeRuleSet(rules: [
+        "¨": ["a": "ǟ"],
+    ])
+
+    @Test func factoryPassesOverridesIntoSettings() {
+        let definition = GridKeyboardFactory.layout(
+            id: "test_compose_overrides",
+            title: "Test Compose Overrides",
+            localeIdentifier: "de_DE",
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["h", "d", "r"],
+                ["t", "e", "s"],
+            ],
+            composeRuleOverrides: overrides
+        )
+        #expect(definition.settings.composeRuleOverrides == overrides)
+    }
+
+    @Test func factoryDefaultsOverridesToNil() {
+        let definition = GridKeyboardFactory.layout(
+            id: "test_compose_overrides",
+            title: "Test Compose Overrides",
+            localeIdentifier: "de_DE",
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["h", "d", "r"],
+                ["t", "e", "s"],
+            ]
+        )
+        #expect(definition.settings.composeRuleOverrides == nil)
+    }
+
+    @Test func overrideWinsOverGlobalRuleThroughPipeline() {
+        let (vm, target) = makeOverrideViewModel(composeRuleOverrides: overrides)
+        target.documentContextBeforeInput = "a"
+        // Global rule is ¨ + a → ä; the override replaces it with ǟ.
+        vm.dispatchAction(.compose(trigger: "¨"))
+        #expect(target.events == [.deleteBackward, .insertText("ǟ")])
+    }
+
+    @Test func globalRulesStillApplyForUnoverriddenBases() {
+        let (vm, target) = makeOverrideViewModel(composeRuleOverrides: overrides)
+        target.documentContextBeforeInput = "o"
+        // "o" is not overridden — the global rule ¨ + o → ö must still fire.
+        vm.dispatchAction(.compose(trigger: "¨"))
+        #expect(target.events == [.deleteBackward, .insertText("ö")])
+    }
+
+    @Test func definitionWithoutOverridesUsesGlobalRules() {
+        let (vm, target) = makeOverrideViewModel(composeRuleOverrides: nil)
+        target.documentContextBeforeInput = "a"
+        vm.dispatchAction(.compose(trigger: "¨"))
+        #expect(target.events == [.deleteBackward, .insertText("ä")])
+    }
+
+    @Test func loadingDefinitionWithoutOverridesRebuildsGlobalEngine() {
+        // Start with an override-carrying definition, then load a shipped
+        // language: the pipeline must fall back to the shared global engine.
+        let (vm, target) = makeOverrideViewModel(composeRuleOverrides: overrides)
+        vm.loadDefinition(for: "de_DE")
+        target.documentContextBeforeInput = "a"
+        vm.dispatchAction(.compose(trigger: "¨"))
+        #expect(target.events == [.deleteBackward, .insertText("ä")])
+    }
+}


### PR DESCRIPTION
## Problem

`KeyboardDefinitionSettings.composeRuleOverrides` was a documented but dead extension point:

- The doc comment claims the overrides are "Merged with global base rules at runtime", but `ComposeMiddleware` was wired to the static `ComposeEngine.shared`, which is built solely from `ComposeRuleSet.global`.
- `ComposeEngine.withGlobalRules(overrides:)` existed but had zero callers.
- `GridKeyboardFactory.layout` hardcoded `composeRuleOverrides: nil`, so no language could even set the field.

Any language that supplied language-specific compose rules through the documented mechanism got a silent no-op.

## Changes

- `GridKeyboardFactory.layout` gains a `composeRuleOverrides: ComposeRuleSet? = nil` parameter that is passed into the definition settings (all existing call sites unchanged).
- `rebuildPipeline()` now builds the compose engine per definition: `ComposeEngine.withGlobalRules(overrides:)` when the loaded definition carries overrides, `ComposeEngine.shared` otherwise. Since `rebuildPipeline()` runs on every `loadDefinition(for:)`, the engine is rebuilt whenever the language changes. Both the `compose` and `cycleAccent` closures use the same per-definition engine, so accent cycles also reflect the merged rule set.
- Sharpened the doc comment on `composeRuleOverrides` to pin the actual merge semantics.

## Merge semantics

`ComposeRuleSet.merging(overrides:)` (unchanged): an override wins over the global rule for the same trigger + base character; all other global rules stay available; new triggers/entries are added.

## Tests

New `ComposeOverrideWiringTests` (Swift Testing) cover the plumbing end to end:

- Factory passes overrides into settings (and still defaults to nil).
- A definition with an override produces the overridden composition through the real view-model pipeline (`¨ + a → ǟ` instead of the global `ä`).
- Non-overridden bases still use global rules (`¨ + o → ö`).
- A definition without overrides behaves exactly as before.
- Loading a shipped language after an override-carrying definition falls back to the shared global engine.

## Notes

No shipped language sets overrides yet — this PR is pure plumbing plus tests. Languages that need language-specific compose rules can now adopt the parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language-specific compose-rule overrides are now supported in keyboard layouts, allowing certain keyboard definitions to use customized compose behavior at runtime.
* **Bug Fixes**
  * Fixed compose and accent-cycling behavior so overridden rules take effect correctly while still preserving the rest of the shared compose rules.
* **Tests**
  * Added end-to-end coverage to verify override behavior and fallback to the default compose rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->