### PR TITLE
Make Compose Trigger Labels Hideable

### DIFF
--- a/wurstfingerKeyboard/Definition/Model/LabelCategory.swift
+++ b/wurstfingerKeyboard/Definition/Model/LabelCategory.swift
@@ -56,15 +56,22 @@ extension LabelCategory {
 
     /// Display category for a binding. The binding's semantic `KeyCategory`
     /// identifies the never-hidden buckets (modifiers, utility, whitespace,
-    /// digits) and compose triggers; letters and symbols are then classified by
+    /// digits); letters, symbols, and compose triggers are then classified by
     /// their label text so the standard/extra split applies.
     static func of(_ binding: KeyBinding) -> LabelCategory {
         switch binding.resolvedCategory {
         case .letter: .letter
         case .digit: .number
-        // Compose/accent triggers are treated like other control keys (shift,
-        // symbols toggle): always visible, never hidden by the toggles.
-        case .modifier, .utility, .whitespace, .compose: .functional
+        case .modifier, .utility, .whitespace: .functional
+        case .compose:
+            // The accent-cycle key (🅒) is a control and stays visible; compose
+            // *triggers* (´ ¨ ~ ° …) read as symbols and hide with the symbol
+            // toggles.
+            if case .cycleAccents = binding.action {
+                .functional
+            } else {
+                classify(binding.label)
+            }
         case .symbol: classify(binding.label)
         }
     }

--- a/wurstfingerTests/LabelCategoryTests.swift
+++ b/wurstfingerTests/LabelCategoryTests.swift
@@ -69,6 +69,9 @@ struct LabelCategoryTests {
                 "\(trigger) should hide with extra symbols"
             )
         }
+        // The grave trigger ˋ (U+02CB, a modifier *letter* per Unicode) is
+        // displayed as "`" on the key face — classify by the shipped label.
+        #expect(LabelCategory.of(binding("`", .compose(trigger: "ˋ"))) == .extraSymbol)
         #expect(LabelCategory.of(binding("°", .compose(trigger: "°"))) == .standardSymbol)
         #expect(LabelCategory.of(binding("*", .compose(trigger: "*"))) == .standardSymbol)
     }

--- a/wurstfingerTests/LabelCategoryTests.swift
+++ b/wurstfingerTests/LabelCategoryTests.swift
@@ -56,8 +56,47 @@ struct LabelCategoryTests {
         #expect(LabelCategory.of(binding("", .switchMode("symbols"))) == .functional) // modifier
         #expect(LabelCategory.of(binding("⌫", .deleteBackward)) == .functional) // utility
         #expect(LabelCategory.of(binding(" ", .space)) == .functional) // whitespace
-        // Compose/accent triggers stay visible like other control keys.
-        #expect(LabelCategory.of(binding("´", .compose(trigger: "´"))) == .functional)
+        // The accent-cycle key is a control and stays visible.
+        #expect(LabelCategory.of(binding("\u{1F152}", .cycleAccents)) == .functional)
+    }
+
+    @Test func composeTriggersHideLikeSymbols() {
+        // Compose triggers read as symbols on the key face, so they follow the
+        // symbol toggles instead of staying pinned like control keys.
+        for trigger in ["´", "^", "~", "¨", "$"] {
+            #expect(
+                LabelCategory.of(binding(trigger, .compose(trigger: trigger))) == .extraSymbol,
+                "\(trigger) should hide with extra symbols"
+            )
+        }
+        #expect(LabelCategory.of(binding("°", .compose(trigger: "°"))) == .standardSymbol)
+        #expect(LabelCategory.of(binding("*", .compose(trigger: "*"))) == .standardSymbol)
+    }
+
+    @Test func hidingEverythingLeavesOnlyControlLabelsOnLetterGrid() throws {
+        // With all three toggles on, the letter grid of the German layout must
+        // show only the accent-cycle key and the shift modifier; the utility
+        // column is not part of this rule and stays untouched.
+        let definition = KeyboardRegistry.load(id: "de_DE")
+        let mode = try #require(definition?.modes[ModeNames.main])
+
+        var visibleLabels: Set<String> = []
+        for slotRow in GridSlot.allSlots {
+            for slot in slotRow {
+                guard let key = mode.keys[slot] else { continue }
+                for (_, keyBinding) in key.bindings where !keyBinding.label.isEmpty {
+                    let category = LabelCategory.of(keyBinding)
+                    if category.isVisible(hideLetters: true, hideStandardSymbols: true, hideExtraSymbols: true) {
+                        visibleLabels.insert(keyBinding.label)
+                    }
+                }
+            }
+        }
+
+        #expect(
+            visibleLabels == ["\u{1F152}", "⇧"],
+            "Unexpected labels survive hide-all: \(visibleLabels.sorted())"
+        )
     }
 
     // MARK: - isVisible(...)


### PR DESCRIPTION
## Problem

The label-visibility feature (#200) classifies every binding with the `.compose` category as `functional` — never hidden. That bucket contains not only the accent-cycle control key (🅒) but also all eight compose *trigger* labels (`´ ˋ ^ $ ~ ¨ * °`), which visually read as symbols on the key faces.

Result: with all three hide toggles enabled, the letter grid still shows those eight symbol labels instead of only the control keys — the classification was incomplete for practicing the layout from memory.

## Fix

`LabelCategory.of` now distinguishes within the `.compose` category:
- `.cycleAccents` (the 🅒 key) remains `functional` — always visible, like shift.
- Compose *triggers* are classified by their label text like any other symbol (`* °` → standard symbols, `´ ^ ~ ¨ $` → extra symbols) and hide with the corresponding toggles.

Modifiers (⇧/⇩), digits, and the utility column are untouched.

## Tests

- `composeTriggersHideLikeSymbols` — pins the new per-trigger classification.
- `hidingEverythingLeavesOnlyControlLabelsOnLetterGrid` — loads the real German definition and asserts that with all toggles on, the 3×3 letter grid shows exactly {🅒, ⇧} and nothing else.
- `mapsControlKeysToFunctional` updated (🅒 instead of the former blanket `´` expectation).

`LabelCategoryTests`, `KeyboardGridRenderingTests`, and `GermanLayoutTests` are green.

Related: the separate compose fix in the `fix/vietnamese-tone-rules-not-global` branch changes the `*` binding to `.commitText` — after both merge, `*` classifies as a standard symbol either way; no conflict (different files).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how compose-related keys are categorized so their visibility now matches the specific label or action.
  * Compose triggers with symbol-like labels may now be hidden or shown correctly based on label visibility settings.
  * Refined behavior so the accent-cycle key stays visible while other compose-trigger keys follow standard visibility rules.

* **Tests**
  * Updated coverage to reflect the new compose-key visibility behavior.
  * Added a broader check confirming only the intended keys remain visible when all hide options are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->