### PR TITLE
Add Space-Bar Label Visibility Gestures

### DIFF
--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -19,6 +19,11 @@ enum SlidePhase: Equatable {
     case ended
     /// Drag ended without exceeding the slide activation threshold → tap.
     case tap
+    /// Vertical up-swipe ended while the horizontal slide never activated.
+    /// `isReturn` is true when the finger came back toward its origin
+    /// (MessagEase: up toggles extra-symbol labels, return-up toggles
+    /// letter + standard-symbol labels).
+    case swipeUp(isReturn: Bool)
     /// Touch sequence was cancelled by the system (incoming call, edge
     /// swipe, keyboard dismissal mid-drag). Consumers must discard drag
     /// state without committing any input.
@@ -33,6 +38,9 @@ struct SlideGestureState {
     private(set) var dragStarted = false
     private(set) var isSliding = false
     private(set) var lastTranslationX: CGFloat = 0
+    /// Most-negative vertical translation seen this gesture (SwiftUI's y axis
+    /// points down, so upward travel is negative). Peak of the up-swipe.
+    private(set) var upwardPeakY: CGFloat = 0
 
     /// Events produced by a single drag update.
     struct Update: Equatable {
@@ -49,6 +57,7 @@ struct SlideGestureState {
         }
 
         let currentX = translation.width
+        upwardPeakY = min(upwardPeakY, translation.height)
 
         if !isSliding, abs(currentX) >= activationThreshold {
             isSliding = true
@@ -72,10 +81,26 @@ struct SlideGestureState {
     }
 
     /// Processes `onEnded`. Returns the phase to report, or nil when the
-    /// gesture qualifies as neither a slide nor a tap.
-    mutating func handleEnded(translation: CGSize, activationThreshold: CGFloat) -> SlidePhase? {
+    /// gesture qualifies as neither a slide, an up-swipe, nor a tap.
+    mutating func handleEnded(
+        translation: CGSize,
+        activationThreshold: CGFloat,
+        swipeUpThreshold: CGFloat = KeyboardConstants.SpaceGestures.swipeUpActivationThreshold
+    ) -> SlidePhase? {
         defer { reset() }
         if isSliding { return .ended }
+        // Vertical classification runs only when the horizontal slide never
+        // activated, so cursor drags with vertical drift are unaffected. It
+        // must precede the tap check: a return-up swipe ends near its origin
+        // and would otherwise be classified as a tap.
+        if -upwardPeakY >= swipeUpThreshold {
+            // Mirror the discrete horizontal classification: a final position
+            // close to the origin relative to the peak means the finger
+            // returned. Downward peaks are never tracked, so down-swipes
+            // still fall through and stay ignored.
+            let ratio = abs(translation.height) / abs(upwardPeakY)
+            return .swipeUp(isReturn: ratio < KeyboardConstants.SpaceGestures.returnSwipeThreshold)
+        }
         // A tap must stay near its origin on *both* axes. Gating on
         // horizontal travel alone would classify a vertical flick (e.g.
         // 80 pt up on the space bar) as a tap and commit its center action.
@@ -96,6 +121,7 @@ struct SlideGestureState {
         dragStarted = false
         isSliding = false
         lastTranslationX = 0
+        upwardPeakY = 0
     }
 }
 

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -382,7 +382,28 @@ extension KeyboardViewModel {
             spaceDragPeak = 0
         case .tap:
             handleGesture(.tap, keyId: key.id, isReturn: false)
+        case let .swipeUp(isReturn):
+            // Only reported when the horizontal slide never activated, so
+            // this cannot interfere with cursor movement in either style.
+            toggleLabelVisibility(grouped: isReturn)
         }
+    }
+
+    /// MessagEase space-bar label toggles. A plain up-swipe flips the
+    /// extra-symbol labels; a return-up swipe (`grouped`) toggles letter and
+    /// standard-symbol labels together: only when both are hidden does it
+    /// show them again, otherwise it hides both.
+    private func toggleLabelVisibility(grouped: Bool) {
+        if grouped {
+            let hidden = sharedDefaults.bool(forKey: SettingsKey.hideLetters.rawValue)
+                && sharedDefaults.bool(forKey: SettingsKey.hideStandardSymbols.rawValue)
+            sharedDefaults.set(!hidden, forKey: SettingsKey.hideLetters.rawValue)
+            sharedDefaults.set(!hidden, forKey: SettingsKey.hideStandardSymbols.rawValue)
+        } else {
+            let hidden = sharedDefaults.bool(forKey: SettingsKey.hideExtraSymbols.rawValue)
+            sharedDefaults.set(!hidden, forKey: SettingsKey.hideExtraSymbols.rawValue)
+        }
+        feedbackTap()
     }
 
     /// Continuous (joystick) mode: emit one character move per `dragStep` of
@@ -502,6 +523,10 @@ extension KeyboardViewModel {
             deleteDragResidual = 0
         case .tap:
             handleGesture(.tap, keyId: key.id, isReturn: false)
+        case .swipeUp:
+            // The delete key has no vertical gestures; label toggles are a
+            // space-bar feature. Vertical flicks stay ignored.
+            break
         }
     }
 

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -138,6 +138,11 @@ enum KeyboardConstants {
         /// Maximum ratio of final displacement to peak displacement for a return swipe.
         /// Below this threshold, the gesture is classified as a return swipe (word movement).
         static let returnSwipeThreshold: CGFloat = 0.3
+
+        /// Minimum upward travel to classify a vertical space-bar swipe
+        /// (label-visibility toggle). Mirrors `Gesture.minSwipeLength` so the
+        /// space bar demands the same commitment as a key swipe.
+        static let swipeUpActivationThreshold: CGFloat = Gesture.minSwipeLength
     }
 
     // MARK: - Delete Key Gestures

--- a/wurstfingerTests/SlideGestureStateTests.swift
+++ b/wurstfingerTests/SlideGestureStateTests.swift
@@ -85,6 +85,104 @@ struct SlideGestureStateTests {
         #expect(phase == nil)
     }
 
+    // MARK: - Vertical up-swipes (label visibility toggles)
+
+    /// Space-bar up-swipe classification threshold.
+    private let upThreshold = KeyboardConstants.SpaceGestures.swipeUpActivationThreshold
+
+    @Test func upSwipeBeyondThresholdClassifiesAsSwipeUp() {
+        var state = SlideGestureState()
+        _ = state.handleChanged(
+            translation: CGSize(width: 2, height: -upThreshold), activationThreshold: threshold
+        )
+        _ = state.handleChanged(
+            translation: CGSize(width: 2, height: -upThreshold - 30), activationThreshold: threshold
+        )
+        let phase = state.handleEnded(
+            translation: CGSize(width: 2, height: -upThreshold - 30), activationThreshold: threshold
+        )
+        #expect(phase == .swipeUp(isReturn: false))
+    }
+
+    @Test func upSwipeReturningToOriginClassifiesAsReturn() {
+        var state = SlideGestureState()
+        _ = state.handleChanged(
+            translation: CGSize(width: 0, height: -upThreshold - 30), activationThreshold: threshold
+        )
+        _ = state.handleChanged(
+            translation: CGSize(width: 0, height: -4), activationThreshold: threshold
+        )
+        let phase = state.handleEnded(
+            translation: CGSize(width: 0, height: -4), activationThreshold: threshold
+        )
+        // Ends near the origin (below the tap threshold!) but the peak makes
+        // it a return-up swipe, not a tap.
+        #expect(phase == .swipeUp(isReturn: true))
+    }
+
+    @Test func upSwipeBelowThresholdIsIgnored() {
+        var state = SlideGestureState()
+        let translation = CGSize(width: 0, height: -upThreshold + 4)
+        _ = state.handleChanged(translation: translation, activationThreshold: threshold)
+        let phase = state.handleEnded(translation: translation, activationThreshold: threshold)
+        #expect(phase == nil)
+    }
+
+    @Test func downwardSwipeIsIgnored() {
+        var state = SlideGestureState()
+        let translation = CGSize(width: 0, height: upThreshold + 30)
+        _ = state.handleChanged(translation: translation, activationThreshold: threshold)
+        let phase = state.handleEnded(translation: translation, activationThreshold: threshold)
+        #expect(phase == nil)
+    }
+
+    @Test func upSwipeAfterHorizontalActivationEndsAsSlide() {
+        var state = SlideGestureState()
+        // Horizontal slide activates first, then the finger drifts far up:
+        // the gesture stays a cursor slide, never a label toggle.
+        _ = state.handleChanged(
+            translation: CGSize(width: threshold + 4, height: 0), activationThreshold: threshold
+        )
+        _ = state.handleChanged(
+            translation: CGSize(width: threshold + 4, height: -upThreshold - 30),
+            activationThreshold: threshold
+        )
+        let phase = state.handleEnded(
+            translation: CGSize(width: threshold + 4, height: -upThreshold - 30),
+            activationThreshold: threshold
+        )
+        #expect(phase == .ended)
+    }
+
+    @Test func tapWithSmallVerticalJitterIsStillATap() {
+        var state = SlideGestureState()
+        _ = state.handleChanged(
+            translation: CGSize(width: 1, height: -3), activationThreshold: threshold
+        )
+        let phase = state.handleEnded(
+            translation: CGSize(width: 1, height: -3), activationThreshold: threshold
+        )
+        #expect(phase == .tap)
+    }
+
+    @Test func cancellationResetsVerticalTracking() {
+        var state = SlideGestureState()
+        _ = state.handleChanged(
+            translation: CGSize(width: 0, height: -upThreshold - 70), activationThreshold: threshold
+        )
+        _ = state.handleCancelled()
+
+        // Next touch: a small movement must be a tap — a stale upward peak
+        // would classify it as a return-up swipe and toggle labels.
+        _ = state.handleChanged(
+            translation: CGSize(width: 1, height: -2), activationThreshold: threshold
+        )
+        let phase = state.handleEnded(
+            translation: CGSize(width: 1, height: -2), activationThreshold: threshold
+        )
+        #expect(phase == .tap)
+    }
+
     // MARK: - Touch cancellation (Bug 1)
 
     @Test func cancellationMidSlideReportsCancelled() {
@@ -175,5 +273,71 @@ struct SlideCancellationPipelineTests {
         vm.handleSlide(deleteKey, phase: .cancelled)
         #expect(!vm.isDeleteDragging)
         #expect(target.events.isEmpty)
+    }
+}
+
+// MARK: - Space-bar label visibility toggles (.swipeUp)
+
+@Suite(.serialized)
+struct SpaceLabelTogglePipelineTests {
+    private func hides(_ vm: KeyboardViewModel, _ key: SettingsKey) -> Bool {
+        vm.sharedDefaults.bool(forKey: key.rawValue)
+    }
+
+    @Test(arguments: [CursorMovementStyle.continuous, .discrete])
+    func upSwipeTogglesExtraSymbolsWithoutTextInput(style: CursorMovementStyle) throws {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+        vm.sharedDefaults.set(style.rawValue, forKey: SettingsKey.cursorMovementStyle.rawValue)
+        let spaceKey = try #require(vm.activeModeFromDefinition?.key(for: UtilitySlot.space))
+
+        vm.handleSlide(spaceKey, phase: .swipeUp(isReturn: false))
+        #expect(hides(vm, .hideExtraSymbols))
+        // No space typed, no cursor movement.
+        #expect(target.events.isEmpty)
+
+        vm.handleSlide(spaceKey, phase: .swipeUp(isReturn: false))
+        #expect(!hides(vm, .hideExtraSymbols))
+        #expect(target.events.isEmpty)
+        // Letter/standard visibility is untouched by the plain up-swipe.
+        #expect(!hides(vm, .hideLetters))
+        #expect(!hides(vm, .hideStandardSymbols))
+    }
+
+    /// Return-up group semantics: only when letters AND standard symbols are
+    /// both hidden does the gesture show them again; any other combination
+    /// hides both.
+    @Test(arguments: [
+        (letters: false, symbols: false, expected: true),
+        (letters: true, symbols: false, expected: true),
+        (letters: false, symbols: true, expected: true),
+        (letters: true, symbols: true, expected: false),
+    ])
+    func returnUpSwipeTogglesLettersAndStandardSymbolsAsGroup(
+        start: (letters: Bool, symbols: Bool, expected: Bool)
+    ) throws {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+        vm.sharedDefaults.set(start.letters, forKey: SettingsKey.hideLetters.rawValue)
+        vm.sharedDefaults.set(start.symbols, forKey: SettingsKey.hideStandardSymbols.rawValue)
+        let spaceKey = try #require(vm.activeModeFromDefinition?.key(for: UtilitySlot.space))
+
+        vm.handleSlide(spaceKey, phase: .swipeUp(isReturn: true))
+        #expect(hides(vm, .hideLetters) == start.expected)
+        #expect(hides(vm, .hideStandardSymbols) == start.expected)
+        // Extra symbols belong to the plain up-swipe, not the return swipe.
+        #expect(!hides(vm, .hideExtraSymbols))
+        #expect(target.events.isEmpty)
+    }
+
+    @Test func upSwipeOnDeleteKeyIsIgnored() throws {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+        target.documentContextBeforeInput = "hello"
+        let deleteKey = try #require(vm.activeModeFromDefinition?.key(for: UtilitySlot.delete))
+
+        vm.handleSlide(deleteKey, phase: .swipeUp(isReturn: false))
+        vm.handleSlide(deleteKey, phase: .swipeUp(isReturn: true))
+        #expect(target.events.isEmpty)
+        #expect(!hides(vm, .hideLetters))
+        #expect(!hides(vm, .hideStandardSymbols))
+        #expect(!hides(vm, .hideExtraSymbols))
     }
 }


### PR DESCRIPTION
> **Stacked on #206 — merge #206 first, then retarget this PR to `develop` before squash-merging.**

## What

Restores the original MessagEase space-bar gestures for toggling key-label visibility:

- **Swipe up** on the space bar: toggles the extra-symbol labels (`hideExtraSymbols`).
- **Return swipe up** (up and back toward the origin): toggles letter and standard-symbol labels **as a group** (`hideLetters` + `hideStandardSymbols`).
- Downward swipes stay ignored, and the delete key gets no vertical gestures (`handleDeleteSlide` explicitly ignores the new phase).

## How

- `SlideGestureState` now tracks the upward peak (`min` of `translation.height`; SwiftUI's y axis points down). In `handleEnded`, when the horizontal slide never activated and the peak exceeds the new `KeyboardConstants.SpaceGestures.swipeUpActivationThreshold` (mirrors `Gesture.minSwipeLength`, 30 pt), it emits `SlidePhase.swipeUp(isReturn:)`. Return classification reuses the existing `returnSwipeThreshold` peak/final ratio from the discrete horizontal path. The vertical check runs **before** the tap check, because a return-up swipe ends near its origin and would otherwise register as a tap.
- Cancellation and normal endings reset the vertical tracking, so a stale peak can never leak into the next touch.

### Works identically in both cursor-movement styles

The vertical axis was previously unused by the cursor logic (both continuous and discrete only consume `deltaX`). The new classification is guarded on `isSliding == false`, i.e. it only fires when the horizontal slide never activated — an activated cursor drag with vertical drift still ends as `.ended`, and taps with small vertical jitter still type a space. Since the `.swipeUp` phase is produced upstream of the discrete/continuous decision and never coexists with a slide, behavior is identical in both styles (covered by parameterized tests).

### Group-toggle semantics (return swipe)

`hidden = hideLetters && hideStandardSymbols`, then both keys are set to `!hidden`: only when **both** are already hidden does the gesture show them again; any other combination (both visible or mixed) hides both. This makes the gesture deterministic from mixed states.

### Routing decision: view-model method instead of a new `KeyAction`

The toggle is dispatched from `handleSpaceSlide` as a small private view-model method (`toggleLabelVisibility(grouped:)`) writing the settings keys to `sharedDefaults`, rather than a new `KeyAction` case + middleware. Rationale:

- `KeyAction` is the vocabulary of *bindable key actions* resolved from `KeyBinding`s; this gesture is a slide-phase event that never goes through the resolver chain, exactly like the existing word-jump/cursor logic that also lives in `handleSpaceSlide`.
- A new action case would require a new settings middleware (or widening an existing one) purely for plumbing, with no key binding ever able to reference it.
- Direct settings writes from the view model have precedent (`switchToNextLanguage` persists `selectedLanguageId` the same way). `KeyView` reads the keys live via `@AppStorage(store: SharedDefaults.store)`, so the rendered labels and the host-app Settings screen update automatically.

Haptics: the toggle triggers `feedbackTap()` (same feedback a dispatched action would get from `HapticMiddleware`).

## Tests

- `SlideGestureStateTests`: up-swipe classification, return-up classification (ends inside the tap radius), sub-threshold up-swipe ignored, downward swipe ignored, vertical-after-horizontal-activation stays a slide, tap with small vertical jitter stays a tap, cancellation resets vertical tracking.
- `SpaceLabelTogglePipelineTests`: up-swipe flips `hideExtraSymbols` without inserting text or moving the cursor (parameterized over `.continuous` and `.discrete`), return-up group semantics for all four start states, `.swipeUp` on the delete key is a no-op.
- Existing space-tap, cursor-movement, and cancellation suites stay green.

Full `WurstfingerTests` target: 786 passed; a handful of unrelated suites intermittently report 0.000 s "failures" with no recorded issues under full test parallelism (known simulator-clone infra flake) — all of them pass in targeted reruns.