### PR TITLE
Use Window Bounds Instead of Screen Bounds for Keyboard Sizing

### DIFF
--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -139,6 +139,10 @@ final class KeyboardViewController: UIInputViewController {
         // Update viewModel with current width so SwiftUI re-renders after
         // orientation changes that happen while the keyboard is backgrounded.
         viewModel.updateViewWidth(view.bounds.width)
+        // Window (not screen) bounds keep sizing correct in Split View and
+        // Stage Manager; UIApplication.shared is unavailable in extensions,
+        // so the window is reached through the view hierarchy.
+        viewModel.updateWindowBounds(view.window?.bounds)
     }
 
     override var needsInputModeSwitchKey: Bool {

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -59,6 +59,14 @@ final class KeyboardViewModel: ObservableObject {
     /// Updated by the controller in `viewWillLayoutSubviews()` so that
     /// SwiftUI re-evaluates layout after orientation changes.
     @Published private(set) var viewWidth: CGFloat = UIScreen.main.bounds.width
+    /// Shortest side of the hosting window, used to cap the keyboard width so
+    /// it keeps its portrait width in landscape. Measured from the actual
+    /// window (not the full screen) so sizing stays correct in Split View and
+    /// Stage Manager; falls back to the device screen until a window is
+    /// attached.
+    @Published private(set) var windowShortestSide: CGFloat = min(
+        DeviceLayoutUtils.screenBounds.width, DeviceLayoutUtils.screenBounds.height
+    )
     /// The currently active keyboard mode.
     @Published var currentMode: KeyboardMode?
     /// Name of the currently active mode in the data-driven definition.
@@ -188,6 +196,16 @@ final class KeyboardViewModel: ObservableObject {
     func updateViewWidth(_ width: CGFloat) {
         guard width != viewWidth else { return }
         viewWidth = width
+    }
+
+    /// Updates the tracked window bounds. Called by the controller in
+    /// `viewWillLayoutSubviews()` with the hosting window's bounds; a nil
+    /// window (not yet attached) falls back to the device screen.
+    func updateWindowBounds(_ bounds: CGRect?) {
+        let reference = bounds ?? DeviceLayoutUtils.screenBounds
+        let shortestSide = min(reference.width, reference.height)
+        guard shortestSide > 0, shortestSide != windowShortestSide else { return }
+        windowShortestSide = shortestSide
     }
 
     // MARK: - Arrangement Selection

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -22,10 +22,9 @@ struct DataDrivenKeyboardRootView: View {
     private var keyboardStyle: KeyboardStyle = .classic
 
     var body: some View {
-        let screenBounds = DeviceLayoutUtils.screenBounds
-        let screenShortestSide = min(screenBounds.width, screenBounds.height)
+        let containerShortestSide = viewModel.windowShortestSide
         let currentWidth = overrideWidth ?? viewModel.viewWidth
-        let baseWidth = min(currentWidth, screenShortestSide)
+        let baseWidth = min(currentWidth, containerShortestSide)
         let scaledWidth = baseWidth * viewModel.keyboardScale
         let availableSpace = currentWidth - scaledWidth
         let horizontalOffset = availableSpace * (viewModel.keyboardHorizontalPosition - 0.5)

--- a/wurstfingerTests/OrientationLayoutTests.swift
+++ b/wurstfingerTests/OrientationLayoutTests.swift
@@ -51,4 +51,58 @@ struct OrientationLayoutTests {
         #expect(publishCount == 1, "Same width should not publish again")
         _ = cancellable
     }
+
+    // MARK: - Window bounds (Split View / Stage Manager, issue #116)
+
+    @Test("Window bounds publish their shortest side")
+    func windowBoundsPublishShortestSide() {
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+
+        // Landscape Split View pane: height is the shortest side.
+        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 507, height: 834))
+        #expect(viewModel.windowShortestSide == 507)
+
+        // Portrait pane: width is the shortest side.
+        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 320, height: 1180))
+        #expect(viewModel.windowShortestSide == 320)
+    }
+
+    @Test("Nil window falls back to the device screen")
+    func nilWindowFallsBackToScreen() {
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        let screenShortestSide = min(
+            DeviceLayoutUtils.screenBounds.width, DeviceLayoutUtils.screenBounds.height
+        )
+
+        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 507, height: 834))
+        viewModel.updateWindowBounds(nil)
+
+        #expect(viewModel.windowShortestSide == screenShortestSide)
+    }
+
+    @Test("Same window bounds do not trigger redundant publish")
+    func sameWindowBoundsNoRedundantPublish() {
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+
+        var publishCount = 0
+        let cancellable = viewModel.$windowShortestSide
+            .dropFirst()
+            .sink { _ in publishCount += 1 }
+
+        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 507, height: 834))
+        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 507, height: 834))
+
+        #expect(publishCount == 1, "Same bounds should not publish again")
+        _ = cancellable
+    }
+
+    @Test("Degenerate window bounds are ignored")
+    func degenerateWindowBoundsIgnored() {
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+
+        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 507, height: 834))
+        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 0, height: 834))
+
+        #expect(viewModel.windowShortestSide == 507, "Zero-sized bounds must not be adopted")
+    }
 }


### PR DESCRIPTION
Closes #116.

## Problem

`DataDrivenKeyboardRootView` capped the keyboard width against `DeviceLayoutUtils.screenBounds` (`UIScreen.main.bounds`). Full-screen dimensions are wrong whenever the hosting window is smaller than the screen — Split View and Stage Manager on iPad — and `UIScreen.main` is deprecated since iOS 16. The app is currently iPhone-only, so this cannot misbehave in production yet; this change is preparation for the planned iPad support.

## Fix

- `KeyboardViewModel` gains a published `windowShortestSide` (initialized from the screen as a pre-attach fallback) with an equality-guarded `updateWindowBounds(_:)`, mirroring the existing `viewWidth`/`updateViewWidth` pattern. Nil bounds (no window attached yet) fall back to `DeviceLayoutUtils.screenBounds`; degenerate zero-sized bounds are ignored.
- `KeyboardViewController.viewWillLayoutSubviews` feeds `view.window?.bounds` into the view model — the window is reached through the view hierarchy since `UIApplication.shared` is unavailable in extensions.
- `DataDrivenKeyboardRootView` uses `viewModel.windowShortestSide` for the width cap instead of reading `UIScreen.main` directly.

On iPhone, window bounds always equal screen bounds, so behavior is unchanged today.

## Not in scope

`DeviceLayoutUtils.defaultKeyboardScale` still derives the *registered default* scale from screen width (host-app side, full-screen window on iPhone). Worth revisiting when iPad support actually lands, since the sensible default may become size-class-dependent anyway.

## Tests

New cases in `OrientationLayoutTests`: shortest-side selection for landscape/portrait panes, nil-window screen fallback, equality-guarded publishing, and rejection of zero-sized bounds. Suite is green.

Manual verification once iPad support exists: enable the keyboard in a Split View pane and confirm it sizes to the pane, not the screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard sizing in split-screen and Stage Manager layouts by using the window’s actual bounds.
  * Updated layout calculations to follow the current shortest window side, helping keep the keyboard sized correctly after rotation or window changes.

* **Tests**
  * Added coverage for window-bound updates, fallback behavior, unchanged values, and zero-sized bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->