### PR TITLE
WIP: Learned touch-offset correction (Key-Target-Resizing)

### DIFF
--- a/docs/touch-offset-correction-impl-plan.md
+++ b/docs/touch-offset-correction-impl-plan.md
@@ -1,0 +1,177 @@
+# v1-Implementierungsplan: Lernende Touch-Offset-Korrektur
+
+> Begleitdokument zu `touch-offset-correction.md` (Rev. 7). Setzt **nur v1** um. Abschnitts-
+> verweise (§) zeigen auf die Spezifikation.
+
+## Leitprinzipien
+
+- **Default-aus & gegated** (§6.1): Das Feature ist hinter einem Toggle; es kann **inkrementell
+  gemerged** werden, ohne Nutzer zu beeinflussen, bis es aktiviert wird.
+- **Inside-out:** erst der reine, testbare Kern (Modell/Regime/Persistenz), dann Plumbing, dann
+  Lernen, dann Anwendung, zuletzt UI.
+- **Jede Phase ist grün-testbar und für sich mergebar.**
+- **Worktree-Konvention:** alle Code-Änderungen in eigenem Worktree, Basis **`origin/develop`**.
+- **Bestehende Tests bleiben grün** — besonders bei Eingriffen in Gesten-/Layout-Code.
+
+## Worktree-Setup (Schritt 0)
+
+```bash
+# Basis aktualisieren und Worktree anlegen (Basis: origin/develop)
+git fetch origin
+git worktree add worktrees/touch-offset -b feature/touch-offset-correction origin/develop
+```
+
+Neues Verzeichnis für die Komponenten: `wurstfingerKeyboard/Runtime/TouchModel/`.
+SwiftFormat/SwiftLint `--strict` lint-clean halten.
+
+## Komponenten-Inventar
+
+**Neu** (`wurstfingerKeyboard/Runtime/TouchModel/`):
+| Datei | Inhalt | Spec |
+|---|---|---|
+| `TouchRegime.swift` | Regime-Typ + `derivePosture(scale, position)` + Orientierung | §3.1 |
+| `ReachSurface.swift` | Ridge-WLS-Fit (bilinear/linear), Auswertung, Rang-Guard | §3.2, §4.2-S2 |
+| `TouchOffsetModel.swift` | Per-Taste `{m_k,n_k,s_k}`, Update (Huber/Running-Mean/EW-MAD), Shrinkage+Clamp → Offset | §4.2 |
+| `TouchOffsetStore.swift` | Codable-Schema, `SharedDefaults`-Persistenz, Versionierung, Reset, debounced write | §7 |
+| `AcceptanceTracker.swift` | Ring-Puffer committeter Taps, Burst-Veto, Span-Alignment | §4.1 |
+| `GestureTelemetryModel.swift` | Per-`(Regime,Klasse[,Richtung])` Welford-Stats + Korrektur-Zähler + Histogramme | §13 |
+| `TouchLearningMiddleware.swift` | Pipeline-Sink: Acceptance + Offset-Sampling + Telemetrie | §5, §4.1, §13 |
+
+**Geändert:**
+| Datei | Änderung | Spec |
+|---|---|---|
+| `Runtime/Gesture/KeyGestureRecognizer.swift` | `startLocation` erfassen; Feature-Vektor mitliefern | §5, §13 |
+| `Runtime/Gesture/GesturePreprocessor.swift` | Features in `GestureClassification` exponieren | §13 |
+| `Runtime/View/KeyView.swift` | `onGesture`-Signatur (+ Touchdown) | §5 |
+| `Runtime/View/KeyboardGridLayout.swift` | `cellFrames` offset-bewusst (Grenzverschiebung) | §5.4 |
+| `Runtime/View/KeyboardGridView.swift` | asymmetrischer `visualInset`; Offsets injizieren | §5.5 |
+| `Runtime/Pipeline/KeyboardViewModel+Pipeline.swift` | `handleGesture`-Signatur; Middleware verdrahten | §5 |
+| `Settings/KeyboardSettings.swift` | `SettingsKey`: Toggle + Schema-Version | §6.1, §7 |
+| Host-App (`wurstfinger/`) | Settings-Unterseite (Toggle, Viz, Debug) | §6 |
+
+## Abhängigkeitsgraph
+
+```
+P1 Regime ─┐
+P2 Modell ─┼─→ P5 Lern-Middleware ─→ P7 Resizing-Anwendung ─→ P8 UI ─→ P9 Validierung
+P3 Persist ┘        ↑                        ↑
+P4 Plumbing ────────┴────────────────────────┘
+P6 Telemetrie ──────┘
+```
+P1–P3 (reiner Kern) sind unabhängig von P4 (Plumbing) → parallelisierbar. P5 braucht P2/P3/P4.
+P7 braucht P2/P4. P6 braucht P4.
+
+---
+
+## Phasen
+
+### P0 — Scaffolding (S)
+Worktree, Verzeichnis, `SettingsKey.touchOffsetEnabled` + `touchModelSchemaVersion`, leere
+Modul-Dateien mit Doc-Headern. **Exit:** Build grün, Toggle-Key existiert (noch ohne Wirkung).
+
+### P1 — Regime-Auflösung (S, rein)
+`TouchRegime` + `derivePosture` exakt nach der Partition §3.1 (inkl. „schmal & mittig → twoThumb",
+Floating = keine v1-Klasse). Hysterese-Hook (Schwellen als Parameter).
+**Tests:** Partition an allen Ecken + Schwellen-Grenzfällen; Hysterese verhindert Flackern.
+**Exit:** `(orientation, scale, position) → Regime` deterministisch, 100 % getestet.
+
+### P2 — TouchOffsetModel-Kern (L, rein) — *algorithmisches Herz*
+- State + Initialzustand (`m=0,n=0,s=s_prior≈0,10`, §4.2).
+- Update: absolutes Dwell-Gate-Hook, Outlier-Gate (nach `warmup`), **Huber-Clip**, Running-Mean,
+  EW-MAD, `n_max`-Deckel (§4.2-S1).
+- `ReachSurface`: Ridge-WLS, Basis **je Regime** (bilinear Einhand / linear twoThumb-Hälfte),
+  **Cache + Invalidierung**, Rang-Guard, Konstanten-Term = global (§4.2-S2).
+- Anwendung: `prior_k + (m_k−prior_k)·n_k/(n_k+κ)`, euklidischer **Clamp** ≤ 0,35 Pitch (§4.2-S3).
+**Tests (umfangreich):** unverzerrte Konvergenz auf konstanten Bias; Huber kappt Ausreißer;
+`n_max`-Plastizität überschreibt Altzustand; Shrinkage zieht sparse Tasten zur Fläche;
+Rang-Guard (<3 Tasten → Fläche≈0); Zwei-Hälften-Split; Clamp; **Feedback-Schleife driftet nicht**.
+**Exit:** Modell rein, deterministisch, alle Robustheits-Szenarien grün.
+
+### P3 — Persistenz (M)
+`Codable`-Schema, `SharedDefaults` (App-Group), Schema-Version + **partielle Invalidierung** bei
+Layout-Änderung (stabile `keyId`s), Reset (alles / pro Regime), **debounced/periodischer Write**.
+**Tests:** Round-Trip; Version-Bump invalidiert; partielle Invalidierung erhält gültige Keys;
+Reset nullt korrekt.
+**Exit:** Modell überlebt Neustart; Reset + Migration getestet.
+
+### P3.5 — De-Risking-Slice (S) — *früh, optional aber empfohlen*
+Dünner vertikaler Schnitt **vor** dem vollen Lernen: ein **hartkodierter** Konstant-Offset für eine
+Taste → durch `cellFrames`-Resizing (Vorgriff auf P7) → am **Gerät** verifizieren, dass sich die
+Tastenauswahl an der Grenze messbar verschiebt und der sichtbare Key stehen bleibt. Bestätigt den
+§11.6-Redirect (Key-Target-Resizing) praktisch, bevor viel gebaut wird. Danach zurückbauen.
+
+### P4 — Touchdown- & Feature-Plumbing (M) — *Eingriff in Bestandscode*
+- `KeyGestureRecognizer`: `value.startLocation` erfassen → key-lokaler Touchdown → an `onGesture`.
+- `GestureClassification` um optionalen **Feature-Vektor** erweitern (native Einheit, §13-A).
+- `onGesture`-/`handleGesture`-Signatur erweitern (Touchdown + Features); `ActionContext` bzw.
+  separater Lern-Sink trägt `keyId` + Touchdown (§5).
+**Tests:** Gesten-Klassifikation **unverändert** (Regressionsschutz); Touchdown korrekt in
+Keyboard-Koordinaten; Features korrekt durchgereicht.
+**Exit:** bestehende Gesten-Tests grün; neue Daten kommen an, noch ohne Konsument.
+
+### P5 — Lern-Middleware (M)
+- `AcceptanceTracker`: Ring-Puffer (Tap → `keyId`, Touchdown, Zeichen-Span), **Burst-Veto über
+  alle gelöschten Taps**, **Span-Alignment** (nicht 1:1), Trigger auf `.deleteBackward`-**Action**
+  (nicht Target!), Slide-Delete abdecken (§4.1).
+- Middleware am Pipeline-Ende: akzeptierte **interiore** Taps (`m_interior` gegen wahre Geometrie)
+  → `TouchOffsetModel`; akzeptierte Gesten **aller Klassen** → `GestureTelemetryModel`.
+- Verdrahtung in `rebuildPipeline()`; nur aktiv bei Toggle an.
+**Tests (Mock-Target):** Veto-Logik (immediate + delayed Burst); Compose/Telex-interne Deletes
+zählen **nicht**; Interior-Gate; Anti-Drift (Lernen nur interior).
+**Exit:** Modell + Telemetrie füllen sich aus echten Pipeline-Events.
+
+### P6 — GestureTelemetryModel (M)
+Welford-Stats je `(Regime, Klasse[, Richtung])` (Richtung nur Swipe/Circle, §13-C), Korrektur-
+Zähler, grobe Histogramme (Bins um Default-Schwelle), Persistenz (§13), Gating (§13-D).
+**Tests:** Stats korrekt; Richtungs-Keying; Korrektur-Zähler; Round-Trip.
+**Exit:** Telemetrie erhoben + persistiert (noch ohne Anzeige).
+
+### P7 — Key-Target-Resizing-Anwendung (M) — *der „es wirkt"-Schritt*
+- `KeyboardGridLayout.cellFrames` offset-bewusst: geteilte Grenzen verschieben nach §5.4 (innere
+  V/H-Kanten `+= (o_A+o_B)/2`, Rand fix, eine-Kante-ein-Wert, Nicht-Degeneriertheit per Clamp).
+- `KeyboardGridView`: **asymmetrischer** `visualInset` kompensiert → sichtbarer Key unverändert (§5.5).
+- Offsets pro **aktivem Regime** aus `TouchOffsetModel` injizieren; **Apply-Gate** (Regime-Reife:
+  Flächen-Rang ∧ Σ`n_k` ≥ `apply_on`) + Hysterese (§4.4).
+**Tests:** `KeyboardGridLayoutTouchCoverageTests` erweitern → nach Resizing **vollständige, disjunkte**
+Überdeckung; nicht-degeneriert; sichtbare Frames unverändert; #198-Kachelung intakt.
+**Exit:** Korrektur wirkt auf die Tastenauswahl; Layout bleibt valide.
+
+### P8 — UI (L)
+- **Toggle** + Datenschutz-Hinweis + Status (§6.1).
+- **Settings-Viz** (`SharedDefaults`-Snapshot): Tastatur-Rendering wiederverwenden, Offset-**Pfeile**
+  (wahres Zentrum → gelernt) + Konfidenz-Deckkraft; **Regime-Selektor** (§6.2/6.3).
+- **Reset** (alles / pro Regime) (§6.4).
+- **Debug-View**: Sample-Streufeld, Reach-Vektorfeld, **Gesten-Diagnose** (Cluster-Kerne/Randdichte/
+  Korrekturraten je Klasse, §6.5/§13).
+**Tests:** UI-Tests (Toggle, Reset, Regime-Selektor via stabile Identifier); Snapshot-Render.
+**Exit:** Nutzer kann aktivieren, sehen, zurücksetzen; Autor kann debuggen.
+
+### P9 — Validierung & Abnahme (M)
+Lokale Proxy-Metrik (Backspace-/Korrektur-Rate) + **A/B-Toggle-Mechanismus** (§8). Abnahme:
+messbare Senkung **ohne** Anstieg in irgendeinem Regime → erst dann ggf. Default-an erwägen.
+**Exit:** Belegbarer Nutzen (oder dokumentierter Nicht-Nutzen) → Datengrundlage für die
+Default-Entscheidung.
+
+---
+
+## Test-Strategie (quer)
+Apple `Testing`-Framework, co-loziert. Schwerpunkt **reine Unit-Tests** ohne Simulator (P1/P2/P3/P5/P6
+mit Mock-`TextInputTarget`). Layout-Coverage-Tests für P7. UI-Tests (stabile Slot-Ids) für P8.
+Robustheits-Szenarien (Wasser, Feedback-Schleife, Zensierungs-Bias) als explizite Tests (§12).
+
+## Reihenfolge-Empfehlung (solo)
+`P0 → P1 ∥ P2 ∥ P3 → P3.5 (Spike) → P4 → P5 → P6 → P7 → P8 → P9`.
+Mergebare Schnitte: nach P3 (Kern), nach P5 (Lernen), nach P7 (Anwendung), nach P8 (UI). Jeder
+Schnitt ist hinter dem Toggle inert, also gefahrlos in `develop` integrierbar.
+
+## Risiken / Checkpoints
+- **P3.5-Spike** klärt das einzige verbliebene praktische Risiko (Resizing am Gerät) früh.
+- **P4** ist der Bestandscode-Eingriff → Regressionsschutz der Gesten-Tests ist Pflicht.
+- **P7** muss die lückenlose Kachelung (#198) wahren → Coverage-Tests sind das Sicherheitsnetz.
+- **Kalibrierung** (κ, n_max, m_interior, derivePosture-/Dwell-Schwellen, Histogramm-Bins) erfolgt
+  in P5–P9 am Gerät, nicht vorab (§10).
+
+## Nicht in v1 (Verweise)
+Per-Geste-*räumliches* Residuum, stetige Größen/Aspect-Interpolation, Live-Extension-Overlay,
+Gegenhand-Spiegelung, quadratische Fläche (alle **v2**); Negativ-Signal/Relabeln (**v3**, §9);
+**Adaption** der Gestenparameter (separater Track — v1 nur Erhebung, §13).

--- a/docs/touch-offset-correction-impl-plan.md
+++ b/docs/touch-offset-correction-impl-plan.md
@@ -149,8 +149,9 @@ Zähler, grobe Histogramme (Bins um Default-Schwelle), Persistenz (§13), Gating
 **Exit:** Nutzer kann aktivieren, sehen, zurücksetzen; Autor kann debuggen.
 
 ### P9 — Validierung & Abnahme (M)
-Lokale Proxy-Metrik (Backspace-/Korrektur-Rate) + **A/B-Toggle-Mechanismus** (§8). Abnahme:
-messbare Senkung **ohne** Anstieg in irgendeinem Regime → erst dann ggf. Default-an erwägen.
+Lokale **kontrafaktische** Nutzen-Metrik (caught/caused/net aus Flip-Erkennung, self-populating —
+kein Toggle-A/B, das die Aus-Gruppe nie füllt) + per-Klasse-Korrekturraten (§8/§13). Abnahme:
+`net` positiv **ohne** Anstieg der Korrekturrate in irgendeinem Regime → erst dann Default-an erwägen.
 **Exit:** Belegbarer Nutzen (oder dokumentierter Nicht-Nutzen) → Datengrundlage für die
 Default-Entscheidung.
 

--- a/docs/touch-offset-correction-impl-plan.md
+++ b/docs/touch-offset-correction-impl-plan.md
@@ -29,7 +29,7 @@ SwiftFormat/SwiftLint `--strict` lint-clean halten.
 **Neu** (`wurstfingerKeyboard/Runtime/TouchModel/`):
 | Datei | Inhalt | Spec |
 |---|---|---|
-| `TouchRegime.swift` | Regime-Typ + `derivePosture(scale, position)` + Orientierung | §3.1 |
+| `TouchRegime.swift` | Regime-Typ + `PostureClass(settingValue:)` (explizite Wahl) + Orientierung | §3.1 |
 | `ReachSurface.swift` | Ridge-WLS-Fit (bilinear/linear), Auswertung, Rang-Guard | §3.2, §4.2-S2 |
 | `TouchOffsetModel.swift` | Per-Taste `{m_k,n_k,s_k}`, Update (Huber/Running-Mean/EW-MAD), Shrinkage+Clamp → Offset | §4.2 |
 | `TouchOffsetStore.swift` | Codable-Schema, `SharedDefaults`-Persistenz, Versionierung, Reset, debounced write | §7 |
@@ -70,9 +70,11 @@ Worktree, Verzeichnis, `SettingsKey.touchOffsetEnabled` + `touchModelSchemaVersi
 Modul-Dateien mit Doc-Headern. **Exit:** Build grün, Toggle-Key existiert (noch ohne Wirkung).
 
 ### P1 — Regime-Auflösung (S, rein)
-`TouchRegime` + `derivePosture` exakt nach der Partition §3.1 (inkl. „schmal & mittig → twoThumb",
-Floating = keine v1-Klasse). Hysterese-Hook (Schwellen als Parameter).
-**Tests:** Partition an allen Ecken + Schwellen-Grenzfällen; Hysterese verhindert Flackern.
+`TouchRegime` + explizite Posture-Wahl `PostureClass(settingValue:)` (§3.1/§6.3); Default
+`oneThumbRight`, Fallback bei fehlendem/unbekanntem Wert. Floating = keine v1-Klasse.
+**Tests:** Setting-Mapping (Default/Fallback/Round-Trip), Split-Flag, stabiler Regime-Key.
+*(Historisch: eine `derivePosture(scale, position)`-Heuristik wurde verworfen — im Praxistest
+fehlklassifiziert, 11.1.)*
 **Exit:** `(orientation, scale, position) → Regime` deterministisch, 100 % getestet.
 
 ### P2 — TouchOffsetModel-Kern (L, rein) — *algorithmisches Herz*
@@ -168,7 +170,7 @@ Schnitt ist hinter dem Toggle inert, also gefahrlos in `develop` integrierbar.
 - **P3.5-Spike** klärt das einzige verbliebene praktische Risiko (Resizing am Gerät) früh.
 - **P4** ist der Bestandscode-Eingriff → Regressionsschutz der Gesten-Tests ist Pflicht.
 - **P7** muss die lückenlose Kachelung (#198) wahren → Coverage-Tests sind das Sicherheitsnetz.
-- **Kalibrierung** (κ, n_max, m_interior, derivePosture-/Dwell-Schwellen, Histogramm-Bins) erfolgt
+- **Kalibrierung** (κ, n_max, m_interior, Dwell-Schwelle, Histogramm-Bins) erfolgt
   in P5–P9 am Gerät, nicht vorab (§10).
 
 ## Nicht in v1 (Verweise)

--- a/docs/touch-offset-correction-impl-plan.md
+++ b/docs/touch-offset-correction-impl-plan.md
@@ -27,8 +27,9 @@ SwiftFormat/SwiftLint `--strict` lint-clean halten.
 ## Komponenten-Inventar
 
 **Neu** (`wurstfingerKeyboard/Runtime/TouchModel/`):
+
 | Datei | Inhalt | Spec |
-|---|---|---|
+| --- | --- | --- |
 | `TouchRegime.swift` | Regime-Typ + `PostureClass(settingValue:)` (explizite Wahl) + Orientierung | §3.1 |
 | `ReachSurface.swift` | Ridge-WLS-Fit (bilinear/linear), Auswertung, Rang-Guard | §3.2, §4.2-S2 |
 | `TouchOffsetModel.swift` | Per-Taste `{m_k,n_k,s_k}`, Update (Huber/Running-Mean/EW-MAD), Shrinkage+Clamp → Offset | §4.2 |
@@ -38,8 +39,9 @@ SwiftFormat/SwiftLint `--strict` lint-clean halten.
 | `TouchLearningMiddleware.swift` | Pipeline-Sink: Acceptance + Offset-Sampling + Telemetrie | §5, §4.1, §13 |
 
 **Geändert:**
+
 | Datei | Änderung | Spec |
-|---|---|---|
+| --- | --- | --- |
 | `Runtime/Gesture/KeyGestureRecognizer.swift` | `startLocation` erfassen; Feature-Vektor mitliefern | §5, §13 |
 | `Runtime/Gesture/GesturePreprocessor.swift` | Features in `GestureClassification` exponieren | §13 |
 | `Runtime/View/KeyView.swift` | `onGesture`-Signatur (+ Touchdown) | §5 |
@@ -51,13 +53,14 @@ SwiftFormat/SwiftLint `--strict` lint-clean halten.
 
 ## Abhängigkeitsgraph
 
-```
+```text
 P1 Regime ─┐
 P2 Modell ─┼─→ P5 Lern-Middleware ─→ P7 Resizing-Anwendung ─→ P8 UI ─→ P9 Validierung
 P3 Persist ┘        ↑                        ↑
 P4 Plumbing ────────┴────────────────────────┘
 P6 Telemetrie ──────┘
 ```
+
 P1–P3 (reiner Kern) sind unabhängig von P4 (Plumbing) → parallelisierbar. P5 braucht P2/P3/P4.
 P7 braucht P2/P4. P6 braucht P4.
 
@@ -66,10 +69,12 @@ P7 braucht P2/P4. P6 braucht P4.
 ## Phasen
 
 ### P0 — Scaffolding (S)
+
 Worktree, Verzeichnis, `SettingsKey.touchOffsetEnabled` + `touchModelSchemaVersion`, leere
 Modul-Dateien mit Doc-Headern. **Exit:** Build grün, Toggle-Key existiert (noch ohne Wirkung).
 
 ### P1 — Regime-Auflösung (S, rein)
+
 `TouchRegime` + explizite Posture-Wahl `PostureClass(settingValue:)` (§3.1/§6.3); Default
 `oneThumbRight`, Fallback bei fehlendem/unbekanntem Wert. Floating = keine v1-Klasse.
 **Tests:** Setting-Mapping (Default/Fallback/Round-Trip), Split-Flag, stabiler Regime-Key.
@@ -78,6 +83,7 @@ fehlklassifiziert, 11.1.)*
 **Exit:** `(orientation, scale, position) → Regime` deterministisch, 100 % getestet.
 
 ### P2 — TouchOffsetModel-Kern (L, rein) — *algorithmisches Herz*
+
 - State + Initialzustand (`m=0,n=0,s=s_prior≈0,10`, §4.2).
 - Update: absolutes Dwell-Gate-Hook, Outlier-Gate (nach `warmup`), **Huber-Clip**, Running-Mean,
   EW-MAD, `n_max`-Deckel (§4.2-S1).
@@ -90,6 +96,7 @@ Rang-Guard (<3 Tasten → Fläche≈0); Zwei-Hälften-Split; Clamp; **Feedback-S
 **Exit:** Modell rein, deterministisch, alle Robustheits-Szenarien grün.
 
 ### P3 — Persistenz (M)
+
 `Codable`-Schema, `SharedDefaults` (App-Group), Schema-Version + **partielle Invalidierung** bei
 Layout-Änderung (stabile `keyId`s), Reset (alles / pro Regime), **debounced/periodischer Write**.
 **Tests:** Round-Trip; Version-Bump invalidiert; partielle Invalidierung erhält gültige Keys;
@@ -97,12 +104,14 @@ Reset nullt korrekt.
 **Exit:** Modell überlebt Neustart; Reset + Migration getestet.
 
 ### P3.5 — De-Risking-Slice (S) — *früh, optional aber empfohlen*
+
 Dünner vertikaler Schnitt **vor** dem vollen Lernen: ein **hartkodierter** Konstant-Offset für eine
 Taste → durch `cellFrames`-Resizing (Vorgriff auf P7) → am **Gerät** verifizieren, dass sich die
 Tastenauswahl an der Grenze messbar verschiebt und der sichtbare Key stehen bleibt. Bestätigt den
 §11.6-Redirect (Key-Target-Resizing) praktisch, bevor viel gebaut wird. Danach zurückbauen.
 
 ### P4 — Touchdown- & Feature-Plumbing (M) — *Eingriff in Bestandscode*
+
 - `KeyGestureRecognizer`: `value.startLocation` erfassen → key-lokaler Touchdown → an `onGesture`.
 - `GestureClassification` um optionalen **Feature-Vektor** erweitern (native Einheit, §13-A).
 - `onGesture`-/`handleGesture`-Signatur erweitern (Touchdown + Features); `ActionContext` bzw.
@@ -112,6 +121,7 @@ Keyboard-Koordinaten; Features korrekt durchgereicht.
 **Exit:** bestehende Gesten-Tests grün; neue Daten kommen an, noch ohne Konsument.
 
 ### P5 — Lern-Middleware (M)
+
 - `AcceptanceTracker`: Ring-Puffer (Tap → `keyId`, Touchdown, Zeichen-Span), **Burst-Veto über
   alle gelöschten Taps**, **Span-Alignment** (nicht 1:1), Trigger auf `.deleteBackward`-**Action**
   (nicht Target!), Slide-Delete abdecken (§4.1).
@@ -123,12 +133,14 @@ zählen **nicht**; Interior-Gate; Anti-Drift (Lernen nur interior).
 **Exit:** Modell + Telemetrie füllen sich aus echten Pipeline-Events.
 
 ### P6 — GestureTelemetryModel (M)
+
 Welford-Stats je `(Regime, Klasse[, Richtung])` (Richtung nur Swipe/Circle, §13-C), Korrektur-
 Zähler, grobe Histogramme (Bins um Default-Schwelle), Persistenz (§13), Gating (§13-D).
 **Tests:** Stats korrekt; Richtungs-Keying; Korrektur-Zähler; Round-Trip.
 **Exit:** Telemetrie erhoben + persistiert (noch ohne Anzeige).
 
 ### P7 — Key-Target-Resizing-Anwendung (M) — *der „es wirkt"-Schritt*
+
 - `KeyboardGridLayout.cellFrames` offset-bewusst: geteilte Grenzen verschieben nach §5.4 (innere
   V/H-Kanten `+= (o_A+o_B)/2`, Rand fix, eine-Kante-ein-Wert, Nicht-Degeneriertheit per Clamp).
 - `KeyboardGridView`: **asymmetrischer** `visualInset` kompensiert → sichtbarer Key unverändert (§5.5).
@@ -139,6 +151,7 @@ Zähler, grobe Histogramme (Bins um Default-Schwelle), Persistenz (§13), Gating
 **Exit:** Korrektur wirkt auf die Tastenauswahl; Layout bleibt valide.
 
 ### P8 — UI (L)
+
 - **Toggle** + Datenschutz-Hinweis + Status (§6.1).
 - **Settings-Viz** (`SharedDefaults`-Snapshot): Tastatur-Rendering wiederverwenden, Offset-**Pfeile**
   (wahres Zentrum → gelernt) + Konfidenz-Deckkraft; **Regime-Selektor** (§6.2/6.3).
@@ -149,6 +162,7 @@ Zähler, grobe Histogramme (Bins um Default-Schwelle), Persistenz (§13), Gating
 **Exit:** Nutzer kann aktivieren, sehen, zurücksetzen; Autor kann debuggen.
 
 ### P9 — Validierung & Abnahme (M)
+
 Lokale **kontrafaktische** Nutzen-Metrik (caught/caused/net aus Flip-Erkennung, self-populating —
 kein Toggle-A/B, das die Aus-Gruppe nie füllt) + per-Klasse-Korrekturraten (§8/§13). Abnahme:
 `net` positiv **ohne** Anstieg der Korrekturrate in irgendeinem Regime → erst dann Default-an erwägen.
@@ -158,16 +172,19 @@ Default-Entscheidung.
 ---
 
 ## Test-Strategie (quer)
+
 Apple `Testing`-Framework, co-loziert. Schwerpunkt **reine Unit-Tests** ohne Simulator (P1/P2/P3/P5/P6
 mit Mock-`TextInputTarget`). Layout-Coverage-Tests für P7. UI-Tests (stabile Slot-Ids) für P8.
 Robustheits-Szenarien (Wasser, Feedback-Schleife, Zensierungs-Bias) als explizite Tests (§12).
 
 ## Reihenfolge-Empfehlung (solo)
+
 `P0 → P1 ∥ P2 ∥ P3 → P3.5 (Spike) → P4 → P5 → P6 → P7 → P8 → P9`.
 Mergebare Schnitte: nach P3 (Kern), nach P5 (Lernen), nach P7 (Anwendung), nach P8 (UI). Jeder
 Schnitt ist hinter dem Toggle inert, also gefahrlos in `develop` integrierbar.
 
 ## Risiken / Checkpoints
+
 - **P3.5-Spike** klärt das einzige verbliebene praktische Risiko (Resizing am Gerät) früh.
 - **P4** ist der Bestandscode-Eingriff → Regressionsschutz der Gesten-Tests ist Pflicht.
 - **P7** muss die lückenlose Kachelung (#198) wahren → Coverage-Tests sind das Sicherheitsnetz.
@@ -175,6 +192,7 @@ Schnitt ist hinter dem Toggle inert, also gefahrlos in `develop` integrierbar.
   in P5–P9 am Gerät, nicht vorab (§10).
 
 ## Nicht in v1 (Verweise)
+
 Per-Geste-*räumliches* Residuum, stetige Größen/Aspect-Interpolation, Live-Extension-Overlay,
 Gegenhand-Spiegelung, quadratische Fläche (alle **v2**); Negativ-Signal/Relabeln (**v3**, §9);
 **Adaption** der Gestenparameter (separater Track — v1 nur Erhebung, §13).

--- a/docs/touch-offset-correction-research.md
+++ b/docs/touch-offset-correction-research.md
@@ -153,7 +153,7 @@ al., *Simulating Errors in Touchscreen Typing* (CHI 2025, arXiv:2502.03560) · P
   sinnvolle, aber **nicht belegte** Ergänzungen. Als solche kennzeichnen.
 
 ## Evidenzlücke (ehrlich)
-Es gibt **praktisch keine** peer-reviewte Arbeit zu MessagEase-/Grid-/Gesten-/Swipe-Keyboards mit
+Es gibt **praktisch keine** peer-reviewte Arbeit zu Grid-/Gesten-/Swipe-Keyboards mit
 gelernter Offset-Korrektur. Alle Evidenz stammt von **QWERTY-Tap** und diskreter Zielauswahl. Die
 biomechanischen Grundlagen (systematischer, posture-/positionsabhängiger Offset; Varianz-Boden) sind
 **layout-unabhängig** und gelten für den Touchdown jeder Geste → **plausibel übertragbar, aber nicht

--- a/docs/touch-offset-correction-research.md
+++ b/docs/touch-offset-correction-research.md
@@ -1,0 +1,187 @@
+# Literaturrecherche: Touch-Offset-Korrektur für Soft-Keyboards
+
+> Begleitdokument zu `touch-offset-correction.md`. Stand: Deep-Research-Lauf, 25 adversarial
+> verifizierte Claims (3-Stimmen-Voting), 18 Primärquellen. Dient als Beleg-/Korrektur-Basis
+> für die Designentscheidungen.
+
+## Kernbefund
+
+Die etablierte Methode (Forschung + Industrie) deckt sich **im Kern exakt** mit unserem Design:
+Touch-Selektion wird als **bivariate Gauß-Verteilung pro Taste** modelliert; deren **Mittel** ist
+der systematische Offset, online geschätzt als **laufender Mittelwert** mit **Reifezähler pro
+Taste** und **hierarchischem Backoff** (global → Cluster/Posture → Taste), solange Daten/Konfidenz
+fehlen. Das ist 1:1 unser globaler + per-Taste + Shrinkage-Design mit Konfidenz-Gating.
+
+Drei Korrekturen am Detail (siehe unten): (1) Schätzer ist Running-Mean, nicht konstante EMA;
+(2) Varianz-Boden ≠ Mittel-Offset; (3) positiv-only ist *nicht* State-of-the-Art — das ist
+LM-gestütztes Self-Labeling.
+
+## Was validiert ist
+
+### 1. Modellklasse & Online-Schätzer
+- **Gauß pro Taste, Running-Mean + Reifezähler + Backoff.** Yin & Partridge (CHI 2013, MIT+Google):
+  „Updating the Gaussian model involves computing the running average of the (x, y) offsets from the
+  center of the key … The counter for the number of points … so that we know when a particular
+  Gaussian model is mature. When there are not enough data points, the system backs-off to a lower
+  level model." → validiert Running-Mean + reife-gegatetes hierarchisches Shrinkage.
+  [research.google.com/pubs/archive/41930.pdf]
+- **Gboard „Spatial model personalization"** bestätigt dasselbe global/cluster/key-Backoff mit
+  personalisierten Gauß-Offset-Mitteln + Kovarianzen. [arxiv.org/abs/2209.11311]
+- **Hierarchical Spatial Backoff** (Yin/Ouyang/Partridge/Zhai): Submodell nur anwenden, wenn
+  Posture mit Konfidenz erkannt **und** genug Nutzerdaten; sonst Rückfall, „conservative and biased
+  towards the standard base model". → validiert Konfidenz-/Reife-Gating als Degenerationsschutz.
+  [dl.acm.org/doi/10.1145/2470654.2481384]
+
+### 2. Offsets sind systematisch, lernbar, per-User
+- **Holz & Baudisch (CHI 2010), „Generalized Perceived Input Point":** „the perceived input point
+  is a systematic effect. This allows compensating … by applying an inverse offset." Das
+  generalisierte Modell erklärt **67 %** der zuvor dem „Fat Finger" zugeschriebenen Ungenauigkeit;
+  signifikante Nutzer-Interaktionen → **Per-User schlägt global.**
+- **Bi & Zhai (Bayesian Touch, UIST 2013):** Touches bivariat-gaußisch ums Ziel, Mittel nahe
+  Zentrum mit **kleinem Bias je Handhaltung (Finger vs. Daumen) und Region**; >10 % der Touches
+  fallen auf Phone-Größe neben die Zieltaste.
+
+### 3. Positions-/Reach-Abhängigkeit (stützt die Reach-Fläche)
+- **Henze et al. (MobileHCI 2011, ~120M Touches):** Touch-Positionen systematisch **nach
+  unten-rechts** verschoben, konsistent über 4 Phones. Rein populationsbasierte Kompensation:
+  **−7,79 %** Fehlerrate im Feld.
+- **Park & Han (2010):** „accurate region" und Offset-Richtung hängen von **Tastengröße und -lage**
+  ab; Daumen touchte **links** vom Zentrum, außer nahe der Handwurzel → Reach/Pivot-Effekt real.
+- **Weir et al. (GPType, CHI 2014):** Offset-**Varianz** ist positionsabhängig — „in areas … where
+  the offsets are more variable, the Gaussians are larger". → Reach-Fläche sollte Mittel *und*
+  (später) Streuung modellieren.
+- **Bergström-Lehtovirta & Oulasvirta (CHI 2014):** Daumen-Funktionsfläche parametrisch aus
+  Surface-Größe, Handgröße, Index-Finger-Position vorhersagbar — **aber Hand-/Fingergröße sind auf
+  iOS nicht sensierbar.** → Reach-Fläche muss **gelernt**, nicht analytisch berechnet werden.
+
+### 4. Quantifizierter Nutzen (Erwartungshaltung)
+- Gboard/Yin (CHI 2013): Posture+User+Key-Adaption **−13,2 %** CER über nicht-adaptive Baseline
+  (8,64 → 7,50 %, p=0,015); theoretische Obergrenze ~14 %.
+- Weir GPType (CHI 2014): **−5 bis −7,6 %** über Baseline; **+~1–1,3 %** über SwiftKey. „GP Only"
+  (nur gelernter Mittel-Offset, kein LM) **signifikant besser als Baseline** → **Offset-Korrektur
+  allein wirkt.**
+- Baldwin (2012): 10,4 % relativ. Henze (2011): −7,79 % im Feld.
+- **Fazit:** real, aber **moderat** (~5–13 % über nicht-adaptiv; nur ~1 % über das beste
+  kommerzielle Keyboard). Wurstfinger hat heute *keine* Adaption → wir spielen im 5–13 %-Regime,
+  sofern es sich überträgt.
+
+## Die drei Korrekturen
+
+### A. Schätzer: Running-Mean, nicht konstante EMA
+Die Quellen belegen einen **kumulativen Running-Average** (alle Samples gleich gewichtet) mit
+count-basiertem Backoff — **keine** EMA mit konstantem Forgetting-Factor. Folge: ein Running-Mean
+**konvergiert unverzerrt** auf den wahren Mittelwert; unsere ursprüngliche „EMA + konstantes Decay"
+hatte einen permanenten Schrumpf-Bias (`α/(α+λ)·μ`), den der Running-Mean **nicht** hat.
+→ **Design-Konsequenz:** Schätzer auf **count-gewichtetes Shrinkage** (Partial Pooling /
+James-Stein: Pull-zum-Eltern ∝ Prior-Stärke/(Prior-Stärke+count)) umstellen. Das reduziert die
+Schrumpfung automatisch mit wachsender Konfidenz (kein permanenter Bias) und bildet zugleich das
+literatur-belegte reife-gegatete Backoff ab. Ein *kleines, separates* Forgetting nur, falls
+Plastizität (Drift über Zeit) gewünscht ist — bewusst getrennt vom Shrinkage.
+
+### B. Varianz-Boden ≠ Mittel-Offset (sauber trennen)
+**FFitts (Bi/Li/Zhai, CHI 2013):** Endpunkt = Summe zweier Normalverteilungen,
+`σ² = σ_r² + σ_a²`; **`σ_a ≈ 1,5 mm` ist irreduzibel** (absolute Fingerpräzision, distanz-/
+größenunabhängig). Wichtig: `σ_a` rechtfertigt eine **Reach-/Toleranzfläche (Streuung)**, aber
+**nicht** die Unterkorrektur des **Mittel-Offsets**. Beide Effekte dürfen im Design nicht vermengt
+werden — der Varianz-Boden ist *kein* Argument für „lieber unterkorrigieren".
+→ **Design-Konsequenz:** Die Leitlinie „Unterkorrektur ist sicher" (Spec §1) ausschließlich aus dem
+**Zensierungs-Bias** begründen (Mittel), nicht aus dem Varianz-Boden. Der Varianz-Boden ist ein
+separates Faktum: selbst perfekte Korrektur lässt irreduzibles Streurauschen → erklärt, warum der
+Nutzen moderat bleibt, und motiviert (v2/v3) das Mitlernen der **Kovarianz** pro Taste.
+
+### C. Positiv-only ist nicht SOTA — Self-Labeling ist es
+**Baldwin (2012):** Lernen nur aus Korrektur-Events verzerrt zu Fehlerfällen
+(„skewing the data towards erroneous cases") → der von uns vermutete Zensierungs-Bias ist
+**dokumentiert bestätigt**. Aber deployte Systeme umgehen ihn **nicht** per Acceptance-only,
+sondern per **Self-Labeling**: Yin & Partridge ordnen jedem Touch **probabilistisch die
+wahrscheinlichste Taste** zu (via Spatial+Language-Model), „without relying on the hidden identity
+of the true intended key". Ein echtes Negativ-Signal/EM wird im Gboard-Ansatz nicht genutzt.
+→ **Design-Konsequenz:**
+- Unser „positiv-only" präziser als **„Self-Labeling auf konfidenten (interioren) Taps"**
+  reframen — bei großen Grid-Tasten sind die meisten Taps eindeutig, also *ist* das eine
+  degradierte Self-Labeling-Variante. Die zensierten Fälle sind genau die Grenz-Taps.
+- Ohne LM ist **konservative Unterkorrektur die robuste Wahl** — bewusst, mit bekanntem
+  Trade-off (unterschätzt den Offset).
+- **Konkreter Upgrade-Pfad (v3), literatur-belegt:** Baldwin nutzt Backspace als
+  Supervised-Signal: „the three letters typed after the edit operation were the intended
+  characters for the three characters that were deleted." → genau unser geplantes Negativ-Signal,
+  mit Methode.
+
+## Korrekturverhalten — Fundierung des Acceptance-Filters (2. Recherche)
+
+Fokussierte Folge-Recherche speziell zum Fehler-Korrektur-Verhalten, zur Parametrisierung des
+Acceptance-Filters (§4.1 der Spec).
+
+- **Fenster = Event-/Keystroke-Zählung, nicht ms (belegt):** Alle ernsthaften Self-Labeling-Systeme
+  parametrisieren über die **Edit-Struktur** (Baldwin 2012), nicht über eine ms-Schwelle. Das
+  einzige explizite Zeitfenster ist Gboards Undo-Regel „**immediately, before any other key**" — ein
+  einziger Event-Schritt. **Lücke:** keine peer-reviewte ms-Latenz-Verteilung „Mis-Hit → Backspace".
+- **Korrektur-Modi (belegt):** *immediate* (1 Backspace + Retype) vs. *delayed* (mehrere Backspaces
+  durch korrekte Zeichen bis zum Fehler). Mit Autokorrektur **dominieren immediate** Korrekturen
+  massiv (2,10 vs. 0,47 pro Satz; Shi et al., CHI 2025, Aggregat aus Jiang 2020 / Palin 2019).
+- **Mehrfach-Löschung ist real (belegt):** ~21,6 % aller Daten stecken in Edits (Baldwin); verzögerte
+  Korrekturen löschen durch *korrekte* Zeichen mit (`peeple<<<<ople`). → **Burst-Veto** statt
+  Einzel-Veto (Korrektur an §4.1).
+- **Unkorrigierte Mis-Hits sind selten (belegt):** ~2,3 % unkorrigierte Fehlerrate (Palin et al.
+  2019); „conscientiousness" 0,61–0,78 (Soukoreff/MacKenzie 2003). Baldwins „Character-Level"
+  (allen nicht-editierten Taps vertrauen) erreicht **98,2 % Precision** → Zensierungs-Bias-Beitrag
+  klein, Akzeptanz unkorrigierter Taps vertretbar.
+- **Self-Labeling-Strategien (Baldwin 2012, belegt):** *Conservative* (nur Edits, Adjazenz-
+  Substitution; Recall ~12 %, Fehler <1 %) vs. *Character-Level* (Recall 90,7 %, Precision 98,2 %)
+  vs. *Word-Level* (OOV-Wörter verwerfen). **43,1 % der Edits werden verworfen** (Umformulierungen/
+  uneindeutig) → aggressives Verwerfen ist Standard. Baldwin **relabelt** (Mis-Hit → intendierter
+  Key); unser v1 **vetoed** nur (sicherer, exklusionsbasiert) — Relabeln ist v3.
+- **Edit ≠ Fehlerkorrektur (belegt):** ein erheblicher Teil der Löschungen sind Umformulierungen/
+  Restarts → lange Bursts (ganze Wörter) nicht als Mis-Hit-Signal behandeln.
+- **Taxonomie (belegt):** Soukoreff & MacKenzie (CHI 2003) C/INF/IF/F; Corrected vs. Not-Corrected
+  Error Rate.
+- **Lücken (ehrlich):** Label-/Korrektur-Behandlung beim Trainingsdaten-Aufbau von Fowler (CHI 2015)
+  und Yin (CHI 2013) **nicht** primär verifizierbar; die kursierende Sivek/Riley-2022-Formulierung
+  „backspaced presses removed from training set" konnte **keiner Primärquelle** zugeordnet werden →
+  unbestätigt.
+
+Zusätzliche Quellen: Soukoreff & MacKenzie, *Metrics for text entry research* (CHI 2003,
+yorku.ca/mack/chi03.html) · Baldwin, *Online Adaptation … Text Input Personalization* (PhD MSU 2012)
++ Baldwin & Chai (IUI 2012) · Fowler et al., *Effects of Language Modeling …* (CHI 2015) · Shi et
+al., *Simulating Errors in Touchscreen Typing* (CHI 2025, arXiv:2502.03560) · Palin et al.,
+*Typing37K* (MobileHCI 2019) · Gboard „Undo auto-correct on backspace" (support.google.com).
+
+## Nicht von der Literatur gedeckt (eigene Engineering-Erweiterungen)
+- **Schutz gegen transiente Störungen** (Wasser, Ausreißer-Clamp, robuste Schätzer/Median,
+  Kontaktradius-Gating): in den verifizierten Quellen **nicht** adressiert — dort beschränkt sich
+  Robustheit auf Backoff/Konservatismus/Reife-Gating. Unsere Clamp- und Gating-Mechanismen sind
+  sinnvolle, aber **nicht belegte** Ergänzungen. Als solche kennzeichnen.
+
+## Evidenzlücke (ehrlich)
+Es gibt **praktisch keine** peer-reviewte Arbeit zu MessagEase-/Grid-/Gesten-/Swipe-Keyboards mit
+gelernter Offset-Korrektur. Alle Evidenz stammt von **QWERTY-Tap** und diskreter Zielauswahl. Die
+biomechanischen Grundlagen (systematischer, posture-/positionsabhängiger Offset; Varianz-Boden) sind
+**layout-unabhängig** und gelten für den Touchdown jeder Geste → **plausibel übertragbar, aber nicht
+belegt.** Offene Risiken: Könnte Offset-Korrektur die **8-Richtungs-Swipe-Klassifikation** stören?
+(Unsere Translation am Touchdown lässt die Richtung — aus Deltas — invariant; sie verschiebt nur den
+Tasten-Besitz, was gewollt ist. Trotzdem als Validierungspunkt führen.)
+
+## Quellen (Primär, verifiziert)
+- Yin, Ouyang, Partridge, Zhai — *Making Touchscreen Keyboards Adaptive … Hierarchical Spatial
+  Backoff* (CHI 2013). research.google.com/pubs/archive/41930.pdf ·
+  dl.acm.org/doi/10.1145/2470654.2481384
+- Google/Sivek et al. — *Spatial model personalization* (Gboard, 2022). arxiv.org/abs/2209.11311
+- Holz & Baudisch — *Generalized Perceived Input Point Model* (CHI 2010). christianholz.net
+- Bi & Zhai — *Bayesian Touch* (UIST 2013) · *Dual Gaussian* (UIST 2016)
+- Bi, Li, Zhai — *FFitts Law* (CHI 2013). www3.cs.stonybrook.edu/~xiaojun/pdf/FFitts.pdf
+- Henze, Rukzio, Boll — *100,000,000 Taps* (MobileHCI 2011). nhenze.net
+- Park & Han — *Touch key design … thumb input* (Int. J. Ind. Ergonomics 2010).
+  sciencedirect.com/science/article/abs/pii/S0169814110000806
+- Weir et al. — *Uncertain Text Entry / GPType* (CHI 2014). (darylweir.com abgelaufen; via ACM DL)
+- Bergström-Lehtovirta & Oulasvirta — *Modeling the functional area of the thumb* (CHI 2014).
+- Baldwin — *PhD Dissertation* (MSU 2012). cse.msu.edu/~jchai/Thesis/tyler-baldwin-dissertation-2012.pdf
+- Gunawardana, Paek, Meek — *Usability-Guided Key-Target Resizing* (IUI 2010). microsoft.com/research
+
+## Offene Fragen (aus dem Bericht)
+1. Überträgt sich die Gauß-/Backoff-Methodik quantitativ auf Gesten-Grid-Keyboards (Touchdown
+   besitzt Taste **und** bestimmt Swipe-Richtung)? Stört Korrektur die Richtungsklassifikation?
+2. Existiert ein Online-Schätzer (Kalman/RLS/Bayes) mit explizitem Konfidenz-Decay, der unseren
+   Ansatz über das binäre Reife-Gating hinaus validiert?
+3. Welche evaluierten Schutzmechanismen gegen transiente Störungen nutzen Produktionssysteme, und
+   wie viel bringen sie messbar?
+4. Wie viel Zusatznutzen bringt die Per-Geste-Ebene über Per-Taste, ab welcher Datenmenge?

--- a/docs/touch-offset-correction-research.md
+++ b/docs/touch-offset-correction-research.md
@@ -19,6 +19,7 @@ LM-gestütztes Self-Labeling.
 ## Was validiert ist
 
 ### 1. Modellklasse & Online-Schätzer
+
 - **Gauß pro Taste, Running-Mean + Reifezähler + Backoff.** Yin & Partridge (CHI 2013, MIT+Google):
   „Updating the Gaussian model involves computing the running average of the (x, y) offsets from the
   center of the key … The counter for the number of points … so that we know when a particular
@@ -33,6 +34,7 @@ LM-gestütztes Self-Labeling.
   [dl.acm.org/doi/10.1145/2470654.2481384]
 
 ### 2. Offsets sind systematisch, lernbar, per-User
+
 - **Holz & Baudisch (CHI 2010), „Generalized Perceived Input Point":** „the perceived input point
   is a systematic effect. This allows compensating … by applying an inverse offset." Das
   generalisierte Modell erklärt **67 %** der zuvor dem „Fat Finger" zugeschriebenen Ungenauigkeit;
@@ -42,6 +44,7 @@ LM-gestütztes Self-Labeling.
   fallen auf Phone-Größe neben die Zieltaste.
 
 ### 3. Positions-/Reach-Abhängigkeit (stützt die Reach-Fläche)
+
 - **Henze et al. (MobileHCI 2011, ~120M Touches):** Touch-Positionen systematisch **nach
   unten-rechts** verschoben, konsistent über 4 Phones. Rein populationsbasierte Kompensation:
   **−7,79 %** Fehlerrate im Feld.
@@ -55,6 +58,7 @@ LM-gestütztes Self-Labeling.
   iOS nicht sensierbar.** → Reach-Fläche muss **gelernt**, nicht analytisch berechnet werden.
 
 ### 4. Quantifizierter Nutzen (Erwartungshaltung)
+
 - Gboard/Yin (CHI 2013): Posture+User+Key-Adaption **−13,2 %** CER über nicht-adaptive Baseline
   (8,64 → 7,50 %, p=0,015); theoretische Obergrenze ~14 %.
 - Weir GPType (CHI 2014): **−5 bis −7,6 %** über Baseline; **+~1–1,3 %** über SwiftKey. „GP Only"
@@ -68,6 +72,7 @@ LM-gestütztes Self-Labeling.
 ## Die drei Korrekturen
 
 ### A. Schätzer: Running-Mean, nicht konstante EMA
+
 Die Quellen belegen einen **kumulativen Running-Average** (alle Samples gleich gewichtet) mit
 count-basiertem Backoff — **keine** EMA mit konstantem Forgetting-Factor. Folge: ein Running-Mean
 **konvergiert unverzerrt** auf den wahren Mittelwert; unsere ursprüngliche „EMA + konstantes Decay"
@@ -79,6 +84,7 @@ literatur-belegte reife-gegatete Backoff ab. Ein *kleines, separates* Forgetting
 Plastizität (Drift über Zeit) gewünscht ist — bewusst getrennt vom Shrinkage.
 
 ### B. Varianz-Boden ≠ Mittel-Offset (sauber trennen)
+
 **FFitts (Bi/Li/Zhai, CHI 2013):** Endpunkt = Summe zweier Normalverteilungen,
 `σ² = σ_r² + σ_a²`; **`σ_a ≈ 1,5 mm` ist irreduzibel** (absolute Fingerpräzision, distanz-/
 größenunabhängig). Wichtig: `σ_a` rechtfertigt eine **Reach-/Toleranzfläche (Streuung)**, aber
@@ -90,6 +96,7 @@ separates Faktum: selbst perfekte Korrektur lässt irreduzibles Streurauschen �
 Nutzen moderat bleibt, und motiviert (v2/v3) das Mitlernen der **Kovarianz** pro Taste.
 
 ### C. Positiv-only ist nicht SOTA — Self-Labeling ist es
+
 **Baldwin (2012):** Lernen nur aus Korrektur-Events verzerrt zu Fehlerfällen
 („skewing the data towards erroneous cases") → der von uns vermutete Zensierungs-Bias ist
 **dokumentiert bestätigt**. Aber deployte Systeme umgehen ihn **nicht** per Acceptance-only,
@@ -97,6 +104,7 @@ sondern per **Self-Labeling**: Yin & Partridge ordnen jedem Touch **probabilisti
 wahrscheinlichste Taste** zu (via Spatial+Language-Model), „without relying on the hidden identity
 of the true intended key". Ein echtes Negativ-Signal/EM wird im Gboard-Ansatz nicht genutzt.
 → **Design-Konsequenz:**
+
 - Unser „positiv-only" präziser als **„Self-Labeling auf konfidenten (interioren) Taps"**
   reframen — bei großen Grid-Tasten sind die meisten Taps eindeutig, also *ist* das eine
   degradierte Self-Labeling-Variante. Die zensierten Fälle sind genau die Grenz-Taps.
@@ -142,17 +150,19 @@ Acceptance-Filters (§4.1 der Spec).
 
 Zusätzliche Quellen: Soukoreff & MacKenzie, *Metrics for text entry research* (CHI 2003,
 yorku.ca/mack/chi03.html) · Baldwin, *Online Adaptation … Text Input Personalization* (PhD MSU 2012)
-+ Baldwin & Chai (IUI 2012) · Fowler et al., *Effects of Language Modeling …* (CHI 2015) · Shi et
+· Baldwin & Chai (IUI 2012) · Fowler et al., *Effects of Language Modeling …* (CHI 2015) · Shi et
 al., *Simulating Errors in Touchscreen Typing* (CHI 2025, arXiv:2502.03560) · Palin et al.,
 *Typing37K* (MobileHCI 2019) · Gboard „Undo auto-correct on backspace" (support.google.com).
 
 ## Nicht von der Literatur gedeckt (eigene Engineering-Erweiterungen)
+
 - **Schutz gegen transiente Störungen** (Wasser, Ausreißer-Clamp, robuste Schätzer/Median,
   Kontaktradius-Gating): in den verifizierten Quellen **nicht** adressiert — dort beschränkt sich
   Robustheit auf Backoff/Konservatismus/Reife-Gating. Unsere Clamp- und Gating-Mechanismen sind
   sinnvolle, aber **nicht belegte** Ergänzungen. Als solche kennzeichnen.
 
 ## Evidenzlücke (ehrlich)
+
 Es gibt **praktisch keine** peer-reviewte Arbeit zu Grid-/Gesten-/Swipe-Keyboards mit
 gelernter Offset-Korrektur. Alle Evidenz stammt von **QWERTY-Tap** und diskreter Zielauswahl. Die
 biomechanischen Grundlagen (systematischer, posture-/positionsabhängiger Offset; Varianz-Boden) sind
@@ -162,6 +172,7 @@ belegt.** Offene Risiken: Könnte Offset-Korrektur die **8-Richtungs-Swipe-Klass
 Tasten-Besitz, was gewollt ist. Trotzdem als Validierungspunkt führen.)
 
 ## Quellen (Primär, verifiziert)
+
 - Yin, Ouyang, Partridge, Zhai — *Making Touchscreen Keyboards Adaptive … Hierarchical Spatial
   Backoff* (CHI 2013). research.google.com/pubs/archive/41930.pdf ·
   dl.acm.org/doi/10.1145/2470654.2481384
@@ -178,6 +189,7 @@ Tasten-Besitz, was gewollt ist. Trotzdem als Validierungspunkt führen.)
 - Gunawardana, Paek, Meek — *Usability-Guided Key-Target Resizing* (IUI 2010). microsoft.com/research
 
 ## Offene Fragen (aus dem Bericht)
+
 1. Überträgt sich die Gauß-/Backoff-Methodik quantitativ auf Gesten-Grid-Keyboards (Touchdown
    besitzt Taste **und** bestimmt Swipe-Richtung)? Stört Korrektur die Richtungsklassifikation?
 2. Existiert ein Online-Schätzer (Kalman/RLS/Bayes) mit explizitem Konfidenz-Decay, der unseren

--- a/docs/touch-offset-correction.md
+++ b/docs/touch-offset-correction.md
@@ -18,7 +18,7 @@ systematisch hintippt; die Voronoi-Grenzen zwischen Tasten verschieben sich ents
 
 ### Erwartungshaltung
 
-Bei MessagEase (3×3-Grid, große Tasten) ist reine Tasten-Verwechslung seltener als bei
+Bei einem 3×3-Grid mit großen Tasten ist reine Tasten-Verwechslung seltener als bei
 QWERTY. Der Nutzen liegt schwerpunktmäßig bei **Tastengrenzen** und dem **Gesten-Startpunkt**
 (der Touchdown bestimmt, welche Taste eine Geste „besitzt", inkl. Richtungs- und
 Return-Swipes). **Quantifizierte Erwartung aus der Literatur** (siehe
@@ -281,7 +281,7 @@ Damit ist der Fixpunkt der echte User-Bias, nicht das Auswahl-Ergebnis ⇒ keine
 
 ### 4.2 Lern-Algorithmus: Empirical-Bayes-Shrinkage mit bounded-influence Running-Mean
 
-Der Algorithmus nutzt aus, dass es **pro Regime nur eine Handvoll Tasten** gibt (MessagEase ≈ 9
+Der Algorithmus nutzt aus, dass es **pro Regime nur eine Handvoll Tasten** gibt (3×3-Grid ≈ 9
 Buchstaben-Positionen + Utility) und die Reach-Fläche nur 3–4 Koeffizienten hat. Damit ist die
 Flächenschätzung ein **winziger Closed-Form-Solve**, der bei Bedarf (Lesen/Persistieren) aus den
 Per-Tasten-Statistiken neu gerechnet wird — **kein** Online-RLS, **kein** Backfitting, **keine**
@@ -731,7 +731,7 @@ sie künstlich zu füllen (außer optionalem Spiegeln in v2).
 
 ### 11.3 Übertragbarkeit auf Gesten-Grid-Keyboards (Evidenzlücke, nicht Show-Stopper)
 
-Der Literatur-Review ergab: **es gibt keine peer-reviewte Arbeit zu MessagEase-/Grid-/Gesten-/
+Der Literatur-Review ergab: **es gibt keine peer-reviewte Arbeit zu Grid-/Gesten-/
 Swipe-Keyboards** mit gelernter Offset-Korrektur. Alle Evidenz (Gauß-Modelle, Backoff,
 systematischer Offset, Varianz-Boden) stammt von **QWERTY-Tap** und diskreter Zielauswahl. Die
 biomechanischen Grundlagen sind layout-unabhängig → **plausibel übertragbar, aber nicht belegt.**

--- a/docs/touch-offset-correction.md
+++ b/docs/touch-offset-correction.md
@@ -1,0 +1,849 @@
+# Feature-Spezifikation: Lernende Touch-Offset-Korrektur
+
+> Status: Entwurf (Rev. 7, + Gestenparameter-Telemetrie §13) · Sprache: Deutsch · Scope: Keyboard-Extension
+> + Host-App-Settings · Forschungsbelege & -korrekturen: `touch-offset-correction-research.md`
+
+## 1. Motivation & Ziel
+
+Menschen treffen Tasten nicht mittig. Es gibt einen **systematischen Versatz** (Offset)
+zwischen dem beabsichtigten Tastenzentrum und dem tatsächlichen Touchdown-Punkt — abhängig
+von Nutzer, Taste, Geste, Handhaltung und Tastaturgeometrie. Dieses Feature **lernt diesen
+Versatz während der Benutzung** und korrigiert den Touchdown-Punkt, bevor die Geste
+klassifiziert wird, sodass die beabsichtigte Taste/Geste zuverlässiger erkannt wird.
+
+Das Verfahren ist ein etabliertes HCI-Muster (Touch-Model-Personalisierung /
+Key-Target-Resizing, vgl. Gunawardana/Paek/Meek 2010; Apple System-Keyboard). Mentales
+Modell: das **effektive Tastenzentrum** wird dorthin verschoben, wo der Nutzer tatsächlich
+systematisch hintippt; die Voronoi-Grenzen zwischen Tasten verschieben sich entsprechend mit.
+
+### Erwartungshaltung
+
+Bei MessagEase (3×3-Grid, große Tasten) ist reine Tasten-Verwechslung seltener als bei
+QWERTY. Der Nutzen liegt schwerpunktmäßig bei **Tastengrenzen** und dem **Gesten-Startpunkt**
+(der Touchdown bestimmt, welche Taste eine Geste „besitzt", inkl. Richtungs- und
+Return-Swipes). **Quantifizierte Erwartung aus der Literatur** (siehe
+`touch-offset-correction-research.md`): personalisierte Offset-Korrektur bringt **~5–13 %
+relative Fehlerreduktion** gegenüber einer nicht-adaptiven Baseline (Gboard −13,2 %; Weir GPType
+−5 bis −7,6 %), aber nur **~1 %** gegenüber dem besten kommerziellen Keyboard. Wurstfinger ist
+heute nicht-adaptiv, spielt also im 5–13 %-Regime — **sofern es sich auf Gesten-Grids überträgt
+(nicht empirisch belegt, 11.3).** Reale, aber moderate Verbesserung; zusätzlich gibt es einen
+**irreduziblen Streu-Boden** (FFitts `σ_a ≈ 1,5 mm`), der selbst bei perfekter Korrektur bleibt.
+
+### Grundhaltung: Unterkorrektur ist der sichere Fehlermodus
+
+Eine Leitentscheidung, die das ganze Design prägt: **lieber zu wenig als zu viel korrigieren.**
+Unterkorrektur verschlechtert die Erkennung sanft (Status quo ohne Feature); Überkorrektur macht
+die Tastatur aktiv schlechter und untergräbt das Vertrauen. Mehrere Designentscheidungen
+(Self-Labeling auf konfidenten Taps, Shrinkage, Clamp) tendieren bewusst zur Unterkorrektur.
+
+> **Wichtige Präzisierung (aus Literatur-Review):** Die Unterkorrektur wird **ausschließlich**
+> mit dem **Zensierungs-Bias** des Self-Labelings begründet (Mittel-Offset, 4.1) — **nicht** mit
+> dem Streu-Boden `σ_a`. `σ_a` betrifft die **Varianz** (rechtfertigt die Reach-/Toleranzfläche),
+> nicht den systematischen Mittel-Offset; beides ist sauber zu trennen. Der Streu-Boden ist *kein*
+> Argument fürs Unterkorrigieren, sondern erklärt nur, warum der Nutzen moderat bleibt.
+
+## 2. Ziele / Nicht-Ziele
+
+**Ziele**
+- Opt-in-Feature, das den Touchdown-Punkt vor der Klassifikation korrigiert.
+- Lernen aus der laufenden Nutzung, ohne expliziten Kalibrierungsmodus.
+- Robust gegen Degeneration (Feedback-Schleifen) und gegen Ausreißer (Wasser auf dem
+  Display, versehentliche Touches, Gerät weitergereicht).
+- Selbstheilend: ein verkorkster Zustand wird über das Plastizitäts-Fenster (4.2) + Reset geheilt.
+- Unabhängiges Lernen pro biomechanischem Regime.
+- Visualisierung in den Settings zur Vertrauensbildung und zum Debuggen.
+
+**Nicht-Ziele (v1)**
+- Kein expliziter Kalibrierungs-/Trainingsbildschirm.
+- Keine sprachmodell-basierte Intent-Inferenz.
+- Keine Korrektur-Attribution über Backspace-Erkennung (Negativ-Signal) — v3.
+- **Keine stetige Anpassung an Tastaturgröße/Aspect** (normalisierte Einheiten, Interpolation
+  über Größen) — auf v2 verschoben (Begründung 3.5).
+- Keine Per-Geste-Ebene — v2.
+- Keine Cloud-/Cross-Device-Synchronisation. **Alle Daten bleiben lokal auf dem Gerät.**
+
+## 3. Modell-Design
+
+Die zentrale Designentscheidung: **diskrete Regime** (echte, separate Modelle) sauber von
+**stetiger Geometrie** (parametrisch, gepoolt) trennen. Das Tupel
+`(Orientierung, Größe, Aspect, Position)` als Modellschlüssel zu verwenden ist die zu
+vermeidende Falle — es sprengt den Konfigurationsraum und zerstört die Datendichte, von der
+das hierarchische Shrinkage lebt.
+
+### 3.1 Diskrete Regime (separate Modelle)
+
+Nur dort getrennt lernen, wo sich die *Biomechanik* sprunghaft ändert. Beide Achsen sind zur
+Laufzeit **ohne Detektion** bekannt (siehe geklärtes Risiko 11.1):
+
+- **Orientierung:** Portrait / Landscape — zuverlässig vom Controller geliefert
+  (`detectIsLandscape()` via `windowScene.interfaceOrientation` → `viewModel.isLandscape`; die
+  Keyboard-Bounds selbst taugen dafür *nicht*, da immer höher als breit).
+- **Posture-Klasse:** **abgeleitet aus den bekannten User-Settings**, nicht detektiert. iOS
+  bietet Dritt-Tastaturen keinen Einhand-/Floating-State; stattdessen ist Wurstfingers *eigene*
+  Positionierung der Einhand-Mechanismus:
+
+  ```
+  postureClass = derivePosture(keyboardScale, keyboardHorizontalPosition):
+    narrow = scale < S_thresh
+    left   = position < 0.5 − P_thresh ;  right = position > 0.5 + P_thresh
+    → oneThumbLeft    falls narrow && left     (eine Fläche, Pivot links, 3.2)
+      oneThumbRight   falls narrow && right    (eine Fläche, Pivot rechts)
+      twoThumb        sonst                     (Split-Fläche links/rechts; auch
+                                                 „schmal & mittig" → Default, Hand unbekannt)
+  ```
+  `S_thresh`/`P_thresh` sind kalibriert + Hysterese (§10). **Floating (iPad)** ist in v1 **keine
+  eigene Klasse** → fällt per `derivePosture` in die passende Klasse; eigene Behandlung ist v2.
+
+  `keyboardScale`, `keyAspectRatio`, `keyboardHorizontalPosition` liegen exakt in
+  `SharedDefaults` und werden bereits über `GesturePreprocessorConfig.fromUserDefaults()`
+  gelesen. `derivePosture` nutzt **nur `scale` + `position`** (`keyAspectRatio` fließt in v1 nicht
+  ein — Aspect-Handling ist v2, 3.5). Die Heuristik läuft über *bekannte* Werte; eine
+  Fehlklassifikation kostet nur Pooling-Effizienz und korrigiert sich selbst.
+
+Regime-Schlüssel = `(Orientierung, postureClass)`. Kein State zu erraten, kein Spike nötig.
+
+### 3.2 Stetige Geometrie: die Reach-Fläche
+
+Der Reach-Bias (Daumen trifft Richtung ferner Tasten systematisch daneben) hängt am Abstand
+der Taste zum **Daumen-Drehpunkt**. Modelliert als glatte, niederdimensionale Fläche über die
+**Tastenposition innerhalb der Tastatur** (auf `[0,1]²` normiert, siehe Koordinaten 5.2).
+
+**Zwei-Daumen-Korrektur (wichtig, aus Review):** Bei *einem* Daumen (Einhand) gibt es
+*einen* Pivot — eine einzelne bilineare Fläche ist eine brauchbare Näherung. Beim
+**twoThumb-Regime (Standard-Posture) tippen die meisten mit zwei Daumen** → *zwei* Pivots, das
+Bias-Feld hat zwei Zentren und ist über die Breite nicht-monoton. Eine einzelne Fläche kann das
+nicht abbilden. Deshalb:
+
+- **twoThumb-Regime:** die Tastatur an der **vertikalen Mittellinie** in linke/rechte Hälfte
+  splitten, **je eine eigene Reach-Fläche** (je ein Daumen-Pivot). Tasten auf der Mittelachse
+  werden der jeweils näheren Hälfte zugeordnet.
+- **Einhand-Regime (`oneThumbLeft`/`oneThumbRight`):** eine einzelne Fläche genügt. (Floating ist in
+  v1 keine eigene Klasse, 3.1.)
+
+**Ordnung (Entscheidung, revidierbar):** richtet sich nach der stützenden Tastenzahl —
+
+- **Einhand (eine Fläche über ~9–12 Tasten):** **bilinear** `φ = [1, u, v, uv]` (4 Koeff.).
+- **twoThumb (Split, je Hälfte nur ~4–5 Tasten):** **linear** `φ = [1, u, v]` (3 Koeff.). Eine
+  bilineare Fläche (4 Koeff.) wäre über 4–5 Punkte grenzwertig/unterbestimmt; der Split trägt
+  bereits die Nicht-Monotonie über die Breite, die Rest-Krümmung je Hälfte ist gering genug für
+  linear.
+
+Höhere Ordnung (bilinear je Hälfte / quadratisch) nur, wenn Residuen Krümmung nachweisen. Ridge
+(`λ_ridge`, 4.2) hält den Fit auch bei knapper Datenlage stabil — das ist die Antwort auf den
+Daten-Hunger des Splits: lieber niedrige Ordnung + Ridge als eine reich parametrisierte Fläche, die
+über wenige Punkte überanpasst.
+
+**Tastaturposition braucht keinen eigenen State:** Verschiebt sich die Tastatur, wandern die
+Tasten im *Screen*-Raum, aber die Fläche lebt im *tastaturlokalen* `[0,1]²`-Raum — der
+Daumen-Pivot wandert mit der Tastatur mit, der Bias relativ zur Tastatur bleibt stabil. (Falls
+die absolute Bildschirmhöhe der Tastatur den Reach messbar verändert, ist das ein v2-Thema, kein
+v1-State.)
+
+### 3.3 Modellformel (v1)
+
+Konzeptionell ist die Korrektur eine Summe aus gepoolter Fläche und Per-Tasten-Abweichung; der
+konstante Term der Fläche **ist** der globale Offset (ein separater `global`-Term wäre kollinear/
+nicht identifizierbar). **Gespeichert wird aber nicht diese Zerlegung**, sondern pro Taste der rohe
+Running-Mean `m_k` des Gesamt-Offsets; die Fläche wird daraus *abgeleitet*, die Per-Tasten-
+Abweichung ist *implizit* (siehe Algorithmus 4.2):
+
+```
+# Gespeichert pro (Regime R, Taste K, Achse):  m_k (Gesamt-Offset-Mittel), n_k, s_k
+# Abgeleitet:   reachSurface[R][H] = Ridge-WLS-Fit über die m_k   (H = Hälfte, nur twoThumb)
+# Angewandt:    Korrektur(K) = prior_k + (m_k − prior_k)·n_k/(n_k+κ),   prior_k = surface(pos_K)
+```
+
+Es gibt also **keine separat persistierte `keyResidual`-Map** — die „Ebene" ist eine Sichtweise,
+kein Speicher. Die finale Korrektur wird in Punkte zurückgerechnet (× Tastenpitch) und geclampt
+(4.3). Per-Geste-Residuum: v2.
+
+### 3.4 Hierarchisches Shrinkage
+
+Die angewandte Per-Tasten-Abweichung `(m_k − prior_k)·n_k/(n_k+κ)` wird über den Faktor
+`n_k/(n_k+κ)` zur Flächen-Vorhersage gezogen: wenig Daten ⇒ Abweichung ≈ 0, es greift nur die
+(gepoolte, datenreiche) Fläche; viele Daten ⇒ die Taste folgt **unverzerrt** ihrem eigenen `m_k`.
+Das sichert den **Cold-Start** (ohne Daten ist die Fläche flach ≈ 0 ⇒ neutral) und löst
+Datenknappheit auf Tastenebene. Formal ist es **Empirical Bayes**: die Fläche (Hyperprior) wird aus
+denselben `m_k` geschätzt, zu denen dann geschrumpft wird — bei ~9 Tasten unkritisch (Standard-EB).
+
+### 3.5 Warum Größe/Aspect in v1 wegfällt (Vereinfachung aus Review)
+
+Auf *einem* Gerät ist in *einem* Regime die Tastengeometrie nahezu konstant. Die reale
+Größen-/Aspect-Variation entsteht fast nur durch Einhand (und Floating, v2) — und das ist **bereits
+ein eigenes Regime**. Damit ist die „stetig-in-der-Geometrie"-Maschinerie (normalisierte
+Cross-Size-Einheiten, Interpolation über Größen) in der Praxis selten gefordert und für v1
+unnötiges Risiko. v1 speichert `m_k` weiterhin in **Tastenpitch-Anteilen** (billiger
+Schutz gegen kleine Größenänderungen), aber ohne explizite Interpolation über mehrere Größen.
+Diese kommt in v2, falls Bedarf nachgewiesen wird.
+
+### 3.6 Geltungsbereich des Modells (Sprachen & Modi)
+
+Der Offset ist **physisch** (Daumen-/Finger-Biomechanik), nicht buchstabenabhängig. Daher:
+
+- **Verankert an der Slot-Position (`keyId`), nicht am Buchstaben** — `keyId`s sind stabile Slot-Ids
+  (gleiche Position über alle Sprachen, vgl. `accessibilityIdentifier`).
+- **Geteilt über Sprachen** (de/en/…) und über die **Alpha-Modi** (Buchstaben-Layouts) — maximiert
+  Datendichte; der physische Bias ist sprachunabhängig.
+- **Numerische/Symbol-Modi separat:** andere Tasten-Anordnung/Trefferflächen → eigenes Modell (oder
+  bei identischem Grid teilbar; Default: separat, geringe Kosten).
+- Damit ist der vollständige Modell-Schlüssel: `(Orientierung, postureClass, Arrangement-Familie)` —
+  **nicht** Sprache. Regime-Schlüssel (3.1) bleibt `(Orientierung, postureClass)`; die
+  Arrangement-Familie (alpha vs. numerisch) ist die dritte Dimension.
+
+## 4. Lernen
+
+### 4.1 Lernsignal (v1: Self-Labeling auf konfidenten Taps) — inkl. Zensierungs-Bias
+
+Offset = `roher Touchdown − wahres Zentrum der beabsichtigten Taste`. Da die beabsichtigte Taste
+nicht direkt bekannt ist, wird sie per **Self-Labeling** zugeordnet — das ist der
+literatur-belegte SOTA-Ansatz (Yin & Partridge, CHI 2013: „probabilistically assigning a key to
+each of the user touch points, without relying on the hidden identity of the true intended key").
+v1 nutzt die **degradierte, LM-freie Variante**: bei den großen Grid-Tasten ist der weitaus
+größte Teil der Taps eindeutig, daher:
+
+> Landet ein **akzeptierter** Tap (kein sofortiges Löschen/Ersetzen) eindeutig in Taste K, gilt K
+> als beabsichtigt und `roher Touchdown − center(K)` wird als Sample gelernt.
+
+Das ist Self-Labeling, beschränkt auf konfidente (interiore) Taps — kein naives
+„Acceptance-only", sondern dessen LM-freie Spielart.
+
+**Operationalisierung von „konfident/interior" (`m_interior`):** Ein akzeptierter Tap zählt nur
+fürs Lernen, wenn der rohe Touchdown **mehr als `m_interior`** (Anteil des Tastenpitchs) vom
+nächsten Tastenrand entfernt liegt — grenznahe Taps werden vom *Lernen* ausgeschlossen (korrigiert
+werden trotzdem alle). `m_interior` ist **der zentrale Bias-Varianz-Knopf** (Tuning-Parameter §10):
+- **groß** (streng interior) → kaum Mislabeling, aber **maximaler Zensierungs-Bias** (die
+  informativen Grenzfälle fehlen) → stärkere Unterkorrektur.
+- **klein** (auch grenznahe Taps) → weniger Bias, aber Risiko, falsch zugeordnete Grenz-Taps zu
+  lernen.
+
+**Default v1: moderat** — bewusst Richtung „streng" (konsistent mit „Unterkorrektur ist sicher",
+§1); am Gerät kalibrieren.
+
+**Welche Gesten lernen?** Nur **Taps** liefern in v1 Samples. Richtungs-/Return-Swipes liefern
+**kein** `m_k`-Sample (ihr Startpunkt ist absichtlich versetzt → würde verzerren).
+**Slide-Gesten** (Space-Cursor, Delete) lernen nie und werden nie korrigiert (kein Tastenzentrum
+gemeint). Per-Geste-Lernen ist v2.
+
+**Welche Tasten?** **Alle Nicht-Slide-Tasten** nehmen teil — Lernen, Resizing *und* Flächen-Fit
+(über ihren sichtbaren Mittelpunkt, 5.2). Das schließt Utility-Tasten (Shift, Mode-Switch, Globe,
+Return-Tap) ein; sie werden selten getippt → niedriges `n_k` → ohnehin stark zur Fläche geschrumpft
+(selbstregulierend, kein Sonderfall). **Slide-Tasten** (Space, Delete) sind komplett ausgenommen.
+
+**Acceptance-Filter (Mechanismus, Code-verifiziert §11.5, literatur-fundiert §«Korrekturverhalten» im
+Research-Doc):** „kein sofortiges Löschen/Ersetzen" wird so umgesetzt: ein kleiner **Ring-Puffer
+zuletzt committeter Taps** (`keyId`, Touchdown) wird geführt; eine **Backspace-Sequenz** vetoed
+**alle dadurch gelöschten Taps** (nicht gelernt). Fenster über **Aktions-Zählung**, nicht über eine
+Uhr — die Literatur parametrisiert Korrektur durchweg über Edit-Struktur, nicht über ms (Baldwin
+2012; Gboard „Undo: before any other key"); eine ms-Latenz-Verteilung existiert nicht.
+- **Burst statt Einzel-Veto (Korrektur aus Literatur):** Bei *verzögerter* Korrektur löscht der
+  Nutzer **durch korrekte Zeichen hindurch** bis zum Fehler (`peeple<<<<ople`). Nur den jüngsten Tap
+  zu vetoen träfe oft einen korrekten statt des Mis-Hits → **alle vom Burst gelöschten Taps**
+  ausschließen. Ausschluss schadet nie (kostet nur Recall), Relabeln wäre riskant (→ v3).
+- **Tap↔Zeichen-Alignment (nicht 1:1!):** Compose/Telex committen/ersetzen mehrere Zeichen pro Tap,
+  also gilt **nicht** „k Backspaces = k Taps". Lösung: der Ring-Puffer merkt pro Tap die **netto
+  erzeugte Zeichen-Spanne** (Länge des `insertText` minus etwaiger interner Ersetzungen). Ein
+  Nutzer-Burst entfernt L Zeichen vom Dokumentende → **vetoe jeden Tap, dessen Spanne (ganz oder
+  teilweise) in diesen L Zeichen liegt**. Über-Ausschluss (teilweise getroffene Taps) ist sicher.
+- **Edit ≠ Fehlerkorrektur:** lange Bursts, die ganze Wörter/Sätze entfernen, sind Umformulierungen
+  (Baldwin: 43,1 % der Edits sind so) → kein Mis-Hit-Signal; Burst-Länge deckeln, darüber ignorieren.
+- **Fallstrick (wichtig):** Es muss auf die **`.deleteBackward`-`KeyAction` in der `ActionPipeline`**
+  getriggert werden (= Nutzer hat die Löschtaste benutzt), **nicht** auf `TextInputTarget.delete­Backward()`
+  — denn `ComposeMiddleware`/`TelexMiddleware` rufen das Target im *Normalbetrieb* intern auf
+  (Akzent/Digraph ersetzen). Diese internen Deletes umgehen die Pipeline; eine Lern-Middleware in
+  der Pipeline sieht daher sauber nur Nutzer-Aktionen. Der **Slide-basierte Delete** (`handleSlide`)
+  ist ein separater Pfad und muss ebenfalls als Korrektur zählen.
+
+**Zensierungs-Bias (literatur-bestätigt, bewusst akzeptiert):** Baldwin (2012) dokumentiert, dass
+Lernen ohne wahres Label zu Fehlerfällen verzerrt; unser konfidentes Self-Labeling sieht nur Taps
+*in* der Taste, die Grenz-Mis-Hits fehlen → der Offset wird **systematisch zu klein** geschätzt
+(Regression zur Mitte). Das ist konsistent mit „Unterkorrektur ist sicher" (1) und in v1 **bewusst
+in Kauf genommen**. Der SOTA umgeht den Bias *nicht* per Acceptance-only, sondern per
+LM-/Decoder-Self-Labeling — das haben wir nicht. **Beruhigend (Literatur):** der Rausch-Beitrag
+unkorrigiert akzeptierter Mis-Hits ist klein — unkorrigierte Fehler sind selten (~2,3 % bei Palin
+2019; „conscientiousness" 0,61–0,78 bei Soukoreff/MacKenzie 2003), und Baldwins „Character-Level"-
+Strategie (allen nicht-editierten Taps vertrauen) erreicht trotzdem **98,2 % Precision**. Die
+unverzerrte Korrektur erfordert ein **Negativ-Signal** und ist auf v3 terminiert, mit Baldwins
+konkreter Methode (siehe §9). Dokumentiert, damit später niemand die Unterkorrektur für einen Bug
+hält.
+
+**Entkopplung von Messung und Anwendung (verhindert Degeneration — zentral bei Key-Target-Resizing):**
+Mit verschobenen Hit-Zellen (§5) droht eine konkrete Feedback-Schleife: eine vergrößerte Zelle fängt
+grenznahe Taps ein, die — gegen das *wahre* Zentrum gemessen — großen Offset haben; würden die
+gelernt, bliese sich `m_k` weiter auf → Zelle wächst → Drift. Bruch der Schleife, dreifach:
+- **`m_interior` gegen die *wahre* Geometrie:** gelernt wird nur aus Taps **interior zur echten
+  (unverschobenen) Zelle** (`m_interior` vom *wahren* Tastenrand). Genau die aufgeblähten Grenz-Taps
+  fallen damit raus → speisen die Schleife nicht. (`m_interior` ist doppelt load-bearing:
+  Zensierungs-Bias *und* Anti-Drift.)
+- **Messung gegen feste Geometrie:** stets `roher Touchdown − wahres center(K)`, nie gegen das
+  verschobene Zentrum.
+- **Clamp** (§4.3) deckelt die Grenzverschiebung hart → selbst Restdrift bleibt begrenzt.
+Damit ist der Fixpunkt der echte User-Bias, nicht das Auswahl-Ergebnis ⇒ keine Selbstverstärkung.
+
+### 4.2 Lern-Algorithmus: Empirical-Bayes-Shrinkage mit bounded-influence Running-Mean
+
+Der Algorithmus nutzt aus, dass es **pro Regime nur eine Handvoll Tasten** gibt (MessagEase ≈ 9
+Buchstaben-Positionen + Utility) und die Reach-Fläche nur 3–4 Koeffizienten hat. Damit ist die
+Flächenschätzung ein **winziger Closed-Form-Solve**, der bei Bedarf (Lesen/Persistieren) aus den
+Per-Tasten-Statistiken neu gerechnet wird — **kein** Online-RLS, **kein** Backfitting, **keine**
+zwei Zeitskalen. Das Lernen zerfällt in drei entkoppelte, je triviale Teile. Alle Achsen (x, y)
+werden **unabhängig** behandelt (Kovarianz ignoriert — für den *Mittel*-Offset ausreichend, da der
+Mittelwert separabel ist); alle Größen in **Tastenpitch-Anteilen**.
+
+**State pro (Regime, Taste k, Achse):** `n_k` (effektive Sample-Zahl, gedeckelt bei `n_max`),
+`m_k` (bounded-influence Running-Mean), `s_k` (robuste Streuung, EW-MAD).
+**Initialzustand:** `m_k = 0`, `n_k = 0`, `s_k = s_prior ≈ 0,10 Pitch` (≈ FFitts `σ_a`).
+
+**Schritt 1 — Per-Tasten-Update (online, je akzeptiertem Tap).** `e = rohTouchdown − center(k)`,
+*nach* dem absoluten **Dwell-Gate** (Kontaktradius/Multitouch entfallen, 4.3/11.4):
+
+```
+if n_k ≥ warmup and |e − m_k| > k_gate · s_k:   skip      # Outlier-Gate (erst nach Warm-up)
+δ   = clip(e − m_k, ±c · s_k)                              # Huber: gekappter Einfluss
+n_k = min(n_k + 1, n_max)
+m_k = m_k + δ / n_k                                        # Running-Mean (unverzerrt)
+s_k = s_k + β · (|e − m_k| − s_k)                          # robuste Streuung
+```
+
+Der **Huber-Clip** ist der zentrale Ausreißer-/Wasser-Schutz: ein einzelnes Sample bewegt `m_k`
+nie um mehr als `c · s_k / n_k` (bounded influence), bleibt für saubere Daten aber unverzerrt —
+ersetzt einen teuren Online-Median fast gratis.
+
+**Schritt 2 — Reach-Fläche (Closed-Form, gecacht).** Pro Regime (beim `twoThumb`-Regime je Hälfte,
+3.2) aus den Tasten als gewichtete Punkte. Basis **je nach Regime** (3.2): `φ = [1, u, v, uv]`
+(bilinear, Einhand) bzw. `φ = [1, u, v]` (linear, twoThumb-Hälften); `W = diag(n_k)`,
+Ridge → 0:
+
+```
+β_surface = (Φᵀ W Φ + λ_ridge · I)⁻¹ Φᵀ W m              # gewichtetes Ridge-LS, m = Vektor der m_k
+surface(pos) = φ(pos) · β_surface
+```
+
+`β_surface` wird **gecacht** und nur bei `m_k`/`n_k`-Änderungen invalidiert (nicht pro Tap neu
+gelöst); Schritt 3 liest aus dem Cache. **Rang-Defizit-Guard:** solange weniger Tasten Daten haben
+als die Basis Koeffizienten hat (z. B. <3 je linearer Hälfte), ist `ΦᵀWΦ` singulär — `λ_ridge·I`
+macht den Solve wohldefiniert und zieht die Fläche ≈ 0 (≈ gewichteter Mittel-Offset), bis genug
+Tasten belegt sind. So sichert Ridge zugleich Cold-Start und Daten-Hunger des Splits. Der
+Konstanten-Term von `β_surface` ist der „globale" Offset (3.3).
+
+**Schritt 3 — Angewandte Korrektur (Shrinkage zum Flächen-Prior).**
+
+```
+prior_k = surface(pos_k)
+r_k     = prior_k + (m_k − prior_k) · n_k / (n_k + κ)     # Partial Pooling / James-Stein (je Achse)
+offset_k = clamp_betrag((r_kx, r_ky), ≤ 0,35 · pitch)    # euklid. Betrag des 2D-Vektors, in Punkte (4.3)
+#          → speist als Grenzverschiebung das Key-Target-Resizing (§5, §4.4)
+```
+
+`n_k / (n_k + κ)` ist die **stufenlose Variante des reife-gegateten Backoffs** (Yin & Partridge,
+CHI 2013): junge/sparse Tasten hängen am Flächen-Prior, gut belegte konvergieren **unverzerrt**
+auf ihren eigenen Mittelwert. Das ersetzt die ursprüngliche EMA, deren konstantes Decay einen
+permanenten Schrumpf-Bias `α/(α+λ)·μ` hatte.
+
+**Warum diese Wahl (statt Alternativen):**
+
+| Wahl | statt | Grund |
+|---|---|---|
+| Running-Mean | konstante EMA | unverzerrt; EMA hatte permanenten Schrumpf-Bias |
+| count-gewichtetes Shrinkage (`κ`) | hartes Reife-Backoff | gleicher Effekt, aber stufenlos → kein Flackern an der Schwelle |
+| Closed-Form-WLS-Refit der Fläche | Backfitting / Online-RLS | nur ~9 Punkte → trivialer Solve; eliminiert Zwei-Zeitskalen-Tanz |
+| Huber-Clip | reiner Mittelwert / Online-Median | bounded influence gegen Ausreißer, fast gratis, unverzerrt für saubere Daten |
+| `n_max`-Deckel | konstantes Decay | trennt Plastizität/Selbstheilung sauber von Shrinkage (`κ`) |
+
+**Plastizität / Selbstheilung:** der Deckel `n_max` macht aus dem Running-Mean ab `n_max` eine EMA
+mit `α = 1/n_max` → neue (gute) Samples überschreiben einen verkorksten Zustand in begrenzter Zeit.
+`κ` (Pooling/Konfidenz) und `n_max` (Recency) sind bewusst getrennt einstellbar. **Default v1:**
+großzügiges `n_max` (langsame Plastizität); aggressiver nur bei beobachtetem Drift.
+
+**Kalman pro Taste/Achse** wurde bewusst *nicht* gewählt: eleganter (Konfidenz + Recency for free),
+aber das Prozessrauschen ist nur ein verkapptes Forgetting — mehr Tuning/State ohne Mehrwert für
+v1. Klare v2-Option, falls adaptives Drift-Tracking nötig wird.
+
+`n_k`/`s_k` steuern außerdem Anzeige-Deckkraft (UI) und das Apply-Gate (4.4).
+
+### 4.3 Robustheit & Degenerations-Schutz
+
+Gestaffelte Verteidigungslinien:
+
+- **Messung ↔ Anwendung entkoppelt** (4.1) — struktureller Schutz gegen Feedback-Drift.
+- **Hierarchisches Shrinkage** (3.4) — sparse Tasten bleiben an der gepoolten Fläche.
+- **Begrenzung (Clamp):** der **Betrag des 2D-Korrekturvektors** `(r_kx, r_ky)` (Fläche schon
+  eingefaltet, 4.2) hart deckeln (z. B. ≤ 35 % des Tastenpitchs). Eine Taste kann nie mehr als
+  „halb daneben" verschoben werden — Worst Case bleibt benutzbar.
+- **count-gewichtetes Shrinkage** (4.2) — sparse/junge Tasten bleiben nahe der gepoolten Fläche;
+  zugleich das literatur-belegte reife-gegatete Backoff.
+- **Selbstheilung über das Plastizitäts-Fenster** (4.2) — durch das gedeckelte `n_max`
+  überschreiben neue (gute) Samples einen alten verkorksten Zustand in begrenzter Zeit; plus
+  manueller Reset (6.4).
+- **Plausibilitäts-Gate vor dem Lernen:** Sample nur verwenden bei
+  - normaler **Dwell-Zeit** (aus `DragGesture.Value.time`, Dauer onChanged→onEnded; lange/
+    erratische Berührung → raus),
+  - (nach Warm-up) Abweichung < `k_gate · s_k` vom aktuellen Schätzwert (zusammen mit Huber-Clip).
+  - ⚠️ **Kontaktradius & Multitouch entfallen (Code verifiziert, 11.4):** der Touchpfad ist
+    SwiftUI `DragGesture` → **kein** `UITouch.majorRadius`, keine Touch-Zahl. Der geplante
+    Kontaktradius-Gate gegen Wasser/Handballen ist mit der aktuellen Architektur nicht umsetzbar.
+- **Streuung definiert & Cold-Start-Policy (aus Review):** `s_k` ist eine robuste
+  Online-Größe (EW-MAD, 4.2) mit breitem Prior. Das varianzbasierte Outlier-Gate greift erst
+  **nach `warmup` Samples**; davor schützen ausschließlich das *absolute* Dwell-Gate plus der
+  Clamp. So gibt es kein „kein Schätzwert → kein Schutz"-Loch beim Start.
+- **Regularisierung der Reach-Koeffizienten:** niedrige Ordnung (bilinear/linear), L2 → 0.
+
+> **Ehrliche Einordnung (Literatur-Review + Code-Check):** Konfidenz-/Reife-Gating und
+> Backoff/Shrinkage sind literatur-belegt (Yin & Partridge). Die Mechanismen gegen **transiente
+> Störungen** (Clamp, Dwell-/Outlier-Gate, robuste Streuung) sind eigene Erweiterungen ohne externe
+> Validierung. Mit dem Wegfall des Kontaktradius (11.4) ruht die Wasser-Verteidigung in v1 auf
+> **Dwell-Gate + Outlier-Gate/Huber-Clip + Clamp + Plastizitäts-Heilung + manuellem Reset** —
+> schwächer als ursprünglich geplant, aber das Modell kann nicht *nachhaltig* degenerieren.
+
+### 4.4 Anwendung & Apply-Gate
+
+- Die Korrektur wirkt als **Verschiebung der Hit-Zellgrenzen** (Key-Target-Resizing, §5), nicht als
+  Punkt-Translation. Sie ändert damit ausschließlich die **Tastenauswahl** an Grenzen; die
+  Innerhalb-Tasten-Klassifikation (Tap/Swipe-Richtung/Return) bleibt unberührt.
+- **Apply-Gate mit Hysterese (auf Regime-Ebene, 11.5):** die Korrektur eines Regimes wird erst
+  angewandt, wenn **Flächen-Rang erfüllt UND `Σ n_k ≥ apply_on`**; sie wird erst wieder ausgesetzt,
+  wenn `Σ n_k < apply_off` (`< apply_on`). Per-Taste ist kein hartes Gate nötig — niedriges `n_k`
+  regelt das Shrinkage (4.2) bereits stufenlos. Hysterese verhindert Flackern.
+
+### 4.5 Wasser-Szenario (explizit)
+
+Wasser ⇒ erratische Touches mit untypischen Dwell-Zeiten und großer Streuung. Da Kontaktradius/
+Multitouch **nicht** verfügbar sind (11.4), greift das **Dwell-Gate** als einziger absoluter Filter;
+der Rest wird über das **Outlier-Gate/Huber-Clip** abgefangen (erratische Punkte liegen weit vom
+`m_k` → gekappt/verworfen). Was durchrutscht, ist durch **Clamp** begrenzt und wird bei normaler
+Nutzung über das **Plastizitäts-Fenster** (`n_max`, 4.2) überschrieben; zusätzlich **manueller
+Reset** (6.4). Schwächer als mit Kontaktradius, aber: das Modell kann nicht *nachhaltig* kippen.
+
+## 5. Architektur & Integration
+
+- **Anwendung — Key-Target-Resizing in `KeyboardGridLayout.cellFrames` (Code-verifiziert, 11.6):**
+  *Nicht* den Touchdown-Punkt verschieben — das geht in der Per-KeyView-Architektur nicht (die
+  Tastenzuordnung fällt bei SwiftUIs Hit-Testing, *bevor* ein Handler den Punkt sieht). Stattdessen
+  die **Hit-Zellgrenzen** verschieben: `cellFrames` ist die zentrale, reine, bereits unit-getestete
+  Funktion, die jeder Taste ihren Touch-Frame zuteilt. Der gelernte Per-Tasten-Offset verschiebt die
+  **gemeinsame Grenze** zweier Nachbartasten (≈ um `(offset_A+offset_B)/2`) → ein grenznaher Tap
+  landet in der vergrößerten Zelle der intendierten Taste. Das ist das literatur-kanonische
+  **Key-Target-Resizing** (Gunawardana 2010) und macht §1 wörtlich wahr.
+  - **Sichtbar ≠ Touch (passt schon):** Die Architektur trennt bereits **Touch-Frame** (`cellFrames`)
+    vom **sichtbaren** Key (per `visualInset` zurückgesetzt). Wir verschieben nur den Touch-Frame; der
+    sichtbare Tastatur-Eindruck bleibt stabil — genau das unsichtbare Resizing wie bei Apple/Gboard.
+  - **Innerhalb-Tasten-Gesten unberührt:** `KeyGestureRecognizer` arbeitet in Translation-Koordinaten
+    relativ zum Touchdown → Tap/Swipe-Richtung/Return sind vom Offset **nachweislich unbeeinflusst**
+    (löst die Sorge aus 11.3).
+- **Modell:** neue Komponente `TouchOffsetModel` (pro Regime: Per-Taste `{m_k, n_k, s_k}`; die
+  Reach-Fläche[n] werden daraus **abgeleitet/gecacht**, nicht separat als „keyResidual" persistiert
+  — 3.3/4.2). Vom Preprocessor zur Korrektur konsultiert, aus Feedback aktualisiert.
+- **Lern-Feedback:** schlanke **Lern-Middleware am Pipeline-Ende** beobachtet `.commitText` (Tap)
+  und `.deleteBackward` (Nutzer-Korrektur → Acceptance-Veto, 4.1) und sieht so sauber nur
+  Nutzer-Aktionen.
+- **⚠️ Touchdown-Plumbing (Haupt-Integrationsposten, Code-verifiziert):** Der rohe Touchdown wird
+  heute **nirgends durchgereicht** — `KeyGestureRecognizer` verwirft die absolute `startLocation`
+  (nur `translation` wird intern genutzt), und `ActionContext` trägt weder `keyId` noch Punkt. Für
+  `e = Touchdown − center(K)` muss der **key-lokale Touchdown** neu durchgefädelt werden:
+  `KeyGestureRecognizer` (erfasst `value.startLocation`) → `onGesture`-Callback (`KeyView`) →
+  `handleGesture` (kennt bereits `keyId`) → Lern-Middleware. Praktisch: `keyId` + Touchdown in den
+  `ActionContext` aufnehmen (oder einen separaten Lern-Sink aus `handleGesture` speisen). Das ändert
+  die Gesten-API-Signatur — überschaubar, aber der größte einzelne Eingriff.
+- **Regime-Kontext:** Regime-Schlüssel + Geometrie sind zur Laufzeit aus
+  `KeyboardViewController`/View-State verfügbar (Posture-Klasse abgeleitet, 11.1).
+- **Persistenz:** `SharedDefaults` (App-Group), versioniertes Schema; `keyId`s sind stabile
+  Slot-Ids, daher bei Layout-Änderung **partielle** Invalidierung (nur entfallene Keys), nicht
+  alles wegwerfen.
+
+### 5.1 Prozessgrenze (Gotcha)
+
+Settings-Unterseite läuft in der **Host-App**, das Modell entsteht in der **Extension** (eigener
+Prozess). Die Settings-Viz zeichnet nur den **`SharedDefaults`-Snapshot** (mit „zuletzt
+aktualisiert") — kein Live-Mittippen, da in der Host-App nicht die eigene Extension als Eingabe
+aktiv ist. Echtes Live gehört in ein Debug-Overlay *in der Extension* (6.6).
+
+### 5.2 Koordinatensystem (eindeutig festlegen)
+
+- **Touchdown & Tastenzentren:** im **Tastatur-View-Koordinatenraum** (Punkte, Ursprung oben
+  links der Tastatur-View, in der *aktuellen* Orientierung — Rotation hat das View-System bereits
+  aufgelöst). **`center(K)`** = geometrischer Mittelpunkt des **sichtbaren** Keys (nicht der
+  Touch-Zelle); spannende Tasten nutzen den Mittelpunkt ihres vollen sichtbaren Rechtecks.
+- **Reach-Flächen-Eingabe:** Tastenposition in diesem Raum, normiert auf `[0,1]²`
+  (`posInKeyboard`). Bei der **twoThumb-Split-Fläche** ist `u` **halb-lokal** auf `[0,1]` je Hälfte
+  normiert (jede Hälfte spannt ihren eigenen `[0,1]²`-Raum auf, ein Pivot pro Hälfte).
+- **`m_k`, Korrektur-Offsets & Clamp:** in **Tastenpitch-Anteilen** (dx/Breite, dy/Höhe), erst bei
+  der Anwendung mit dem aktuellen Pitch in Punkte zurückgerechnet.
+
+### 5.3 Wechselwirkung mit lückenloser Kachelung / Totzonen (#198)
+
+Key-Target-Resizing (§5) verschiebt **gemeinsame Zellgrenzen** in `cellFrames`. Kritisch: die
+Kachelung muss **lückenlos UND überlappungsfrei** bleiben (#198) — eine verschobene Grenze muss die
+Nachbarzelle exakt gegengleich nachführen (**eine Kante = ein Wert**, von beiden Zellen geteilt),
+sonst entstehen Totzonen oder Doppelzuordnungen. Die Grenzverschiebung ist zu clampen, damit eine
+Zelle nie ihre Nachbarn „überrennt". `cellFrames` ist rein → in
+`KeyboardGridLayoutTouchCoverageTests` direkt testbar: nach Resizing weiterhin **vollständige,
+disjunkte** Überdeckung.
+
+### 5.4 Resizing-Geometrie (exakt)
+
+Jede Taste K hat einen geclampten 2D-Offset `offset_K = (ox_K, oy_K)` (Pitch-Anteile, §4.2);
+Interpretation: das *effektive* Zentrum ist `center(K) + offset_K`. Die Zell-Grenzen folgen den
+Mittelsenkrechten zwischen effektiven Zentren — in einem achsparallelen Gitter exakt so:
+
+- **Innere vertikale Kante** (geteilt von A links, B rechts): Position `+= (ox_A + ox_B) / 2`.
+- **Innere horizontale Kante** (geteilt von A oben, B unten): Position `+= (oy_A + oy_B) / 2`.
+- **Äußere/Rand-Kanten** (kein Nachbar): **bleiben fix** — die Tastatur-Außengrenzen ändern sich
+  nicht (kein Overflow).
+- **Eine Kante = ein Wert**, von beiden Zellen geteilt → lückenlose, überlappungsfreie Partition
+  bleibt automatisch erhalten (§5.3).
+- **Diagonale Nachbarn** brauchen keine Behandlung: im Rechteck-Gitter gibt es nur H/V-Kanten; der
+  2D-Offset ist über die x-/y-Komponenten vollständig erfasst.
+- **Nicht-Degeneriertheit:** Bei Offset-Clamp ≤ 0,35 Pitch (§4.3) bewegt sich jede Kante ≤ 0,35
+  Pitch; eine Zelle behält Breite/Höhe ≥ `1 − 2·0,35 = 0,3` Pitch → nie invertiert/verschwunden.
+- **Spannende Tasten** (row/col-span): nutzen ihren sichtbaren Mittelpunkt; jede ihrer geteilten
+  Kanten wird mit der jeweils angrenzenden Nachbartaste nach derselben Regel verschoben.
+
+### 5.5 Faktische Umsetzung / Routing
+
+**Die Tastenzuordnung schreiben *wir* nicht — SwiftUI hit-testet gegen die platzierten Frames.**
+Jede `KeyView` wird vom `KeyboardGridLayout` an einem Frame platziert (`.contentShape(Rectangle())`);
+SwiftUI liefert die Geste an die KeyView, deren Frame den Touchdown enthält. Wir steuern **nur die
+Frames** — es gibt keine eigene „Koordinate → Taste"-Logik.
+
+**Touch-Frame ≠ sichtbarer Key (das ist der Kern):** Die Touch-Zellen kacheln die *gesamte*
+Oberfläche lückenlos → jeder Punkt liegt in **genau einer** Zelle. Der sichtbare Key ist per
+`visualInset` nach innen gezeichnet. Folge — und Auflösung des „der Touch ist gar nicht auf der
+Taste"-Einwands:
+
+> Der Touchdown liegt **immer in genau einer Touch-Zelle**, darf aber **außerhalb des gezeichneten
+> Keys** liegen (im Spalt / optisch über dem Nachbarn). Das ist das *unsichtbare* Resizing: der
+> Nutzer sieht eine stabile Tastatur, die Trefferzonen verschieben sich darunter.
+
+**Minimaler Eingriff — gespiegelte Frames offset-bewusst machen:** Heute leiten sich `cellFrames`
+(Touch-Frame, gewachsen) und `visualInset` (zieht den Key zurück) aus **derselben** `gapInsets`-
+Quelle ab und spiegeln sich. Key-Target-Resizing erweitert genau diese geteilte Rechnung:
+- Touch-Frame-Grenze verschiebt sich nach §5.4.
+- `visualInset` kompensiert um **denselben Betrag pro Kante** (jetzt **asymmetrisch**) → der
+  gezeichnete Key bleibt **exakt** an seiner Stelle.
+- Da „eine Kante = ein Wert", bleibt die Kachelung **disjunkt** → genau eine Taste pro Punkt, kein
+  Overlap/Z-Order-Problem.
+
+**Keine Per-Touch-Korrektur-Rechnung:** Der Offset ist in die Layout-Frames „eingebacken". Beim
+Tippen passiert *null* Zusatzarbeit; SwiftUI routet gegen die ohnehin platzierten Frames. Re-Layout
+nur bei (seltener) Offset-Änderung. Die Offsets fließen pro **aktivem Regime** (3.1) aus dem
+`TouchOffsetModel` in den `KeyboardGridLayout`-Konstruktor.
+
+**Lern-Koordinate (getrennt von der Zuordnung):** `value.startLocation` ist **lokal zum
+(verschobenen) KeyView-Frame** → plus Frame-Origin ergibt den **absoluten** Touchdown im
+Tastatur-Raum; dann `e = absoluter Touchdown − wahres center(K)` (5.2). So wird gegen die *feste*
+Geometrie gemessen, obwohl das Routing über verschobene Frames lief — die §4.1-Entkopplung konkret.
+
+**Verworfene Alternative:** Eine **einzelne** keyboard-weite Geste, die selbst „korrigierter Punkt →
+nächstes effektives Zentrum" rechnet. Funktional äquivalent, aber größerer Architektureingriff und
+überflüssig, da das Frame-Verschieben in der zentralen, reinen `cellFrames` dasselbe liefert und
+SwiftUIs Hit-Testing die Zuordnung gratis macht.
+
+## 6. UI
+
+### 6.1 Settings-Toggle
+
+- **Ein Schalter** fürs gesamte Feature: **Aus** = weder lernen noch anwenden (Default);
+  **An** = lernen *und* anwenden.
+- **Kurzerklärung** + **Datenschutz-Hinweis** (alles bleibt lokal auf dem Gerät).
+- **Status-Zeile:** „lernt noch / genug Daten", mit Sample-Anzahl.
+
+### 6.2 Visualisierung (Settings-Unterseite)
+
+Rendert die Tastatur (Wiederverwendung der daten-getriebenen Darstellung,
+`KeyboardGridView`/Showcase), Offsets als Overlay; Quelle: `SharedDefaults`-Snapshot mit
+„zuletzt aktualisiert".
+
+- **Wahres Zentrum (Fadenkreuz) → gelernter Punkt (roter Punkt), verbunden durch Pfeil** —
+  Richtung *und* Betrag.
+- **Konfidenz über Deckkraft/Größe** (wenig Samples → blass). Farbe nur Akzent.
+
+### 6.3 Regime-Selektor (kritisch)
+
+**Segmented Control** für Orientierung × Posture-Klasse (`twoThumb` / `oneThumbLeft` /
+`oneThumbRight`); rendert das gewählte Regime an repräsentativer Geometrie. Ohne Selektor vermischt
+die Anzeige Modelle und führt in die Irre.
+
+### 6.4 Reset
+
+- **„Gelernte Korrektur zurücksetzen"** — Pflicht (Wasser-Notausgang).
+- Zwei Stufen: **alles** *und* **nur das aktuell angezeigte Regime**.
+
+### 6.5 User-View vs. Debug-View
+
+- **User:** schlicht — Pfeile + Konfidenz, „so passe ich mich an dich an".
+- **Debug** (hinter Debug-Toggle/versteckter Geste): rohes **Touch-Sample-Streufeld** pro Taste,
+  **Reach-Vektorfeld** (je Hälfte beim twoThumb-Regime), rohe Zahlen (max. Korrektur, `n_k`,
+  `s_k`), Per-Regime-Reset.
+- **Gesten-Diagnose** (Zukunfts-Track §13): Feature-Cluster-Kerne, Randdichte und Korrekturraten je
+  Gestenklasse (Tap/Swipe/Return/Circle) — reine Anzeige, hilft beim Default-Schwellen-Tuning.
+
+### 6.6 Live-Debug-Overlay (Extension, v2)
+
+Echtes Live nur in der Extension möglich. Hinter Debug-Flag. **Speicher-Vorsicht**
+(jetsam-kritischer Prozess). Nicht in v1.
+
+## 7. Datenmodell / Persistenz
+
+- `SharedDefaults` (App-Group), versioniertes Schema.
+- Pro Regime: Per-Taste `{m_k, n_k, s_k}` (Gesamt-Offset-Mittel, Sample-Zahl, Streuung; je Achse).
+  Die Reach-Flächen-Koeffizienten sind **abgeleitet** (Cache, kein Pflicht-Persist — beim Laden aus
+  den `m_k` rekonstruierbar). **Keine** separate `keyResidual`-Map (3.3).
+- `m_k` in **Tastenpitch-Anteilen**; Reach-Eingabe in `[0,1]²` (5.2).
+- Schema-Version + stabile `keyId`s → partielle Invalidierung bei Layout-Änderung.
+- **Footprint:** ~12 Tasten × ~5 Floats + Flächenkoeff., × ~6 reale Regime ≈ **wenige KB** — im
+  jetsam-kritischen Extension-Prozess unkritisch.
+- **Schreib-Kadenz:** **nicht pro Tap** (Perf). Debounced/periodisch — z. B. alle N Taps und bei
+  `viewWillDisappear`/Background — damit der Settings-Snapshot (5.1) hinreichend frisch bleibt.
+- **Datenschutz:** Rohpunkte werden **nicht** dauerhaft gespeichert — nur aggregierte Schätzer.
+  `PRIVACY.md` ist entsprechend zu ergänzen (Feature zeichnet Touch-Positionen lokal aus,
+  verlässt das Gerät nie).
+
+## 8. Validierung & Abnahme
+
+- **Proxy-Metrik rein lokal** mitloggen (Backspace-Rate, Anteil grenznaher Taps) — verlässt das
+  Gerät nicht, dient nur Debug/Selbstkontrolle.
+- **Abnahmekriterium v1 (Vorschlag):** in einem A/B-Selbstversuch (Feature an vs. aus über je
+  N Sitzungen) sinkt die Backspace-/Korrektur-Rate messbar, **ohne** dass die Rate in irgendeinem
+  Regime steigt. Solange das nicht belegt ist, bleibt das Feature Default-aus.
+- Debug-View zeigt Samples/Regime, max. Korrektur, `s_k` zur Plausibilisierung.
+
+## 9. Phasierung
+
+**v1 (schlank geschnitten)**
+- Regime: Orientierung × `derivePosture(scale, position)` — beides detektionsfrei aus
+  Controller-State bzw. `SharedDefaults` (11.1).
+- Modell: Per-Taste `{m_k,n_k,s_k}`; Reach-Fläche abgeleitet (bilinear Einhand, linear je
+  Hälfte bei twoThumb; Konstanten-Term = global). Keine separate `keyResidual`-Persistenz.
+- Lernsignal: Self-Labeling auf konfidenten Taps (LM-frei, Interior-Margin `m_interior`), **nur Taps**.
+- Update (4.2): Empirical-Bayes-Shrinkage — bounded-influence Running-Mean pro Taste (Huber-Clip),
+  Closed-Form-WLS-Refit der bilinearen Reach-Fläche, count-gewichtetes Shrinkage zum Flächen-Prior;
+  Outlier-Gate nach Warm-up, absolute Gates + Clamp + Apply-Hysterese.
+- Persistenz pro Regime; partielle Invalidierung.
+- **Gestenparameter-Telemetrie (nur Erhebung + Debug-Diagnose, KEINE Adaption, §13):** akzeptierte
+  Gesten → Feature-Aggregate je Klasse + Korrektur-Zähler. Bewusst mitgenommen, da die Stats-Infra
+  ohnehin entsteht; verhindert späteres Retrofitting.
+- UI: Toggle (+ Datenschutz, Status), Settings-Viz (Snapshot, Vektoren, Konfidenz),
+  Regime-Selektor, Reset (alles + pro Regime), User/Debug-Trennung.
+
+**v2**
+- Per-Geste-Residuum (per-Geste *räumlicher* Offset). Setzt voraus, dass v1 dafür Samples sammelt —
+  tut es **nicht** (v1 lernt nur aus Taps, §4.1). Also erst, wenn v1 auf Swipe-Start-Sampling
+  erweitert ist und dieses einen Gesten-spezifischen Bias belegt. (Nicht zu verwechseln mit der
+  §13-Telemetrie, die *Klassifikations-Features* sammelt, nicht räumliche Offsets.)
+- Stetige Größen-/Aspect-Anpassung + Interpolation (falls Bedarf belegt).
+- Live-Debug-Overlay in der Extension.
+- Cold-Start eines leeren Regimes via **gespiegelter Gegenhand** (Einhand-links ≈ -rechts
+  gespiegelt).
+- Ggf. quadratische Reach-Fläche, falls Residuen Krümmung belegen.
+
+**v3**
+- Negativ-Signal (Korrektur-Attribution via Backspace) → behebt den Zensierungs-Bias (4.1),
+  ermöglicht volle statt konservativer Korrektur. **Konkrete Methode (Baldwin 2012, „Conservative"):**
+  die nach der Löschung neu getippten Zeichen mit den gelöschten **alignen**; nur **relabeln**, wenn
+  das Alignment eine reine **Nachbartasten-Substitution** ist (Mis-Hit-Touchdown → intendierter Key
+  als positives Sample), sonst verwerfen. Aggressives Verwerfen ist Standard (43,1 % der Edits
+  uneindeutig); Baldwin: Recall ~12 %, Fehler <1 % — Genauigkeit vor Datenmenge.
+
+## 10. Offene Hyperparameter (empirisch zu tunen)
+
+Alle Symbole referenzieren den Algorithmus in 4.2:
+
+- `κ` — Shrinkage-Stärke (Prior-Pseudo-Counts); wie schnell eine Taste vom Flächen-Prior auf den
+  eigenen Mittelwert übergeht.
+- `n_max` — Plastizitäts-Deckel; Recency/Selbstheilung (ab hier wirkt der Running-Mean wie EMA mit
+  `α = 1/n_max`).
+- `c` — Huber-Clip-Faktor (gekappter Sample-Einfluss, in `s_k`-Einheiten).
+- `k_gate`, `β`, `warmup` — Outlier-Gate-Schwelle, EW-MAD-Rate der Streuung, Warm-up vor Gate-Start.
+- `m_interior` — Interior-Margin fürs Lernen (Bias-Varianz-Knopf, 4.1); groß = streng = mehr
+  Unterkorrektur.
+- `apply_on` / `apply_off` — Apply-Gate mit Hysterese auf **Regime-Reife** (4.4, 11.5).
+- `λ_ridge` — Ridge-Regularisierung der Reach-Fläche (Schritt 2).
+- Clamp-Grenze (% Pitch) — max. Betrag des Korrekturvektors (Default ≤ 0,35).
+- Dwell-Max — einziger absoluter Plausibilitäts-Filter (Kontaktradius entfällt, 11.4); am Gerät
+  messen (Tap-Dauer-Verteilung, ~150–200 ms).
+- `derivePosture`-Schwellen **+ Hysterese** — ab wann scale/position als Einhand klassifiziert wird
+  (3.1); Hysterese verhindert Regime-Flackern (Daten-Split) nahe der Schwelle.
+
+Am Gerät kalibrieren.
+
+## 11. Offene Risiken — zuerst verifizieren
+
+### 11.1 Regime-Erkennbarkeit — GEKLÄRT (kein Risiko)
+
+Per Codebase-Untersuchung aufgelöst; das ursprünglich vermutete Show-Stopper-Risiko existiert
+nicht. Befunde:
+
+- **Es gibt keinen zu *erratenden* Handhaltungs-State.** iOS bietet Dritt-Tastaturen keinen
+  Einhand-Modus (System-Keyboard-only) und meldet einer Custom-Extension keine Floating-/
+  Posture-Info. Die ursprüngliche Annahme zielte auf einen nicht existenten Sensor.
+- **Die relevanten Größen sind explizite, deterministische User-Settings** in `SharedDefaults`
+  (`keyboardScale`, `keyAspectRatio`, `keyboardHorizontalPosition`), zur Laufzeit exakt bekannt
+  und bereits über `GesturePreprocessorConfig.fromUserDefaults()` gelesen. Wurstfingers eigene
+  Positionierung *ist* der Einhand-Mechanismus → die Posture-Klasse wird daraus **abgeleitet**
+  (3.1), nicht detektiert.
+- **Orientierung** kommt zuverlässig vom Controller (`detectIsLandscape()` →
+  `viewModel.isLandscape`); aus den Keyboard-Bounds allein ginge es nicht (dokumentiert im Code).
+
+Konsequenz: Regime-Schlüssel `(Orientierung, derivePosture(scale, position))` ist vollständig
+ohne Detektion bestimmbar. Kein Spike, kein Fallback-auf-Standard nötig. Einzige verbleibende
+Feinarbeit: die `derivePosture`-Schwellen (ab wann „schmal & versetzt genug" = Einhand)
+empirisch festlegen — eine Heuristik über bekannte Werte, kein Plattformrisiko.
+
+### 11.2 Datenarmut seltener Regime
+
+Einhand-Regime (und v2: Floating) werden selten genutzt → bleiben evtl. dauerhaft kalt. Das ist
+**akzeptabel** (sie bleiben neutral = Status quo), aber bewusst so dokumentiert; kein Versuch,
+sie künstlich zu füllen (außer optionalem Spiegeln in v2).
+
+### 11.3 Übertragbarkeit auf Gesten-Grid-Keyboards (Evidenzlücke, nicht Show-Stopper)
+
+Der Literatur-Review ergab: **es gibt keine peer-reviewte Arbeit zu MessagEase-/Grid-/Gesten-/
+Swipe-Keyboards** mit gelernter Offset-Korrektur. Alle Evidenz (Gauß-Modelle, Backoff,
+systematischer Offset, Varianz-Boden) stammt von **QWERTY-Tap** und diskreter Zielauswahl. Die
+biomechanischen Grundlagen sind layout-unabhängig → **plausibel übertragbar, aber nicht belegt.**
+
+- **Konkretes Risiko:** Könnte die Korrektur die **8-Richtungs-Swipe-Klassifikation** stören? Per
+  Design *nein* — die Korrektur ist reines Key-Target-Resizing (Zellgrenzen, §5/11.6); der
+  `KeyGestureRecognizer` arbeitet in Translation-Koordinaten und wird **gar nicht** angefasst. Nur
+  der *Tasten-Besitz* verschiebt sich, was gewollt ist. Trotzdem als Validierungspunkt führen.
+- **Aktion:** Das v1-Abnahmekriterium (§8) ist der eigentliche Beleg der Übertragbarkeit — bis das
+  A/B die Übertragung bestätigt, bleibt das Feature Default-aus.
+
+### 11.4 Kontaktradius/Multitouch im Gesten-Stack — GEKLÄRT (Einschränkung, kein Show-Stopper)
+
+Per Code-Check aufgelöst: `KeyGestureRecognizer` ist ein SwiftUI-`ViewModifier` auf Basis von
+`DragGesture(minimumDistance: 0)` (`onChanged`/`onEnded`). `DragGesture.Value` liefert nur
+`location`, `startLocation`, `translation`, `velocity`, `time` — **kein `UITouch.majorRadius`,
+keine Touch-Anzahl**.
+
+- **Folge:** Der geplante Kontaktradius-Gate (Hauptverteidigung gegen Wasser/Handballen) entfällt in
+  v1 (4.3/4.5). Wasser-Schutz ruht auf Dwell-Gate + Outlier-Gate/Huber-Clip + Clamp + Heilung +
+  Reset.
+- **Implementierungs-Hinweis:** Der Recognizer behält aktuell nur `value.translation` und verwirft
+  die absolute `value.startLocation`. Fürs Lernen brauchen wir den **absoluten Touchdown relativ
+  zum Tastenrahmen** — `startLocation` ist verfügbar, muss aber zusätzlich erfasst werden.
+- **Wenn der Kontaktradius später doch gewünscht ist:** Touch-Eingabe auf einen UIKit-
+  `UIGestureRecognizer`/`touchesBegan` (mit `UITouch.majorRadius`) umstellen — größerer
+  Architektureingriff, für v1 nicht vorgesehen.
+
+### 11.5 Verbleibend offen (Klärungsweg dokumentiert)
+
+- **Apply-Gate-Ebene (entschieden):** **Regime-/Flächen-Reife-Gate** statt hartem Per-Tasten-Gate —
+  konsistent mit dem submodell-Reife-Backoff (Yin & Partridge); per-Taste regelt ohnehin schon das
+  Shrinkage. `apply_on/off` gaten damit die *Regime*-Reife.
+- **Acceptance-Fenster (#4) — GEKLÄRT (Code):** Detektion über die `.deleteBackward`-`KeyAction` in
+  der `ActionPipeline` (= Nutzer-Löschung); Ring-Puffer zuletzt committeter Taps, Veto des jüngsten
+  bei Folge-Löschung, Fenster über Aktions-Zählung (Mechanismus in 4.1). **Fallstrick:** *nicht*
+  `TextInputTarget.deleteBackward()` beobachten — Compose/Telex rufen es im Normalbetrieb intern auf;
+  die Pipeline-Action ist der saubere Nutzer-Signal-Pfad. Slide-Delete (`handleSlide`) zusätzlich
+  abdecken. Einzige Restarbeit ist das Touchdown-Plumbing (§5), das v1 ohnehin braucht.
+- **`derivePosture`-Schwellen (#5):** aus den bekannten `scale`/`position`-Ranges ableiten + UX am
+  Gerät; keine Literatur.
+- **A/B-Harness (#7):** Eval-Protokoll aus Gboard/Weir adaptieren (gegenbalancierte Sessions, CER/
+  Backspace-Rate als Metrik).
+
+### 11.6 Wirkmechanismus: Punkt-Translation vs. Key-Target-Resizing — GEKLÄRT (Redirect)
+
+Per Code-Check (`KeyView` + `KeyboardGridLayout`) aufgelöst. Befund: jede `KeyView` trägt ihre
+**eigene** `DragGesture` (`.contentShape(Rectangle())`); SwiftUIs Hit-Testing entscheidet die
+Tastenzuordnung **vor** jedem Handler, und `KeyGestureRecognizer` arbeitet nur in
+Translation-Koordinaten. Ein Touchdown-„Verschieben" im `GesturePreprocessor` kann die Tastenauswahl
+daher **nicht** ändern — der ursprünglich in der Spec angenommene Wirkmechanismus war falsch.
+
+**Redirect (kein Blocker, eher Vereinfachung):** Die Korrektur gehört ins zentrale, reine
+`KeyboardGridLayout.cellFrames` als **Key-Target-Resizing** (Grenzen verschieben, §5). Vorteile:
+- zentral & rein (eine Funktion besitzt alle Touch-Frames; bereits unit-getestet),
+- **Touch-Frame schon vom sichtbaren Key getrennt** (`visualInset`) → unsichtbares Resizing „for free",
+- literatur-kanonisch (Key-Target-Resizing, Gunawardana 2010), macht §1 wörtlich wahr,
+- `KeyGestureRecognizer`/Innerhalb-Tasten-Gesten unberührt → Swipe-Klassifikation nachweislich
+  unbeeinflusst (11.3).
+
+Restarbeit unverändert: Touchdown-Plumbing fürs *Lernen* (§5) + Anti-Drift via `m_interior` gegen
+wahre Geometrie (§4.1).
+
+## 12. Test-Ansatz
+
+- Unit-Tests (Swift `Testing`, Mock-`TextInputTarget`):
+  - Korrektur-Anwendung im `GesturePreprocessor` (Punkt rein → korrigierter Punkt raus, Clamp).
+  - Schätzer (4.2): Running-Mean konvergiert **unverzerrt** auf konstanten Bias (kein
+    Schrumpf-Bias bei hoher `n_k`); Huber-Clip kappt Einzel-Sample-Einfluss; count-gewichtetes
+    Shrinkage zieht sparse Tasten zum Flächen-Prior; Plastizitäts-Deckel `n_max` überschreibt
+    alten Zustand in begrenzter Zeit.
+  - Reach-Fläche: Closed-Form-WLS-Refit aus Per-Tasten-Statistiken bildet linearen Trend ab,
+    Ridge → 0 bei wenigen Datenpunkten; Zwei-Hälften-Split beim `twoThumb`-Regime.
+  - Outlier-Gate inkl. Cold-Start (absolute Gates schützen vor Warm-up); `s_k`-Schätzung.
+  - Regime-Trennung: Samples eines Regimes beeinflussen andere nicht; `derivePosture`-Klassifikation.
+  - Persistenz: Round-Trip durch `SharedDefaults`, Schema-Version, partielle Invalidierung.
+  - Hit-Testing-Wechselwirkung mit lückenloser Kachelung (#198).
+- Robustheits-/Degenerations-Szenarien als Tests:
+  - „Wasser": Flut erratischer Samples (großer Kontaktradius/Multitouch) ändert das Modell nicht
+    nachhaltig (absolute Gates + Clamp + Plastizitäts-Fenster).
+  - Feedback-Schleife: wiederholte Anwendung treibt den Schätzer nicht (Messung gegen feste
+    Geometrie, Attribution über rohen Punkt).
+  - Zensierungs-Bias: Schätzer unterschätzt erwartungsgemäß (dokumentiert, nicht „korrigiert").
+
+## 13. Zukunfts-Track: Adaptive Gestenparameter (Daten *jetzt* erheben)
+
+**Entscheidung:** Die *Adaption* der Gesten-Schwellen ist ein **separater, späterer Track** — nicht
+v1/v2. Aber da v1 ohnehin eine Statistik-/Lern-Infrastruktur baut (Lern-Middleware,
+SharedDefaults-Aggregate), werden die **dafür nötigen Daten gleich mit erhoben**, um späteres
+Retrofitting zu vermeiden. v1-Scope hier = **reine Erhebung + Debug-Diagnose, keine Anwendung.**
+
+### Hintergrund (aus der Designdiskussion)
+Die 4 Gestenklassen — **Tap / Swipe / Swipe-Return / Circle** — werden über schwellenbasierte
+Features getrennt; die Defaults sind aktuell **geraten**, nicht datenkalibriert. Aus **akzeptierten
+(unkorrigierten)** Gesten lassen sich die **Cluster-Kerne** je Klasse robust schätzen → spätere
+**kern-verankerte** Anpassung (Konvergenz-Garant; Grenz-/„Tal"-Fitting wäre durch Randzensur
+instabil). Zwei bekannte Grenzen: (a) **Klassen-Zensur** — eine systematisch versagende Klasse hat
+~0 akzeptierte Beispiele und ist aus Positiven nicht heilbar; (b) **Datenarmut** seltener Klassen
+(v. a. Circle). Beides macht die *Diagnose* nötig, bevor man Adaption baut. Der per-Richtung
+**Winkel-Offset** ist der sauberste erste Kandidat (direkt analog zum Spatial-Offset, §3).
+
+### Was erhoben wird (nur Aggregate, nur aus akzeptierten Gesten)
+Pro `(Regime, Gestenklasse[, Richtung])` Running-Stats `{n, mean, M2→Streuung}` (Welford) der
+**diskriminierenden Features** — Namen wie in `GestureClassificationThresholds`:
+- `maxDisplacement` (Tap ↔ Swipe)
+- `returnRatio` (Swipe ↔ Swipe-Return)
+- `circularity`, `angularSpan`, `turnConsistency`, `orientedCompactness`, `pathSeparation` (Circle)
+- `dominantAngle` **pro Richtung** (für den späteren Winkel-Offset)
+
+**Erfassungs-Scope (≠ Offset-Lernen):** Die Telemetrie ist ein **separater Konsument** derselben
+Lern-Middleware. Anders als das Offset-Lernen (**nur Taps**, §4.1) erfasst sie **alle 4 Klassen**
+(sonst keine Swipe-/Return-/Circle-Cluster). Sie nutzt **dieselbe Acceptance-Bestimmung**
+(Ring-Puffer + Delete-Veto, §4.1); das Klassen-Label ist die Klassifikator-Ausgabe.
+
+**Einheiten (kritisch für spätere Nutzbarkeit):** Features werden in der **nativen
+Klassifikator-Einheit** abgelegt (Preprocessor-Raum, per `aspectRatio` normiert) — **identisch zu
+den Schwellen** (`minSwipeLength` etc.). Nur so sind die Aggregate später direkt mit den Schwellen
+vergleichbar. Die Partition nach **Regime** hält die Geometrie ohnehin konstant.
+
+**Richtungs-Sub-Key:** `[Richtung]` gilt nur für **Swipe** (8 Richtungen) und **Circle** (CW/CCW);
+**Tap** und **Swipe-Return** werden ohne Richtungs-Sub-Key geführt.
+
+**Gating:** Erhebung läuft **hinter demselben Feature-Toggle/Debug-Flag** wie die Offset-Korrektur
+(Datenschutz-Konsistenz — keine stille Hintergrund-Erfassung).
+
+Zusätzlich:
+- **grobe Histogramme** des Primärfeatures je Klasse (wenige feste Bins) — für die Randdichte-
+  Diagnose („schneidet die Schwelle ins Cluster?"). *Bin-Range/-Anzahl: bei Implementierung
+  festlegen* (z. B. um die jeweilige Default-Schwelle zentriert).
+- **Pro-Klasse-Korrektur-Zähler** (wie oft jede Klasse korrigiert wird) — sehr billig, macht die
+  **Klassen-Zensur** sichtbar (versagende Klasse = hohe Korrekturrate + wenig Positive).
+
+### Wo / Wie
+- **Quelle:** dieselbe **Lern-Middleware** (kennt Klassifikationsergebnis + Accepted/Corrected, §5).
+- **Plumbing:** der Klassifikator muss den **Feature-Vektor mitliefern** (heute gibt
+  `GestureClassification` nur `gesture` + `isReturn` zurück) — kleiner Eingriff, analog zum
+  Touchdown-Plumbing (§5).
+- **Speicher/Datenschutz:** nur Aggregate in `SharedDefaults`, versioniert, **lokal** (§7) — keine
+  rohen Trajektorien. Footprint vernachlässigbar (4 Klassen × wenige Features × `{n,mean,M2}` + Bins);
+  Schreibkadenz wie beim Offset-Modell (debounced/periodisch, §7).
+
+### Nutzen *jetzt* (auch ohne Adaption)
+- **Diagnose im Debug-View** (6.5): Cluster-Kerne, Randdichte, Korrekturraten je Klasse.
+- Hilft, die **statischen** Default-Schwellen zu tunen (die ohnehin offene Schuld aus §10).
+- Zeigt **empirisch**, ob Per-Nutzer-Adaption lohnt und ob seltene Klassen (Circle) überhaupt genug
+  Daten haben — *bevor* der Adaptions-Track gebaut wird.
+
+### Scope-Grenze (klar)
+v1: **erheben + anzeigen**. **Keine** Schwellen-/Feature-Anpassung zur Laufzeit. Adaption (kern-
+verankert, geclampt, reversibel, default-aus; Winkel-Offset zuerst) ist ein eigener späterer Track.

--- a/docs/touch-offset-correction.md
+++ b/docs/touch-offset-correction.md
@@ -631,9 +631,15 @@ Echtes Live nur in der Extension möglich. Hinter Debug-Flag. **Speicher-Vorsich
   - Flip akzeptiert (kein Backspace) → **caught** (wahrscheinlich abgefangener Fehler),
   - Flip verworfen (Backspace) → **caused** (wahrscheinlich verursachter Fehler),
   - kein Flip → korrektur-irrelevant (kein Signal, korrekt ignoriert).
-  „Net = caught − caused". Selbst-etikettiert (Akzeptanz ≠ Ground Truth, gleiche Annahme wie das
-  Lernen); Näherung: eigener Tasten-Offset für beide Zellkanten (glattes Reach-Feld dominiert).
-- **Abnahmekriterium v1:** `net` deutlich positiv über die Regime, **ohne** dass die
+- **Relative Fehlerraten (primäre Anzeige).** Aus denselben Zählern folgen beide Backspace-Raten
+  über die Gesamt-Taps `n` und die beobachteten Löschungen `d` (pro Regime):
+  - **mit** Korrektur (beobachtet): `d / n`,
+  - **ohne** Korrektur (kontrafaktisch): `(d + caught − caused) / n` — caught-Flips wären Fehler
+    gewesen, caused-Flips nicht. Beide Raten ∈ [0,1] (caught/Löschungen disjunkt).
+  „Net = caught − caused" = absolute Fehler-Differenz. Selbst-etikettiert (Akzeptanz ≠ Ground
+  Truth, gleiche Annahme wie das Lernen); Näherung: eigener Tasten-Offset für beide Zellkanten
+  (glattes Reach-Feld dominiert).
+- **Abnahmekriterium v1:** Rate **mit** < Rate **ohne** deutlich über die Regime, **ohne** dass die
   per-Klasse-Korrekturrate (§13) in irgendeinem Regime steigt. Solange nicht belegt: Default-aus.
 - Debug-View zeigt Samples/Regime, max. Korrektur, `s_k` zur Plausibilisierung.
 

--- a/docs/touch-offset-correction.md
+++ b/docs/touch-offset-correction.md
@@ -478,24 +478,34 @@ Zelle nie ihre Nachbarn „überrennt". `cellFrames` ist rein → in
 `KeyboardGridLayoutTouchCoverageTests` direkt testbar: nach Resizing weiterhin **vollständige,
 disjunkte** Überdeckung.
 
-### 5.4 Resizing-Geometrie (exakt)
+### 5.4 Resizing-Geometrie (exakt) — Korrektur: separables Linien-Verschieben
 
-Jede Taste K hat einen geclampten 2D-Offset `offset_K = (ox_K, oy_K)` (Pitch-Anteile, §4.2);
-Interpretation: das *effektive* Zentrum ist `center(K) + offset_K`. Die Zell-Grenzen folgen den
-Mittelsenkrechten zwischen effektiven Zentren — in einem achsparallelen Gitter exakt so:
+> **Korrektur (durch Implementierungs-Test gefunden):** Die ursprüngliche Idee, *jede Zelle ihre
+> vier Kanten unabhängig* verschieben zu lassen (`Kante += (o_A+o_B)/2`), **kachelt bei *2D*-Offsets
+> nicht**: verschiebt eine Zelle gleichzeitig horizontal *und* vertikal, klafft an ihren Ecken eine
+> Lücke/Überlappung zum **Diagonalnachbarn**, der die Verschiebung nicht mitmacht. Auf einem
+> Rechteck-Gitter ist eine gültige, achsparallele Partition nur über **gemeinsame Gitterlinien**
+> möglich (Eckpunkte müssen von allen vier angrenzenden Zellen geteilt werden).
 
-- **Innere vertikale Kante** (geteilt von A links, B rechts): Position `+= (ox_A + ox_B) / 2`.
-- **Innere horizontale Kante** (geteilt von A oben, B unten): Position `+= (oy_A + oy_B) / 2`.
-- **Äußere/Rand-Kanten** (kein Nachbar): **bleiben fix** — die Tastatur-Außengrenzen ändern sich
-  nicht (kein Overflow).
-- **Eine Kante = ein Wert**, von beiden Zellen geteilt → lückenlose, überlappungsfreie Partition
-  bleibt automatisch erhalten (§5.3).
-- **Diagonale Nachbarn** brauchen keine Behandlung: im Rechteck-Gitter gibt es nur H/V-Kanten; der
-  2D-Offset ist über die x-/y-Komponenten vollständig erfasst.
-- **Nicht-Degeneriertheit:** Bei Offset-Clamp ≤ 0,35 Pitch (§4.3) bewegt sich jede Kante ≤ 0,35
-  Pitch; eine Zelle behält Breite/Höhe ≥ `1 − 2·0,35 = 0,3` Pitch → nie invertiert/verschwunden.
-- **Spannende Tasten** (row/col-span): nutzen ihren sichtbaren Mittelpunkt; jede ihrer geteilten
-  Kanten wird mit der jeweils angrenzenden Nachbartaste nach derselben Regel verschoben.
+Korrektes Verfahren — **separable Perturbation der Gitterlinien**:
+
+- Jede **innere vertikale Linie** (zwischen Spalte c−1 und c) verschiebt sich um **einen** Wert
+  `δ_x[c]`; jede **innere horizontale Linie** um `δ_y[r]`. **Äußere Linien bleiben fix** (Außengrenze).
+- Eine Linie ist von *allen* Zellen entlang ihr geteilt → die per-Tasten-Offsets links/rechts (bzw.
+  oben/unten) der Linie werden **auf die Linie gemittelt**:
+  `δ_x[c] = mittel_r ( (ox(r,c−1) + ox(r,c)) / 2 ) · Spaltenbreite`.
+- Jede Zelle = `[xLinie[col], xLinie[col+span]] × [yLinie[row], yLinie[row+span]]` → **immer** eine
+  disjunkte, lückenlose Partition (Teleskopsumme der Intervalle = feste Außenbreite), auch in 2D.
+- **Konsequenz/Trade-off:** Der **glatte Reach-Bias** (Hauptsignal, §3.2) wird voll abgebildet; reine
+  **Per-Tasten-Residuen** werden durch die Linien-Mittelung nur *teilweise* realisiert. Das ist der
+  Preis einer achsparallelen Rechteck-Partition (eine pro-Zelle-exakte Lösung bräuchte
+  nicht-rechteckige Zellen, die SwiftUI nicht platzieren kann).
+- **Nicht-Degeneriertheit:** Bei Clamp ≤ 0,35 Pitch bewegt sich jede Linie ≤ 0,35 Spaltenbreite;
+  benachbarte Spalten behalten Breite ≥ 0,3 → nie invertiert.
+- **Spannende Tasten:** spannen einfach mehrere Linien-Intervalle; keine Sonderbehandlung nötig.
+
+(Implementiert in `KeyboardGridLayout.lineShifts`; verifiziert in `KeyboardGridResizingTests` —
+2D-Offsets erhalten die exakte Kachelung.)
 
 ### 5.5 Faktische Umsetzung / Routing
 

--- a/docs/touch-offset-correction.md
+++ b/docs/touch-offset-correction.md
@@ -78,27 +78,27 @@ Laufzeit **ohne Detektion** bekannt (siehe geklärtes Risiko 11.1):
 - **Orientierung:** Portrait / Landscape — zuverlässig vom Controller geliefert
   (`detectIsLandscape()` via `windowScene.interfaceOrientation` → `viewModel.isLandscape`; die
   Keyboard-Bounds selbst taugen dafür *nicht*, da immer höher als breit).
-- **Posture-Klasse:** **abgeleitet aus den bekannten User-Settings**, nicht detektiert. iOS
-  bietet Dritt-Tastaturen keinen Einhand-/Floating-State; stattdessen ist Wurstfingers *eigene*
-  Positionierung der Einhand-Mechanismus:
+- **Posture-Klasse:** **explizit vom Nutzer gewählt** (Einstellung `touchOffsetPosture`), nicht
+  detektiert. iOS bietet Dritt-Tastaturen keinen Einhand-/Floating-State. Eine frühere Ableitung
+  aus `keyboardScale`/`keyboardHorizontalPosition` war unzuverlässig: ein rechts-einhändiger
+  Nutzer mit mittig-breiter Tastatur wurde als „zwei Daumen" klassifiziert — genau der Fall, in
+  dem das Two-Thumb-**Split**-Modell die kontralaterale Hälfte mit einem falschen zweiten Pivot
+  fittet (3.2) und damit **aktiv falsch** korrigiert (nicht nur Pooling-Effizienz kostet). Weil
+  die Fehlklassifikation den Nutzen dort zerstört, wo Einhand-Reach ihn am dringendsten bräuchte,
+  ist die Wahl eine **bewusste Entscheidung**:
 
   ```
-  postureClass = derivePosture(keyboardScale, keyboardHorizontalPosition):
-    narrow = scale < S_thresh
-    left   = position < 0.5 − P_thresh ;  right = position > 0.5 + P_thresh
-    → oneThumbLeft    falls narrow && left     (eine Fläche, Pivot links, 3.2)
-      oneThumbRight   falls narrow && right    (eine Fläche, Pivot rechts)
-      twoThumb        sonst                     (Split-Fläche links/rechts; auch
-                                                 „schmal & mittig" → Default, Hand unbekannt)
+  postureClass ∈ {
+    oneThumbRight   (eine Fläche, Pivot rechts)   — Default: Einhand ist der Normalfall,
+                                                     rechts die häufigste Hand
+    oneThumbLeft    (eine Fläche, Pivot links, 3.2)
+    twoThumb        (Split-Fläche links/rechts, 3.2)
+  }
   ```
-  `S_thresh`/`P_thresh` sind kalibriert + Hysterese (§10). **Floating (iPad)** ist in v1 **keine
-  eigene Klasse** → fällt per `derivePosture` in die passende Klasse; eigene Behandlung ist v2.
-
-  `keyboardScale`, `keyAspectRatio`, `keyboardHorizontalPosition` liegen exakt in
-  `SharedDefaults` und werden bereits über `GesturePreprocessorConfig.fromUserDefaults()`
-  gelesen. `derivePosture` nutzt **nur `scale` + `position`** (`keyAspectRatio` fließt in v1 nicht
-  ein — Aspect-Handling ist v2, 3.5). Die Heuristik läuft über *bekannte* Werte; eine
-  Fehlklassifikation kostet nur Pooling-Effizienz und korrigiert sich selbst.
+  UI-Reihenfolge: **rechts → links → beide** (§6.3). **Floating (iPad)** ist in v1 **keine eigene
+  Klasse**. Die Wahl liegt in `SharedDefaults`; die Extension liest sie **pro Geste frisch**
+  (`currentTouchRegime`), ein Handwechsel in der App wirkt also ab dem nächsten Tap ohne
+  Keyboard-Neustart. `keyAspectRatio` fließt in v1 nicht ein (Aspect-Handling ist v2, 3.5).
 
 Regime-Schlüssel = `(Orientierung, postureClass)`. Kein State zu erraten, kein Spike nötig.
 
@@ -566,11 +566,20 @@ Rendert die Tastatur (Wiederverwendung der daten-getriebenen Darstellung,
   Richtung *und* Betrag.
 - **Konfidenz über Deckkraft/Größe** (wenig Samples → blass). Farbe nur Akzent.
 
-### 6.3 Regime-Selektor (kritisch)
+### 6.3 Posture-Wahl (kritisch, Entscheidung statt Ansicht)
 
-**Segmented Control** für Orientierung × Posture-Klasse (`twoThumb` / `oneThumbLeft` /
-`oneThumbRight`); rendert das gewählte Regime an repräsentativer Geometrie. Ohne Selektor vermischt
-die Anzeige Modelle und führt in die Irre.
+Die Posture-Klasse ist **keine Ansicht, die man umschaltet, sondern eine Entscheidung mit
+Konsequenz**: Sie wählt das aktive Lern-Regime *und* das angewandte Modell (3.1). Deshalb eine
+klar als Entscheidung gerahmte **Auswahl-Liste** („Wie tippst du?"), nicht ein beiläufiger
+Segmented-Filter:
+
+- Optionen in der Reihenfolge **rechts → links → beide**
+  (`oneThumbRight` / `oneThumbLeft` / `twoThumb`), Default `oneThumbRight` (Einhand ist der
+  Normalfall). Persistiert als `touchOffsetPosture`; die Extension liest sie pro Geste frisch.
+- Footer erklärt die Konsequenz: separates Profil je Haltung, falsche Wahl kann Tasten in die
+  *falsche* Richtung schieben — daher **bewusst wählen, nicht auto-detektieren**.
+- Die Offset-Karte darunter zeigt genau das gewählte (= aktive) Regime, ist also für den
+  Normalfall nicht leer und wirkt nicht „kaputt".
 
 ### 6.4 Reset
 
@@ -619,8 +628,8 @@ Echtes Live nur in der Extension möglich. Hinter Debug-Flag. **Speicher-Vorsich
 ## 9. Phasierung
 
 **v1 (schlank geschnitten)**
-- Regime: Orientierung × `derivePosture(scale, position)` — beides detektionsfrei aus
-  Controller-State bzw. `SharedDefaults` (11.1).
+- Regime: Orientierung × `touchOffsetPosture` — Orientierung deterministisch vom Controller,
+  Posture explizit vom Nutzer gewählt (11.1).
 - Modell: Per-Taste `{m_k,n_k,s_k}`; Reach-Fläche abgeleitet (bilinear Einhand, linear je
   Hälfte bei twoThumb; Konstanten-Term = global). Keine separate `keyResidual`-Persistenz.
 - Lernsignal: Self-Labeling auf konfidenten Taps (LM-frei, Interior-Margin `m_interior`), **nur Taps**.
@@ -670,14 +679,13 @@ Alle Symbole referenzieren den Algorithmus in 4.2:
 - Clamp-Grenze (% Pitch) — max. Betrag des Korrekturvektors (Default ≤ 0,35).
 - Dwell-Max — einziger absoluter Plausibilitäts-Filter (Kontaktradius entfällt, 11.4); am Gerät
   messen (Tap-Dauer-Verteilung, ~150–200 ms).
-- `derivePosture`-Schwellen **+ Hysterese** — ab wann scale/position als Einhand klassifiziert wird
-  (3.1); Hysterese verhindert Regime-Flackern (Daten-Split) nahe der Schwelle.
+  (Posture-Schwellen/Hysterese entfallen — Posture wird gewählt, nicht klassifiziert, 3.1/11.1.)
 
 Am Gerät kalibrieren.
 
 ## 11. Offene Risiken — zuerst verifizieren
 
-### 11.1 Regime-Erkennbarkeit — GEKLÄRT (kein Risiko)
+### 11.1 Regime-Erkennbarkeit — GEKLÄRT (Posture wird gewählt, nicht erkannt)
 
 Per Codebase-Untersuchung aufgelöst; das ursprünglich vermutete Show-Stopper-Risiko existiert
 nicht. Befunde:
@@ -685,18 +693,17 @@ nicht. Befunde:
 - **Es gibt keinen zu *erratenden* Handhaltungs-State.** iOS bietet Dritt-Tastaturen keinen
   Einhand-Modus (System-Keyboard-only) und meldet einer Custom-Extension keine Floating-/
   Posture-Info. Die ursprüngliche Annahme zielte auf einen nicht existenten Sensor.
-- **Die relevanten Größen sind explizite, deterministische User-Settings** in `SharedDefaults`
-  (`keyboardScale`, `keyAspectRatio`, `keyboardHorizontalPosition`), zur Laufzeit exakt bekannt
-  und bereits über `GesturePreprocessorConfig.fromUserDefaults()` gelesen. Wurstfingers eigene
-  Positionierung *ist* der Einhand-Mechanismus → die Posture-Klasse wird daraus **abgeleitet**
-  (3.1), nicht detektiert.
 - **Orientierung** kommt zuverlässig vom Controller (`detectIsLandscape()` →
   `viewModel.isLandscape`); aus den Keyboard-Bounds allein ginge es nicht (dokumentiert im Code).
+- **Die Posture wird nicht abgeleitet, sondern vom Nutzer gewählt.** Ein früher Ansatz leitete sie
+  aus `keyboardScale`/`keyboardHorizontalPosition` ab; ein Praxistest zeigte die Fehlklassifikation
+  (rechts-einhändig → fälschlich `twoThumb`), und weil ein falsches Split-Modell **aktiv falsch**
+  korrigiert (3.2), ist eine stille Heuristik hier schädlicher als eine bewusste Wahl. Die Posture
+  ist daher eine explizite Einstellung `touchOffsetPosture` (3.1/6.3).
 
-Konsequenz: Regime-Schlüssel `(Orientierung, derivePosture(scale, position))` ist vollständig
-ohne Detektion bestimmbar. Kein Spike, kein Fallback-auf-Standard nötig. Einzige verbleibende
-Feinarbeit: die `derivePosture`-Schwellen (ab wann „schmal & versetzt genug" = Einhand)
-empirisch festlegen — eine Heuristik über bekannte Werte, kein Plattformrisiko.
+Konsequenz: Regime-Schlüssel `(Orientierung, touchOffsetPosture)` ist vollständig ohne Detektion
+bestimmbar — Orientierung deterministisch vom Controller, Posture direkt vom Nutzer. Kein Spike,
+keine zu kalibrierenden Schwellen, kein Regime-Flackern (Hysterese entfällt).
 
 ### 11.2 Datenarmut seltener Regime
 
@@ -746,8 +753,8 @@ keine Touch-Anzahl**.
   `TextInputTarget.deleteBackward()` beobachten — Compose/Telex rufen es im Normalbetrieb intern auf;
   die Pipeline-Action ist der saubere Nutzer-Signal-Pfad. Slide-Delete (`handleSlide`) zusätzlich
   abdecken. Einzige Restarbeit ist das Touchdown-Plumbing (§5), das v1 ohnehin braucht.
-- **`derivePosture`-Schwellen (#5):** aus den bekannten `scale`/`position`-Ranges ableiten + UX am
-  Gerät; keine Literatur.
+- **Posture-Wahl (#5):** explizite Nutzer-Einstellung `touchOffsetPosture` statt Ableitung —
+  Praxistest zeigte, dass die scale/position-Heuristik fehlklassifiziert (3.1/6.3/11.1).
 - **A/B-Harness (#7):** Eval-Protokoll aus Gboard/Weir adaptieren (gegenbalancierte Sessions, CER/
   Backspace-Rate als Metrik).
 
@@ -781,7 +788,8 @@ wahre Geometrie (§4.1).
   - Reach-Fläche: Closed-Form-WLS-Refit aus Per-Tasten-Statistiken bildet linearen Trend ab,
     Ridge → 0 bei wenigen Datenpunkten; Zwei-Hälften-Split beim `twoThumb`-Regime.
   - Outlier-Gate inkl. Cold-Start (absolute Gates schützen vor Warm-up); `s_k`-Schätzung.
-  - Regime-Trennung: Samples eines Regimes beeinflussen andere nicht; `derivePosture`-Klassifikation.
+  - Regime-Trennung: Samples eines Regimes beeinflussen andere nicht; Posture-Setting-Mapping
+    (`PostureClass(settingValue:)`, Default/Fallback).
   - Persistenz: Round-Trip durch `SharedDefaults`, Schema-Version, partielle Invalidierung.
   - Hit-Testing-Wechselwirkung mit lückenloser Kachelung (#198).
 - Robustheits-/Degenerations-Szenarien als Tests:

--- a/docs/touch-offset-correction.md
+++ b/docs/touch-offset-correction.md
@@ -618,11 +618,23 @@ Echtes Live nur in der Extension möglich. Hinter Debug-Flag. **Speicher-Vorsich
 
 ## 8. Validierung & Abnahme
 
-- **Proxy-Metrik rein lokal** mitloggen (Backspace-Rate, Anteil grenznaher Taps) — verlässt das
-  Gerät nicht, dient nur Debug/Selbstkontrolle.
-- **Abnahmekriterium v1 (Vorschlag):** in einem A/B-Selbstversuch (Feature an vs. aus über je
-  N Sitzungen) sinkt die Backspace-/Korrektur-Rate messbar, **ohne** dass die Rate in irgendeinem
-  Regime steigt. Solange das nicht belegt ist, bleibt das Feature Default-aus.
+- **Proxy-Metrik rein lokal** mitloggen — verlässt das Gerät nicht, dient nur
+  Debug/Selbstkontrolle.
+- **Kontrafaktische Nutzen-Metrik (primär, self-populating).** Ein toggle-basiertes A/B
+  („Feature an vs. aus über je N Sitzungen") füllt in der Praxis nie die Aus-Gruppe — niemand
+  schaltet die Korrektur freiwillig ab. Stattdessen wird der Nutzen **kontrafaktisch** aus der
+  Geometrie bestimmt: Bei eingeschaltetem Feature kennen wir pro Tap sowohl die zugewiesene
+  Taste (`K_on`) als auch die, die der rohe Touchdown **unverschoben** getroffen hätte (`K_off`).
+  Der unkorrigierte Punkt ist `p = touchdown + offset` (Touchdown normalisiert in der verschobenen
+  Zelle); verlässt `p` je Achse `[0,1]`, hat die Korrektur die Taste **umgebogen** (ein „Flip").
+  Über dasselbe Akzeptanz-Veto-Fenster wie das Lernen (§4.1):
+  - Flip akzeptiert (kein Backspace) → **caught** (wahrscheinlich abgefangener Fehler),
+  - Flip verworfen (Backspace) → **caused** (wahrscheinlich verursachter Fehler),
+  - kein Flip → korrektur-irrelevant (kein Signal, korrekt ignoriert).
+  „Net = caught − caused". Selbst-etikettiert (Akzeptanz ≠ Ground Truth, gleiche Annahme wie das
+  Lernen); Näherung: eigener Tasten-Offset für beide Zellkanten (glattes Reach-Feld dominiert).
+- **Abnahmekriterium v1:** `net` deutlich positiv über die Regime, **ohne** dass die
+  per-Klasse-Korrekturrate (§13) in irgendeinem Regime steigt. Solange nicht belegt: Default-aus.
 - Debug-View zeigt Samples/Regime, max. Korrektur, `s_k` zur Plausibilisierung.
 
 ## 9. Phasierung

--- a/docs/touch-offset-correction.md
+++ b/docs/touch-offset-correction.md
@@ -1,7 +1,8 @@
 # Feature-Spezifikation: Lernende Touch-Offset-Korrektur
 
-> Status: Entwurf (Rev. 7, + Gestenparameter-Telemetrie §13) · Sprache: Deutsch · Scope: Keyboard-Extension
-> + Host-App-Settings · Forschungsbelege & -korrekturen: `touch-offset-correction-research.md`
+> Status: Entwurf (Rev. 7, + Gestenparameter-Telemetrie §13) · Sprache: Deutsch
+> Scope: Keyboard-Extension + Host-App-Settings
+> Forschungsbelege & -korrekturen: `touch-offset-correction-research.md`
 
 ## 1. Motivation & Ziel
 
@@ -45,6 +46,7 @@ die Tastatur aktiv schlechter und untergräbt das Vertrauen. Mehrere Designentsc
 ## 2. Ziele / Nicht-Ziele
 
 **Ziele**
+
 - Opt-in-Feature, das den Touchdown-Punkt vor der Klassifikation korrigiert.
 - Lernen aus der laufenden Nutzung, ohne expliziten Kalibrierungsmodus.
 - Robust gegen Degeneration (Feedback-Schleifen) und gegen Ausreißer (Wasser auf dem
@@ -54,6 +56,7 @@ die Tastatur aktiv schlechter und untergräbt das Vertrauen. Mehrere Designentsc
 - Visualisierung in den Settings zur Vertrauensbildung und zum Debuggen.
 
 **Nicht-Ziele (v1)**
+
 - Kein expliziter Kalibrierungs-/Trainingsbildschirm.
 - Keine sprachmodell-basierte Intent-Inferenz.
 - Keine Korrektur-Attribution über Backspace-Erkennung (Negativ-Signal) — v3.
@@ -87,7 +90,7 @@ Laufzeit **ohne Detektion** bekannt (siehe geklärtes Risiko 11.1):
   die Fehlklassifikation den Nutzen dort zerstört, wo Einhand-Reach ihn am dringendsten bräuchte,
   ist die Wahl eine **bewusste Entscheidung**:
 
-  ```
+  ```text
   postureClass ∈ {
     oneThumbRight   (eine Fläche, Pivot rechts)   — Default: Einhand ist der Normalfall,
                                                      rechts die häufigste Hand
@@ -95,6 +98,7 @@ Laufzeit **ohne Detektion** bekannt (siehe geklärtes Risiko 11.1):
     twoThumb        (Split-Fläche links/rechts, 3.2)
   }
   ```
+
   UI-Reihenfolge: **rechts → links → beide** (§6.3). **Floating (iPad)** ist in v1 **keine eigene
   Klasse**. Die Wahl liegt in `SharedDefaults`; die Extension liest sie **pro Geste frisch**
   (`currentTouchRegime`), ein Handwechsel in der App wirkt also ab dem nächsten Tap ohne
@@ -147,7 +151,7 @@ nicht identifizierbar). **Gespeichert wird aber nicht diese Zerlegung**, sondern
 Running-Mean `m_k` des Gesamt-Offsets; die Fläche wird daraus *abgeleitet*, die Per-Tasten-
 Abweichung ist *implizit* (siehe Algorithmus 4.2):
 
-```
+```text
 # Gespeichert pro (Regime R, Taste K, Achse):  m_k (Gesamt-Offset-Mittel), n_k, s_k
 # Abgeleitet:   reachSurface[R][H] = Ridge-WLS-Fit über die m_k   (H = Hälfte, nur twoThumb)
 # Angewandt:    Korrektur(K) = prior_k + (m_k − prior_k)·n_k/(n_k+κ),   prior_k = surface(pos_K)
@@ -211,6 +215,7 @@ Das ist Self-Labeling, beschränkt auf konfidente (interiore) Taps — kein naiv
 fürs Lernen, wenn der rohe Touchdown **mehr als `m_interior`** (Anteil des Tastenpitchs) vom
 nächsten Tastenrand entfernt liegt — grenznahe Taps werden vom *Lernen* ausgeschlossen (korrigiert
 werden trotzdem alle). `m_interior` ist **der zentrale Bias-Varianz-Knopf** (Tuning-Parameter §10):
+
 - **groß** (streng interior) → kaum Mislabeling, aber **maximaler Zensierungs-Bias** (die
   informativen Grenzfälle fehlen) → stärkere Unterkorrektur.
 - **klein** (auch grenznahe Taps) → weniger Bias, aber Risiko, falsch zugeordnete Grenz-Taps zu
@@ -235,6 +240,7 @@ zuletzt committeter Taps** (`keyId`, Touchdown) wird geführt; eine **Backspace-
 **alle dadurch gelöschten Taps** (nicht gelernt). Fenster über **Aktions-Zählung**, nicht über eine
 Uhr — die Literatur parametrisiert Korrektur durchweg über Edit-Struktur, nicht über ms (Baldwin
 2012; Gboard „Undo: before any other key"); eine ms-Latenz-Verteilung existiert nicht.
+
 - **Burst statt Einzel-Veto (Korrektur aus Literatur):** Bei *verzögerter* Korrektur löscht der
   Nutzer **durch korrekte Zeichen hindurch** bis zum Fehler (`peeple<<<<ople`). Nur den jüngsten Tap
   zu vetoen träfe oft einen korrekten statt des Mis-Hits → **alle vom Burst gelöschten Taps**
@@ -270,6 +276,7 @@ hält.
 Mit verschobenen Hit-Zellen (§5) droht eine konkrete Feedback-Schleife: eine vergrößerte Zelle fängt
 grenznahe Taps ein, die — gegen das *wahre* Zentrum gemessen — großen Offset haben; würden die
 gelernt, bliese sich `m_k` weiter auf → Zelle wächst → Drift. Bruch der Schleife, dreifach:
+
 - **`m_interior` gegen die *wahre* Geometrie:** gelernt wird nur aus Taps **interior zur echten
   (unverschobenen) Zelle** (`m_interior` vom *wahren* Tastenrand). Genau die aufgeblähten Grenz-Taps
   fallen damit raus → speisen die Schleife nicht. (`m_interior` ist doppelt load-bearing:
@@ -296,7 +303,7 @@ Mittelwert separabel ist); alle Größen in **Tastenpitch-Anteilen**.
 **Schritt 1 — Per-Tasten-Update (online, je akzeptiertem Tap).** `e = rohTouchdown − center(k)`,
 *nach* dem absoluten **Dwell-Gate** (Kontaktradius/Multitouch entfallen, 4.3/11.4):
 
-```
+```text
 if n_k ≥ warmup and |e − m_k| > k_gate · s_k:   skip      # Outlier-Gate (erst nach Warm-up)
 δ   = clip(e − m_k, ±c · s_k)                              # Huber: gekappter Einfluss
 n_k = min(n_k + 1, n_max)
@@ -313,7 +320,7 @@ ersetzt einen teuren Online-Median fast gratis.
 (bilinear, Einhand) bzw. `φ = [1, u, v]` (linear, twoThumb-Hälften); `W = diag(n_k)`,
 Ridge → 0:
 
-```
+```text
 β_surface = (Φᵀ W Φ + λ_ridge · I)⁻¹ Φᵀ W m              # gewichtetes Ridge-LS, m = Vektor der m_k
 surface(pos) = φ(pos) · β_surface
 ```
@@ -327,7 +334,7 @@ Konstanten-Term von `β_surface` ist der „globale" Offset (3.3).
 
 **Schritt 3 — Angewandte Korrektur (Shrinkage zum Flächen-Prior).**
 
-```
+```text
 prior_k = surface(pos_k)
 r_k     = prior_k + (m_k − prior_k) · n_k / (n_k + κ)     # Partial Pooling / James-Stein (je Achse)
 offset_k = clamp_betrag((r_kx, r_ky), ≤ 0,35 · pitch)    # euklid. Betrag des 2D-Vektors, in Punkte (4.3)
@@ -342,7 +349,7 @@ permanenten Schrumpf-Bias `α/(α+λ)·μ` hatte.
 **Warum diese Wahl (statt Alternativen):**
 
 | Wahl | statt | Grund |
-|---|---|---|
+| --- | --- | --- |
 | Running-Mean | konstante EMA | unverzerrt; EMA hatte permanenten Schrumpf-Bias |
 | count-gewichtetes Shrinkage (`κ`) | hartes Reife-Backoff | gleicher Effekt, aber stufenlos → kein Flackern an der Schwelle |
 | Closed-Form-WLS-Refit der Fläche | Backfitting / Online-RLS | nur ~9 Punkte → trivialer Solve; eliminiert Zwei-Zeitskalen-Tanz |
@@ -526,6 +533,7 @@ Taste"-Einwands:
 **Minimaler Eingriff — gespiegelte Frames offset-bewusst machen:** Heute leiten sich `cellFrames`
 (Touch-Frame, gewachsen) und `visualInset` (zieht den Key zurück) aus **derselben** `gapInsets`-
 Quelle ab und spiegeln sich. Key-Target-Resizing erweitert genau diese geteilte Rechnung:
+
 - Touch-Frame-Grenze verschiebt sich nach §5.4.
 - `visualInset` kompensiert um **denselben Betrag pro Kante** (jetzt **asymmetrisch**) → der
   gezeichnete Key bleibt **exakt** an seiner Stelle.
@@ -646,6 +654,7 @@ Echtes Live nur in der Extension möglich. Hinter Debug-Flag. **Speicher-Vorsich
 ## 9. Phasierung
 
 **v1 (schlank geschnitten)**
+
 - Regime: Orientierung × `touchOffsetPosture` — Orientierung deterministisch vom Controller,
   Posture explizit vom Nutzer gewählt (11.1).
 - Modell: Per-Taste `{m_k,n_k,s_k}`; Reach-Fläche abgeleitet (bilinear Einhand, linear je
@@ -662,6 +671,7 @@ Echtes Live nur in der Extension möglich. Hinter Debug-Flag. **Speicher-Vorsich
   Regime-Selektor, Reset (alles + pro Regime), User/Debug-Trennung.
 
 **v2**
+
 - Per-Geste-Residuum (per-Geste *räumlicher* Offset). Setzt voraus, dass v1 dafür Samples sammelt —
   tut es **nicht** (v1 lernt nur aus Taps, §4.1). Also erst, wenn v1 auf Swipe-Start-Sampling
   erweitert ist und dieses einen Gesten-spezifischen Bias belegt. (Nicht zu verwechseln mit der
@@ -673,6 +683,7 @@ Echtes Live nur in der Extension möglich. Hinter Debug-Flag. **Speicher-Vorsich
 - Ggf. quadratische Reach-Fläche, falls Residuen Krümmung belegen.
 
 **v3**
+
 - Negativ-Signal (Korrektur-Attribution via Backspace) → behebt den Zensierungs-Bias (4.1),
   ermöglicht volle statt konservativer Korrektur. **Konkrete Methode (Baldwin 2012, „Conservative"):**
   die nach der Löschung neu getippten Zeichen mit den gelöschten **alignen**; nur **relabeln**, wenn
@@ -786,6 +797,7 @@ daher **nicht** ändern — der ursprünglich in der Spec angenommene Wirkmechan
 
 **Redirect (kein Blocker, eher Vereinfachung):** Die Korrektur gehört ins zentrale, reine
 `KeyboardGridLayout.cellFrames` als **Key-Target-Resizing** (Grenzen verschieben, §5). Vorteile:
+
 - zentral & rein (eine Funktion besitzt alle Touch-Frames; bereits unit-getestet),
 - **Touch-Frame schon vom sichtbaren Key getrennt** (`visualInset`) → unsichtbares Resizing „for free",
 - literatur-kanonisch (Key-Target-Resizing, Gunawardana 2010), macht §1 wörtlich wahr,
@@ -825,6 +837,7 @@ SharedDefaults-Aggregate), werden die **dafür nötigen Daten gleich mit erhoben
 Retrofitting zu vermeiden. v1-Scope hier = **reine Erhebung + Debug-Diagnose, keine Anwendung.**
 
 ### Hintergrund (aus der Designdiskussion)
+
 Die 4 Gestenklassen — **Tap / Swipe / Swipe-Return / Circle** — werden über schwellenbasierte
 Features getrennt; die Defaults sind aktuell **geraten**, nicht datenkalibriert. Aus **akzeptierten
 (unkorrigierten)** Gesten lassen sich die **Cluster-Kerne** je Klasse robust schätzen → spätere
@@ -835,8 +848,10 @@ instabil). Zwei bekannte Grenzen: (a) **Klassen-Zensur** — eine systematisch v
 **Winkel-Offset** ist der sauberste erste Kandidat (direkt analog zum Spatial-Offset, §3).
 
 ### Was erhoben wird (nur Aggregate, nur aus akzeptierten Gesten)
+
 Pro `(Regime, Gestenklasse[, Richtung])` Running-Stats `{n, mean, M2→Streuung}` (Welford) der
 **diskriminierenden Features** — Namen wie in `GestureClassificationThresholds`:
+
 - `maxDisplacement` (Tap ↔ Swipe)
 - `returnRatio` (Swipe ↔ Swipe-Return)
 - `circularity`, `angularSpan`, `turnConsistency`, `orientedCompactness`, `pathSeparation` (Circle)
@@ -859,6 +874,7 @@ vergleichbar. Die Partition nach **Regime** hält die Geometrie ohnehin konstant
 (Datenschutz-Konsistenz — keine stille Hintergrund-Erfassung).
 
 Zusätzlich:
+
 - **grobe Histogramme** des Primärfeatures je Klasse (wenige feste Bins) — für die Randdichte-
   Diagnose („schneidet die Schwelle ins Cluster?"). *Bin-Range/-Anzahl: bei Implementierung
   festlegen* (z. B. um die jeweilige Default-Schwelle zentriert).
@@ -866,6 +882,7 @@ Zusätzlich:
   **Klassen-Zensur** sichtbar (versagende Klasse = hohe Korrekturrate + wenig Positive).
 
 ### Wo / Wie
+
 - **Quelle:** dieselbe **Lern-Middleware** (kennt Klassifikationsergebnis + Accepted/Corrected, §5).
 - **Plumbing:** der Klassifikator muss den **Feature-Vektor mitliefern** (heute gibt
   `GestureClassification` nur `gesture` + `isReturn` zurück) — kleiner Eingriff, analog zum
@@ -875,11 +892,13 @@ Zusätzlich:
   Schreibkadenz wie beim Offset-Modell (debounced/periodisch, §7).
 
 ### Nutzen *jetzt* (auch ohne Adaption)
+
 - **Diagnose im Debug-View** (6.5): Cluster-Kerne, Randdichte, Korrekturraten je Klasse.
 - Hilft, die **statischen** Default-Schwellen zu tunen (die ohnehin offene Schuld aus §10).
 - Zeigt **empirisch**, ob Per-Nutzer-Adaption lohnt und ob seltene Klassen (Circle) überhaupt genug
   Daten haben — *bevor* der Adaptions-Track gebaut wird.
 
 ### Scope-Grenze (klar)
+
 v1: **erheben + anzeigen**. **Keine** Schwellen-/Feature-Anpassung zur Laufzeit. Adaption (kern-
 verankert, geclampt, reversibel, default-aus; Winkel-Offset zuerst) ist ein eigener späterer Track.

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -19178,6 +19178,3431 @@
         }
       },
       "comment": "ACCESSIBILITY action name for the question-mark swipe; the Arabic script substitutes ؟ (VoiceOver)"
+    },
+    "Adapt targets to your taps": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مواءمة مناطق اللمس مع لمساتك"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trefferflächen an dein Tippen anpassen"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Προσαρμογή των στόχων στα πατήματά σας"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adapta las zonas táctiles a tus toques"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تطبیق هدف‌های لمس با ضربه‌های شما"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sovita kosketusalueet napautuksiisi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iakma ang mga target sa iyong mga tap"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adapte les zones tactiles à vos appuis"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "התאמת אזורי המגע להקשות שלך"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "टारगेट को अपने टैप के अनुसार ढालें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prilagodi ciljeve tvojim dodirima"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adatta le aree tattili ai tuoi tocchi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タップに合わせてキーの反応範囲を調整"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭에 맞춰 터치 영역 조정"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dopasuj obszary klawiszy do swoich stuknięć"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adapta as zonas de toque aos seus toques"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подстроить зоны клавиш под ваши нажатия"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anpassa träffytorna till dina tryck"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปรับเป้าสัมผัสตามการแตะของคุณ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підлаштувати зони клавіш під ваші дотики"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹچ ایریا کو آپ کے ٹیپ کے مطابق ڈھالیں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Điều chỉnh vùng chạm theo cách bạn chạm"
+          }
+        }
+      }
+    },
+    "Cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Άκυρο"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لغو"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Peruuta"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kanselahin"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ביטול"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रद्द करें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odustani"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anuluj"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отменить"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avbryt"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยกเลิก"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скасувати"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منسوخ کریں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hủy"
+          }
+        }
+      }
+    },
+    "Correct my typing": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصحيح كتابتي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mein Tippen korrigieren"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διόρθωση της πληκτρολόγησής μου"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corregir mi escritura"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اصلاح تایپ من"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korjaa napautuksiani"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Itama ang pagta-type ko"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corriger ma frappe"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תיקון ההקלדה שלי"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मेरी टाइपिंग सुधारें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ispravljaj moje tipkanje"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correggi la mia digitazione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "入力を補正する"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내 입력 보정"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koryguj moje pisanie"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corrigir a minha escrita"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Корректировать мой набор"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korrigera mina tryck"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปรับแก้การพิมพ์ของฉัน"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Коригувати мій набір"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "میری ٹائپنگ درست کریں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiệu chỉnh thao tác gõ của tôi"
+          }
+        }
+      }
+    },
+    "Error rate": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معدّل الخطأ"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehlerrate"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ποσοστό σφάλματος"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasa de error"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نرخ خطا"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Virheprosentti"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rate ng error"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taux d'erreur"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שיעור שגיאות"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "त्रुटि दर"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stopa pogrešaka"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasso di errore"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エラー率"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오류율"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odsetek błędów"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taxa de erro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Доля ошибок"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Felfrekvens"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อัตราความผิดพลาด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Частка помилок"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غلطی کی شرح"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tỷ lệ lỗi"
+          }
+        }
+      }
+    },
+    "Gesture correction rates": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معدّلات تصحيح الإيماءات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korrekturraten pro Geste"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ποσοστά διόρθωσης χειρονομιών"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasas de corrección por gesto"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نرخ اصلاح اشاره‌ها"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korjausosuudet eleittäin"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga rate ng pagtatama ng galaw"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taux de correction par geste"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שיעורי תיקון המחוות"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जेस्चर सुधार दरें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stope ispravaka po gesti"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Percentuali di correzione per gesto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ジェスチャごとの補正率"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제스처별 보정 비율"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odsetek korekt gestów"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taxas de correção por gesto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Доля коррекции жестов"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korrigeringsfrekvens per gest"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อัตราการปรับแก้ตามท่าทาง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Частка корекції жестів"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اشاروں کی درستی کی شرحیں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tỷ lệ hiệu chỉnh theo cử chỉ"
+          }
+        }
+      }
+    },
+    "How do you type?": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كيف تكتب؟"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wie tippst du?"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πώς πληκτρολογείτε;"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Cómo escribes?"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چگونه تایپ می‌کنید؟"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Miten kirjoitat?"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paano ka nagta-type?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comment tapez-vous ?"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "איך אתה מקליד?"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आप कैसे टाइप करते हैं?"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kako tipkaš?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Come digiti?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "どのように入力しますか？"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "어떻게 입력하시나요?"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jak piszesz?"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Como escreve?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Как вы набираете?"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hur skriver du?"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คุณพิมพ์อย่างไร"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Як ви набираєте?"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آپ کیسے ٹائپ کرتے ہیں؟"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bạn gõ như thế nào?"
+          }
+        }
+      }
+    },
+    "How often each gesture class gets corrected (rate · sample count). A high rate hints at a mis-tuned threshold for that gesture.": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عدد مرات تصحيح كل فئة إيماءات (المعدّل · عدد العيّنات). المعدّل المرتفع يشير إلى عتبة غير مضبوطة لتلك الإيماءة."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wie oft jede Gestenklasse korrigiert wird (Rate · Stichproben). Eine hohe Rate deutet auf einen falsch eingestellten Schwellenwert für diese Geste hin."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πόσο συχνά διορθώνεται κάθε κατηγορία χειρονομίας (ποσοστό · πλήθος δειγμάτων). Ένα υψηλό ποσοστό υποδηλώνει κακορυθμισμένο κατώφλι για τη συγκεκριμένη χειρονομία."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Con qué frecuencia se corrige cada clase de gesto (tasa · número de muestras). Una tasa alta apunta a un umbral mal ajustado para ese gesto."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اینکه هر ردهٔ اشاره چقدر اصلاح می‌شود (نرخ · تعداد نمونه). نرخ بالا نشانهٔ آن است که آستانهٔ آن اشاره درست تنظیم نشده است."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kuinka usein kutakin eleluokkaa korjataan (osuus · otosten määrä). Korkea osuus viittaa kyseisen eleen väärin säädettyyn kynnysarvoon."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kung gaano kadalas naitatama ang bawat klase ng galaw (rate · bilang ng sample). Ang mataas na rate ay senyales na hindi maayos ang pagkaka-tune ng threshold para sa galaw na iyon."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "À quelle fréquence chaque classe de geste est corrigée (taux · nombre d'échantillons). Un taux élevé indique un seuil mal réglé pour ce geste."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "באיזו תדירות מתוקן כל סוג מחווה (שיעור · מספר דגימות). שיעור גבוה מרמז שהסף של אותה מחווה אינו מכוונן היטב."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हर जेस्चर श्रेणी कितनी बार सुधारी जाती है (दर · सैंपल संख्या)। ज़्यादा दर का मतलब है कि उस जेस्चर की थ्रेशोल्ड ठीक से सेट नहीं है।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koliko se često ispravlja svaka vrsta geste (stopa · broj uzoraka). Visoka stopa upućuje na loše podešen prag za tu gestu."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Con quale frequenza viene corretta ogni classe di gesto (percentuale · numero di campioni). Una percentuale alta suggerisce una soglia mal tarata per quel gesto."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ジェスチャの種類ごとに、どのくらいの頻度で補正されたかを示します（補正率 · サンプル数）。値が高いときは、そのジェスチャのしきい値が合っていない可能性があります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제스처 종류별로 얼마나 자주 보정되는지 보여줍니다(보정 비율 · 샘플 수). 비율이 높으면 해당 제스처의 임계값이 잘 맞지 않는다는 뜻일 수 있습니다."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jak często korygowana jest każda klasa gestów (odsetek · liczba próbek). Wysoki odsetek wskazuje na źle dobrany próg dla tego gestu."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Com que frequência cada classe de gesto é corrigida (taxa · número de amostras). Uma taxa elevada indica um limiar mal ajustado para esse gesto."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Как часто корректируется каждый класс жестов (доля · количество замеров). Высокая доля указывает на неудачно настроенный порог для этого жеста."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hur ofta varje gestklass korrigeras (frekvens · antal stickprov). En hög frekvens tyder på ett feljusterat tröskelvärde för den gesten."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ความถี่ที่ท่าทางแต่ละประเภทถูกปรับแก้ (อัตรา · จำนวนตัวอย่าง) อัตราที่สูงบ่งชี้ว่าเกณฑ์ของท่าทางนั้นตั้งไว้ไม่เหมาะสม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Як часто коригується кожен клас жестів (частка · кількість зразків). Висока частка вказує на невдало налаштований поріг для цього жесту."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہر اشارہ قسم کتنی بار درست کی جاتی ہے (شرح · نمونوں کی تعداد)۔ زیادہ شرح اس اشارے کی غلط ٹیون شدہ حد کی نشاندہی کرتی ہے۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mức độ thường xuyên mà mỗi loại cử chỉ được hiệu chỉnh (tỷ lệ · số mẫu). Tỷ lệ cao cho thấy ngưỡng của cử chỉ đó chưa được tinh chỉnh đúng."
+          }
+        }
+      }
+    },
+    "Learned adjustments": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التعديلات المُكتسَبة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gelernte Anpassungen"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Εκμαθημένες προσαρμογές"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes aprendidos"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنظیم‌های آموخته‌شده"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opitut säädöt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga natutunang pag-aayos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustements appris"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "התאמות שנלמדו"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सीखे गए समायोजन"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naučene prilagodbe"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regolazioni apprese"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学習した調整"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학습된 조정"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyuczone poprawki"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes aprendidos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выученные поправки"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inlärda justeringar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การปรับที่เรียนรู้แล้ว"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вивчені поправки"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سیکھی گئی ایڈجسٹمنٹس"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Điều chỉnh đã học"
+          }
+        }
+      }
+    },
+    "Learned touch-offset map": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خريطة إزاحة اللمس المُكتسَبة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Karte der gelernten Tippversätze"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Χάρτης εκμαθημένης μετατόπισης αφής"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mapa de desviaciones táctiles aprendidas"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقشهٔ آموخته‌شدهٔ انحراف لمس"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opittujen kosketuspoikkeamien kartta"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mapa ng natutunang touch offset"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carte des décalages tactiles appris"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מפת סטיות המגע שנלמדה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सीखा गया टच-ऑफ़सेट मैप"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Karta naučenih odmaka dodira"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mappa degli scostamenti di tocco appresi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学習したタッチずれのマップ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학습된 터치 오프셋 맵"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mapa wyuczonych odchyleń dotyku"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mapa de desvios de toque aprendidos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Карта выученных смещений нажатий"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Karta över inlärda tryckförskjutningar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แผนผังค่าเยื้องการสัมผัสที่เรียนรู้แล้ว"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Карта вивчених зміщень дотиків"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سیکھا گیا ٹچ آفسیٹ نقشہ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bản đồ độ lệch chạm đã học"
+          }
+        }
+      }
+    },
+    "Learning your taps": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتعلّم لمساتك"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lernt dein Tippverhalten"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Μαθαίνει τα πατήματά σας"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aprendiendo tus toques"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "در حال یادگیری ضربه‌های شما"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oppii napautuksesi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Natututo sa iyong mga tap"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apprend vos appuis"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "לומד את ההקשות שלך"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आपके टैप सीख रहा है"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uči tvoje dodire"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sta imparando i tuoi tocchi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タップを学習中"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭을 학습하는 중"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uczy się Twoich stuknięć"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A aprender os seus toques"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изучает ваши нажатия"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lär sig dina tryck"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กำลังเรียนรู้การแตะของคุณ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вивчає ваші дотики"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آپ کے ٹیپ سیکھ رہا ہے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang học cách bạn chạm"
+          }
+        }
+      }
+    },
+    "Learns where you tend to tap each key and quietly adjusts the touch targets to match. Everything is learned **on this device** and never leaves it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتعلّم أين تميل إلى لمس كل مفتاح ويضبط مناطق اللمس بهدوء لتطابق ذلك. يتم كل التعلّم **على هذا الجهاز** ولا يغادره أبدًا."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lernt, wo du jede Taste typischerweise triffst, und passt die Trefferflächen unauffällig daran an. Alles wird **auf diesem Gerät** gelernt und verlässt es nie."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Μαθαίνει πού τείνετε να πατάτε κάθε πλήκτρο και προσαρμόζει διακριτικά τους στόχους αφής ανάλογα. Όλα μαθαίνονται **σε αυτή τη συσκευή** και δεν φεύγουν ποτέ από αυτήν."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aprende dónde sueles tocar cada tecla y ajusta discretamente las zonas táctiles para que coincidan. Todo se aprende **en este dispositivo** y nunca sale de él."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "یاد می‌گیرد که معمولاً هر کلید را کجا لمس می‌کنید و هدف‌های لمس را بی‌سروصدا با آن هماهنگ می‌کند. همه‌چیز **روی همین دستگاه** یاد گرفته می‌شود و هرگز از آن خارج نمی‌شود."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oppii, mihin kohtaan kutakin näppäintä yleensä napautat, ja säätää kosketusalueet huomaamattomasti sen mukaan. Kaikki opitaan **tällä laitteella**, eikä mikään lähde siitä pois."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Natututo kung saan ka madalas mag-tap sa bawat key at tahimik na inaayos ang mga touch target para tumugma. Lahat ay natututunan **sa device na ito** at hindi kailanman lumalabas dito."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apprend où vous avez tendance à toucher chaque touche et ajuste discrètement les zones tactiles en conséquence. Tout est appris **sur cet appareil** et n'en sort jamais."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "לומד היכן אתה נוטה להקיש על כל מקש ומתאים בשקט את אזורי המגע בהתאם. הכול נלמד **במכשיר הזה** ולעולם אינו יוצא ממנו."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "यह सीखता है कि आप हर कुंजी पर आमतौर पर कहाँ टैप करते हैं और टच टारगेट को उसी के अनुसार चुपचाप समायोजित करता है। सब कुछ **इसी डिवाइस पर** सीखा जाता है और कभी बाहर नहीं जाता।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uči gdje obično dodiruješ svaku tipku i nenametljivo prilagođava ciljeve dodira. Sve se uči **na ovom uređaju** i nikad ga ne napušta."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impara dove tendi a toccare ogni tasto e adatta discretamente le aree tattili di conseguenza. Tutto viene appreso **su questo dispositivo** e non lo lascia mai."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各キーをタップしがちな位置を学習し、それに合わせてタッチ範囲をそっと調整します。学習はすべて**この端末内**で行われ、端末の外に出ることはありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "각 키를 주로 어디에 탭하는지 학습해 터치 영역을 그에 맞게 조용히 조정합니다. 모든 학습은 **이 기기에서** 이루어지며 기기를 벗어나지 않습니다."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uczy się, w którym miejscu zwykle stukasz w każdy klawisz, i dyskretnie dopasowuje do tego obszary dotyku. Wszystko jest uczone **na tym urządzeniu** i nigdy go nie opuszcza."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aprende onde costuma tocar em cada tecla e ajusta discretamente as zonas de toque em conformidade. Tudo é aprendido **neste dispositivo** e nunca sai dele."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запоминает, куда вы обычно нажимаете на каждой клавише, и незаметно подстраивает под это зоны нажатия. Всё обучение происходит **на этом устройстве** и никогда его не покидает."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lär sig var du brukar trycka på varje tangent och justerar träffytorna diskret därefter. Allt lärs in **på den här enheten** och lämnar den aldrig."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เรียนรู้ว่าคุณมักแตะตรงจุดใดของแต่ละปุ่ม แล้วค่อยๆ ปรับเป้าสัมผัสให้ตรงกันโดยอัตโนมัติ ทุกอย่างเรียนรู้ **บนอุปกรณ์นี้** เท่านั้น และไม่ถูกส่งออกไปที่ใด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запам’ятовує, куди ви зазвичай торкаєтеся кожної клавіші, і непомітно підлаштовує під це зони дотику. Усе навчання відбувається **на цьому пристрої** й ніколи його не залишає."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "یہ سیکھتا ہے کہ آپ ہر کی کو کہاں ٹیپ کرتے ہیں اور ٹچ ایریا کو خاموشی سے اسی کے مطابق ایڈجسٹ کرتا ہے۔ سب کچھ **اسی ڈیوائس پر** سیکھا جاتا ہے اور کبھی اس سے باہر نہیں جاتا۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Học vị trí bạn thường chạm trên mỗi phím và âm thầm điều chỉnh vùng chạm cho khớp. Mọi thứ đều được học **trên thiết bị này** và không bao giờ rời khỏi máy."
+          }
+        }
+      }
+    },
+    "No data yet for this posture — type this way and the keyboard learns it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد بيانات بعد لوضعية اليد هذه — اكتب بهذه الطريقة وستتعلّمها لوحة المفاتيح."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Daten für diese Handhaltung — tippe so, und die Tastatur lernt sie."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Δεν υπάρχουν ακόμη δεδομένα για αυτόν τον τρόπο πληκτρολόγησης — πληκτρολογήστε έτσι και το πληκτρολόγιο θα τον μάθει."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún no hay datos para esta postura — escribe así y el teclado lo aprenderá."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هنوز داده‌ای برای این حالت دست وجود ندارد — به همین شکل تایپ کنید تا صفحه‌کلید آن را یاد بگیرد."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ei vielä tietoja tälle otteelle — kirjoita näin, niin näppäimistö oppii sen."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wala pang data para sa posturang ito — mag-type nang ganito at matututo ang keyboard."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas encore de données pour cette posture — tapez ainsi et le clavier l'apprendra."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אין עדיין נתונים לתנוחה הזו — הקלד כך והמקלדת תלמד אותה."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इस मुद्रा के लिए अभी कोई डेटा नहीं — इसी तरह टाइप करें और कीबोर्ड इसे सीख लेगा।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Još nema podataka za ovaj način tipkanja — tipkaj ovako i tipkovnica će ga naučiti."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ancora nessun dato per questa postura — digita in questo modo e la tastiera lo imparerà."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この持ち方のデータはまだありません。この持ち方で入力すると、キーボードが学習します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 자세에 대한 데이터가 아직 없습니다. 이 자세로 입력하면 키보드가 학습합니다."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brak jeszcze danych dla tego sposobu pisania — pisz tak, a klawiatura się nauczy."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda não há dados para esta postura — escreva desta forma e o teclado aprende."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для этого способа набора ещё нет данных — набирайте так, и клавиатура научится."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inga data ännu för det här greppet — skriv så här, så lär sig tangentbordet det."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยังไม่มีข้อมูลสำหรับท่าพิมพ์นี้ — พิมพ์ด้วยท่านี้แล้วคีย์บอร์ดจะเรียนรู้เอง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для цього способу набору ще немає даних — набирайте так, і клавіатура навчиться."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہاتھ کی اس پوزیشن کے لیے ابھی کوئی ڈیٹا نہیں — اسی طرح ٹائپ کریں اور کی بورڈ اسے سیکھ لے گا۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chưa có dữ liệu cho tư thế này — hãy gõ theo cách này để bàn phím học."
+          }
+        }
+      }
+    },
+    "No gesture data yet for this posture.": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد بيانات إيماءات بعد لوضعية اليد هذه."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Gestendaten für diese Handhaltung."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Δεν υπάρχουν ακόμη δεδομένα χειρονομιών για αυτόν τον τρόπο πληκτρολόγησης."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún no hay datos de gestos para esta postura."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هنوز داده‌ای از اشاره‌ها برای این حالت دست وجود ندارد."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ei vielä eletietoja tälle otteelle."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wala pang data ng galaw para sa posturang ito."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas encore de données de gestes pour cette posture."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אין עדיין נתוני מחוות לתנוחה הזו."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इस मुद्रा के लिए अभी कोई जेस्चर डेटा नहीं है।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Još nema podataka o gestama za ovaj način tipkanja."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ancora nessun dato sui gesti per questa postura."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この持ち方のジェスチャデータはまだありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 자세에 대한 제스처 데이터가 아직 없습니다."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brak jeszcze danych o gestach dla tego sposobu pisania."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda não há dados de gestos para esta postura."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для этого способа набора ещё нет данных о жестах."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inga gestdata ännu för det här greppet."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยังไม่มีข้อมูลท่าทางสำหรับท่าพิมพ์นี้"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для цього способу набору ще немає даних про жести."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہاتھ کی اس پوزیشن کے لیے ابھی کوئی اشارہ ڈیٹا نہیں ہے۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chưa có dữ liệu cử chỉ cho tư thế này."
+          }
+        }
+      }
+    },
+    "No taps recorded yet — keep typing with this posture.": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم تُسجَّل أي لمسات بعد — واصل الكتابة بوضعية اليد هذه."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Eingaben erfasst — tippe weiter in dieser Handhaltung."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Δεν έχουν καταγραφεί ακόμη πατήματα — συνεχίστε να πληκτρολογείτε με αυτόν τον τρόπο."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aún no se han registrado toques — sigue escribiendo con esta postura."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هنوز ضربه‌ای ثبت نشده است — با همین حالت دست به تایپ ادامه دهید."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Napautuksia ei ole vielä tallennettu — jatka kirjoittamista tällä otteella."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wala pang naitatalang tap — magpatuloy sa pagta-type gamit ang posturang ito."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun appui enregistré pour l'instant — continuez à taper avec cette posture."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "עדיין לא נרשמו הקשות — המשך להקליד בתנוחה הזו."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अभी कोई टैप रिकॉर्ड नहीं हुआ — इसी मुद्रा में टाइप करते रहें।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Još nema zabilježenih dodira — nastavi tipkati na ovaj način."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun tocco registrato finora — continua a digitare con questa postura."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "まだタップが記録されていません。この持ち方で入力を続けてください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아직 기록된 탭이 없습니다. 이 자세로 계속 입력해 보세요."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie zarejestrowano jeszcze stuknięć — pisz dalej w ten sposób."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda não foram registados toques — continue a escrever com esta postura."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нажатия ещё не записаны — продолжайте набирать этим способом."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inga tryck registrerade ännu — fortsätt skriva med det här greppet."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยังไม่มีการบันทึกการแตะ — พิมพ์ด้วยท่าพิมพ์นี้ต่อไป"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дотиків ще не записано — продовжуйте набирати цим способом."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ابھی کوئی ٹیپ ریکارڈ نہیں ہوئی — ہاتھ کی اسی پوزیشن کے ساتھ ٹائپ کرتے رہیں۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chưa ghi nhận lần chạm nào — hãy tiếp tục gõ với tư thế này."
+          }
+        }
+      }
+    },
+    "One hand — left thumb": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يد واحدة — الإبهام الأيسر"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine Hand — linker Daumen"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ένα χέρι — αριστερός αντίχειρας"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una mano — pulgar izquierdo"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "یک دست — شست چپ"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yksi käsi — vasen peukalo"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isang kamay — kaliwang hinlalaki"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une main — pouce gauche"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "יד אחת — אגודל שמאל"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एक हाथ — बायाँ अंगूठा"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jedna ruka — lijevi palac"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una mano — pollice sinistro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "片手 — 左の親指"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한 손 — 왼손 엄지"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jedna ręka — lewy kciuk"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uma mão — polegar esquerdo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Одна рука — левый большой палец"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En hand — vänster tumme"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "มือเดียว — นิ้วโป้งซ้าย"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Одна рука — лівий великий палець"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ایک ہاتھ — بایاں انگوٹھا"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Một tay — ngón cái trái"
+          }
+        }
+      }
+    },
+    "One hand — right thumb": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يد واحدة — الإبهام الأيمن"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine Hand — rechter Daumen"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ένα χέρι — δεξιός αντίχειρας"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una mano — pulgar derecho"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "یک دست — شست راست"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yksi käsi — oikea peukalo"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isang kamay — kanang hinlalaki"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une main — pouce droit"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "יד אחת — אגודל ימין"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एक हाथ — दायाँ अंगूठा"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jedna ruka — desni palac"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una mano — pollice destro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "片手 — 右の親指"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한 손 — 오른손 엄지"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jedna ręka — prawy kciuk"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uma mão — polegar direito"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Одна рука — правый большой палец"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En hand — höger tumme"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "มือเดียว — นิ้วโป้งขวา"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Одна рука — правий великий палець"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ایک ہاتھ — دایاں انگوٹھا"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Một tay — ngón cái phải"
+          }
+        }
+      }
+    },
+    "Reset all learned corrections?": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تعيين كل التصحيحات المُكتسَبة؟"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle gelernten Korrekturen zurücksetzen?"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επαναφορά όλων των εκμαθημένων διορθώσεων;"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Restablecer todas las correcciones aprendidas?"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "همهٔ اصلاح‌های آموخته‌شده بازنشانی شود؟"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Palautetaanko kaikki opitut korjaukset?"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-reset ang lahat ng natutunang pagtatama?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinitialiser toutes les corrections apprises ?"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "לאפס את כל התיקונים שנלמדו?"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सभी सीखे गए सुधार रीसेट करें?"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vratiti izvorno sve naučene ispravke?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ripristinare tutte le correzioni apprese?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学習した補正をすべてリセットしますか？"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학습된 보정을 모두 재설정하시겠습니까?"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zresetować wszystkie wyuczone poprawki?"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repor todas as correções aprendidas?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить все выученные поправки?"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Återställ alla inlärda korrigeringar?"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รีเซ็ตการปรับแก้ที่เรียนรู้ไว้ทั้งหมดหรือไม่"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скинути всі вивчені поправки?"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تمام سیکھی گئی درستیاں ری سیٹ کریں؟"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đặt lại toàn bộ hiệu chỉnh đã học?"
+          }
+        }
+      }
+    },
+    "Reset everything": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تعيين كل شيء"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles zurücksetzen"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επαναφορά όλων"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer todo"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازنشانی همه‌چیز"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Palauta kaikki"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-reset ang lahat"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout réinitialiser"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אפס הכול"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सब कुछ रीसेट करें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vrati sve izvorno"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ripristina tutto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてリセット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 재설정"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetuj wszystko"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repor tudo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить всё"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Återställ allt"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รีเซ็ตทั้งหมด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скинути все"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سب کچھ ری سیٹ کریں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đặt lại tất cả"
+          }
+        }
+      }
+    },
+    "Reset this posture": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تعيين وضعية اليد هذه"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Handhaltung zurücksetzen"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επαναφορά αυτού του τρόπου"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer esta postura"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازنشانی این حالت دست"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Palauta tämä ote"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-reset ang posturang ito"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinitialiser cette posture"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אפס תנוחה זו"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "यह मुद्रा रीसेट करें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vrati izvorno ovaj način"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ripristina questa postura"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この持ち方をリセット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 자세 재설정"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetuj ten profil"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repor esta postura"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить этот профиль"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Återställ det här greppet"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รีเซ็ตท่าพิมพ์นี้"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скинути цей профіль"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہاتھ کی یہ پوزیشن ری سیٹ کریں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đặt lại tư thế này"
+          }
+        }
+      }
+    },
+    "See whether correction is helping and the per-gesture correction rates.": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اطّلع على ما إذا كان التصحيح مفيدًا وعلى معدّلات التصحيح لكل إيماءة."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeigt, ob die Korrektur hilft, und die Korrekturraten pro Geste."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Δείτε αν η διόρθωση βοηθάει, καθώς και τα ποσοστά διόρθωσης ανά χειρονομία."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprueba si la corrección está ayudando y las tasas de corrección por gesto."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ببینید آیا اصلاح کمک می‌کند و نرخ اصلاح هر اشاره چقدر است."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näyttää, auttaako korjaus, sekä korjausosuudet eleittäin."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tingnan kung nakakatulong ang pagtatama at ang mga rate ng pagtatama kada galaw."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voyez si la correction aide et les taux de correction par geste."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "בדוק אם התיקון עוזר, ומהם שיעורי התיקון לכל מחווה."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "देखें कि सुधार से मदद मिल रही है या नहीं, और हर जेस्चर की सुधार दर क्या है।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pogledaj pomaže li ispravljanje i kolike su stope ispravaka po gesti."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scopri se la correzione sta aiutando e le percentuali di correzione per gesto."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "補正が役に立っているかどうかと、ジェスチャごとの補正率を確認できます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보정이 도움이 되는지와 제스처별 보정 비율을 확인할 수 있습니다."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprawdź, czy korekta pomaga, oraz odsetek korekt dla poszczególnych gestów."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veja se a correção está a ajudar e as taxas de correção por gesto."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Посмотрите, помогает ли коррекция, и долю коррекции по каждому жесту."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visar om korrigeringen hjälper och korrigeringsfrekvensen per gest."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ดูว่าการปรับแก้ช่วยได้จริงหรือไม่ พร้อมอัตราการปรับแก้ของแต่ละท่าทาง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перегляньте, чи допомагає корекція, і частку корекції для кожного жесту."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دیکھیں کہ درستی مددگار ہے یا نہیں، اور فی اشارہ درستی کی شرحیں۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xem việc hiệu chỉnh có hiệu quả không và tỷ lệ hiệu chỉnh của từng cử chỉ."
+          }
+        }
+      }
+    },
+    "Statistics": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإحصائيات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistik"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Στατιστικά"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estadísticas"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آمار"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilastot"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Istatistika"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiques"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סטטיסטיקה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आँकड़े"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistika"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistiche"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "통계"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statystyki"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estatísticas"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статистика"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statistik"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สถิติ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статистика"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اعداد و شمار"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thống kê"
+          }
+        }
+      }
+    },
+    "Touch Correction": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصحيح اللمس"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touch-Korrektur"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διόρθωση αφής"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corrección táctil"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اصلاح لمس"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kosketuskorjaus"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagtatama ng Touch"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correction tactile"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תיקון מגע"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "टच सुधार"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ispravljanje dodira"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correzione del tocco"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タッチ補正"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터치 보정"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korekta dotyku"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correção do toque"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Коррекция нажатий"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tryckkorrigering"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การปรับแก้การสัมผัส"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Корекція дотиків"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹچ کی درستی"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiệu chỉnh chạm"
+          }
+        }
+      }
+    },
+    "Touch correction": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصحيح اللمس"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touch-Korrektur"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διόρθωση αφής"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corrección táctil"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اصلاح لمس"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kosketuskorjaus"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pagtatama ng touch"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correction tactile"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תיקון מגע"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "टच सुधार"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ispravljanje dodira"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correzione del tocco"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タッチ補正"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터치 보정"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korekta dotyku"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correção do toque"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Коррекция нажатий"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tryckkorrigering"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การปรับแก้การสัมผัส"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Корекція дотиків"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹچ کی درستی"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiệu chỉnh chạm"
+          }
+        }
+      }
+    },
+    "Two thumbs": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كلا الإبهامين"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwei Daumen"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Δύο αντίχειρες"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dos pulgares"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دو شست"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaksi peukaloa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dalawang hinlalaki"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deux pouces"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שני אגודלים"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "दोनों अंगूठे"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dva palca"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Due pollici"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "両手の親指"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "양손 엄지"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dwa kciuki"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dois polegares"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Два больших пальца"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Två tummar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สองนิ้วโป้ง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Два великі пальці"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دونوں انگوٹھے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hai ngón cái"
+          }
+        }
+      }
+    },
+    "Wurstfinger keeps a **separate** profile per posture, because a thumb reaching across the keyboard lands differently than two thumbs. A wrong choice can nudge keys the wrong way, so this isn't auto-detected.": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يحتفظ Wurstfinger بملف تعريف **منفصل** لكل وضعية يد، لأن الإبهام الذي يمتد عبر لوحة المفاتيح يهبط بشكل مختلف عن الإبهامين. الاختيار الخاطئ قد يزيح المفاتيح في الاتجاه الخاطئ، لذلك لا يتم اكتشاف ذلك تلقائيًا."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger pflegt für jede Handhaltung ein **eigenes** Profil, denn ein Daumen, der quer über die Tastatur greift, trifft anders als zwei Daumen. Eine falsche Wahl kann Tasten in die falsche Richtung verschieben, deshalb wird die Handhaltung nicht automatisch erkannt."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Το Wurstfinger διατηρεί **ξεχωριστό** προφίλ για κάθε τρόπο πληκτρολόγησης, επειδή ένας αντίχειρας που φτάνει διαγώνια σε όλο το πληκτρολόγιο πατάει αλλιώς από δύο αντίχειρες. Μια λανθασμένη επιλογή μπορεί να μετατοπίσει τα πλήκτρα προς λάθος κατεύθυνση, γι' αυτό δεν εντοπίζεται αυτόματα."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger mantiene un perfil **independiente** para cada postura, porque un pulgar que cruza el teclado no aterriza igual que dos pulgares. Una elección equivocada puede desplazar las teclas en la dirección errónea, por eso no se detecta automáticamente."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger برای هر حالت دست یک نمایهٔ **جداگانه** نگه می‌دارد، چون شستی که از عرض صفحه‌کلید عبور می‌کند، جایی متفاوت از حالت دو شستی فرود می‌آید. انتخاب نادرست ممکن است کلیدها را به سمت اشتباه جابه‌جا کند، بنابراین به‌طور خودکار تشخیص داده نمی‌شود."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger pitää jokaiselle otteelle **erillistä** profiilia, koska näppäimistön yli kurottava peukalo osuu eri tavalla kuin kaksi peukaloa. Väärä valinta voi siirtää näppäimiä väärään suuntaan, joten otetta ei tunnisteta automaattisesti."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nagpapanatili ang Wurstfinger ng **hiwalay** na profile para sa bawat postura, dahil iba ang dapo ng hinlalaking umaabot sa kabila ng keyboard kaysa sa dalawang hinlalaki. Ang maling pagpili ay puwedeng magtulak sa mga key sa maling direksyon, kaya hindi ito awtomatikong nade-detect."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger conserve un profil **distinct** pour chaque posture, car un pouce qui traverse le clavier ne se pose pas de la même façon que deux pouces. Un mauvais choix peut décaler les touches dans le mauvais sens, la détection n'est donc pas automatique."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger שומר פרופיל **נפרד** לכל תנוחה, כי אגודל שנמתח לרוחב המקלדת נוחת אחרת משני אגודלים. בחירה שגויה עלולה להסיט את המקשים לכיוון הלא נכון, ולכן היא אינה מזוהה אוטומטית."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger हर मुद्रा के लिए **अलग** प्रोफ़ाइल रखता है, क्योंकि पूरे कीबोर्ड तक पहुँचता हुआ एक अंगूठा दोनों अंगूठों से अलग जगह पड़ता है। गलत चुनाव कीज़ को गलत दिशा में खिसका सकता है, इसलिए इसका अपने-आप पता नहीं लगाया जाता।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger čuva **zaseban** profil za svaki način tipkanja jer palac koji poseže preko tipkovnice pogađa drukčije nego dva palca. Pogrešan odabir može pomaknuti tipke u krivom smjeru, pa se to ne prepoznaje automatski."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger mantiene un profilo **separato** per ogni postura, perché un pollice che attraversa la tastiera atterra in modo diverso rispetto a due pollici. Una scelta sbagliata può spostare i tasti nella direzione errata, perciò non viene rilevata automaticamente."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfingerは持ち方ごとに**別々の**プロファイルを保持します。キーボードをまたいで届かせる親指は、両手の親指とは指の着地する位置が違うためです。選択を間違えるとキーが誤った方向にずれることがあるため、自動判定は行いません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger는 타이핑 자세마다 **별도의** 프로필을 유지합니다. 키보드를 가로질러 뻗은 엄지는 양손 엄지와 닿는 위치가 다르기 때문입니다. 자세를 잘못 선택하면 키가 엉뚱한 방향으로 밀릴 수 있어 자동으로 감지하지 않습니다."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger prowadzi **osobny** profil dla każdego sposobu pisania, ponieważ kciuk sięgający przez całą klawiaturę trafia inaczej niż dwa kciuki. Zły wybór może przesunąć klawisze w złą stronę, dlatego nie jest to wykrywane automatycznie."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Wurstfinger mantém um perfil **separado** para cada postura, porque um polegar que atravessa o teclado acerta de forma diferente de dois polegares. Uma escolha errada pode deslocar as teclas no sentido errado, por isso não é detetada automaticamente."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger ведёт **отдельный** профиль для каждого способа набора, потому что большой палец, тянущийся через всю клавиатуру, попадает иначе, чем два больших пальца. Неверный выбор может сместить клавиши не в ту сторону, поэтому это не определяется автоматически."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger sparar en **separat** profil för varje grepp, eftersom en tumme som sträcker sig över tangentbordet träffar annorlunda än två tummar. Ett felaktigt val kan förskjuta tangenterna åt fel håll, så greppet identifieras inte automatiskt."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger เก็บโปรไฟล์ **แยกกัน** สำหรับแต่ละท่าพิมพ์ เพราะนิ้วโป้งที่ต้องเอื้อมข้ามคีย์บอร์ดจะลงตำแหน่งต่างจากการใช้สองนิ้วโป้ง หากเลือกผิด ปุ่มอาจถูกขยับไปผิดทาง แอปจึงไม่ตรวจจับให้อัตโนมัติ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger веде **окремий** профіль для кожного способу набору, бо великий палець, що тягнеться через усю клавіатуру, влучає інакше, ніж два великі пальці. Хибний вибір може зсунути клавіші не в той бік, тому це не визначається автоматично."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger ہاتھ کی ہر پوزیشن کے لیے **الگ** پروفائل رکھتا ہے، کیونکہ کی بورڈ کے آر پار پہنچنے والا انگوٹھا دونوں انگوٹھوں کے مقابلے میں مختلف جگہ پڑتا ہے۔ غلط انتخاب کیز کو غلط سمت میں کھسکا سکتا ہے، اس لیے یہ خودکار طور پر نہیں پہچانا جاتا۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wurstfinger giữ một hồ sơ **riêng** cho mỗi tư thế, vì một ngón cái vươn qua cả bàn phím sẽ có điểm chạm khác với khi dùng hai ngón cái. Chọn sai có thể đẩy các phím lệch hướng, nên điều này không được tự động nhận diện."
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -52,6 +52,9 @@ struct SettingsView: View {
     @AppStorage(SettingsKey.gestureTrailEnabled.rawValue, store: SharedDefaults.store)
     private var gestureTrailEnabled = false
 
+    @AppStorage(SettingsKey.touchOffsetEnabled.rawValue, store: SharedDefaults.store)
+    private var touchOffsetEnabled = false
+
     @AppStorage(SettingsKey.keyboardFullAccess.rawValue, store: SharedDefaults.store)
     private var hasFullAccess = false
 
@@ -196,6 +199,15 @@ struct SettingsView: View {
                     color: .green,
                     title: "Size & Position",
                     subtitle: sizePositionDescription
+                )
+            }
+
+            NavigationLink(destination: TouchOffsetSettingsView()) {
+                SettingsRow(
+                    icon: "scope",
+                    color: .red,
+                    title: "Touch Correction",
+                    subtitle: touchOffsetEnabled ? "Learning your taps" : "Adapt targets to your taps"
                 )
             }
 

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -207,7 +207,9 @@ struct SettingsView: View {
                     icon: "scope",
                     color: .red,
                     title: "Touch Correction",
-                    subtitle: touchOffsetEnabled ? "Learning your taps" : "Adapt targets to your taps"
+                    subtitle: touchOffsetEnabled
+                        ? String(localized: "Learning your taps")
+                        : String(localized: "Adapt targets to your taps")
                 )
             }
 

--- a/wurstfinger/TouchOffsetSettingsView.swift
+++ b/wurstfinger/TouchOffsetSettingsView.swift
@@ -129,16 +129,28 @@ private struct TouchOffsetStatsView: View {
     @State private var telemetry: TelemetrySnapshot = .empty(schemaVersion: GestureTelemetryStore.currentSchemaVersion)
     private let telemetryStore = GestureTelemetryStore(defaults: SharedDefaults.store)
 
+    private var counterfactual: CounterfactualMetric {
+        telemetry.counterfactual[regimeKey] ?? CounterfactualMetric()
+    }
+
     var body: some View {
         Form {
             Section {
-                abRow("With correction", telemetry.abEnabled)
-                abRow("Without correction", telemetry.abDisabled)
+                if counterfactual.total == 0 {
+                    Text("No corrections have changed a key yet — keep typing with this posture.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    countRow("Errors caught", counterfactual.caught, tint: .green)
+                    countRow("Corrections reverted", counterfactual.caused, tint: .red)
+                    countRow("Net benefit", counterfactual.net, tint: counterfactual.net >= 0 ? .green : .red, signed: true)
+                }
             } header: {
                 Text("Does it help?")
             } footer: {
-                Text("Your correction (backspace) rate while the feature is on vs off, "
-                    + "measured locally. A lower rate with it on means it's helping.")
+                Text("Counts taps where the correction moved the key under your finger. If you "
+                    + "kept the result it likely **caught** a misfire; if you deleted it right "
+                    + "after, the correction likely **caused** one. Measured live while the "
+                    + "feature is on.")
             }
 
             if let classes = telemetry.classes[regimeKey], !classes.isEmpty {
@@ -170,10 +182,10 @@ private struct TouchOffsetStatsView: View {
         .onAppear { telemetry = telemetryStore.load() }
     }
 
-    private func abRow(_ title: LocalizedStringKey, _ metric: ABMetric) -> some View {
+    private func countRow(_ title: LocalizedStringKey, _ value: Int, tint: Color, signed: Bool = false) -> some View {
         LabeledContent(title) {
-            Text(metric.total > 0 ? "\(percent(metric.correctionRate)) · \(metric.total)" : "no data")
-                .foregroundStyle(.secondary)
+            Text(signed && value >= 0 ? "+\(value)" : "\(value)")
+                .foregroundStyle(tint)
                 .monospacedDigit()
         }
     }

--- a/wurstfinger/TouchOffsetSettingsView.swift
+++ b/wurstfinger/TouchOffsetSettingsView.swift
@@ -17,9 +17,11 @@ struct TouchOffsetSettingsView: View {
 
     @State private var posture: PostureClass = .twoThumb
     @State private var snapshot: TouchOffsetSnapshot = .empty(schemaVersion: TouchOffsetStore.currentSchemaVersion)
+    @State private var telemetry: TelemetrySnapshot = .empty(schemaVersion: GestureTelemetryStore.currentSchemaVersion)
     @State private var showResetDialog = false
 
     private let store = TouchOffsetStore(defaults: SharedDefaults.store)
+    private let telemetryStore = GestureTelemetryStore(defaults: SharedDefaults.store)
     private let arrangement = StandardArrangements.grid3x3[.portrait]
 
     private var regime: TouchRegime {
@@ -65,6 +67,35 @@ struct TouchOffsetSettingsView: View {
             }
 
             Section {
+                abRow("With correction", telemetry.abEnabled)
+                abRow("Without correction", telemetry.abDisabled)
+            } header: {
+                Text("Does it help?")
+            } footer: {
+                Text("Your correction (backspace) rate while the feature is on vs off, "
+                    + "measured locally. A lower rate with it on means it's helping.")
+            }
+
+            if let classes = telemetry.classes[regime.key], !classes.isEmpty {
+                Section {
+                    ForEach(classes.keys.sorted(), id: \.self) { key in
+                        if let stats = classes[key] {
+                            LabeledContent(key) {
+                                Text("\(percent(stats.correctionRate)) · \(stats.total)")
+                                    .foregroundStyle(.secondary)
+                                    .monospacedDigit()
+                            }
+                        }
+                    }
+                } header: {
+                    Text("Gesture correction rates")
+                } footer: {
+                    Text("How often each gesture class gets corrected (rate · sample count). "
+                        + "A high rate hints at a mis-tuned threshold for that gesture.")
+                }
+            }
+
+            Section {
                 Button("Reset this posture", role: .destructive) {
                     store.reset(regimeKey: regime.key)
                     reload()
@@ -81,10 +112,23 @@ struct TouchOffsetSettingsView: View {
         .confirmationDialog("Reset all learned corrections?", isPresented: $showResetDialog, titleVisibility: .visible) {
             Button("Reset everything", role: .destructive) {
                 store.resetAll()
+                telemetryStore.reset()
                 reload()
             }
             Button("Cancel", role: .cancel) {}
         }
+    }
+
+    private func abRow(_ title: String, _ metric: ABMetric) -> some View {
+        LabeledContent(title) {
+            Text(metric.total > 0 ? "\(percent(metric.correctionRate)) · \(metric.total)" : "no data")
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+    }
+
+    private func percent(_ rate: Double) -> String {
+        String(format: "%.1f%%", rate * 100)
     }
 
     private var appliedOffsets: [String: CGVector] {
@@ -97,6 +141,7 @@ struct TouchOffsetSettingsView: View {
 
     private func reload() {
         snapshot = store.load()
+        telemetry = telemetryStore.load()
     }
 }
 

--- a/wurstfinger/TouchOffsetSettingsView.swift
+++ b/wurstfinger/TouchOffsetSettingsView.swift
@@ -136,21 +136,22 @@ private struct TouchOffsetStatsView: View {
     var body: some View {
         Form {
             Section {
-                if counterfactual.total == 0 {
-                    Text("No corrections have changed a key yet — keep typing with this posture.")
+                if counterfactual.taps == 0 {
+                    Text("No taps recorded yet — keep typing with this posture.")
                         .foregroundStyle(.secondary)
                 } else {
-                    countRow("Errors caught", counterfactual.caught, tint: .green)
-                    countRow("Corrections reverted", counterfactual.caused, tint: .red)
-                    countRow("Net benefit", counterfactual.net, tint: counterfactual.net >= 0 ? .green : .red, signed: true)
+                    let helping = counterfactual.errorRateWith <= counterfactual.errorRateWithout
+                    rateRow("With correction", counterfactual.errorRateWith, tint: helping ? .green : .red)
+                    rateRow("Without correction", counterfactual.errorRateWithout, tint: .secondary)
                 }
             } header: {
-                Text("Does it help?")
+                Text("Error rate")
             } footer: {
-                Text("Counts taps where the correction moved the key under your finger. If you "
-                    + "kept the result it likely **caught** a misfire; if you deleted it right "
-                    + "after, the correction likely **caused** one. Measured live while the "
-                    + "feature is on.")
+                Text("Estimated backspace rate **with** the correction vs. what it would have "
+                    + "been **without** it — inferred per tap from whether correction changed a "
+                    + "key you then kept or deleted. Lower with correction means it's helping. "
+                    + "(\(counterfactual.taps) taps · \(counterfactual.caught) caught · "
+                    + "\(counterfactual.caused) caused)")
             }
 
             if let classes = telemetry.classes[regimeKey], !classes.isEmpty {
@@ -182,9 +183,9 @@ private struct TouchOffsetStatsView: View {
         .onAppear { telemetry = telemetryStore.load() }
     }
 
-    private func countRow(_ title: LocalizedStringKey, _ value: Int, tint: Color, signed: Bool = false) -> some View {
+    private func rateRow(_ title: LocalizedStringKey, _ rate: Double, tint: Color) -> some View {
         LabeledContent(title) {
-            Text(signed && value >= 0 ? "+\(value)" : "\(value)")
+            Text(percent(rate))
                 .foregroundStyle(tint)
                 .monospacedDigit()
         }

--- a/wurstfinger/TouchOffsetSettingsView.swift
+++ b/wurstfinger/TouchOffsetSettingsView.swift
@@ -3,10 +3,11 @@
 //  wurstfinger
 //
 //  Settings subpage for the learned touch-offset correction (spec §6):
-//  the master toggle, an explicit hand-posture choice that selects the active
-//  learning regime (§6.3), a visualization of the learned per-key offsets read
-//  from the persisted snapshot, diagnostics, and reset controls. All data is
-//  local; the visualization shows the last persisted snapshot (§5.1).
+//  the master toggle, a compact explicit hand-posture choice that selects the
+//  active learning regime (§6.3), a visualization of the learned per-key offsets
+//  read from the persisted snapshot, a link to the statistics subpage, and reset
+//  controls. All data is local; the visualization shows the last persisted
+//  snapshot (§5.1).
 //
 
 import CoreGraphics
@@ -21,7 +22,6 @@ struct TouchOffsetSettingsView: View {
     @AppStorage(SettingsKey.touchOffsetPosture.rawValue, store: SharedDefaults.store)
     private var posture: PostureClass = .oneThumbRight
     @State private var snapshot: TouchOffsetSnapshot = .empty(schemaVersion: TouchOffsetStore.currentSchemaVersion)
-    @State private var telemetry: TelemetrySnapshot = .empty(schemaVersion: GestureTelemetryStore.currentSchemaVersion)
     @State private var showResetDialog = false
 
     private let store = TouchOffsetStore(defaults: SharedDefaults.store)
@@ -56,14 +56,10 @@ struct TouchOffsetSettingsView: View {
                     Text("One hand — left thumb").tag(PostureClass.oneThumbLeft)
                     Text("Two thumbs").tag(PostureClass.twoThumb)
                 }
-                .pickerStyle(.inline)
-            } header: {
-                Text("How do you type?")
             } footer: {
-                Text("Pick the way you actually hold the phone. Wurstfinger keeps a "
-                    + "**separate** profile per posture, because a thumb reaching across "
-                    + "the keyboard lands differently than two thumbs. A wrong choice can "
-                    + "nudge keys the wrong way, so this isn't auto-detected.")
+                Text("Wurstfinger keeps a **separate** profile per posture, because a thumb "
+                    + "reaching across the keyboard lands differently than two thumbs. A wrong "
+                    + "choice can nudge keys the wrong way, so this isn't auto-detected.")
             }
 
             Section {
@@ -80,32 +76,11 @@ struct TouchOffsetSettingsView: View {
             }
 
             Section {
-                abRow("With correction", telemetry.abEnabled)
-                abRow("Without correction", telemetry.abDisabled)
-            } header: {
-                Text("Does it help?")
-            } footer: {
-                Text("Your correction (backspace) rate while the feature is on vs off, "
-                    + "measured locally. A lower rate with it on means it's helping.")
-            }
-
-            if let classes = telemetry.classes[regime.key], !classes.isEmpty {
-                Section {
-                    ForEach(classes.keys.sorted(), id: \.self) { key in
-                        if let stats = classes[key] {
-                            LabeledContent(key) {
-                                Text("\(percent(stats.correctionRate)) · \(stats.total)")
-                                    .foregroundStyle(.secondary)
-                                    .monospacedDigit()
-                            }
-                        }
-                    }
-                } header: {
-                    Text("Gesture correction rates")
-                } footer: {
-                    Text("How often each gesture class gets corrected (rate · sample count). "
-                        + "A high rate hints at a mis-tuned threshold for that gesture.")
+                NavigationLink("Statistics") {
+                    TouchOffsetStatsView(regimeKey: regime.key)
                 }
+            } footer: {
+                Text("See whether correction is helping and the per-gesture correction rates.")
             }
 
             Section {
@@ -132,18 +107,6 @@ struct TouchOffsetSettingsView: View {
         }
     }
 
-    private func abRow(_ title: String, _ metric: ABMetric) -> some View {
-        LabeledContent(title) {
-            Text(metric.total > 0 ? "\(percent(metric.correctionRate)) · \(metric.total)" : "no data")
-                .foregroundStyle(.secondary)
-                .monospacedDigit()
-        }
-    }
-
-    private func percent(_ rate: Double) -> String {
-        String(format: "%.1f%%", rate * 100)
-    }
-
     private var appliedOffsets: [String: CGVector] {
         TouchOffsetModel(regime: regime, snapshot: snapshot).allOffsets()
     }
@@ -154,7 +117,69 @@ struct TouchOffsetSettingsView: View {
 
     private func reload() {
         snapshot = store.load()
-        telemetry = telemetryStore.load()
+    }
+}
+
+/// Read-only statistics subpage (§8/§13): the A/B proxy metric and the
+/// per-gesture correction rates for the active posture. Loaded fresh from the
+/// persisted telemetry snapshot on appear.
+private struct TouchOffsetStatsView: View {
+    let regimeKey: String
+
+    @State private var telemetry: TelemetrySnapshot = .empty(schemaVersion: GestureTelemetryStore.currentSchemaVersion)
+    private let telemetryStore = GestureTelemetryStore(defaults: SharedDefaults.store)
+
+    var body: some View {
+        Form {
+            Section {
+                abRow("With correction", telemetry.abEnabled)
+                abRow("Without correction", telemetry.abDisabled)
+            } header: {
+                Text("Does it help?")
+            } footer: {
+                Text("Your correction (backspace) rate while the feature is on vs off, "
+                    + "measured locally. A lower rate with it on means it's helping.")
+            }
+
+            if let classes = telemetry.classes[regimeKey], !classes.isEmpty {
+                Section {
+                    ForEach(classes.keys.sorted(), id: \.self) { key in
+                        if let stats = classes[key] {
+                            LabeledContent(key) {
+                                Text("\(percent(stats.correctionRate)) · \(stats.total)")
+                                    .foregroundStyle(.secondary)
+                                    .monospacedDigit()
+                            }
+                        }
+                    }
+                } header: {
+                    Text("Gesture correction rates")
+                } footer: {
+                    Text("How often each gesture class gets corrected (rate · sample count). "
+                        + "A high rate hints at a mis-tuned threshold for that gesture.")
+                }
+            } else {
+                Section {
+                    Text("No gesture data yet for this posture.")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .navigationTitle("Statistics")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { telemetry = telemetryStore.load() }
+    }
+
+    private func abRow(_ title: LocalizedStringKey, _ metric: ABMetric) -> some View {
+        LabeledContent(title) {
+            Text(metric.total > 0 ? "\(percent(metric.correctionRate)) · \(metric.total)" : "no data")
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+    }
+
+    private func percent(_ rate: Double) -> String {
+        String(format: "%.1f%%", rate * 100)
     }
 }
 

--- a/wurstfinger/TouchOffsetSettingsView.swift
+++ b/wurstfinger/TouchOffsetSettingsView.swift
@@ -1,0 +1,157 @@
+//
+//  TouchOffsetSettingsView.swift
+//  wurstfinger
+//
+//  Settings subpage for the learned touch-offset correction (spec §6):
+//  the master toggle, a visualization of the learned per-key offsets read from
+//  the persisted snapshot, a regime selector, and reset controls. All data is
+//  local; the visualization shows the last persisted snapshot (§5.1).
+//
+
+import CoreGraphics
+import SwiftUI
+
+struct TouchOffsetSettingsView: View {
+    @AppStorage(SettingsKey.touchOffsetEnabled.rawValue, store: SharedDefaults.store)
+    private var enabled = false
+
+    @State private var posture: PostureClass = .twoThumb
+    @State private var snapshot: TouchOffsetSnapshot = .empty(schemaVersion: TouchOffsetStore.currentSchemaVersion)
+    @State private var showResetDialog = false
+
+    private let store = TouchOffsetStore(defaults: SharedDefaults.store)
+    private let arrangement = StandardArrangements.grid3x3[.portrait]
+
+    private var regime: TouchRegime {
+        TouchRegime(orientation: .portrait, posture: posture)
+    }
+
+    private var regimeKeys: [String: KeyOffsetState] {
+        snapshot.regimes[regime.key] ?? [:]
+    }
+
+    private var totalSamples: Int {
+        regimeKeys.values.reduce(0) { $0 + $1.count }
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Correct my typing", isOn: $enabled)
+            } footer: {
+                Text("Learns where you tend to tap each key and quietly adjusts the "
+                    + "touch targets to match. Everything is learned **on this device** "
+                    + "and never leaves it.")
+            }
+
+            Section {
+                Picker("Hand posture", selection: $posture) {
+                    Text("Two thumbs").tag(PostureClass.twoThumb)
+                    Text("Left hand").tag(PostureClass.oneThumbLeft)
+                    Text("Right hand").tag(PostureClass.oneThumbRight)
+                }
+                .pickerStyle(.segmented)
+
+                OffsetMapView(arrangement: arrangement, offsets: appliedOffsets, sampleCount: sampleCount)
+                    .frame(height: 230)
+                    .padding(.vertical, 4)
+            } header: {
+                Text("Learned adjustments")
+            } footer: {
+                Text(totalSamples > 0
+                    ? "\(totalSamples) taps learned for this posture. The red arrow shows how far "
+                    + "each key's target has moved; fainter means less data."
+                    : "No data yet for this posture — type with the keyboard to teach it.")
+            }
+
+            Section {
+                Button("Reset this posture", role: .destructive) {
+                    store.reset(regimeKey: regime.key)
+                    reload()
+                }
+                .disabled(totalSamples == 0)
+                Button("Reset everything", role: .destructive) {
+                    showResetDialog = true
+                }
+            }
+        }
+        .navigationTitle("Touch correction")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear(perform: reload)
+        .confirmationDialog("Reset all learned corrections?", isPresented: $showResetDialog, titleVisibility: .visible) {
+            Button("Reset everything", role: .destructive) {
+                store.resetAll()
+                reload()
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+    }
+
+    private var appliedOffsets: [String: CGVector] {
+        TouchOffsetModel(regime: regime, snapshot: snapshot).allOffsets()
+    }
+
+    private func sampleCount(_ keyId: String) -> Int {
+        regimeKeys[keyId]?.count ?? 0
+    }
+
+    private func reload() {
+        snapshot = store.load()
+    }
+}
+
+/// Draws the keyboard grid with a red arrow per key from its true center to the
+/// learned (shifted) point; opacity encodes confidence (sample count).
+private struct OffsetMapView: View {
+    let arrangement: GridArrangement?
+    let offsets: [String: CGVector]
+    let sampleCount: (String) -> Int
+
+    var body: some View {
+        Canvas { context, size in
+            guard let arrangement else { return }
+            let cells = GridLayoutSolver.solve(arrangement)
+            let columns = CGFloat(max(arrangement.columns, 1))
+            let rows = CGFloat(max(GridLayoutSolver.rowCount(arrangement), 1))
+            let cellW = size.width / columns
+            let cellH = size.height / rows
+
+            for cell in cells {
+                let rect = CGRect(
+                    x: CGFloat(cell.column) * cellW,
+                    y: CGFloat(cell.row) * cellH,
+                    width: CGFloat(cell.columnSpan) * cellW,
+                    height: CGFloat(cell.rowSpan) * cellH
+                ).insetBy(dx: 2, dy: 2)
+                context.fill(
+                    Path(roundedRect: rect, cornerRadius: 5),
+                    with: .color(.secondary.opacity(0.12))
+                )
+
+                let center = CGPoint(x: rect.midX, y: rect.midY)
+                guard let offset = offsets[cell.keyId], offset.dx != 0 || offset.dy != 0 else { continue }
+                let opacity = min(Double(sampleCount(cell.keyId)) / 20.0, 1.0)
+
+                // True center crosshair.
+                var cross = Path()
+                cross.move(to: CGPoint(x: center.x - 3, y: center.y))
+                cross.addLine(to: CGPoint(x: center.x + 3, y: center.y))
+                cross.move(to: CGPoint(x: center.x, y: center.y - 3))
+                cross.addLine(to: CGPoint(x: center.x, y: center.y + 3))
+                context.stroke(cross, with: .color(.secondary.opacity(0.45)), lineWidth: 1)
+
+                // Arrow to the learned point.
+                let end = CGPoint(x: center.x + offset.dx * cellW, y: center.y + offset.dy * cellH)
+                var line = Path()
+                line.move(to: center)
+                line.addLine(to: end)
+                context.stroke(line, with: .color(.red.opacity(opacity)), lineWidth: 2)
+                context.fill(
+                    Path(ellipseIn: CGRect(x: end.x - 3, y: end.y - 3, width: 6, height: 6)),
+                    with: .color(.red.opacity(opacity))
+                )
+            }
+        }
+        .accessibilityLabel("Learned touch-offset map")
+    }
+}

--- a/wurstfinger/TouchOffsetSettingsView.swift
+++ b/wurstfinger/TouchOffsetSettingsView.swift
@@ -3,8 +3,9 @@
 //  wurstfinger
 //
 //  Settings subpage for the learned touch-offset correction (spec §6):
-//  the master toggle, a visualization of the learned per-key offsets read from
-//  the persisted snapshot, a regime selector, and reset controls. All data is
+//  the master toggle, an explicit hand-posture choice that selects the active
+//  learning regime (§6.3), a visualization of the learned per-key offsets read
+//  from the persisted snapshot, diagnostics, and reset controls. All data is
 //  local; the visualization shows the last persisted snapshot (§5.1).
 //
 
@@ -15,7 +16,10 @@ struct TouchOffsetSettingsView: View {
     @AppStorage(SettingsKey.touchOffsetEnabled.rawValue, store: SharedDefaults.store)
     private var enabled = false
 
-    @State private var posture: PostureClass = .twoThumb
+    /// The user's explicit hand posture — a real decision that selects the
+    /// active learning regime, not just a view filter (§3.1/§6.3).
+    @AppStorage(SettingsKey.touchOffsetPosture.rawValue, store: SharedDefaults.store)
+    private var posture: PostureClass = .oneThumbRight
     @State private var snapshot: TouchOffsetSnapshot = .empty(schemaVersion: TouchOffsetStore.currentSchemaVersion)
     @State private var telemetry: TelemetrySnapshot = .empty(schemaVersion: GestureTelemetryStore.currentSchemaVersion)
     @State private var showResetDialog = false
@@ -47,13 +51,22 @@ struct TouchOffsetSettingsView: View {
             }
 
             Section {
-                Picker("Hand posture", selection: $posture) {
+                Picker("How do you type?", selection: $posture) {
+                    Text("One hand — right thumb").tag(PostureClass.oneThumbRight)
+                    Text("One hand — left thumb").tag(PostureClass.oneThumbLeft)
                     Text("Two thumbs").tag(PostureClass.twoThumb)
-                    Text("Left hand").tag(PostureClass.oneThumbLeft)
-                    Text("Right hand").tag(PostureClass.oneThumbRight)
                 }
-                .pickerStyle(.segmented)
+                .pickerStyle(.inline)
+            } header: {
+                Text("How do you type?")
+            } footer: {
+                Text("Pick the way you actually hold the phone. Wurstfinger keeps a "
+                    + "**separate** profile per posture, because a thumb reaching across "
+                    + "the keyboard lands differently than two thumbs. A wrong choice can "
+                    + "nudge keys the wrong way, so this isn't auto-detected.")
+            }
 
+            Section {
                 OffsetMapView(arrangement: arrangement, offsets: appliedOffsets, sampleCount: sampleCount)
                     .frame(height: 230)
                     .padding(.vertical, 4)
@@ -63,7 +76,7 @@ struct TouchOffsetSettingsView: View {
                 Text(totalSamples > 0
                     ? "\(totalSamples) taps learned for this posture. The red arrow shows how far "
                     + "each key's target has moved; fainter means less data."
-                    : "No data yet for this posture — type with the keyboard to teach it.")
+                    : "No data yet for this posture — type this way and the keyboard learns it.")
             }
 
             Section {

--- a/wurstfinger/TouchOffsetSettingsView.swift
+++ b/wurstfinger/TouchOffsetSettingsView.swift
@@ -45,9 +45,14 @@ struct TouchOffsetSettingsView: View {
             Section {
                 Toggle("Correct my typing", isOn: $enabled)
             } footer: {
-                Text("Learns where you tend to tap each key and quietly adjusts the "
-                    + "touch targets to match. Everything is learned **on this device** "
-                    + "and never leaves it.")
+                // One literal, never a `+` concatenation: only a literal binds to `Text`'s
+                // `LocalizedStringKey` overload, so a concatenated footer would be
+                // untranslatable and would render its markdown as raw asterisks.
+                // swiftlint:disable line_length
+                Text(
+                    "Learns where you tend to tap each key and quietly adjusts the touch targets to match. Everything is learned **on this device** and never leaves it."
+                )
+                // swiftlint:enable line_length
             }
 
             Section {
@@ -57,9 +62,11 @@ struct TouchOffsetSettingsView: View {
                     Text("Two thumbs").tag(PostureClass.twoThumb)
                 }
             } footer: {
-                Text("Wurstfinger keeps a **separate** profile per posture, because a thumb "
-                    + "reaching across the keyboard lands differently than two thumbs. A wrong "
-                    + "choice can nudge keys the wrong way, so this isn't auto-detected.")
+                // swiftlint:disable line_length
+                Text(
+                    "Wurstfinger keeps a **separate** profile per posture, because a thumb reaching across the keyboard lands differently than two thumbs. A wrong choice can nudge keys the wrong way, so this isn't auto-detected."
+                )
+                // swiftlint:enable line_length
             }
 
             Section {
@@ -69,10 +76,17 @@ struct TouchOffsetSettingsView: View {
             } header: {
                 Text("Learned adjustments")
             } footer: {
-                Text(totalSamples > 0
-                    ? "\(totalSamples) taps learned for this posture. The red arrow shows how far "
-                    + "each key's target has moved; fainter means less data."
-                    : "No data yet for this posture — type this way and the keyboard learns it.")
+                // Two `Text`s rather than one with a ternary: each branch stays a bare
+                // literal and therefore a `LocalizedStringKey`.
+                if totalSamples > 0 {
+                    // swiftlint:disable line_length
+                    Text(
+                        "\(totalSamples) taps learned for this posture. The red arrow shows how far each key's target has moved; fainter means less data."
+                    )
+                    // swiftlint:enable line_length
+                } else {
+                    Text("No data yet for this posture — type this way and the keyboard learns it.")
+                }
             }
 
             Section {
@@ -147,11 +161,11 @@ private struct TouchOffsetStatsView: View {
             } header: {
                 Text("Error rate")
             } footer: {
-                Text("Estimated backspace rate **with** the correction vs. what it would have "
-                    + "been **without** it — inferred per tap from whether correction changed a "
-                    + "key you then kept or deleted. Lower with correction means it's helping. "
-                    + "(\(counterfactual.taps) taps · \(counterfactual.caught) caught · "
-                    + "\(counterfactual.caused) caused)")
+                // swiftlint:disable line_length
+                Text(
+                    "Estimated backspace rate **with** the correction vs. what it would have been **without** it — inferred per tap from whether correction changed a key you then kept or deleted. Lower with correction means it's helping. (\(counterfactual.taps) taps · \(counterfactual.caught) caught · \(counterfactual.caused) caused)"
+                )
+                // swiftlint:enable line_length
             }
 
             if let classes = telemetry.classes[regimeKey], !classes.isEmpty {
@@ -168,8 +182,11 @@ private struct TouchOffsetStatsView: View {
                 } header: {
                     Text("Gesture correction rates")
                 } footer: {
-                    Text("How often each gesture class gets corrected (rate · sample count). "
-                        + "A high rate hints at a mis-tuned threshold for that gesture.")
+                    // swiftlint:disable line_length
+                    Text(
+                        "How often each gesture class gets corrected (rate · sample count). A high rate hints at a mis-tuned threshold for that gesture."
+                    )
+                    // swiftlint:enable line_length
                 }
             } else {
                 Section {

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -158,6 +158,18 @@ final class KeyboardViewModel: ObservableObject {
     private var userDefaultsObserver: NSObjectProtocol?
     private var settingsCancellables = Set<AnyCancellable>()
 
+    /// Learns and (P7) applies per-key touch-offset correction (spec §4.1, §5).
+    /// Inert unless the feature toggle is on. Lazy so its closures can capture
+    /// `self` after initialization.
+    lazy var touchLearning: TouchLearningController = .init(
+        store: TouchOffsetStore(defaults: sharedDefaults),
+        isEnabled: { [weak self] in self?.isTouchOffsetEnabled ?? false },
+        currentRegime: { [weak self] in
+            self?.currentTouchRegime ?? TouchRegime(orientation: .portrait, posture: .twoThumb)
+        },
+        keyPosition: { [weak self] in self?.normalizedKeyPosition($0) }
+    )
+
     init(
         userDefaults: UserDefaults? = nil,
         shouldPersistSettings: Bool = true

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -170,6 +170,16 @@ final class KeyboardViewModel: ObservableObject {
         keyPosition: { [weak self] in self?.normalizedKeyPosition($0) }
     )
 
+    /// Collects gesture telemetry (§13) and the A/B proxy metric (§8). Lazy so
+    /// its closures can capture `self`.
+    lazy var telemetry: TelemetryController = .init(
+        store: GestureTelemetryStore(defaults: sharedDefaults),
+        isFeatureEnabled: { [weak self] in self?.isTouchOffsetEnabled ?? false },
+        currentRegime: { [weak self] in
+            self?.currentTouchRegime ?? TouchRegime(orientation: .portrait, posture: .twoThumb)
+        }
+    )
+
     init(
         userDefaults: UserDefaults? = nil,
         shouldPersistSettings: Bool = true

--- a/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
@@ -15,6 +15,13 @@ import SwiftUI
 struct GestureClassification {
     let gesture: GestureType
     let isReturn: Bool
+    /// Touchdown location normalized to the key's frame (`[0,1]²`, 0.5 = center).
+    /// Feeds offset learning (`e = touchdown − center`, §4.1). Defaults to center
+    /// (used by callers that don't supply a real touchdown, e.g. tests).
+    var touchdown: CGPoint = .init(x: 0.5, y: 0.5)
+    /// Discriminating gesture features for telemetry (§13); `nil` when the
+    /// classification was built from synthetic features without plumbing.
+    var features: GestureFeatures?
 }
 
 /// Touch-sequence state backing `KeyGestureRecognizer`.
@@ -109,6 +116,12 @@ struct KeyGestureRecognizer: ViewModifier {
     @State private var longPress: LongPressScheduler
     /// Identifies this key's touch sequence to the shared trail recorder.
     @StateObject private var trailToken = GestureTrailToken()
+    /// The key's rendered cell, measured in the same coordinate space the drag
+    /// gesture reports its locations in. Used to normalize the touchdown to
+    /// `[0,1]²`; the gesture runs in the shared trail space (the trail needs
+    /// grid-wide points), so a cell-local `startLocation` is not available and
+    /// the cell's own frame in that space supplies the origin and the size.
+    @State private var cellFrame: CGRect = .zero
     @Binding var isActive: Bool
 
     /// True while a touch sequence is in flight. Unlike `@State`, SwiftUI
@@ -145,6 +158,14 @@ struct KeyGestureRecognizer: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+            .background(
+                GeometryReader { proxy in
+                    let frame = proxy.frame(in: GestureTrailRecorder.coordinateSpace)
+                    Color.clear
+                        .onAppear { cellFrame = frame }
+                        .onChange(of: frame) { _, newFrame in cellFrame = newFrame }
+                }
+            )
             .gesture(
                 // The coordinate space affects only `value.location`, which the
                 // trail records. `value.translation` is a delta, so the
@@ -188,10 +209,15 @@ struct KeyGestureRecognizer: ViewModifier {
                             isActive = false
                             return
                         }
-                        let classification = sequence.handleEnded(
+                        var classification = sequence.handleEnded(
                             translation: value.translation,
                             aspectRatio: aspectRatio
                         )
+                        // The touchdown arrives in the shared gesture space
+                        // (see the coordinate space above); normalize it against
+                        // this cell so the learner can compute `e = touchdown −
+                        // center` in pitch fractions (§4.1, §5.5).
+                        classification.touchdown = Self.normalizedTouchdown(value.startLocation, inCell: cellFrame)
                         trail?.finish(from: trailToken)
                         isActive = false
                         onGestureRecognized(classification)
@@ -266,6 +292,27 @@ struct KeyGestureRecognizer: ViewModifier {
         }
     }
 
+    /// Normalizes a cell-local point to `[0,1]²` (0.5 = cell center). Falls back
+    /// to the center if the size is not yet known.
+    static func normalizedTouchdown(_ point: CGPoint, in size: CGSize) -> CGPoint {
+        guard size.width > 0, size.height > 0 else { return CGPoint(x: 0.5, y: 0.5) }
+        return CGPoint(
+            x: min(max(point.x / size.width, 0), 1),
+            y: min(max(point.y / size.height, 0), 1)
+        )
+    }
+
+    /// Normalizes a point reported in the shared gesture coordinate space to
+    /// `[0,1]²` inside `cell`, the key's frame measured in that same space.
+    /// A distinct argument label rather than an overload, so the cell-local
+    /// form above stays unambiguous at its call sites.
+    static func normalizedTouchdown(_ point: CGPoint, inCell cell: CGRect) -> CGPoint {
+        normalizedTouchdown(
+            CGPoint(x: point.x - cell.minX, y: point.y - cell.minY),
+            in: cell.size
+        )
+    }
+
     /// Guarantees the touch-down origin `(0,0)` is the first sample.
     ///
     /// Every recorded point is a translation relative to touch-down, so the
@@ -310,7 +357,9 @@ struct KeyGestureRecognizer: ViewModifier {
         let processed = preprocessor.preprocess(positions)
         let features = GestureFeatures.extract(from: processed, thresholds: thresholds)
 
-        return classify(features: features)
+        var classification = classify(features: features)
+        classification.features = features
+        return classification
     }
 
     /// Classifies already-extracted features. Useful for testing with

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -312,9 +312,26 @@ extension KeyboardViewModel {
     /// The long-press path uses this to decide whether the touch is consumed:
     /// a key without a long-press binding (e.g. return, globe) must keep its
     /// normal tap on release instead of being swallowed by the failed hold.
+    ///
+    /// - Parameters:
+    ///   - touchdown: the touchdown normalized to the key's frame (`[0,1]²`),
+    ///     plumbed for offset learning (§4.1). `nil` from callers that don't
+    ///     supply it (tests, internal slide-driven taps). Consumed in P5.
+    ///   - features: discriminating gesture features for telemetry (§13).
     @discardableResult
-    func handleGesture(_ gesture: GestureType, keyId: String, isReturn: Bool) -> Bool {
+    func handleGesture(
+        _ gesture: GestureType,
+        keyId: String,
+        isReturn: Bool,
+        touchdown: CGPoint? = nil,
+        features: GestureFeatures? = nil
+    ) -> Bool {
         guard let mode = activeModeFromDefinition else { return false }
+
+        // P5: forward (keyId, gesture, isReturn, touchdown, features) to the
+        // touch-learning middleware here once it exists. For now the data is
+        // plumbed end-to-end but not yet consumed.
+        _ = (touchdown, features)
 
         // Circular gestures: try requested direction, fall back to opposite.
         if gesture == .circularClockwise || gesture == .circularCounterclockwise {

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -244,6 +244,12 @@ extension KeyboardViewModel {
             }
         ))
 
+        // Touch-offset learning: observe user `.deleteBackward` for the
+        // acceptance-filter veto (§4.1). Inert unless the feature is on.
+        middlewares.append(TouchLearningMiddleware(onUserDelete: { [weak self] in
+            self?.touchLearning.recordUserDelete()
+        }))
+
         pipeline = ActionPipeline(middlewares: middlewares)
     }
 
@@ -304,6 +310,44 @@ extension KeyboardViewModel {
         switchToMode(ModeNames.main)
     }
 
+    // MARK: - Touch-Offset Learning Context
+
+    /// Whether the learned touch-offset correction is enabled (§6.1).
+    var isTouchOffsetEnabled: Bool {
+        sharedDefaults.bool(forKey: SettingsKey.touchOffsetEnabled.rawValue)
+    }
+
+    /// The active learning regime: orientation × derived posture (§3.1).
+    ///
+    /// On this branch the keyboard renders a portrait arrangement in all
+    /// orientations and the view model does not expose the physical orientation,
+    /// so orientation is fixed to `.portrait` for v1. Add the orientation axis
+    /// once the controller plumbs physical orientation through.
+    var currentTouchRegime: TouchRegime {
+        let scale = sharedDefaults.object(forKey: SettingsKey.keyboardScale.rawValue) as? Double
+            ?? DeviceLayoutUtils.defaultKeyboardScale
+        let position = sharedDefaults.object(forKey: SettingsKey.keyboardHorizontalPosition.rawValue) as? Double
+            ?? DeviceLayoutUtils.defaultKeyboardPosition
+        return TouchRegime(
+            orientation: .portrait,
+            posture: PostureResolver.derivePosture(scale: scale, position: position)
+        )
+    }
+
+    /// Normalized center position of a key in the current arrangement (`[0,1]²`),
+    /// used as the reach-surface input (§5.2). `nil` if the key is not placed.
+    func normalizedKeyPosition(_ keyId: String) -> CGPoint? {
+        guard let arrangement = currentArrangement else { return nil }
+        let cells = GridLayoutSolver.solve(arrangement)
+        guard let cell = cells.first(where: { $0.keyId == keyId }) else { return nil }
+        let columns = max(arrangement.columns, 1)
+        let rows = max(GridLayoutSolver.rowCount(arrangement), 1)
+        return CGPoint(
+            x: (Double(cell.column) + Double(cell.columnSpan) / 2) / Double(columns),
+            y: (Double(cell.row) + Double(cell.rowSpan) / 2) / Double(rows)
+        )
+    }
+
     // MARK: - Gesture Dispatch
 
     /// Central entry point for the data-driven gesture path.
@@ -328,11 +372,6 @@ extension KeyboardViewModel {
     ) -> Bool {
         guard let mode = activeModeFromDefinition else { return false }
 
-        // P5: forward (keyId, gesture, isReturn, touchdown, features) to the
-        // touch-learning middleware here once it exists. For now the data is
-        // plumbed end-to-end but not yet consumed.
-        _ = (touchdown, features)
-
         // Circular gestures: try requested direction, fall back to opposite.
         if gesture == .circularClockwise || gesture == .circularCounterclockwise {
             handleCircular(keyId: keyId, in: mode, gesture: gesture)
@@ -341,6 +380,14 @@ extension KeyboardViewModel {
 
         let chain = isReturn ? returnSwipeResolverChain : resolverChain
         guard let binding = chain?.resolve(keyId: keyId, gesture: gesture, in: mode) else { return false }
+
+        // Touch-offset learning (§4.1): record real taps (with a touchdown) for
+        // the acceptance filter. Swipes/returns are excluded; user deletes are
+        // observed by TouchLearningMiddleware. Inert unless the feature is on.
+        if gesture == .tap, !isReturn, let touchdown {
+            touchLearning.recordTap(keyId: keyId, touchdown: touchdown)
+        }
+        _ = features // P6: feed gesture telemetry here.
 
         // Mode and language switches bypass the pipeline, so their
         // confirmation tick fires here instead of in the haptic middleware —

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -401,6 +401,15 @@ extension KeyboardViewModel {
         // observed by TouchLearningMiddleware. Inert unless the feature is on.
         if gesture == .tap, !isReturn, let touchdown {
             touchLearning.recordTap(keyId: keyId, touchdown: touchdown)
+            // Counterfactual benefit (§8): did the applied correction change which
+            // key this tap hit? Uses the same offset that drove the assignment.
+            if isTouchOffsetEnabled {
+                let offset = currentTouchCorrectionOffsets()[keyId] ?? .zero
+                telemetry.recordTapOutcome(
+                    regimeKey: currentTouchRegime.key,
+                    isFlip: TelemetryController.isFlip(touchdown: touchdown, offset: offset)
+                )
+            }
         }
 
         // Mode and language switches bypass the pipeline, so their

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -320,21 +320,19 @@ extension KeyboardViewModel {
         sharedDefaults.bool(forKey: SettingsKey.touchOffsetEnabled.rawValue)
     }
 
-    /// The active learning regime: orientation × derived posture (§3.1).
+    /// The active learning regime: orientation × the user's declared posture
+    /// (§3.1/§6.3). Posture is read fresh from `SharedDefaults` so a change in
+    /// the host app takes effect on the next gesture without a keyboard restart.
     ///
     /// On this branch the keyboard renders a portrait arrangement in all
     /// orientations and the view model does not expose the physical orientation,
     /// so orientation is fixed to `.portrait` for v1. Add the orientation axis
     /// once the controller plumbs physical orientation through.
     var currentTouchRegime: TouchRegime {
-        let scale = sharedDefaults.object(forKey: SettingsKey.keyboardScale.rawValue) as? Double
-            ?? DeviceLayoutUtils.defaultKeyboardScale
-        let position = sharedDefaults.object(forKey: SettingsKey.keyboardHorizontalPosition.rawValue) as? Double
-            ?? DeviceLayoutUtils.defaultKeyboardPosition
-        return TouchRegime(
-            orientation: .portrait,
-            posture: PostureResolver.derivePosture(scale: scale, position: position)
+        let posture = PostureClass(
+            settingValue: sharedDefaults.string(forKey: SettingsKey.touchOffsetPosture.rawValue)
         )
+        return TouchRegime(orientation: .portrait, posture: posture)
     }
 
     /// The per-key offsets to apply right now (§4.4, §5.4): the learned model's

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -245,9 +245,12 @@ extension KeyboardViewModel {
         ))
 
         // Touch-offset learning: observe user `.deleteBackward` for the
-        // acceptance-filter veto (§4.1). Inert unless the feature is on.
+        // acceptance-filter veto (§4.1) and the telemetry/A/B correction
+        // counters (§13/§8). Inert unless the feature is on (telemetry A/B
+        // counts always).
         middlewares.append(TouchLearningMiddleware(onUserDelete: { [weak self] in
             self?.touchLearning.recordUserDelete()
+            self?.telemetry.recordUserDelete()
         }))
 
         pipeline = ActionPipeline(middlewares: middlewares)
@@ -382,6 +385,10 @@ extension KeyboardViewModel {
     ) -> Bool {
         guard let mode = activeModeFromDefinition else { return false }
 
+        // Telemetry (§13) + A/B proxy metric (§8): record every classified
+        // gesture (all classes, incl. circular below).
+        telemetry.recordGesture(gesture, isReturn: isReturn, features: features)
+
         // Circular gestures: try requested direction, fall back to opposite.
         if gesture == .circularClockwise || gesture == .circularCounterclockwise {
             handleCircular(keyId: keyId, in: mode, gesture: gesture)
@@ -397,7 +404,6 @@ extension KeyboardViewModel {
         if gesture == .tap, !isReturn, let touchdown {
             touchLearning.recordTap(keyId: keyId, touchdown: touchdown)
         }
-        _ = features // P6: feed gesture telemetry here.
 
         // Mode and language switches bypass the pipeline, so their
         // confirmation tick fires here instead of in the haptic middleware —

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -334,6 +334,16 @@ extension KeyboardViewModel {
         )
     }
 
+    /// The per-key offsets to apply right now (§4.4, §5.4): the learned model's
+    /// offsets for the current regime, gated by the toggle and the regime's
+    /// maturity. Empty when off or not yet mature → no correction.
+    func currentTouchCorrectionOffsets() -> [String: CGVector] {
+        guard isTouchOffsetEnabled else { return [:] }
+        let model = touchLearning.model(for: currentTouchRegime)
+        guard model.maturity >= TouchOffsetConfig.default.applyOn else { return [:] }
+        return model.allOffsets()
+    }
+
     /// Normalized center position of a key in the current arrangement (`[0,1]²`),
     /// used as the reach-surface input (§5.2). `nil` if the key is not placed.
     func normalizedKeyPosition(_ keyId: String) -> CGPoint? {

--- a/wurstfingerKeyboard/Runtime/TouchModel/AcceptanceTracker.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/AcceptanceTracker.swift
@@ -1,0 +1,62 @@
+//
+//  AcceptanceTracker.swift
+//  Wurstfinger
+//
+//  Self-labeling acceptance filter (spec §4.1): holds recently committed taps
+//  in a small veto window. A user delete vetoes the most recent pending tap(s)
+//  (immediate + short-burst correction); taps that age out of the window are
+//  "accepted" and returned for learning. Only user deletes (the `.deleteBackward`
+//  KeyAction in the pipeline) reach this — compose/Telex internal deletes bypass
+//  the pipeline and are correctly ignored.
+//
+
+import CoreGraphics
+import Foundation
+
+/// A committed tap awaiting acceptance confirmation.
+struct PendingTap: Equatable {
+    let keyId: String
+    /// Touchdown normalized to the key frame (`[0,1]²`, 0.5 = center).
+    let touchdown: CGPoint
+    let regime: TouchRegime
+}
+
+/// Ring of pending taps with a veto window. Not thread-safe (main-thread use).
+final class AcceptanceTracker {
+    /// How many of the most recent taps remain vetoable. Older taps are
+    /// confirmed (returned for learning) on the next tap.
+    private let window: Int
+    private var pending: [PendingTap] = []
+
+    init(window: Int = 3) {
+        self.window = max(1, window)
+    }
+
+    /// Records a tap and returns any taps that just aged out of the veto window
+    /// (now accepted → learn them).
+    func recordTap(_ tap: PendingTap) -> [PendingTap] {
+        pending.append(tap)
+        guard pending.count > window else { return [] }
+        let overflow = pending.count - window
+        let confirmed = Array(pending.prefix(overflow))
+        pending.removeFirst(overflow)
+        return confirmed
+    }
+
+    /// A user delete: veto the most recent `count` pending taps (a burst deletes
+    /// several). They were corrected, so they are never learned.
+    func recordUserDelete(count: Int = 1) {
+        pending.removeLast(min(max(count, 0), pending.count))
+    }
+
+    /// Confirms and returns everything still pending (e.g. on teardown).
+    func flush() -> [PendingTap] {
+        defer { pending.removeAll() }
+        return pending
+    }
+
+    /// Number of taps currently awaiting confirmation (for tests/diagnostics).
+    var pendingCount: Int {
+        pending.count
+    }
+}

--- a/wurstfingerKeyboard/Runtime/TouchModel/GestureTelemetry.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/GestureTelemetry.swift
@@ -6,9 +6,11 @@
 //  - P6 (§13): per-(regime, gesture-class) running feature statistics + a
 //    correction counter, for the future adaptive gesture-parameter track. Only
 //    collected when the feature is enabled.
-//  - P9 (§8): an A/B proxy metric — gestures and corrections split by whether
-//    the correction feature was active, so the benefit can be measured before
-//    ever defaulting the feature on. Always collected (local counts only).
+//  - P9 (§8): a **counterfactual** benefit metric. For each tap where the
+//    applied correction changed which key was hit (a "flip"), whether the
+//    changed key was kept (a likely caught error) or deleted (a likely caused
+//    one). Self-populating while the feature is on — no A/B toggle dance — since
+//    the uncorrected outcome is recoverable from geometry (§8 counterfactual).
 //
 //  Only aggregates are stored — never raw trajectories (privacy, §7).
 //
@@ -50,13 +52,22 @@ struct ClassTelemetry: Codable, Equatable {
     }
 }
 
-/// A/B proxy metric for one condition (feature on / off).
-struct ABMetric: Codable, Equatable {
-    var total = 0
-    var corrections = 0
+/// Counterfactual benefit of the correction (§8): among taps where the applied
+/// correction changed which key was hit (a "flip"), how many the user kept
+/// (`caught` — a likely prevented error) vs deleted (`caused` — a likely
+/// introduced one). Self-labeled via the same acceptance window as learning
+/// (§4.1): not ground truth, but it isolates exactly the taps the correction
+/// actually touched, which the toggle-based A/B could not.
+struct CounterfactualMetric: Codable, Equatable {
+    var caught = 0
+    var caused = 0
 
-    var correctionRate: Double {
-        total > 0 ? Double(corrections) / Double(total) : 0
+    var net: Int {
+        caught - caused
+    }
+
+    var total: Int {
+        caught + caused
     }
 }
 
@@ -64,10 +75,8 @@ struct TelemetrySnapshot: Codable, Equatable {
     var schemaVersion: Int
     /// `regimeKey` → `classKey` → telemetry (P6, feature-gated).
     var classes: [String: [String: ClassTelemetry]] = [:]
-    /// P9: correction feature active.
-    var abEnabled = ABMetric()
-    /// P9: correction feature inactive (control).
-    var abDisabled = ABMetric()
+    /// P9: counterfactual correction benefit per `regimeKey`.
+    var counterfactual: [String: CounterfactualMetric] = [:]
 
     static func empty(schemaVersion: Int) -> TelemetrySnapshot {
         TelemetrySnapshot(schemaVersion: schemaVersion)
@@ -77,7 +86,7 @@ struct TelemetrySnapshot: Codable, Equatable {
 /// Persists the telemetry snapshot (App-Group `SharedDefaults`; tests inject a
 /// throwaway suite).
 final class GestureTelemetryStore {
-    static let currentSchemaVersion = 1
+    static let currentSchemaVersion = 2
     static let storageKey = "gestureTelemetry.snapshot"
 
     private let defaults: UserDefaults

--- a/wurstfingerKeyboard/Runtime/TouchModel/GestureTelemetry.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/GestureTelemetry.swift
@@ -52,22 +52,38 @@ struct ClassTelemetry: Codable, Equatable {
     }
 }
 
-/// Counterfactual benefit of the correction (§8): among taps where the applied
-/// correction changed which key was hit (a "flip"), how many the user kept
-/// (`caught` — a likely prevented error) vs deleted (`caused` — a likely
-/// introduced one). Self-labeled via the same acceptance window as learning
-/// (§4.1): not ground truth, but it isolates exactly the taps the correction
-/// actually touched, which the toggle-based A/B could not.
+/// Counterfactual benefit of the correction (§8). For every resolved tap we know
+/// the observed outcome (kept / deleted) and — when the correction changed which
+/// key was hit (a "flip") — what the uncorrected outcome would have been. From
+/// `caught` (flip kept → error the correction prevented) and `caused` (flip
+/// deleted → error it introduced) plus the raw tap/delete counts, both **error
+/// rates** follow: the observed one (correction on) and the counterfactual one
+/// (had no correction been applied). Self-labeled via the same acceptance window
+/// as learning (§4.1) — not ground truth, but it isolates exactly the taps the
+/// correction actually touched, which the toggle-based A/B could not.
 struct CounterfactualMetric: Codable, Equatable {
+    /// Total resolved taps (confirmed or vetoed) recorded with correction on.
+    var taps = 0
+    /// Taps the user deleted — the observed error signal with correction on.
+    var deletes = 0
+    /// Flip kept → an error the correction prevented (error only without it).
     var caught = 0
+    /// Flip deleted → an error the correction introduced (error only with it).
     var caused = 0
+
+    /// Observed backspace rate with the correction on.
+    var errorRateWith: Double {
+        taps > 0 ? Double(deletes) / Double(taps) : 0
+    }
+
+    /// Counterfactual backspace rate had no correction been applied: caught
+    /// flips would have been errors, caused flips would not (§8).
+    var errorRateWithout: Double {
+        taps > 0 ? Double(deletes + caught - caused) / Double(taps) : 0
+    }
 
     var net: Int {
         caught - caused
-    }
-
-    var total: Int {
-        caught + caused
     }
 }
 
@@ -86,7 +102,7 @@ struct TelemetrySnapshot: Codable, Equatable {
 /// Persists the telemetry snapshot (App-Group `SharedDefaults`; tests inject a
 /// throwaway suite).
 final class GestureTelemetryStore {
-    static let currentSchemaVersion = 2
+    static let currentSchemaVersion = 3
     static let storageKey = "gestureTelemetry.snapshot"
 
     private let defaults: UserDefaults

--- a/wurstfingerKeyboard/Runtime/TouchModel/GestureTelemetry.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/GestureTelemetry.swift
@@ -1,0 +1,110 @@
+//
+//  GestureTelemetry.swift
+//  Wurstfinger
+//
+//  Aggregates for two data-collection tracks, both fed from the gesture path:
+//  - P6 (§13): per-(regime, gesture-class) running feature statistics + a
+//    correction counter, for the future adaptive gesture-parameter track. Only
+//    collected when the feature is enabled.
+//  - P9 (§8): an A/B proxy metric — gestures and corrections split by whether
+//    the correction feature was active, so the benefit can be measured before
+//    ever defaulting the feature on. Always collected (local counts only).
+//
+//  Only aggregates are stored — never raw trajectories (privacy, §7).
+//
+
+import Foundation
+
+/// Online mean/variance (Welford) of one feature.
+struct FeatureStat: Codable, Equatable {
+    private(set) var count = 0
+    private(set) var mean = 0.0
+    private(set) var m2 = 0.0
+
+    mutating func add(_ value: Double) {
+        count += 1
+        let delta = value - mean
+        mean += delta / Double(count)
+        m2 += delta * (value - mean)
+    }
+
+    var variance: Double {
+        count > 1 ? m2 / Double(count - 1) : 0
+    }
+
+    var stdDev: Double {
+        variance.squareRoot()
+    }
+}
+
+/// Feature stats + correction count for one gesture class in one regime.
+struct ClassTelemetry: Codable, Equatable {
+    var features: [String: FeatureStat] = [:]
+    /// Total gestures of this class recorded.
+    var total = 0
+    /// How many were corrected (a user delete followed).
+    var corrections = 0
+
+    var correctionRate: Double {
+        total > 0 ? Double(corrections) / Double(total) : 0
+    }
+}
+
+/// A/B proxy metric for one condition (feature on / off).
+struct ABMetric: Codable, Equatable {
+    var total = 0
+    var corrections = 0
+
+    var correctionRate: Double {
+        total > 0 ? Double(corrections) / Double(total) : 0
+    }
+}
+
+struct TelemetrySnapshot: Codable, Equatable {
+    var schemaVersion: Int
+    /// `regimeKey` → `classKey` → telemetry (P6, feature-gated).
+    var classes: [String: [String: ClassTelemetry]] = [:]
+    /// P9: correction feature active.
+    var abEnabled = ABMetric()
+    /// P9: correction feature inactive (control).
+    var abDisabled = ABMetric()
+
+    static func empty(schemaVersion: Int) -> TelemetrySnapshot {
+        TelemetrySnapshot(schemaVersion: schemaVersion)
+    }
+}
+
+/// Persists the telemetry snapshot (App-Group `SharedDefaults`; tests inject a
+/// throwaway suite).
+final class GestureTelemetryStore {
+    static let currentSchemaVersion = 1
+    static let storageKey = "gestureTelemetry.snapshot"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    func load() -> TelemetrySnapshot {
+        guard
+            let data = defaults.data(forKey: Self.storageKey),
+            let snapshot = try? JSONDecoder().decode(TelemetrySnapshot.self, from: data),
+            snapshot.schemaVersion == Self.currentSchemaVersion
+        else {
+            return .empty(schemaVersion: Self.currentSchemaVersion)
+        }
+        return snapshot
+    }
+
+    func save(_ snapshot: TelemetrySnapshot) {
+        var stamped = snapshot
+        stamped.schemaVersion = Self.currentSchemaVersion
+        guard let data = try? JSONEncoder().encode(stamped) else { return }
+        defaults.set(data, forKey: Self.storageKey)
+    }
+
+    func reset() {
+        defaults.removeObject(forKey: Self.storageKey)
+    }
+}

--- a/wurstfingerKeyboard/Runtime/TouchModel/ReachSurface.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/ReachSurface.swift
@@ -1,0 +1,117 @@
+//
+//  ReachSurface.swift
+//  Wurstfinger
+//
+//  Low-order reach-bias surface fitted from per-key offset means by weighted
+//  ridge least squares (spec §3.2, §4.2 Step 2). Ridge keeps the fit
+//  well-defined when fewer keys than basis dimensions carry data
+//  (rank-deficient → shrinks toward 0): cold-start + split-half safety.
+//
+
+import Foundation
+
+/// Polynomial basis over the normalized key position `(u, v) ∈ [0,1]²`.
+enum SurfaceBasis: String, Codable {
+    /// `[1, u, v]` — used for the data-starved twoThumb split halves (§3.2).
+    case linear
+    /// `[1, u, v, u·v]` — used for the single-surface one-thumb regimes.
+    case bilinear
+
+    var dimension: Int {
+        self == .linear ? 3 : 4
+    }
+
+    func features(u: Double, v: Double) -> [Double] {
+        switch self {
+        case .linear: [1, u, v]
+        case .bilinear: [1, u, v, u * v]
+        }
+    }
+}
+
+/// A fitted scalar reach surface (predicts one axis of the offset prior).
+struct ReachSurface: Codable, Equatable {
+    let basis: SurfaceBasis
+    let coefficients: [Double]
+
+    static func zero(basis: SurfaceBasis) -> ReachSurface {
+        ReachSurface(basis: basis, coefficients: Array(repeating: 0, count: basis.dimension))
+    }
+
+    func evaluate(u: Double, v: Double) -> Double {
+        let phi = basis.features(u: u, v: v)
+        return zip(phi, coefficients).reduce(0) { $0 + $1.0 * $1.1 }
+    }
+
+    /// Constant term — the "global" offset folded into the surface (§3.3).
+    var constant: Double {
+        coefficients.first ?? 0
+    }
+}
+
+/// A weighted observation for the surface fit: per-key mean at its position.
+struct SurfacePoint {
+    let u: Double
+    let v: Double
+    let target: Double
+    let weight: Double
+}
+
+enum ReachSurfaceFitter {
+    /// Ridge-regularized weighted least squares: solves
+    /// `(ΦᵀWΦ + λI) β = ΦᵀW y`. With zero/sparse data the ridge term makes the
+    /// system well-posed and pulls `β → 0` (flat surface).
+    static func fit(points: [SurfacePoint], basis: SurfaceBasis, lambda: Double) -> ReachSurface {
+        let k = basis.dimension
+        var ata = [[Double]](repeating: [Double](repeating: 0, count: k), count: k)
+        var atb = [Double](repeating: 0, count: k)
+        for p in points where p.weight > 0 {
+            let phi = basis.features(u: p.u, v: p.v)
+            for i in 0 ..< k {
+                atb[i] += p.weight * phi[i] * p.target
+                for j in 0 ..< k {
+                    ata[i][j] += p.weight * phi[i] * phi[j]
+                }
+            }
+        }
+        for i in 0 ..< k {
+            ata[i][i] += lambda
+        }
+        let coeffs = Self.solve(ata, atb) ?? Array(repeating: 0, count: k)
+        return ReachSurface(basis: basis, coefficients: coeffs)
+    }
+
+    /// Gaussian elimination with partial pivoting for a small system `A x = b`.
+    /// Returns `nil` if `A` is (numerically) singular — caller falls back to 0.
+    static func solve(_ matrix: [[Double]], _ rhs: [Double]) -> [Double]? {
+        let n = rhs.count
+        guard n > 0 else { return [] }
+        var a = matrix
+        var b = rhs
+        for col in 0 ..< n {
+            var pivot = col
+            for row in (col + 1) ..< n where abs(a[row][col]) > abs(a[pivot][col]) {
+                pivot = row
+            }
+            if abs(a[pivot][col]) < 1e-12 { return nil }
+            if pivot != col { a.swapAt(col, pivot); b.swapAt(col, pivot) }
+            for row in (col + 1) ..< n {
+                let factor = a[row][col] / a[col][col]
+                guard factor != 0 else { continue }
+                for c in col ..< n {
+                    a[row][c] -= factor * a[col][c]
+                }
+                b[row] -= factor * b[col]
+            }
+        }
+        var x = [Double](repeating: 0, count: n)
+        for row in stride(from: n - 1, through: 0, by: -1) {
+            var sum = b[row]
+            for c in (row + 1) ..< n {
+                sum -= a[row][c] * x[c]
+            }
+            x[row] = sum / a[row][row]
+        }
+        return x
+    }
+}

--- a/wurstfingerKeyboard/Runtime/TouchModel/RunningOffset.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/RunningOffset.swift
@@ -1,0 +1,54 @@
+//
+//  RunningOffset.swift
+//  Wurstfinger
+//
+//  Per-(regime, key, axis) bounded-influence running-mean estimator of the
+//  systematic touch offset (spec §4.2 Step 1). Unbiased running mean (no
+//  constant-decay shrinkage bias), with a Huber clip for outlier/water
+//  robustness and a capped count for plasticity.
+//
+
+import Foundation
+
+/// One axis (x or y) of a key's offset estimate, in key-pitch fractions.
+struct RunningOffset: Codable, Equatable {
+    /// Bounded-influence running mean of the offset (`m_k`).
+    private(set) var mean: Double
+    /// Effective sample count, capped at `nMax` (`n_k`).
+    private(set) var count: Int
+    /// Robust online spread, EW-MAD (`s_k`).
+    private(set) var spread: Double
+
+    init(spreadPrior: Double) {
+        mean = 0
+        count = 0
+        spread = spreadPrior
+    }
+
+    /// Folds one accepted, plausibility-gated sample into the estimate.
+    ///
+    /// - Returns: `true` if the sample was used, `false` if rejected by the
+    ///   variance outlier gate (only active after `warmup`).
+    @discardableResult
+    mutating func update(sample s: Double, config: TouchOffsetConfig) -> Bool {
+        // Variance outlier gate — only after enough samples for a stable spread.
+        if count >= config.warmup, abs(s - mean) > config.kGate * spread {
+            return false
+        }
+        // Huber clip: a single sample moves `mean` by at most c·spread/count.
+        let bound = config.huberC * spread
+        let delta = clamp(s - mean, -bound, bound)
+        count = min(count + 1, config.nMax)
+        mean += delta / Double(count)
+        // Robust spread (EW-MAD) on the post-update deviation.
+        spread += config.betaMad * (abs(s - mean) - spread)
+        return true
+    }
+
+    /// Resets to the cold-start state.
+    mutating func reset(spreadPrior: Double) {
+        mean = 0
+        count = 0
+        spread = spreadPrior
+    }
+}

--- a/wurstfingerKeyboard/Runtime/TouchModel/TelemetryController.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/TelemetryController.swift
@@ -2,38 +2,49 @@
 //  TelemetryController.swift
 //  Wurstfinger
 //
-//  Records gesture telemetry (§13) and the A/B proxy metric (§8) from the
-//  gesture path. Correction attribution uses the last recorded gesture: a user
-//  delete is charged to the most recent gesture's class (immediate correction
-//  dominates, §4.1). Feature stats are recorded per gesture while the feature is
-//  on (a diagnostic; the small fraction of corrected gestures is negligible and
-//  separately captured by the correction counters).
+//  Records gesture telemetry (§13) and the counterfactual benefit metric (§8)
+//  from the gesture path. Per-class correction attribution uses the last
+//  recorded gesture: a user delete is charged to the most recent gesture's class
+//  (immediate correction dominates, §4.1). The counterfactual metric mirrors the
+//  learning acceptance window (§4.1): a tap whose applied correction changed the
+//  key ("flip") is credited as `caught` when it ages out unvetoed, or `caused`
+//  when a user delete vetoes it. Feature stats + counterfactual are collected
+//  only while the feature is on.
 //
 
+import CoreGraphics
 import Foundation
 
 final class TelemetryController {
     private let store: GestureTelemetryStore
     private let saveEvery: Int
+    /// Acceptance veto window — must match the learning controller's so a tap is
+    /// labeled identically for learning and for the counterfactual metric (§4.1).
+    private let window: Int
 
     private(set) var snapshot: TelemetrySnapshot
 
-    /// Whether the correction feature is active — gates P6 stats and selects the
-    /// P9 A/B condition.
+    /// Whether the correction feature is active — gates P6 stats and the
+    /// counterfactual metric.
     var isFeatureEnabled: () -> Bool
     var currentRegime: () -> TouchRegime
 
     private var lastGesture: (regime: String, cls: String)?
+    /// Pending flipped/unflipped taps awaiting acceptance (mirrors the learning
+    /// controller's `AcceptanceTracker`, but only needs the flip flag + regime).
+    private var pendingTaps: [(regime: String, isFlip: Bool)] = []
     private var dirty = 0
 
     init(
         store: GestureTelemetryStore,
         saveEvery: Int = 20,
+        window: Int = 3,
         isFeatureEnabled: @escaping () -> Bool,
         currentRegime: @escaping () -> TouchRegime
     ) {
         self.store = store
         self.saveEvery = saveEvery
+        self.window = max(1, window)
         snapshot = store.load()
         self.isFeatureEnabled = isFeatureEnabled
         self.currentRegime = currentRegime
@@ -42,38 +53,50 @@ final class TelemetryController {
     // MARK: - Input events
 
     func recordGesture(_ gesture: GestureType, isReturn: Bool, features: GestureFeatures?) {
-        let enabled = isFeatureEnabled()
-        // P9: A/B total (always, both conditions).
-        if enabled { snapshot.abEnabled.total += 1 } else { snapshot.abDisabled.total += 1 }
-
         let regimeKey = currentRegime().key
         let cls = Self.classKey(gesture, isReturn: isReturn)
         lastGesture = (regimeKey, cls)
 
         // P6: per-class feature stats (only while the feature is on).
-        if enabled {
-            var classes = snapshot.classes[regimeKey] ?? [:]
-            var telemetry = classes[cls] ?? ClassTelemetry()
-            telemetry.total += 1
-            if let features {
-                for (name, value) in Self.featureValues(features) {
-                    var stat = telemetry.features[name] ?? FeatureStat()
-                    stat.add(value)
-                    telemetry.features[name] = stat
-                }
+        guard isFeatureEnabled() else { return }
+        var classes = snapshot.classes[regimeKey] ?? [:]
+        var telemetry = classes[cls] ?? ClassTelemetry()
+        telemetry.total += 1
+        if let features {
+            for (name, value) in Self.featureValues(features) {
+                var stat = telemetry.features[name] ?? FeatureStat()
+                stat.add(value)
+                telemetry.features[name] = stat
             }
-            classes[cls] = telemetry
-            snapshot.classes[regimeKey] = classes
         }
+        classes[cls] = telemetry
+        snapshot.classes[regimeKey] = classes
         markDirty()
     }
 
+    /// Records a tap's counterfactual outcome (§8): `isFlip` = the applied
+    /// correction changed which key was hit. Taps aging out of the veto window
+    /// unvetoed are credited as `caught` (a kept flip = likely prevented error).
+    func recordTapOutcome(regimeKey: String, isFlip: Bool) {
+        pendingTaps.append((regimeKey, isFlip))
+        guard pendingTaps.count > window else { return }
+        let overflow = pendingTaps.count - window
+        let confirmed = pendingTaps.prefix(overflow)
+        pendingTaps.removeFirst(overflow)
+        for tap in confirmed where tap.isFlip {
+            snapshot.counterfactual[tap.regime, default: CounterfactualMetric()].caught += 1
+            markDirty()
+        }
+    }
+
     func recordUserDelete() {
-        let enabled = isFeatureEnabled()
-        // P9: A/B corrections.
-        if enabled { snapshot.abEnabled.corrections += 1 } else { snapshot.abDisabled.corrections += 1 }
+        // Counterfactual: veto the most recent pending tap. A vetoed flip means
+        // the correction changed the key to one the user rejected → caused (§8).
+        if let vetoed = pendingTaps.popLast(), vetoed.isFlip {
+            snapshot.counterfactual[vetoed.regime, default: CounterfactualMetric()].caused += 1
+        }
         // P6: charge the correction to the last gesture's class.
-        if enabled, let last = lastGesture {
+        if isFeatureEnabled(), let last = lastGesture {
             snapshot.classes[last.regime]?[last.cls]?.corrections += 1
         }
         markDirty()
@@ -88,12 +111,28 @@ final class TelemetryController {
         snapshot = .empty(schemaVersion: GestureTelemetryStore.currentSchemaVersion)
         store.reset()
         lastGesture = nil
+        pendingTaps.removeAll()
         dirty = 0
     }
 
     private func markDirty() {
         dirty += 1
         if dirty >= saveEvery { persist() }
+    }
+
+    // MARK: - Counterfactual geometry
+
+    /// Whether the applied correction changed which key a tap landed on. The
+    /// touch cell was shifted by `offset` (pitch fractions) and `touchdown` is
+    /// normalized within that **shifted** cell, so the uncorrected position is
+    /// `touchdown + offset`; if it leaves `[0,1]` on either axis an unshifted
+    /// neighbor would have owned the tap (§8). Smooth-field approximation: uses
+    /// the key's own offset for both cell edges (exact when neighbors share the
+    /// offset — the dominant reach component; slightly off at discontinuities).
+    static func isFlip(touchdown: CGPoint, offset: CGVector) -> Bool {
+        let px = Double(touchdown.x) + Double(offset.dx)
+        let py = Double(touchdown.y) + Double(offset.dy)
+        return px < 0 || px > 1 || py < 0 || py > 1
     }
 
     // MARK: - Mapping

--- a/wurstfingerKeyboard/Runtime/TouchModel/TelemetryController.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/TelemetryController.swift
@@ -76,24 +76,33 @@ final class TelemetryController {
 
     /// Records a tap's counterfactual outcome (§8): `isFlip` = the applied
     /// correction changed which key was hit. Taps aging out of the veto window
-    /// unvetoed are credited as `caught` (a kept flip = likely prevented error).
+    /// unvetoed resolve as *kept*: they add to `taps`, and a kept flip adds to
+    /// `caught` (a likely prevented error).
     func recordTapOutcome(regimeKey: String, isFlip: Bool) {
         pendingTaps.append((regimeKey, isFlip))
         guard pendingTaps.count > window else { return }
         let overflow = pendingTaps.count - window
         let confirmed = pendingTaps.prefix(overflow)
         pendingTaps.removeFirst(overflow)
-        for tap in confirmed where tap.isFlip {
-            snapshot.counterfactual[tap.regime, default: CounterfactualMetric()].caught += 1
-            markDirty()
+        for tap in confirmed {
+            var metric = snapshot.counterfactual[tap.regime] ?? CounterfactualMetric()
+            metric.taps += 1
+            if tap.isFlip { metric.caught += 1 }
+            snapshot.counterfactual[tap.regime] = metric
         }
+        if !confirmed.isEmpty { markDirty() }
     }
 
     func recordUserDelete() {
-        // Counterfactual: veto the most recent pending tap. A vetoed flip means
-        // the correction changed the key to one the user rejected → caused (§8).
-        if let vetoed = pendingTaps.popLast(), vetoed.isFlip {
-            snapshot.counterfactual[vetoed.regime, default: CounterfactualMetric()].caused += 1
+        // Counterfactual: veto the most recent pending tap — it resolves as
+        // *deleted* (an observed error). A vetoed flip means the correction
+        // changed the key to one the user rejected → caused (§8).
+        if let vetoed = pendingTaps.popLast() {
+            var metric = snapshot.counterfactual[vetoed.regime] ?? CounterfactualMetric()
+            metric.taps += 1
+            metric.deletes += 1
+            if vetoed.isFlip { metric.caused += 1 }
+            snapshot.counterfactual[vetoed.regime] = metric
         }
         // P6: charge the correction to the last gesture's class.
         if isFeatureEnabled(), let last = lastGesture {

--- a/wurstfingerKeyboard/Runtime/TouchModel/TelemetryController.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/TelemetryController.swift
@@ -1,0 +1,126 @@
+//
+//  TelemetryController.swift
+//  Wurstfinger
+//
+//  Records gesture telemetry (§13) and the A/B proxy metric (§8) from the
+//  gesture path. Correction attribution uses the last recorded gesture: a user
+//  delete is charged to the most recent gesture's class (immediate correction
+//  dominates, §4.1). Feature stats are recorded per gesture while the feature is
+//  on (a diagnostic; the small fraction of corrected gestures is negligible and
+//  separately captured by the correction counters).
+//
+
+import Foundation
+
+final class TelemetryController {
+    private let store: GestureTelemetryStore
+    private let saveEvery: Int
+
+    private(set) var snapshot: TelemetrySnapshot
+
+    /// Whether the correction feature is active — gates P6 stats and selects the
+    /// P9 A/B condition.
+    var isFeatureEnabled: () -> Bool
+    var currentRegime: () -> TouchRegime
+
+    private var lastGesture: (regime: String, cls: String)?
+    private var dirty = 0
+
+    init(
+        store: GestureTelemetryStore,
+        saveEvery: Int = 20,
+        isFeatureEnabled: @escaping () -> Bool,
+        currentRegime: @escaping () -> TouchRegime
+    ) {
+        self.store = store
+        self.saveEvery = saveEvery
+        snapshot = store.load()
+        self.isFeatureEnabled = isFeatureEnabled
+        self.currentRegime = currentRegime
+    }
+
+    // MARK: - Input events
+
+    func recordGesture(_ gesture: GestureType, isReturn: Bool, features: GestureFeatures?) {
+        let enabled = isFeatureEnabled()
+        // P9: A/B total (always, both conditions).
+        if enabled { snapshot.abEnabled.total += 1 } else { snapshot.abDisabled.total += 1 }
+
+        let regimeKey = currentRegime().key
+        let cls = Self.classKey(gesture, isReturn: isReturn)
+        lastGesture = (regimeKey, cls)
+
+        // P6: per-class feature stats (only while the feature is on).
+        if enabled {
+            var classes = snapshot.classes[regimeKey] ?? [:]
+            var telemetry = classes[cls] ?? ClassTelemetry()
+            telemetry.total += 1
+            if let features {
+                for (name, value) in Self.featureValues(features) {
+                    var stat = telemetry.features[name] ?? FeatureStat()
+                    stat.add(value)
+                    telemetry.features[name] = stat
+                }
+            }
+            classes[cls] = telemetry
+            snapshot.classes[regimeKey] = classes
+        }
+        markDirty()
+    }
+
+    func recordUserDelete() {
+        let enabled = isFeatureEnabled()
+        // P9: A/B corrections.
+        if enabled { snapshot.abEnabled.corrections += 1 } else { snapshot.abDisabled.corrections += 1 }
+        // P6: charge the correction to the last gesture's class.
+        if enabled, let last = lastGesture {
+            snapshot.classes[last.regime]?[last.cls]?.corrections += 1
+        }
+        markDirty()
+    }
+
+    func persist() {
+        store.save(snapshot)
+        dirty = 0
+    }
+
+    func reset() {
+        snapshot = .empty(schemaVersion: GestureTelemetryStore.currentSchemaVersion)
+        store.reset()
+        lastGesture = nil
+        dirty = 0
+    }
+
+    private func markDirty() {
+        dirty += 1
+        if dirty >= saveEvery { persist() }
+    }
+
+    // MARK: - Mapping
+
+    /// Collapses a `GestureType` (+ return flag) into the telemetry class key,
+    /// embedding the direction for swipes and circles (§13-C).
+    static func classKey(_ gesture: GestureType, isReturn: Bool) -> String {
+        if isReturn { return "return" }
+        switch gesture {
+        case .tap: return "tap"
+        case .circularClockwise: return "circle.cw"
+        case .circularCounterclockwise: return "circle.ccw"
+        default: return "swipe.\(gesture.rawValue)"
+        }
+    }
+
+    /// The discriminating features recorded per gesture, in the classifier's
+    /// native units so they stay comparable to the thresholds (§13-A).
+    static func featureValues(_ f: GestureFeatures) -> [String: Double] {
+        [
+            "maxDisplacement": Double(f.maxDisplacement),
+            "returnRatio": Double(f.returnRatio),
+            "circularity": Double(f.circularity),
+            "angularSpan": Double(abs(f.angularSpan)),
+            "turnConsistency": Double(f.turnConsistency),
+            "orientedCompactness": Double(f.orientedCompactness),
+            "dominantAngle": Double(f.dominantAngle),
+        ]
+    }
+}

--- a/wurstfingerKeyboard/Runtime/TouchModel/TouchLearningController.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/TouchLearningController.swift
@@ -1,0 +1,122 @@
+//
+//  TouchLearningController.swift
+//  Wurstfinger
+//
+//  Orchestrates touch-offset learning (spec §4.1, §5): records taps with their
+//  touchdown, applies the acceptance filter (veto on user delete) and the
+//  interior gate, computes the sample `e = touchdown − center` and folds it into
+//  the per-regime model, persisting periodically. Inert unless the feature is
+//  enabled. Regime, key position and enabled-state are injected so the
+//  controller is testable without a view model.
+//
+
+import CoreGraphics
+import Foundation
+
+final class TouchLearningController {
+    private let store: TouchOffsetStore
+    private let config: TouchOffsetConfig
+    private let tracker: AcceptanceTracker
+    private let saveEvery: Int
+
+    /// In-memory model state (persisted debounced). `private(set)` for tests.
+    private(set) var snapshot: TouchOffsetSnapshot
+
+    /// Master toggle (§6.1) — learning is inert when this returns `false`.
+    var isEnabled: () -> Bool
+    /// The active regime at the moment of a tap.
+    var currentRegime: () -> TouchRegime
+    /// Normalized key position in the keyboard `[0,1]²` (surface-fit input);
+    /// `nil` if unknown (then the tap is not learned).
+    var keyPosition: (String) -> CGPoint?
+
+    private var dirtyCount = 0
+
+    init(
+        store: TouchOffsetStore,
+        config: TouchOffsetConfig = .default,
+        window: Int = 3,
+        saveEvery: Int = 8,
+        isEnabled: @escaping () -> Bool,
+        currentRegime: @escaping () -> TouchRegime,
+        keyPosition: @escaping (String) -> CGPoint?
+    ) {
+        self.store = store
+        self.config = config
+        tracker = AcceptanceTracker(window: window)
+        self.saveEvery = saveEvery
+        snapshot = store.load()
+        self.isEnabled = isEnabled
+        self.currentRegime = currentRegime
+        self.keyPosition = keyPosition
+    }
+
+    // MARK: - Input events
+
+    /// Records an accepted-so-far tap (a non-slide tap with a touchdown).
+    func recordTap(keyId: String, touchdown: CGPoint) {
+        guard isEnabled() else { return }
+        let confirmed = tracker.recordTap(
+            PendingTap(keyId: keyId, touchdown: touchdown, regime: currentRegime())
+        )
+        confirmed.forEach(learn)
+    }
+
+    /// A user delete (`.deleteBackward` in the pipeline) — vetoes recent taps.
+    func recordUserDelete() {
+        guard isEnabled() else { return }
+        tracker.recordUserDelete()
+    }
+
+    // MARK: - Model access (for UI / P7 application)
+
+    func model(for regime: TouchRegime) -> TouchOffsetModel {
+        TouchOffsetModel(regime: regime, config: config, keys: snapshot.regimes[regime.key] ?? [:])
+    }
+
+    func resetAll() {
+        snapshot = .empty(schemaVersion: TouchOffsetStore.currentSchemaVersion)
+        store.resetAll()
+        dirtyCount = 0
+    }
+
+    func reset(regime: TouchRegime) {
+        snapshot.regimes[regime.key] = nil
+        store.reset(regimeKey: regime.key)
+    }
+
+    /// Forces a persist (call on background/teardown).
+    func persist() {
+        store.save(snapshot)
+        dirtyCount = 0
+    }
+
+    // MARK: - Learning
+
+    private func learn(_ tap: PendingTap) {
+        // Interior gate (§4.1): only learn from taps comfortably inside the key,
+        // measured against the *true* (unshifted) frame. Doubles as anti-drift.
+        let m = config.interiorMargin
+        guard tap.touchdown.x >= m, tap.touchdown.x <= 1 - m,
+              tap.touchdown.y >= m, tap.touchdown.y <= 1 - m,
+              let pos = keyPosition(tap.keyId)
+        else { return }
+
+        // e = touchdown − center, in pitch fractions (frame ≈ pitch).
+        let ex = Double(tap.touchdown.x) - 0.5
+        let ey = Double(tap.touchdown.y) - 0.5
+
+        var model = model(for: tap.regime)
+        model.learn(
+            keyId: tap.keyId,
+            posU: Double(pos.x),
+            posV: Double(pos.y),
+            sampleX: ex,
+            sampleY: ey
+        )
+        snapshot.regimes[tap.regime.key] = model.persistableKeys
+
+        dirtyCount += 1
+        if dirtyCount >= saveEvery { persist() }
+    }
+}

--- a/wurstfingerKeyboard/Runtime/TouchModel/TouchLearningMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/TouchLearningMiddleware.swift
@@ -1,0 +1,24 @@
+//
+//  TouchLearningMiddleware.swift
+//  Wurstfinger
+//
+//  Observes user `.deleteBackward` actions in the ActionPipeline to drive the
+//  acceptance filter's veto (spec §4.1). The pipeline is the single chokepoint
+//  for user-initiated deletes (tap/swipe-resolved and slide-delete both call
+//  `pipeline.process`); compose/Telex internal deletes call the text target
+//  directly and bypass this — exactly as required.
+//
+
+import Foundation
+
+struct TouchLearningMiddleware: ActionMiddleware {
+    /// Called when a user `.deleteBackward` passes through the pipeline.
+    let onUserDelete: () -> Void
+
+    func process(_ context: ActionContext, next: (ActionContext) -> Void) {
+        if case .deleteBackward = context.action {
+            onUserDelete()
+        }
+        next(context)
+    }
+}

--- a/wurstfingerKeyboard/Runtime/TouchModel/TouchOffsetConfig.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/TouchOffsetConfig.swift
@@ -1,0 +1,69 @@
+//
+//  TouchOffsetConfig.swift
+//  Wurstfinger
+//
+//  Hyperparameters for the touch-offset model (spec §4.2, §10). All spatial
+//  quantities are in **key-pitch fractions** (dx/width, dy/height). Defaults
+//  are the spec's starting values; final tuning happens on device (§10).
+//
+
+import Foundation
+
+struct TouchOffsetConfig: Equatable {
+    // MARK: Estimator (§4.2 Step 1)
+
+    /// Plasticity cap: above this the running mean behaves like an EMA with
+    /// α = 1/nMax (recency / self-healing), decoupled from shrinkage.
+    let nMax: Int
+    /// Huber clip factor (× spread): bounds a single sample's influence.
+    let huberC: Double
+    /// Outlier-gate threshold (× spread); rejects samples beyond it after warmup.
+    let kGate: Double
+    /// EW-MAD rate for the robust spread estimate.
+    let betaMad: Double
+    /// Samples before the variance-based outlier gate becomes active.
+    let warmup: Int
+    /// Initial robust spread (≈ FFitts σ_a ≈ 0.10 pitch).
+    let spreadPrior: Double
+
+    // MARK: Shrinkage & application (§4.2 Step 3, §4.3)
+
+    /// Shrinkage strength (prior pseudo-counts): a key needs ≈ κ samples to be
+    /// half-trusted vs. the reach-surface prior.
+    let kappa: Double
+    /// Max magnitude of the applied 2D correction vector, as a pitch fraction.
+    let clampFraction: Double
+    /// Ridge regularization for the reach-surface fit (§4.2 Step 2).
+    let lambdaRidge: Double
+
+    // MARK: Learning gate & application gate (used by P5/P7)
+
+    /// Interior margin (pitch fraction from the *true* key edge) required for a
+    /// tap to be used for learning — bias/variance knob & anti-drift (§4.1).
+    let interiorMargin: Double
+    /// Regime maturity (Σ n_k) at which correction starts being applied (§4.4).
+    let applyOn: Int
+    /// Regime maturity below which correction is suspended again (hysteresis).
+    let applyOff: Int
+
+    static let `default` = TouchOffsetConfig(
+        nMax: 150,
+        huberC: 2.0,
+        kGate: 3.5,
+        betaMad: 0.05,
+        warmup: 8,
+        spreadPrior: 0.10,
+        kappa: 8.0,
+        clampFraction: 0.35,
+        lambdaRidge: 8.0,
+        interiorMargin: 0.10,
+        applyOn: 12,
+        applyOff: 6
+    )
+}
+
+/// Clamps `value` into `[lower, upper]`.
+@inline(__always)
+func clamp<T: Comparable>(_ value: T, _ lower: T, _ upper: T) -> T {
+    min(max(value, lower), upper)
+}

--- a/wurstfingerKeyboard/Runtime/TouchModel/TouchOffsetModel.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/TouchOffsetModel.swift
@@ -1,0 +1,143 @@
+//
+//  TouchOffsetModel.swift
+//  Wurstfinger
+//
+//  Per-regime Empirical-Bayes touch-offset model (spec §4.2). Stores per-key
+//  running offset means; the reach surface is *derived* (fitted from the means)
+//  and the per-key deviation is *implicit* via shrinkage (§3.3). All spatial
+//  quantities are in key-pitch fractions; the applied offset is returned as a
+//  `CGVector` in the same units (P7 converts to points and feeds the cell-frame
+//  resizing, §5.4/§5.5).
+//
+
+import CoreGraphics
+import Foundation
+
+/// Per-key state: both axes plus the key's normalized position in the keyboard.
+struct KeyOffsetState: Codable, Equatable {
+    var x: RunningOffset
+    var y: RunningOffset
+    /// Normalized horizontal position in the keyboard `[0,1]` (§5.2).
+    var posU: Double
+    /// Normalized vertical position in the keyboard `[0,1]`.
+    var posV: Double
+
+    init(spreadPrior: Double, posU: Double, posV: Double) {
+        x = RunningOffset(spreadPrior: spreadPrior)
+        y = RunningOffset(spreadPrior: spreadPrior)
+        self.posU = posU
+        self.posV = posV
+    }
+
+    /// Maturity of this key (min of the two axes' counts).
+    var count: Int {
+        min(x.count, y.count)
+    }
+}
+
+struct TouchOffsetModel {
+    let regime: TouchRegime
+    let config: TouchOffsetConfig
+    private(set) var keys: [String: KeyOffsetState]
+
+    init(regime: TouchRegime, config: TouchOffsetConfig = .default, keys: [String: KeyOffsetState] = [:]) {
+        self.regime = regime
+        self.config = config
+        self.keys = keys
+    }
+
+    // MARK: - Learning (§4.2 Step 1)
+
+    /// Folds one accepted, interior, plausibility-gated tap into the model.
+    /// `sampleX/Y` = `rawTouchdown − trueCenter(key)` in pitch fractions (§4.1).
+    mutating func learn(keyId: String, posU: Double, posV: Double, sampleX: Double, sampleY: Double) {
+        var state = keys[keyId] ?? KeyOffsetState(spreadPrior: config.spreadPrior, posU: posU, posV: posV)
+        state.posU = posU
+        state.posV = posV
+        state.x.update(sample: sampleX, config: config)
+        state.y.update(sample: sampleY, config: config)
+        keys[keyId] = state
+    }
+
+    /// Regime maturity (Σ per-key counts) — drives the apply gate (§4.4).
+    var maturity: Int {
+        keys.values.reduce(0) { $0 + $1.count }
+    }
+
+    // MARK: - Application (§4.2 Step 2 + 3)
+
+    /// Computes the clamped offset for **every** key in one pass (fits the
+    /// surface(s) once). P7 calls this per layout pass to drive cell-frame
+    /// resizing. Returned vectors are in pitch fractions.
+    func allOffsets() -> [String: CGVector] {
+        let priorX = fitSurface { $0.x.mean } weight: { $0.x.count }
+        let priorY = fitSurface { $0.y.mean } weight: { $0.y.count }
+        var result: [String: CGVector] = [:]
+        result.reserveCapacity(keys.count)
+        for (id, state) in keys {
+            let px = priorX(state.posU, state.posV)
+            let py = priorY(state.posU, state.posV)
+            let nx = Double(state.x.count), ny = Double(state.y.count)
+            let rx = px + (state.x.mean - px) * nx / (nx + config.kappa)
+            let ry = py + (state.y.mean - py) * ny / (ny + config.kappa)
+            result[id] = Self.clampMagnitude(CGVector(dx: rx, dy: ry), maxMagnitude: config.clampFraction)
+        }
+        return result
+    }
+
+    /// Offset for a single key (convenience; refits the surface). Returns `.zero`
+    /// for unknown keys.
+    func offset(forKeyId id: String) -> CGVector {
+        allOffsets()[id] ?? .zero
+    }
+
+    // MARK: - Reset
+
+    mutating func reset() {
+        keys.removeAll()
+    }
+
+    // MARK: - Surface fitting
+
+    /// Fits the reach surface for one axis and returns an evaluator
+    /// `(posU, posV) → prior`. Handles the twoThumb left/right split (§3.2),
+    /// where each half is fitted with a **half-local** `u ∈ [0,1]` (§5.2).
+    private func fitSurface(
+        _ mean: (KeyOffsetState) -> Double,
+        weight: (KeyOffsetState) -> Int
+    ) -> (Double, Double) -> Double {
+        if regime.posture.usesSplitSurface {
+            let basis = SurfaceBasis.linear
+            var left: [SurfacePoint] = []
+            var right: [SurfacePoint] = []
+            for state in keys.values {
+                let w = Double(weight(state))
+                if state.posU < 0.5 {
+                    left.append(SurfacePoint(u: state.posU * 2, v: state.posV, target: mean(state), weight: w))
+                } else {
+                    right.append(SurfacePoint(u: (state.posU - 0.5) * 2, v: state.posV, target: mean(state), weight: w))
+                }
+            }
+            let surfL = ReachSurfaceFitter.fit(points: left, basis: basis, lambda: config.lambdaRidge)
+            let surfR = ReachSurfaceFitter.fit(points: right, basis: basis, lambda: config.lambdaRidge)
+            return { u, v in
+                u < 0.5 ? surfL.evaluate(u: u * 2, v: v) : surfR.evaluate(u: (u - 0.5) * 2, v: v)
+            }
+        } else {
+            let basis = SurfaceBasis.bilinear
+            let points = keys.values.map {
+                SurfacePoint(u: $0.posU, v: $0.posV, target: mean($0), weight: Double(weight($0)))
+            }
+            let surface = ReachSurfaceFitter.fit(points: points, basis: basis, lambda: config.lambdaRidge)
+            return { u, v in surface.evaluate(u: u, v: v) }
+        }
+    }
+
+    /// Scales a 2D vector down to `maxMagnitude` if it exceeds it (§4.3 clamp).
+    static func clampMagnitude(_ v: CGVector, maxMagnitude: Double) -> CGVector {
+        let mag = (v.dx * v.dx + v.dy * v.dy).squareRoot()
+        guard mag > maxMagnitude, mag > 0 else { return v }
+        let scale = maxMagnitude / mag
+        return CGVector(dx: v.dx * scale, dy: v.dy * scale)
+    }
+}

--- a/wurstfingerKeyboard/Runtime/TouchModel/TouchOffsetStore.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/TouchOffsetStore.swift
@@ -1,0 +1,88 @@
+//
+//  TouchOffsetStore.swift
+//  Wurstfinger
+//
+//  Persistence for the touch-offset model (spec §7). Only aggregates are stored
+//  ({m_k, n_k, s_k} per key, per regime) — never raw trajectories (privacy). The
+//  reach surface is *derived*, so it is not persisted. A schema version guards
+//  against incompatible stored state; key-level pruning handles layout changes.
+//
+
+import Foundation
+
+/// The full persisted payload: per regime, a map of key id → offset state.
+struct TouchOffsetSnapshot: Codable, Equatable {
+    var schemaVersion: Int
+    /// `regime.key` → (`keyId` → state).
+    var regimes: [String: [String: KeyOffsetState]]
+
+    static func empty(schemaVersion: Int) -> TouchOffsetSnapshot {
+        TouchOffsetSnapshot(schemaVersion: schemaVersion, regimes: [:])
+    }
+
+    /// Drops keys in `regimeKey` that are not in `validIds` — partial
+    /// invalidation on layout change, preserving still-valid keys (§7).
+    mutating func pruneKeys(in regimeKey: String, keeping validIds: Set<String>) {
+        guard var keys = regimes[regimeKey] else { return }
+        keys = keys.filter { validIds.contains($0.key) }
+        regimes[regimeKey] = keys
+    }
+}
+
+/// Loads/saves the snapshot from a `UserDefaults` (production: the App-Group
+/// `SharedDefaults.store`; tests inject a throwaway suite).
+final class TouchOffsetStore {
+    static let currentSchemaVersion = 1
+    static let storageKey = "touchModel.snapshot"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    /// Loads the snapshot, or an empty one if absent / schema-incompatible /
+    /// corrupt (the schema bump invalidates everything at once).
+    func load() -> TouchOffsetSnapshot {
+        guard
+            let data = defaults.data(forKey: Self.storageKey),
+            let snapshot = try? JSONDecoder().decode(TouchOffsetSnapshot.self, from: data),
+            snapshot.schemaVersion == Self.currentSchemaVersion
+        else {
+            return .empty(schemaVersion: Self.currentSchemaVersion)
+        }
+        return snapshot
+    }
+
+    /// Persists the snapshot (stamping the current schema version).
+    func save(_ snapshot: TouchOffsetSnapshot) {
+        var stamped = snapshot
+        stamped.schemaVersion = Self.currentSchemaVersion
+        guard let data = try? JSONEncoder().encode(stamped) else { return }
+        defaults.set(data, forKey: Self.storageKey)
+    }
+
+    /// Clears all learned correction (§6.4 "reset all").
+    func resetAll() {
+        defaults.removeObject(forKey: Self.storageKey)
+    }
+
+    /// Clears one regime (§6.4 "reset current regime"), keeping the rest.
+    func reset(regimeKey: String) {
+        var snapshot = load()
+        snapshot.regimes[regimeKey] = nil
+        save(snapshot)
+    }
+}
+
+extension TouchOffsetModel {
+    /// Builds a model for `regime` from a persisted snapshot.
+    init(regime: TouchRegime, config: TouchOffsetConfig = .default, snapshot: TouchOffsetSnapshot) {
+        self.init(regime: regime, config: config, keys: snapshot.regimes[regime.key] ?? [:])
+    }
+
+    /// The persistable per-key states for this regime.
+    var persistableKeys: [String: KeyOffsetState] {
+        keys
+    }
+}

--- a/wurstfingerKeyboard/Runtime/TouchModel/TouchRegime.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/TouchRegime.swift
@@ -1,0 +1,114 @@
+//
+//  TouchRegime.swift
+//  Wurstfinger
+//
+//  Discrete learning regime for the touch-offset correction (spec §3.1).
+//  A separate offset model is maintained per regime. Both axes are known at
+//  runtime *without* detection: orientation comes from the controller, the
+//  posture class is *derived* from the user's keyboard size/position settings
+//  (iOS gives third-party keyboards no posture state — see §11.1).
+//
+
+import Foundation
+
+/// Screen-orientation dimension of a regime.
+enum RegimeOrientation: String, Codable, CaseIterable {
+    case portrait
+    case landscape
+}
+
+/// Biomechanical posture class, *derived* from settings (§3.1).
+/// `Floating` (iPad) is intentionally **not** a v1 class — it falls through
+/// `derivePosture` into the nearest class (§3.1).
+enum PostureClass: String, Codable, CaseIterable {
+    /// Two-thumb typing — wide/centered keyboard. Uses a left/right split
+    /// reach surface (§3.2).
+    case twoThumb
+    /// One-handed, keyboard narrow and shifted left.
+    case oneThumbLeft
+    /// One-handed, keyboard narrow and shifted right.
+    case oneThumbRight
+
+    /// Whether this posture uses the left/right split reach surface (§3.2).
+    var usesSplitSurface: Bool {
+        self == .twoThumb
+    }
+}
+
+/// A learning regime: the discrete context in which a separate touch-offset
+/// model lives. Stable, hashable key used for persistence (§7).
+struct TouchRegime: Hashable, Codable {
+    let orientation: RegimeOrientation
+    let posture: PostureClass
+
+    /// Stable string key for the persistence map (§7).
+    var key: String {
+        "\(orientation.rawValue).\(posture.rawValue)"
+    }
+}
+
+/// Thresholds for `derivePosture`. Calibrated on device (§10).
+struct PostureThresholds: Equatable {
+    /// Below this keyboard scale the keyboard counts as "narrow"
+    /// (one-thumb candidate).
+    let narrowScale: Double
+    /// Horizontal-position deviation from center (0.5) that counts as "offset".
+    let offsetMargin: Double
+    /// Hysteresis band that resists switching regime near a boundary,
+    /// preventing data-splitting flicker (§3.1, §10).
+    let hysteresis: Double
+
+    static let `default` = PostureThresholds(
+        narrowScale: 0.55,
+        offsetMargin: 0.18,
+        hysteresis: 0.05
+    )
+}
+
+enum PostureResolver {
+    /// Maps the known settings `(scale, position)` to a posture class.
+    ///
+    /// Partition (§3.1):
+    /// ```
+    /// narrow = scale < narrowScale
+    /// left   = position < 0.5 - offsetMargin ;  right = position > 0.5 + offsetMargin
+    /// → oneThumbLeft   if narrow && left
+    ///   oneThumbRight  if narrow && right
+    ///   twoThumb       otherwise   (incl. "narrow & centered" — Default)
+    /// ```
+    ///
+    /// Hysteresis (when `previous` is given): each boundary is biased to *resist
+    /// leaving* the current class, so a setting hovering near a threshold does
+    /// not flap between regimes.
+    ///
+    /// - Parameters:
+    ///   - scale: `keyboardScale` (≈ 0.25…1.0).
+    ///   - position: `keyboardHorizontalPosition` (0…1, 0.5 = centered).
+    ///   - previous: the currently active posture (for hysteresis); `nil` = no
+    ///     hysteresis (nominal classification).
+    static func derivePosture(
+        scale: Double,
+        position: Double,
+        thresholds: PostureThresholds = .default,
+        previous: PostureClass? = nil
+    ) -> PostureClass {
+        let h = previous == nil ? 0 : thresholds.hysteresis
+        let prevIsOneThumb = previous == .oneThumbLeft || previous == .oneThumbRight
+
+        // Narrow boundary: if currently one-thumb, stay narrow longer (+h);
+        // if currently two-thumb, require clearer narrowness to switch (−h).
+        let narrowBoundary = thresholds.narrowScale + (prevIsOneThumb ? h : -h)
+        let narrow = scale < narrowBoundary
+
+        // Offset boundaries: keep the current side longer (−h margin = wider
+        // region); make entering a side harder (+h margin = tighter region).
+        let leftMargin = thresholds.offsetMargin + (previous == .oneThumbLeft ? -h : h)
+        let rightMargin = thresholds.offsetMargin + (previous == .oneThumbRight ? -h : h)
+        let left = position < 0.5 - leftMargin
+        let right = position > 0.5 + rightMargin
+
+        if narrow && left { return .oneThumbLeft }
+        if narrow && right { return .oneThumbRight }
+        return .twoThumb
+    }
+}

--- a/wurstfingerKeyboard/Runtime/TouchModel/TouchRegime.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/TouchRegime.swift
@@ -3,10 +3,11 @@
 //  Wurstfinger
 //
 //  Discrete learning regime for the touch-offset correction (spec §3.1).
-//  A separate offset model is maintained per regime. Both axes are known at
-//  runtime *without* detection: orientation comes from the controller, the
-//  posture class is *derived* from the user's keyboard size/position settings
-//  (iOS gives third-party keyboards no posture state — see §11.1).
+//  A separate offset model is maintained per regime. Orientation comes from the
+//  controller; the posture class is **chosen explicitly by the user** (setting
+//  `touchOffsetPosture`) rather than auto-detected — iOS gives third-party
+//  keyboards no posture state, and deriving it from keyboard size/position
+//  proved unreliable (and a wrong split can actively mis-correct, §3.1/§11.1).
 //
 
 import Foundation
@@ -17,21 +18,33 @@ enum RegimeOrientation: String, Codable, CaseIterable {
     case landscape
 }
 
-/// Biomechanical posture class, *derived* from settings (§3.1).
-/// `Floating` (iPad) is intentionally **not** a v1 class — it falls through
-/// `derivePosture` into the nearest class (§3.1).
+/// Biomechanical posture class, **chosen explicitly by the user** (§3.1).
+/// `Floating` (iPad) is intentionally **not** a v1 class.
 enum PostureClass: String, Codable, CaseIterable {
-    /// Two-thumb typing — wide/centered keyboard. Uses a left/right split
-    /// reach surface (§3.2).
-    case twoThumb
-    /// One-handed, keyboard narrow and shifted left.
-    case oneThumbLeft
-    /// One-handed, keyboard narrow and shifted right.
+    /// One-handed, right thumb (single pivot bottom-right). Default: one-handed
+    /// use is the common case, right thumb the most common hand (§3.1).
     case oneThumbRight
+    /// One-handed, left thumb (single pivot bottom-left).
+    case oneThumbLeft
+    /// Two-thumb typing. Uses a left/right split reach surface (§3.2).
+    case twoThumb
 
     /// Whether this posture uses the left/right split reach surface (§3.2).
     var usesSplitSurface: Bool {
         self == .twoThumb
+    }
+
+    /// The declared default when the user has not chosen yet (§3.1).
+    static var defaultDeclared: PostureClass {
+        .oneThumbRight
+    }
+
+    /// Parses a persisted setting string, falling back to the declared default
+    /// for missing/unknown values (§6.3). Single source of truth for how the
+    /// stored `touchOffsetPosture` string maps to a posture, shared by the
+    /// runtime regime lookup and the settings UI.
+    init(settingValue raw: String?) {
+        self = raw.flatMap(PostureClass.init(rawValue:)) ?? .defaultDeclared
     }
 }
 
@@ -44,71 +57,5 @@ struct TouchRegime: Hashable, Codable {
     /// Stable string key for the persistence map (§7).
     var key: String {
         "\(orientation.rawValue).\(posture.rawValue)"
-    }
-}
-
-/// Thresholds for `derivePosture`. Calibrated on device (§10).
-struct PostureThresholds: Equatable {
-    /// Below this keyboard scale the keyboard counts as "narrow"
-    /// (one-thumb candidate).
-    let narrowScale: Double
-    /// Horizontal-position deviation from center (0.5) that counts as "offset".
-    let offsetMargin: Double
-    /// Hysteresis band that resists switching regime near a boundary,
-    /// preventing data-splitting flicker (§3.1, §10).
-    let hysteresis: Double
-
-    static let `default` = PostureThresholds(
-        narrowScale: 0.55,
-        offsetMargin: 0.18,
-        hysteresis: 0.05
-    )
-}
-
-enum PostureResolver {
-    /// Maps the known settings `(scale, position)` to a posture class.
-    ///
-    /// Partition (§3.1):
-    /// ```
-    /// narrow = scale < narrowScale
-    /// left   = position < 0.5 - offsetMargin ;  right = position > 0.5 + offsetMargin
-    /// → oneThumbLeft   if narrow && left
-    ///   oneThumbRight  if narrow && right
-    ///   twoThumb       otherwise   (incl. "narrow & centered" — Default)
-    /// ```
-    ///
-    /// Hysteresis (when `previous` is given): each boundary is biased to *resist
-    /// leaving* the current class, so a setting hovering near a threshold does
-    /// not flap between regimes.
-    ///
-    /// - Parameters:
-    ///   - scale: `keyboardScale` (≈ 0.25…1.0).
-    ///   - position: `keyboardHorizontalPosition` (0…1, 0.5 = centered).
-    ///   - previous: the currently active posture (for hysteresis); `nil` = no
-    ///     hysteresis (nominal classification).
-    static func derivePosture(
-        scale: Double,
-        position: Double,
-        thresholds: PostureThresholds = .default,
-        previous: PostureClass? = nil
-    ) -> PostureClass {
-        let h = previous == nil ? 0 : thresholds.hysteresis
-        let prevIsOneThumb = previous == .oneThumbLeft || previous == .oneThumbRight
-
-        // Narrow boundary: if currently one-thumb, stay narrow longer (+h);
-        // if currently two-thumb, require clearer narrowness to switch (−h).
-        let narrowBoundary = thresholds.narrowScale + (prevIsOneThumb ? h : -h)
-        let narrow = scale < narrowBoundary
-
-        // Offset boundaries: keep the current side longer (−h margin = wider
-        // region); make entering a side harder (+h margin = tighter region).
-        let leftMargin = thresholds.offsetMargin + (previous == .oneThumbLeft ? -h : h)
-        let rightMargin = thresholds.offsetMargin + (previous == .oneThumbRight ? -h : h)
-        let left = position < 0.5 - leftMargin
-        let right = position > 0.5 + rightMargin
-
-        if narrow && left { return .oneThumbLeft }
-        if narrow && right { return .oneThumbRight }
-        return .twoThumb
     }
 }

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -88,6 +88,11 @@ struct DataDrivenKeyboardRootView: View {
                     languageLabel: viewModel.currentLanguageLabel,
                     isLanguageLabelShown: viewModel.hasMultipleLanguages,
                     renderSettings: renderSettings,
+                    offsets: viewModel.currentTouchCorrectionOffsets(),
+                    // The grid receives this width as its layout bounds (the
+                    // outer frame minus the horizontal padding) — used for the
+                    // visible Key-Target-Resizing compensation (§5.5).
+                    availableWidth: metrics.keyboardWidth - 2 * KeyboardConstants.Layout.horizontalPadding,
                     metrics: metrics
                 )
                 .padding(.horizontal, KeyboardConstants.Layout.horizontalPadding)

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -67,8 +67,14 @@ struct DataDrivenKeyboardRootView: View {
                 KeyboardGridView(
                     arrangement: arrangement,
                     keys: mode.keys,
-                    onGesture: { key, gesture, isReturn in
-                        viewModel.handleGesture(gesture, keyId: key.id, isReturn: isReturn)
+                    onGesture: { key, classification in
+                        viewModel.handleGesture(
+                            classification.gesture,
+                            keyId: key.id,
+                            isReturn: classification.isReturn,
+                            touchdown: classification.touchdown,
+                            features: classification.features
+                        )
                     },
                     onTouchDown: {
                         viewModel.feedbackTap()

--- a/wurstfingerKeyboard/Runtime/View/KeyAccessibilityActions.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyAccessibilityActions.swift
@@ -18,15 +18,23 @@ import SwiftUI
 /// callback as a real touch, so they share the resolver chain and pipeline.
 struct KeyAccessibilityActions: ViewModifier {
     let key: KeyConfig
-    let onGesture: (KeyConfig, GestureType, Bool) -> Void
+    let onGesture: (KeyConfig, GestureClassification) -> Void
 
     func body(content: Content) -> some View {
         withActivation(content)
             .accessibilityActions {
                 ForEach(key.accessibilityActions, id: \.gesture) { action in
-                    Button(action.name) { onGesture(key, action.gesture, false) }
+                    Button(action.name) { onGesture(key, Self.classification(action.gesture)) }
                 }
             }
+    }
+
+    /// A synthesized activation carries no real touch, so it reports the
+    /// centre of the key as its touchdown and no feature vector — it must not
+    /// feed the touch-offset learner a made-up sample (a centred touchdown
+    /// carries zero error and moves no offset).
+    static func classification(_ gesture: GestureType) -> GestureClassification {
+        GestureClassification(gesture: gesture, isReturn: false)
     }
 
     /// Applied only where it is needed: a key whose tap already acts keeps the
@@ -34,7 +42,7 @@ struct KeyAccessibilityActions: ViewModifier {
     @ViewBuilder
     private func withActivation(_ content: Content) -> some View {
         if let gesture = key.accessibilityActivationOverride {
-            content.accessibilityAction { onGesture(key, gesture, false) }
+            content.accessibilityAction { onGesture(key, Self.classification(gesture)) }
         } else {
             content
         }

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -38,7 +38,7 @@ struct KeyRenderSettings: Equatable {
 /// swipe/tap/circular gesture classification.
 struct KeyView: View {
     let key: KeyConfig
-    let onGesture: (KeyConfig, GestureType, Bool) -> Void
+    let onGesture: (KeyConfig, GestureClassification) -> Void
     var onTouchDown: (() -> Void)?
     var onSlide: ((KeyConfig, SlidePhase) -> Void)?
     /// Handles a long press on this key; returns whether it dispatched an
@@ -150,7 +150,7 @@ struct KeyView: View {
         } else {
             base.modifier(KeyGestureRecognizer(
                 onGestureRecognized: { classification in
-                    onGesture(key, classification.gesture, classification.isReturn)
+                    onGesture(key, classification)
                 },
                 onTouchDown: { onTouchDown?() },
                 // Account for the spanned cell: a multi-row/-column key is not

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridLayout.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridLayout.swift
@@ -127,7 +127,11 @@ struct KeyboardGridLayout: Layout {
     /// captured; per-key residual is partially realized). Outer lines stay at 0.
     /// This guarantees a disjoint, gapless partition for arbitrary 2D offsets,
     /// which independent per-edge shifts cannot (diagonal-corner mismatch).
-    private static func lineShifts(
+    /// Per-line touch-grid shifts (points), exposed so `KeyboardGridView` can
+    /// derive the matching **visible** compensation (keep the drawn key fixed
+    /// while the touch frame moves, §5.5). Both callers must use the same
+    /// `columnWidth`/`rowHeight` for the shifts to agree.
+    static func lineShifts(
         cells: [SolvedCell], columns: Int, totalRows: Int,
         offsets: [String: CGVector], clamp: CGFloat, columnWidth: CGFloat, rowHeight: CGFloat
     ) -> (vertical: [CGFloat], horizontal: [CGFloat]) {

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridLayout.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridLayout.swift
@@ -21,6 +21,11 @@ struct KeyboardGridLayout: Layout {
     let rowHeight: CGFloat
     let horizontalSpacing: CGFloat
     let verticalSpacing: CGFloat
+    /// Per-key learned offset in pitch fractions (`keyId` → `(dx, dy)`), driving
+    /// Key-Target-Resizing of the touch cells (§5.4). Empty = no resizing.
+    var offsets: [String: CGVector] = [:]
+    /// Per-axis clamp on the offset (pitch fraction) so cells never invert (§4.3).
+    var offsetClamp: CGFloat = 0.35
 
     private var rowCount: Int {
         cells.map { $0.row + $0.rowSpan }.max() ?? 0
@@ -40,7 +45,9 @@ struct KeyboardGridLayout: Layout {
             bounds: bounds,
             rowHeight: rowHeight,
             horizontalSpacing: horizontalSpacing,
-            verticalSpacing: verticalSpacing
+            verticalSpacing: verticalSpacing,
+            offsets: offsets,
+            offsetClamp: offsetClamp
         )
         for (index, frame) in frames.enumerated() where index < subviews.count {
             subviews[index].place(
@@ -68,12 +75,20 @@ struct KeyboardGridLayout: Layout {
         bounds: CGRect,
         rowHeight: CGFloat,
         horizontalSpacing: CGFloat,
-        verticalSpacing: CGFloat
+        verticalSpacing: CGFloat,
+        offsets: [String: CGVector] = [:],
+        offsetClamp: CGFloat = 0.35
     ) -> [CGRect] {
         guard columns > 0 else { return [] }
         let totalHorizontalSpacing = CGFloat(columns - 1) * horizontalSpacing
         let columnWidth = max((bounds.width - totalHorizontalSpacing) / CGFloat(columns), 0)
         let totalRows = cells.map { $0.row + $0.rowSpan }.max() ?? 0
+        let (vLine, hLine) = offsets.isEmpty
+            ? ([CGFloat](repeating: 0, count: columns + 1), [CGFloat](repeating: 0, count: totalRows + 1))
+            : lineShifts(
+                cells: cells, columns: columns, totalRows: totalRows, offsets: offsets,
+                clamp: offsetClamp, columnWidth: columnWidth, rowHeight: rowHeight
+            )
 
         return cells.map { cell in
             // Visible frame: the key's drawn bounds (geometry unchanged).
@@ -92,13 +107,71 @@ struct KeyboardGridLayout: Layout {
                 horizontalSpacing: horizontalSpacing,
                 verticalSpacing: verticalSpacing
             )
-            return CGRect(
-                x: originX - insets.leading,
-                y: originY - insets.top,
-                width: width + insets.leading + insets.trailing,
-                height: height + insets.top + insets.bottom
-            )
+            // Key-Target-Resizing (§5.4): the touch grid lines are perturbed
+            // (separable per line), so the tiling stays a valid rectangular
+            // partition even for 2D offsets. Each edge follows its shared line.
+            let leftEdge = originX - insets.leading + vLine[cell.column]
+            let rightEdge = originX + width + insets.trailing + vLine[cell.column + cell.columnSpan]
+            let topEdge = originY - insets.top + hLine[cell.row]
+            let bottomEdge = originY + height + insets.bottom + hLine[cell.row + cell.rowSpan]
+            return CGRect(x: leftEdge, y: topEdge, width: rightEdge - leftEdge, height: bottomEdge - topEdge)
         }
+    }
+
+    private struct GridPos: Hashable { let row: Int; let column: Int }
+
+    /// Signed shift (points) of every interior grid line, derived from per-key
+    /// offsets. A single vertical/horizontal line is shared by all cells along
+    /// it, so it must move by **one** value — hence the per-key offsets adjacent
+    /// to a line are averaged onto it (the smooth reach-bias component is
+    /// captured; per-key residual is partially realized). Outer lines stay at 0.
+    /// This guarantees a disjoint, gapless partition for arbitrary 2D offsets,
+    /// which independent per-edge shifts cannot (diagonal-corner mismatch).
+    private static func lineShifts(
+        cells: [SolvedCell], columns: Int, totalRows: Int,
+        offsets: [String: CGVector], clamp: CGFloat, columnWidth: CGFloat, rowHeight: CGFloat
+    ) -> (vertical: [CGFloat], horizontal: [CGFloat]) {
+        var grid: [GridPos: CGVector] = [:]
+        for cell in cells {
+            let raw = offsets[cell.keyId] ?? .zero
+            let clamped = CGVector(dx: min(max(raw.dx, -clamp), clamp), dy: min(max(raw.dy, -clamp), clamp))
+            for r in cell.row ..< (cell.row + cell.rowSpan) {
+                for c in cell.column ..< (cell.column + cell.columnSpan) {
+                    grid[GridPos(row: r, column: c)] = clamped
+                }
+            }
+        }
+
+        var vertical = [CGFloat](repeating: 0, count: columns + 1)
+        if columns > 1 {
+            for c in 1 ..< columns {
+                var sum: CGFloat = 0
+                var n = 0
+                for r in 0 ..< totalRows {
+                    guard let l = grid[GridPos(row: r, column: c - 1)],
+                          let rt = grid[GridPos(row: r, column: c)] else { continue }
+                    sum += (l.dx + rt.dx) / 2 * columnWidth
+                    n += 1
+                }
+                vertical[c] = n > 0 ? sum / CGFloat(n) : 0
+            }
+        }
+
+        var horizontal = [CGFloat](repeating: 0, count: totalRows + 1)
+        if totalRows > 1 {
+            for r in 1 ..< totalRows {
+                var sum: CGFloat = 0
+                var n = 0
+                for c in 0 ..< columns {
+                    guard let t = grid[GridPos(row: r - 1, column: c)],
+                          let b = grid[GridPos(row: r, column: c)] else { continue }
+                    sum += (t.dy + b.dy) / 2 * rowHeight
+                    n += 1
+                }
+                horizontal[r] = n > 0 ? sum / CGFloat(n) : 0
+            }
+        }
+        return (vertical, horizontal)
     }
 
     /// Per-side amount by which a cell's touch frame grows into the gap toward

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 struct KeyboardGridView: View {
     let arrangement: GridArrangement
     let keys: [String: KeyConfig]
-    let onGesture: (KeyConfig, GestureType, Bool) -> Void
+    let onGesture: (KeyConfig, GestureClassification) -> Void
     var onTouchDown: (() -> Void)?
     var onSlide: ((KeyConfig, SlidePhase) -> Void)?
     /// Forwarded to `KeyView`; returns whether the long press was handled.

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -126,40 +126,43 @@ struct KeyboardGridView: View {
         )
     }
 
-    // MARK: - P3.5 Device Spike (TEMPORARY — remove after validation)
+    // MARK: - Resizing Spike (validation hook — TEMPORARY)
+
+    /// Active when the resizing validation spike is enabled. The whole **center
+    /// column** (`topCenter`/`center`/`bottomCenter`) shifts its hit cells
+    /// ~0.18 column right (into the `…Right` column). A fixed screen point just
+    /// right of the nominal center|right boundary is then reassigned from the
+    /// right key to the center key — provable by coordinate taps (the visible
+    /// keys shift too; invisible compensation is P7). Enabled via the
+    /// `TOUCH_OFFSET_SPIKE=1` launch environment (UI tests) or, in DEBUG, the
+    /// manual constant (device runs).
+    private static var spikeEnabled: Bool {
+        if ProcessInfo.processInfo.environment["TOUCH_OFFSET_SPIKE"] == "1" { return true }
+        #if DEBUG
+            return manualSpikeActive
+        #else
+            return false
+        #endif
+    }
 
     #if DEBUG
-        /// Flip to `true`, build & run **on device** to validate Key-Target-
-        /// Resizing: the whole **center column** (`topCenter`/`center`/
-        /// `bottomCenter`) shifts its hit cells ~0.18 column to the right (into
-        /// the `…Right` column), so a tap on the *left edge* of the drawn right
-        /// column produces the center column's character. Proves the touch frame
-        /// — not the drawn key — decides assignment (§5.5/§11.6). The visible
-        /// keys shift too here (invisible compensation is P7). The whole column
-        /// is offset so the per-line averaging (§5.4) does not dilute it.
-        private static let spikeActive = false
-        private var spikeOffsets: [String: CGVector] {
-            guard Self.spikeActive else { return [:] }
-            let shift = CGVector(dx: 0.7, dy: 0) // clamped to 0.35 → ~0.18 col line shift
-            return [
-                GridSlot.topCenter: shift,
-                GridSlot.center: shift,
-                GridSlot.bottomCenter: shift,
-            ]
-        }
-
-        private var spikeClamp: CGFloat {
-            0.35
-        }
-    #else
-        private var spikeOffsets: [String: CGVector] {
-            [:]
-        }
-
-        private var spikeClamp: CGFloat {
-            0.35
-        }
+        /// Manual device toggle (P3.5): flip to `true`, build & run on device.
+        private static let manualSpikeActive = false
     #endif
+
+    private var spikeOffsets: [String: CGVector] {
+        guard Self.spikeEnabled else { return [:] }
+        let shift = CGVector(dx: 0.7, dy: 0) // clamped to 0.35 → ~0.18 col line shift
+        return [
+            GridSlot.topCenter: shift,
+            GridSlot.center: shift,
+            GridSlot.bottomCenter: shift,
+        ]
+    }
+
+    private var spikeClamp: CGFloat {
+        0.35
+    }
 
     // MARK: - Span Inspection (Test Hooks)
 

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -63,7 +63,9 @@ struct KeyboardGridView: View {
             columns: arrangement.columns,
             rowHeight: metrics.rowHeight,
             horizontalSpacing: KeyboardConstants.Layout.gridHorizontalSpacing,
-            verticalSpacing: KeyboardConstants.Layout.gridVerticalSpacing
+            verticalSpacing: KeyboardConstants.Layout.gridVerticalSpacing,
+            offsets: spikeOffsets,
+            offsetClamp: spikeClamp
         ) {
             ForEach(Array(cells.enumerated()), id: \.offset) { _, cell in
                 cellContent(for: cell, totalRows: totalRows)
@@ -123,6 +125,41 @@ struct KeyboardGridView: View {
             trailing: insets.trailing
         )
     }
+
+    // MARK: - P3.5 Device Spike (TEMPORARY — remove after validation)
+
+    #if DEBUG
+        /// Flip to `true`, build & run **on device** to validate Key-Target-
+        /// Resizing: the whole **center column** (`topCenter`/`center`/
+        /// `bottomCenter`) shifts its hit cells ~0.18 column to the right (into
+        /// the `…Right` column), so a tap on the *left edge* of the drawn right
+        /// column produces the center column's character. Proves the touch frame
+        /// — not the drawn key — decides assignment (§5.5/§11.6). The visible
+        /// keys shift too here (invisible compensation is P7). The whole column
+        /// is offset so the per-line averaging (§5.4) does not dilute it.
+        private static let spikeActive = false
+        private var spikeOffsets: [String: CGVector] {
+            guard Self.spikeActive else { return [:] }
+            let shift = CGVector(dx: 0.7, dy: 0) // clamped to 0.35 → ~0.18 col line shift
+            return [
+                GridSlot.topCenter: shift,
+                GridSlot.center: shift,
+                GridSlot.bottomCenter: shift,
+            ]
+        }
+
+        private var spikeClamp: CGFloat {
+            0.35
+        }
+    #else
+        private var spikeOffsets: [String: CGVector] {
+            [:]
+        }
+
+        private var spikeClamp: CGFloat {
+            0.35
+        }
+    #endif
 
     // MARK: - Span Inspection (Test Hooks)
 

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -35,6 +35,13 @@ struct KeyboardGridView: View {
     /// settings.
     let renderSettings: KeyRenderSettings
 
+    /// Learned per-key offsets in pitch fractions, driving Key-Target-Resizing
+    /// (§5.4). Empty = no correction.
+    var offsets: [String: CGVector] = [:]
+    /// The width available to the grid (= the layout's `bounds.width`), needed to
+    /// compute the visible compensation in points so drawn keys stay put (§5.5).
+    var availableWidth: CGFloat = 0
+
     /// Resolved layout metrics injected by `DataDrivenKeyboardRootView` from
     /// the view model rather than read via `@AppStorage`: the root view
     /// derives the keyboard *width* from the same metrics, and reading the
@@ -55,20 +62,42 @@ struct KeyboardGridView: View {
         trailStore.recorder
     }
 
+    /// The offsets that actually drive resizing: the validation spike when
+    /// enabled (UI tests / device), otherwise the learned `offsets`.
+    private var effectiveOffsets: [String: CGVector] {
+        Self.spikeEnabled ? spikeOffsets : offsets
+    }
+
+    private var columnWidth: CGFloat {
+        let columns = max(arrangement.columns, 1)
+        let spacing = CGFloat(columns - 1) * KeyboardConstants.Layout.gridHorizontalSpacing
+        return max((availableWidth - spacing) / CGFloat(columns), 0)
+    }
+
     var body: some View {
         let cells = GridLayoutSolver.solve(arrangement)
         let totalRows = cells.map { $0.row + $0.rowSpan }.max() ?? 0
+        let offs = effectiveOffsets
+        // Same per-line shifts the layout applies to the touch frames; used here
+        // to produce the matching *inverse* visible compensation (§5.5).
+        let lines: (vertical: [CGFloat], horizontal: [CGFloat]) =
+            offs.isEmpty || columnWidth <= 0
+                ? (Array(repeating: 0, count: arrangement.columns + 1), Array(repeating: 0, count: totalRows + 1))
+                : KeyboardGridLayout.lineShifts(
+                    cells: cells, columns: arrangement.columns, totalRows: totalRows,
+                    offsets: offs, clamp: 0.35, columnWidth: columnWidth, rowHeight: metrics.rowHeight
+                )
         KeyboardGridLayout(
             cells: cells,
             columns: arrangement.columns,
             rowHeight: metrics.rowHeight,
             horizontalSpacing: KeyboardConstants.Layout.gridHorizontalSpacing,
             verticalSpacing: KeyboardConstants.Layout.gridVerticalSpacing,
-            offsets: spikeOffsets,
-            offsetClamp: spikeClamp
+            offsets: offs,
+            offsetClamp: 0.35
         ) {
             ForEach(Array(cells.enumerated()), id: \.offset) { _, cell in
-                cellContent(for: cell, totalRows: totalRows)
+                cellContent(for: cell, totalRows: totalRows, lines: lines)
             }
         }
         // Registered here rather than on the root view so it exists wherever a
@@ -85,7 +114,9 @@ struct KeyboardGridView: View {
     }
 
     @ViewBuilder
-    private func cellContent(for cell: SolvedCell, totalRows: Int) -> some View {
+    private func cellContent(
+        for cell: SolvedCell, totalRows: Int, lines: (vertical: [CGFloat], horizontal: [CGFloat])
+    ) -> some View {
         if let key = keys[cell.keyId] {
             KeyView(
                 key: key,
@@ -95,7 +126,7 @@ struct KeyboardGridView: View {
                 onLongPress: onLongPress,
                 gestureTrail: gestureTrail,
                 spanRatio: CGFloat(cell.columnSpan) / CGFloat(cell.rowSpan),
-                visualInset: visualInset(for: cell, totalRows: totalRows),
+                visualInset: visualInset(for: cell, totalRows: totalRows, lines: lines),
                 settings: renderSettings,
                 metrics: metrics,
                 languageLabel: languageLabel,
@@ -107,11 +138,15 @@ struct KeyboardGridView: View {
         }
     }
 
-    /// Inset that keeps the key's drawn bounds unchanged while its touch cell
-    /// fills the gaps to neighbouring keys. Mirrors `KeyboardGridLayout`, which
-    /// grows the cell frame by the same amount.
-    private func visualInset(for cell: SolvedCell, totalRows: Int) -> EdgeInsets {
-        let insets = KeyboardGridLayout.gapInsets(
+    /// Inset that keeps the key's drawn bounds unchanged. Base part fills the
+    /// inter-key gaps (mirrors the touch frame's gap growth); the offset part
+    /// **cancels** the Key-Target-Resizing line shift so the visible key stays
+    /// put while the touch frame moves (§5.5). May go negative (content draws
+    /// outside the touch frame) — SwiftUI allows this and KeyView does not clip.
+    private func visualInset(
+        for cell: SolvedCell, totalRows: Int, lines: (vertical: [CGFloat], horizontal: [CGFloat])
+    ) -> EdgeInsets {
+        let g = KeyboardGridLayout.gapInsets(
             for: cell,
             columns: arrangement.columns,
             totalRows: totalRows,
@@ -119,10 +154,10 @@ struct KeyboardGridView: View {
             verticalSpacing: KeyboardConstants.Layout.gridVerticalSpacing
         )
         return EdgeInsets(
-            top: insets.top,
-            leading: insets.leading,
-            bottom: insets.bottom,
-            trailing: insets.trailing
+            top: g.top - lines.horizontal[cell.row],
+            leading: g.leading - lines.vertical[cell.column],
+            bottom: g.bottom + lines.horizontal[cell.row + cell.rowSpan],
+            trailing: g.trailing + lines.vertical[cell.column + cell.columnSpan]
         )
     }
 
@@ -158,10 +193,6 @@ struct KeyboardGridView: View {
             GridSlot.center: shift,
             GridSlot.bottomCenter: shift,
         ]
-    }
-
-    private var spikeClamp: CGFloat {
-        0.35
     }
 
     // MARK: - Span Inspection (Test Hooks)

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -59,6 +59,12 @@ enum SettingsKey: String, CaseIterable {
     /// redrawing costs battery, so experienced users are not made to pay for
     /// it. Off also keeps the keyboard visually identical to before.
     case gestureTrailEnabled
+    /// Master toggle for the learned touch-offset correction feature (default off).
+    /// See `docs/touch-offset-correction.md` §6.1.
+    case touchOffsetEnabled
+    /// Schema version of the persisted touch-offset model; bump invalidates
+    /// incompatible stored state. See §7.
+    case touchModelSchemaVersion
 }
 
 // MARK: - Haptic Settings

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -62,6 +62,10 @@ enum SettingsKey: String, CaseIterable {
     /// Master toggle for the learned touch-offset correction feature (default off).
     /// See `docs/touch-offset-correction.md` §6.1.
     case touchOffsetEnabled
+    /// User-declared hand posture (`PostureClass.rawValue`) that selects the
+    /// active learning regime. Explicit choice, not auto-detected; default
+    /// `oneThumbRight`. See §3.1/§6.3.
+    case touchOffsetPosture
     /// Schema version of the persisted touch-offset model; bump invalidates
     /// incompatible stored state. See §7.
     case touchModelSchemaVersion

--- a/wurstfingerTests/GestureTouchdownPlumbingTests.swift
+++ b/wurstfingerTests/GestureTouchdownPlumbingTests.swift
@@ -1,0 +1,50 @@
+//
+//  GestureTouchdownPlumbingTests.swift
+//  WurstfingerTests
+//
+//  P4: the gesture recognizer normalizes the touchdown to the key frame and
+//  carries the feature vector in the classification (plumbed for offset
+//  learning §4.1 and telemetry §13).
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct GestureTouchdownPlumbingTests {
+    @Test func normalizesCenterToHalf() {
+        let p = KeyGestureRecognizer.normalizedTouchdown(CGPoint(x: 50, y: 30), in: CGSize(width: 100, height: 60))
+        #expect(abs(p.x - 0.5) < 1e-9)
+        #expect(abs(p.y - 0.5) < 1e-9)
+    }
+
+    @Test func normalizesCornerToZero() {
+        let p = KeyGestureRecognizer.normalizedTouchdown(.zero, in: CGSize(width: 80, height: 40))
+        #expect(p.x == 0 && p.y == 0)
+    }
+
+    @Test func clampsOutOfBoundsTouchdown() {
+        let p = KeyGestureRecognizer.normalizedTouchdown(CGPoint(x: 200, y: -10), in: CGSize(width: 100, height: 60))
+        #expect(p.x == 1 && p.y == 0)
+    }
+
+    @Test func zeroSizeFallsBackToCenter() {
+        let p = KeyGestureRecognizer.normalizedTouchdown(CGPoint(x: 10, y: 10), in: .zero)
+        #expect(p.x == 0.5 && p.y == 0.5)
+    }
+
+    @Test func classificationCarriesFeatures() {
+        // A degenerate (no-displacement) path classifies as a tap and still
+        // carries the extracted feature vector.
+        let result = KeyGestureRecognizer.classify(positions: [.zero, .zero])
+        #expect(result.gesture == .tap)
+        #expect(result.features != nil)
+    }
+
+    @Test func defaultTouchdownIsCenter() {
+        // Callers that build a classification without a touchdown get center.
+        let result = KeyGestureRecognizer.classify(features: .empty())
+        #expect(result.touchdown == CGPoint(x: 0.5, y: 0.5))
+    }
+}

--- a/wurstfingerTests/KeyboardGridRenderingTests.swift
+++ b/wurstfingerTests/KeyboardGridRenderingTests.swift
@@ -162,7 +162,7 @@ struct KeyViewStyleTests {
         )
         let view = KeyView(
             key: key,
-            onGesture: { _, _, _ in },
+            onGesture: { _, _ in },
             onTouchDown: {},
             settings: KeyRenderSettings(),
             metrics: .reference
@@ -187,7 +187,7 @@ struct KeyViewStyleTests {
         )
         let view = KeyView(
             key: key,
-            onGesture: { _, _, _ in },
+            onGesture: { _, _ in },
             onTouchDown: {},
             settings: KeyRenderSettings(),
             metrics: .reference
@@ -212,7 +212,7 @@ struct KeyViewStyleTests {
         )
         let view = KeyView(
             key: key,
-            onGesture: { _, _, _ in },
+            onGesture: { _, _ in },
             onTouchDown: {},
             settings: KeyRenderSettings(),
             metrics: .reference

--- a/wurstfingerTests/KeyboardGridResizingTests.swift
+++ b/wurstfingerTests/KeyboardGridResizingTests.swift
@@ -1,0 +1,81 @@
+//
+//  KeyboardGridResizingTests.swift
+//  WurstfingerTests
+//
+//  Verifies Key-Target-Resizing in cellFrames (spec §5.4): a per-key offset
+//  shifts the shared touch-cell boundaries while the tiling stays a disjoint,
+//  gapless partition. Pure geometry, no SwiftUI host.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct KeyboardGridResizingTests {
+    private let horizontalSpacing = KeyboardConstants.Layout.gridHorizontalSpacing
+    private let verticalSpacing = KeyboardConstants.Layout.gridVerticalSpacing
+    private let rowHeight: CGFloat = 50
+
+    private func frames(
+        _ arrangement: GridArrangement, offsets: [String: CGVector]
+    ) -> (cells: [SolvedCell], frames: [CGRect], bounds: CGRect) {
+        let cells = GridLayoutSolver.solve(arrangement)
+        let rows = GridLayoutSolver.rowCount(arrangement)
+        let height = CGFloat(rows) * rowHeight + CGFloat(max(rows - 1, 0)) * verticalSpacing
+        let bounds = CGRect(x: 0, y: 0, width: 321, height: height)
+        let f = KeyboardGridLayout.cellFrames(
+            cells: cells, columns: arrangement.columns, bounds: bounds,
+            rowHeight: rowHeight, horizontalSpacing: horizontalSpacing,
+            verticalSpacing: verticalSpacing, offsets: offsets, offsetClamp: 0.5
+        )
+        return (cells, f, bounds)
+    }
+
+    private func assertExactTiling(_ frames: [CGRect], bounds: CGRect, _ label: String) {
+        for i in frames.indices {
+            for j in (i + 1) ..< frames.count {
+                let overlap = frames[i].intersection(frames[j])
+                let touchesOnly = overlap.isNull || overlap.width < 0.001 || overlap.height < 0.001
+                #expect(touchesOnly, "\(label): overlap \(overlap)")
+            }
+        }
+        let totalArea = frames.reduce(0) { $0 + $1.width * $1.height }
+        #expect(abs(totalArea - bounds.width * bounds.height) < 0.5, "\(label): coverage gap/overhang")
+    }
+
+    @Test func resizingPreservesExactTiling() throws {
+        let arrangement = try #require(StandardArrangements.grid3x3[.portrait])
+        let (_, f, bounds) = frames(arrangement, offsets: [GridSlot.center: CGVector(dx: 0.4, dy: -0.3)])
+        assertExactTiling(f, bounds: bounds, "resized portrait")
+    }
+
+    @Test func positiveOffsetShiftsCenterCellRight() throws {
+        let arrangement = try #require(StandardArrangements.grid3x3[.portrait])
+        let (cells, baseline, _) = frames(arrangement, offsets: [:])
+        let (_, shifted, _) = frames(arrangement, offsets: [GridSlot.center: CGVector(dx: 0.4, dy: 0)])
+        let idx = try #require(cells.firstIndex { $0.keyId == GridSlot.center })
+        // The center cell's hit frame moves right (both its shared vertical
+        // boundaries shift right by the same amount → translation, width kept).
+        #expect(shifted[idx].minX > baseline[idx].minX + 1.0)
+        #expect(abs(shifted[idx].width - baseline[idx].width) < 0.5)
+    }
+
+    @Test func emptyOffsetsAreIdenticalToBaseline() throws {
+        // Regression guard: the new offset path must not change anything when
+        // no offsets are supplied.
+        let arrangement = try #require(StandardArrangements.grid3x3[.portrait])
+        let (_, withEmpty, _) = frames(arrangement, offsets: [:])
+        let cells = GridLayoutSolver.solve(arrangement)
+        let rows = GridLayoutSolver.rowCount(arrangement)
+        let height = CGFloat(rows) * rowHeight + CGFloat(max(rows - 1, 0)) * verticalSpacing
+        let bounds = CGRect(x: 0, y: 0, width: 321, height: height)
+        let legacy = KeyboardGridLayout.cellFrames(
+            cells: cells, columns: arrangement.columns, bounds: bounds,
+            rowHeight: rowHeight, horizontalSpacing: horizontalSpacing, verticalSpacing: verticalSpacing
+        )
+        for (a, b) in zip(withEmpty, legacy) {
+            #expect(abs(a.minX - b.minX) < 1e-9 && abs(a.width - b.width) < 1e-9)
+        }
+    }
+}

--- a/wurstfingerTests/ReachSurfaceTests.swift
+++ b/wurstfingerTests/ReachSurfaceTests.swift
@@ -1,0 +1,52 @@
+//
+//  ReachSurfaceTests.swift
+//  WurstfingerTests
+//
+//  Tests for the ridge-WLS reach-surface fit + linear solver (spec §4.2 Step 2).
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct ReachSurfaceTests {
+    @Test func solvesKnownLinearSystem() {
+        // [2 1; 1 3] x = [5; 10] → x = [1; 3]
+        let x = ReachSurfaceFitter.solve([[2, 1], [1, 3]], [5, 10])
+        #expect(x != nil)
+        #expect(abs((x?[0] ?? 0) - 1.0) < 1e-9)
+        #expect(abs((x?[1] ?? 0) - 3.0) < 1e-9)
+    }
+
+    @Test func recoversLinearPlaneWithSmallRidge() {
+        // target = 0.20 + 0.10·u − 0.05·v
+        let pts = [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0), (0.5, 0.5)].map {
+            SurfacePoint(u: $0.0, v: $0.1, target: 0.20 + 0.10 * $0.0 - 0.05 * $0.1, weight: 100)
+        }
+        let s = ReachSurfaceFitter.fit(points: pts, basis: .linear, lambda: 0.001)
+        #expect(abs(s.evaluate(u: 0.0, v: 0.0) - 0.20) < 0.01)
+        #expect(abs(s.evaluate(u: 1.0, v: 0.0) - 0.30) < 0.01)
+        #expect(abs(s.evaluate(u: 0.0, v: 1.0) - 0.15) < 0.01)
+    }
+
+    @Test func zeroPointsGivesFlatZeroSurface() {
+        let s = ReachSurfaceFitter.fit(points: [], basis: .bilinear, lambda: 8)
+        #expect(abs(s.evaluate(u: 0.3, v: 0.7)) < 1e-9)
+    }
+
+    @Test func ridgeShrinksTowardZeroWithSparseData() {
+        // A single point with strong ridge → prediction pulled well below target.
+        let pts = [SurfacePoint(u: 0.5, v: 0.5, target: 1.0, weight: 1)]
+        let s = ReachSurfaceFitter.fit(points: pts, basis: .bilinear, lambda: 8)
+        #expect(s.evaluate(u: 0.5, v: 0.5) < 0.5)
+    }
+
+    @Test func largeWeightOverridesRidge() {
+        // With weight ≫ lambda the surface follows the data.
+        let pts = [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0)].map {
+            SurfacePoint(u: $0.0, v: $0.1, target: 0.25, weight: 10000)
+        }
+        let s = ReachSurfaceFitter.fit(points: pts, basis: .bilinear, lambda: 8)
+        #expect(abs(s.evaluate(u: 0.5, v: 0.5) - 0.25) < 0.02)
+    }
+}

--- a/wurstfingerTests/RunningOffsetTests.swift
+++ b/wurstfingerTests/RunningOffsetTests.swift
@@ -1,0 +1,65 @@
+//
+//  RunningOffsetTests.swift
+//  WurstfingerTests
+//
+//  Tests for the bounded-influence running-mean estimator (spec §4.2 Step 1).
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct RunningOffsetTests {
+    private let cfg = TouchOffsetConfig.default
+
+    @Test func convergesUnbiasedToConstantBias() {
+        var o = RunningOffset(spreadPrior: cfg.spreadPrior)
+        for _ in 0 ..< 300 {
+            o.update(sample: 0.12, config: cfg)
+        }
+        #expect(abs(o.mean - 0.12) < 0.005)
+    }
+
+    @Test func huberClipBoundsSingleSampleInfluence() {
+        var o = RunningOffset(spreadPrior: cfg.spreadPrior)
+        // First sample is huge but should be clipped to ±c·spread, not jump to 5.
+        o.update(sample: 5.0, config: cfg)
+        #expect(o.mean <= cfg.huberC * cfg.spreadPrior + 1e-9)
+    }
+
+    @Test func outlierGateRejectsAfterWarmup() {
+        var o = RunningOffset(spreadPrior: cfg.spreadPrior)
+        for _ in 0 ..< cfg.warmup {
+            o.update(sample: 0.0, config: cfg)
+        }
+        let before = o.mean
+        let used = o.update(sample: 5.0, config: cfg)
+        #expect(used == false)
+        #expect(o.mean == before)
+    }
+
+    @Test func gateInactiveBeforeWarmup() {
+        var o = RunningOffset(spreadPrior: cfg.spreadPrior)
+        // First sample (count < warmup) is never gated, only clipped.
+        let used = o.update(sample: 5.0, config: cfg)
+        #expect(used == true)
+    }
+
+    @Test func nMaxGivesPlasticity() {
+        // Small nMax → behaves like an EMA, old state gets overwritten.
+        let plastic = TouchOffsetConfig(
+            nMax: 5, huberC: 100, kGate: 100, betaMad: 0.05, warmup: 100,
+            spreadPrior: 1.0, kappa: 8, clampFraction: 0.35, lambdaRidge: 8,
+            interiorMargin: 0.10, applyOn: 12, applyOff: 6
+        )
+        var o = RunningOffset(spreadPrior: plastic.spreadPrior)
+        for _ in 0 ..< 20 {
+            o.update(sample: 0.0, config: plastic)
+        }
+        #expect(abs(o.mean) < 0.01)
+        for _ in 0 ..< 50 {
+            o.update(sample: 1.0, config: plastic)
+        }
+        #expect(o.mean > 0.9) // overwritten toward the new value
+    }
+}

--- a/wurstfingerTests/TelemetryTests.swift
+++ b/wurstfingerTests/TelemetryTests.swift
@@ -101,31 +101,52 @@ struct TelemetryControllerTests {
         c.recordTapOutcome(regimeKey: regime.key, isFlip: true)
         // A later tap ages the flipped one out of the veto window (unvetoed).
         c.recordTapOutcome(regimeKey: regime.key, isFlip: false)
-        #expect(c.snapshot.counterfactual[regime.key]?.caught == 1)
-        #expect(c.snapshot.counterfactual[regime.key]?.caused == 0)
+        let m = c.snapshot.counterfactual[regime.key]
+        #expect(m?.taps == 1)
+        #expect(m?.caught == 1)
+        #expect(m?.caused == 0)
+        #expect(m?.deletes == 0)
     }
 
     @Test func vetoedFlipCountsAsCaused() {
         let c = make("test.telemetry.caused", enabled: true, window: 1)
         c.recordTapOutcome(regimeKey: regime.key, isFlip: true)
         c.recordUserDelete() // vetoes the still-pending flip
-        #expect(c.snapshot.counterfactual[regime.key]?.caused == 1)
-        #expect(c.snapshot.counterfactual[regime.key]?.caught == nil || c.snapshot.counterfactual[regime.key]?.caught == 0)
+        let m = c.snapshot.counterfactual[regime.key]
+        #expect(m?.taps == 1)
+        #expect(m?.deletes == 1)
+        #expect(m?.caused == 1)
+        #expect(m?.caught == 0)
     }
 
-    @Test func nonFlipTapContributesNothing() {
+    @Test func nonFlipKeptTapCountsButAddsNoError() {
         let c = make("test.telemetry.noflip", enabled: true, window: 1)
         c.recordTapOutcome(regimeKey: regime.key, isFlip: false)
-        c.recordTapOutcome(regimeKey: regime.key, isFlip: false)
-        #expect(c.snapshot.counterfactual[regime.key] == nil)
+        c.recordTapOutcome(regimeKey: regime.key, isFlip: false) // ages the first out
+        let m = c.snapshot.counterfactual[regime.key]
+        #expect(m?.taps == 1)
+        #expect(m?.deletes == 0)
+        #expect(m?.caught == 0)
+        #expect(m?.caused == 0)
     }
 
-    @Test func netIsCaughtMinusCaused() {
+    // MARK: - Error-rate math (§8)
+
+    @Test func errorRatesReflectCounterfactual() {
         var m = CounterfactualMetric()
-        m.caught = 5
-        m.caused = 2
-        #expect(m.net == 3)
-        #expect(m.total == 7)
+        m.taps = 10
+        m.deletes = 3 // observed backspaces with correction on
+        m.caught = 2 // would-have-been errors the correction prevented
+        m.caused = 1 // errors the correction introduced
+        #expect(abs(m.errorRateWith - 0.3) < 1e-9) // 3 / 10
+        #expect(abs(m.errorRateWithout - 0.4) < 1e-9) // (3 + 2 - 1) / 10
+        #expect(m.net == 1)
+    }
+
+    @Test func emptyMetricHasZeroRates() {
+        let m = CounterfactualMetric()
+        #expect(m.errorRateWith == 0)
+        #expect(m.errorRateWithout == 0)
     }
 
     // MARK: - Persistence
@@ -141,5 +162,6 @@ struct TelemetryControllerTests {
         let reloaded = GestureTelemetryStore(defaults: d).load()
         #expect(reloaded.classes[regime.key]?["tap"]?.total == 1)
         #expect(reloaded.counterfactual[regime.key]?.caught == 1)
+        #expect(reloaded.counterfactual[regime.key]?.taps == 1)
     }
 }

--- a/wurstfingerTests/TelemetryTests.swift
+++ b/wurstfingerTests/TelemetryTests.swift
@@ -1,0 +1,90 @@
+//
+//  TelemetryTests.swift
+//  WurstfingerTests
+//
+//  Tests for gesture telemetry (§13) and the A/B proxy metric (§8).
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct FeatureStatTests {
+    @Test func welfordMeanAndStdDev() {
+        var s = FeatureStat()
+        [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0].forEach { s.add($0) }
+        #expect(s.count == 8)
+        #expect(abs(s.mean - 5.0) < 1e-9)
+        // Sample std dev of that classic set is ~2.138 (variance 32/7).
+        #expect(abs(s.stdDev - (32.0 / 7.0).squareRoot()) < 1e-9)
+    }
+
+    @Test func classKeyMapping() {
+        #expect(TelemetryController.classKey(.tap, isReturn: false) == "tap")
+        #expect(TelemetryController.classKey(.swipeUp, isReturn: false) == "swipe.swipeUp")
+        #expect(TelemetryController.classKey(.tap, isReturn: true) == "return")
+        #expect(TelemetryController.classKey(.circularClockwise, isReturn: false) == "circle.cw")
+        #expect(TelemetryController.classKey(.circularCounterclockwise, isReturn: false) == "circle.ccw")
+    }
+}
+
+struct TelemetryControllerTests {
+    private let regime = TouchRegime(orientation: .portrait, posture: .twoThumb)
+
+    private func make(_ suite: String, enabled: Bool) -> TelemetryController {
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        return TelemetryController(
+            store: GestureTelemetryStore(defaults: d),
+            saveEvery: 1,
+            isFeatureEnabled: { enabled },
+            currentRegime: { regime }
+        )
+    }
+
+    @Test func recordsClassStatsAndABWhenEnabled() {
+        let c = make("test.telemetry.enabled", enabled: true)
+        c.recordGesture(.tap, isReturn: false, features: .empty())
+        c.recordGesture(.tap, isReturn: false, features: .empty())
+        let tap = c.snapshot.classes[regime.key]?["tap"]
+        #expect(tap?.total == 2)
+        #expect(tap?.features["maxDisplacement"]?.count == 2)
+        #expect(c.snapshot.abEnabled.total == 2)
+        #expect(c.snapshot.abDisabled.total == 0)
+    }
+
+    @Test func disabledSkipsClassStatsButCountsAB() {
+        let c = make("test.telemetry.disabled", enabled: false)
+        c.recordGesture(.swipeUp, isReturn: false, features: .empty())
+        #expect(c.snapshot.classes.isEmpty)
+        #expect(c.snapshot.abDisabled.total == 1)
+        #expect(c.snapshot.abEnabled.total == 0)
+    }
+
+    @Test func deleteChargesLastClassAndAB() {
+        let c = make("test.telemetry.delete", enabled: true)
+        c.recordGesture(.swipeUp, isReturn: false, features: .empty())
+        c.recordUserDelete()
+        #expect(c.snapshot.classes[regime.key]?["swipe.swipeUp"]?.corrections == 1)
+        #expect(c.snapshot.abEnabled.corrections == 1)
+    }
+
+    @Test func correctionRateComputes() {
+        let c = make("test.telemetry.rate", enabled: true)
+        for _ in 0 ..< 10 {
+            c.recordGesture(.tap, isReturn: false, features: .empty())
+        }
+        c.recordUserDelete()
+        #expect(abs((c.snapshot.abEnabled.correctionRate) - 1.0 / 10.0) < 1e-9)
+    }
+
+    @Test func persistsAcrossReload() throws {
+        let suite = "test.telemetry.persist"
+        let c = make(suite, enabled: true)
+        c.recordGesture(.tap, isReturn: false, features: .empty())
+        c.persist()
+        let d = try #require(UserDefaults(suiteName: suite))
+        let reloaded = GestureTelemetryStore(defaults: d).load()
+        #expect(reloaded.classes[regime.key]?["tap"]?.total == 1)
+    }
+}

--- a/wurstfingerTests/TelemetryTests.swift
+++ b/wurstfingerTests/TelemetryTests.swift
@@ -2,9 +2,10 @@
 //  TelemetryTests.swift
 //  WurstfingerTests
 //
-//  Tests for gesture telemetry (§13) and the A/B proxy metric (§8).
+//  Tests for gesture telemetry (§13) and the counterfactual benefit metric (§8).
 //
 
+import CoreGraphics
 import Foundation
 import Testing
 @testable import WurstfingerApp
@@ -28,63 +29,117 @@ struct FeatureStatTests {
     }
 }
 
+struct FlipDetectionTests {
+    @Test func centeredTapWithNoOffsetIsNotAFlip() {
+        #expect(!TelemetryController.isFlip(touchdown: CGPoint(x: 0.5, y: 0.5), offset: .zero))
+    }
+
+    @Test func offsetPushingPastEdgeIsAFlip() {
+        // touchdown + offset leaves [0,1] → an unshifted neighbor owned the tap.
+        #expect(TelemetryController.isFlip(touchdown: CGPoint(x: 0.9, y: 0.5), offset: CGVector(dx: 0.2, dy: 0)))
+        #expect(TelemetryController.isFlip(touchdown: CGPoint(x: 0.1, y: 0.5), offset: CGVector(dx: -0.2, dy: 0)))
+        #expect(TelemetryController.isFlip(touchdown: CGPoint(x: 0.5, y: 0.95), offset: CGVector(dx: 0, dy: 0.1)))
+    }
+
+    @Test func offsetStayingInsideIsNotAFlip() {
+        #expect(!TelemetryController.isFlip(touchdown: CGPoint(x: 0.6, y: 0.6), offset: CGVector(dx: 0.1, dy: 0.1)))
+    }
+}
+
 struct TelemetryControllerTests {
     private let regime = TouchRegime(orientation: .portrait, posture: .twoThumb)
 
-    private func make(_ suite: String, enabled: Bool) -> TelemetryController {
+    private func make(_ suite: String, enabled: Bool, window: Int = 3) -> TelemetryController {
         let d = UserDefaults(suiteName: suite)!
         d.removePersistentDomain(forName: suite)
         return TelemetryController(
             store: GestureTelemetryStore(defaults: d),
             saveEvery: 1,
+            window: window,
             isFeatureEnabled: { enabled },
             currentRegime: { regime }
         )
     }
 
-    @Test func recordsClassStatsAndABWhenEnabled() {
+    // MARK: - Per-class feature stats (§13)
+
+    @Test func recordsClassStatsWhenEnabled() {
         let c = make("test.telemetry.enabled", enabled: true)
         c.recordGesture(.tap, isReturn: false, features: .empty())
         c.recordGesture(.tap, isReturn: false, features: .empty())
         let tap = c.snapshot.classes[regime.key]?["tap"]
         #expect(tap?.total == 2)
         #expect(tap?.features["maxDisplacement"]?.count == 2)
-        #expect(c.snapshot.abEnabled.total == 2)
-        #expect(c.snapshot.abDisabled.total == 0)
     }
 
-    @Test func disabledSkipsClassStatsButCountsAB() {
+    @Test func disabledSkipsClassStats() {
         let c = make("test.telemetry.disabled", enabled: false)
         c.recordGesture(.swipeUp, isReturn: false, features: .empty())
         #expect(c.snapshot.classes.isEmpty)
-        #expect(c.snapshot.abDisabled.total == 1)
-        #expect(c.snapshot.abEnabled.total == 0)
     }
 
-    @Test func deleteChargesLastClassAndAB() {
+    @Test func deleteChargesLastClass() {
         let c = make("test.telemetry.delete", enabled: true)
         c.recordGesture(.swipeUp, isReturn: false, features: .empty())
         c.recordUserDelete()
         #expect(c.snapshot.classes[regime.key]?["swipe.swipeUp"]?.corrections == 1)
-        #expect(c.snapshot.abEnabled.corrections == 1)
     }
 
-    @Test func correctionRateComputes() {
+    @Test func classCorrectionRateComputes() {
         let c = make("test.telemetry.rate", enabled: true)
         for _ in 0 ..< 10 {
             c.recordGesture(.tap, isReturn: false, features: .empty())
         }
         c.recordUserDelete()
-        #expect(abs((c.snapshot.abEnabled.correctionRate) - 1.0 / 10.0) < 1e-9)
+        #expect(abs((c.snapshot.classes[regime.key]?["tap"]?.correctionRate ?? 0) - 1.0 / 10.0) < 1e-9)
     }
+
+    // MARK: - Counterfactual benefit (§8)
+
+    @Test func keptFlipCountsAsCaught() {
+        let c = make("test.telemetry.caught", enabled: true, window: 1)
+        c.recordTapOutcome(regimeKey: regime.key, isFlip: true)
+        // A later tap ages the flipped one out of the veto window (unvetoed).
+        c.recordTapOutcome(regimeKey: regime.key, isFlip: false)
+        #expect(c.snapshot.counterfactual[regime.key]?.caught == 1)
+        #expect(c.snapshot.counterfactual[regime.key]?.caused == 0)
+    }
+
+    @Test func vetoedFlipCountsAsCaused() {
+        let c = make("test.telemetry.caused", enabled: true, window: 1)
+        c.recordTapOutcome(regimeKey: regime.key, isFlip: true)
+        c.recordUserDelete() // vetoes the still-pending flip
+        #expect(c.snapshot.counterfactual[regime.key]?.caused == 1)
+        #expect(c.snapshot.counterfactual[regime.key]?.caught == nil || c.snapshot.counterfactual[regime.key]?.caught == 0)
+    }
+
+    @Test func nonFlipTapContributesNothing() {
+        let c = make("test.telemetry.noflip", enabled: true, window: 1)
+        c.recordTapOutcome(regimeKey: regime.key, isFlip: false)
+        c.recordTapOutcome(regimeKey: regime.key, isFlip: false)
+        #expect(c.snapshot.counterfactual[regime.key] == nil)
+    }
+
+    @Test func netIsCaughtMinusCaused() {
+        var m = CounterfactualMetric()
+        m.caught = 5
+        m.caused = 2
+        #expect(m.net == 3)
+        #expect(m.total == 7)
+    }
+
+    // MARK: - Persistence
 
     @Test func persistsAcrossReload() throws {
         let suite = "test.telemetry.persist"
-        let c = make(suite, enabled: true)
+        let c = make(suite, enabled: true, window: 1)
         c.recordGesture(.tap, isReturn: false, features: .empty())
+        c.recordTapOutcome(regimeKey: regime.key, isFlip: true)
+        c.recordTapOutcome(regimeKey: regime.key, isFlip: false) // flush → caught
         c.persist()
         let d = try #require(UserDefaults(suiteName: suite))
         let reloaded = GestureTelemetryStore(defaults: d).load()
         #expect(reloaded.classes[regime.key]?["tap"]?.total == 1)
+        #expect(reloaded.counterfactual[regime.key]?.caught == 1)
     }
 }

--- a/wurstfingerTests/TouchLearningTests.swift
+++ b/wurstfingerTests/TouchLearningTests.swift
@@ -1,0 +1,163 @@
+//
+//  TouchLearningTests.swift
+//  WurstfingerTests
+//
+//  Tests for the acceptance filter and the learning controller (spec §4.1, §5).
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct AcceptanceTrackerTests {
+    private let regime = TouchRegime(orientation: .portrait, posture: .twoThumb)
+    private func tap(_ id: String) -> PendingTap {
+        PendingTap(keyId: id, touchdown: CGPoint(x: 0.5, y: 0.5), regime: regime)
+    }
+
+    @Test func holdsTapsWithinWindow() {
+        let t = AcceptanceTracker(window: 2)
+        #expect(t.recordTap(tap("A")).isEmpty)
+        #expect(t.recordTap(tap("B")).isEmpty)
+        #expect(t.pendingCount == 2)
+    }
+
+    @Test func confirmsOldestOnOverflow() {
+        let t = AcceptanceTracker(window: 1)
+        #expect(t.recordTap(tap("A")).isEmpty)
+        let confirmed = t.recordTap(tap("B"))
+        #expect(confirmed.map(\.keyId) == ["A"])
+    }
+
+    @Test func userDeleteVetoesMostRecent() {
+        let t = AcceptanceTracker(window: 3)
+        _ = t.recordTap(tap("A"))
+        _ = t.recordTap(tap("B"))
+        t.recordUserDelete()
+        #expect(t.flush().map(\.keyId) == ["A"]) // B vetoed
+    }
+
+    @Test func burstDeleteVetoesSeveral() {
+        let t = AcceptanceTracker(window: 5)
+        ["A", "B", "C"].forEach { _ = t.recordTap(tap($0)) }
+        t.recordUserDelete(count: 2)
+        #expect(t.flush().map(\.keyId) == ["A"]) // B, C vetoed
+    }
+}
+
+struct TouchLearningControllerTests {
+    private let regime = TouchRegime(orientation: .portrait, posture: .oneThumbLeft)
+
+    private func freshStore(_ suite: String) -> TouchOffsetStore {
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        return TouchOffsetStore(defaults: d)
+    }
+
+    private func makeController(
+        suite: String, enabled: Bool = true, window: Int = 1
+    ) -> TouchLearningController {
+        TouchLearningController(
+            store: freshStore(suite),
+            window: window,
+            saveEvery: 1,
+            isEnabled: { enabled },
+            currentRegime: { regime },
+            keyPosition: { _ in CGPoint(x: 0.5, y: 0.5) }
+        )
+    }
+
+    private func magnitude(_ v: CGVector) -> Double {
+        (v.dx * v.dx + v.dy * v.dy).squareRoot()
+    }
+
+    @Test func learnsInteriorTapOffset() {
+        let c = makeController(suite: "test.learn.interior")
+        // Repeated tap landing right-of-center → learns a rightward offset.
+        for _ in 0 ..< 60 {
+            c.recordTap(keyId: "A", touchdown: CGPoint(x: 0.65, y: 0.5))
+        }
+        let off = c.model(for: regime).offset(forKeyId: "A")
+        #expect(abs(off.dx - 0.15) < 0.03)
+        #expect(abs(off.dy) < 0.02)
+    }
+
+    @Test func disabledLearnsNothing() {
+        let c = makeController(suite: "test.learn.disabled", enabled: false)
+        for _ in 0 ..< 60 {
+            c.recordTap(keyId: "A", touchdown: CGPoint(x: 0.65, y: 0.5))
+        }
+        #expect(magnitude(c.model(for: regime).offset(forKeyId: "A")) < 1e-9)
+    }
+
+    @Test func nonInteriorTapIsExcluded() {
+        let c = makeController(suite: "test.learn.edge")
+        // Touchdown near the left edge (< interiorMargin 0.10) → not learned.
+        for _ in 0 ..< 60 {
+            c.recordTap(keyId: "A", touchdown: CGPoint(x: 0.03, y: 0.5))
+        }
+        #expect(magnitude(c.model(for: regime).offset(forKeyId: "A")) < 1e-9)
+    }
+
+    @Test func vetoedTapIsNotLearned() {
+        let c = makeController(suite: "test.learn.veto", window: 1)
+        // Tap X, then a user delete vetoes it before it can be confirmed.
+        c.recordTap(keyId: "X", touchdown: CGPoint(x: 0.7, y: 0.5))
+        c.recordUserDelete()
+        // Now many taps on Y confirm/learn; X must never be learned.
+        for _ in 0 ..< 60 {
+            c.recordTap(keyId: "Y", touchdown: CGPoint(x: 0.65, y: 0.5))
+        }
+        let model = c.model(for: regime)
+        #expect(magnitude(model.offset(forKeyId: "X")) < 1e-9)
+        #expect(model.offset(forKeyId: "Y").dx > 0.1)
+    }
+
+    @Test func persistsAcrossReload() throws {
+        let suite = "test.learn.persist"
+        let c = makeController(suite: suite)
+        for _ in 0 ..< 60 {
+            c.recordTap(keyId: "A", touchdown: CGPoint(x: 0.65, y: 0.5))
+        }
+        c.persist()
+        // A fresh controller on the same store sees the learned offset.
+        let d = try #require(UserDefaults(suiteName: suite))
+        let reloaded = TouchOffsetModel(regime: regime, snapshot: TouchOffsetStore(defaults: d).load())
+        #expect(abs(reloaded.offset(forKeyId: "A").dx - 0.15) < 0.03)
+    }
+}
+
+/// End-to-end through the real view model (gesture path + regime + key position).
+@Suite(.serialized)
+struct TouchLearningViewModelTests {
+    private func magnitude(_ v: CGVector) -> Double {
+        (v.dx * v.dx + v.dy * v.dy).squareRoot()
+    }
+
+    @Test func learnsFromTapsThroughViewModel() {
+        let (vm, _) = makeViewModel()
+        vm.sharedDefaults.set(true, forKey: SettingsKey.touchOffsetEnabled.rawValue)
+        for _ in 0 ..< 60 {
+            vm.handleGesture(
+                .tap, keyId: GridSlot.topLeft, isReturn: false,
+                touchdown: CGPoint(x: 0.66, y: 0.5)
+            )
+        }
+        let off = vm.touchLearning.model(for: vm.currentTouchRegime).offset(forKeyId: GridSlot.topLeft)
+        #expect(abs(off.dx - 0.16) < 0.04)
+        #expect(abs(off.dy) < 0.03)
+    }
+
+    @Test func disabledToggleLearnsNothing() {
+        let (vm, _) = makeViewModel() // toggle off by default
+        for _ in 0 ..< 60 {
+            vm.handleGesture(
+                .tap, keyId: GridSlot.topLeft, isReturn: false,
+                touchdown: CGPoint(x: 0.66, y: 0.5)
+            )
+        }
+        let off = vm.touchLearning.model(for: vm.currentTouchRegime).offset(forKeyId: GridSlot.topLeft)
+        #expect(magnitude(off) < 1e-9)
+    }
+}

--- a/wurstfingerTests/TouchLearningTests.swift
+++ b/wurstfingerTests/TouchLearningTests.swift
@@ -160,4 +160,24 @@ struct TouchLearningViewModelTests {
         let off = vm.touchLearning.model(for: vm.currentTouchRegime).offset(forKeyId: GridSlot.topLeft)
         #expect(magnitude(off) < 1e-9)
     }
+
+    /// The apply-gate (§4.4): correction is exposed only when enabled AND the
+    /// regime has matured.
+    @Test func applyGateRequiresEnabledAndMature() {
+        let (vm, _) = makeViewModel()
+        #expect(vm.currentTouchCorrectionOffsets().isEmpty) // off
+
+        vm.sharedDefaults.set(true, forKey: SettingsKey.touchOffsetEnabled.rawValue)
+        #expect(vm.currentTouchCorrectionOffsets().isEmpty) // enabled but no data
+
+        for _ in 0 ..< 60 {
+            vm.handleGesture(
+                .tap, keyId: GridSlot.topLeft, isReturn: false,
+                touchdown: CGPoint(x: 0.66, y: 0.5)
+            )
+        }
+        let offsets = vm.currentTouchCorrectionOffsets()
+        #expect(!offsets.isEmpty)
+        #expect((offsets[GridSlot.topLeft]?.dx ?? 0) > 0.05)
+    }
 }

--- a/wurstfingerTests/TouchOffsetModelTests.swift
+++ b/wurstfingerTests/TouchOffsetModelTests.swift
@@ -1,0 +1,87 @@
+//
+//  TouchOffsetModelTests.swift
+//  WurstfingerTests
+//
+//  Tests for the Empirical-Bayes touch-offset model (spec §4.2): convergence,
+//  shrinkage, clamp, split surface, no-drift.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct TouchOffsetModelTests {
+    private let oneThumb = TouchRegime(orientation: .portrait, posture: .oneThumbLeft)
+    private let twoThumb = TouchRegime(orientation: .portrait, posture: .twoThumb)
+
+    private func magnitude(_ v: CGVector) -> Double {
+        (v.dx * v.dx + v.dy * v.dy).squareRoot()
+    }
+
+    @Test func emptyModelReturnsZero() {
+        let model = TouchOffsetModel(regime: oneThumb)
+        #expect(model.offset(forKeyId: "missing") == .zero)
+    }
+
+    @Test func singleSampleNearZeroStaysSmall() {
+        var model = TouchOffsetModel(regime: oneThumb)
+        model.learn(keyId: "A", posU: 0.5, posV: 0.5, sampleX: 0, sampleY: 0)
+        #expect(magnitude(model.offset(forKeyId: "A")) < 0.01)
+    }
+
+    @Test func convergesToConstantBias() {
+        var model = TouchOffsetModel(regime: oneThumb)
+        for _ in 0 ..< 300 {
+            model.learn(keyId: "A", posU: 0.5, posV: 0.5, sampleX: 0.15, sampleY: -0.10)
+        }
+        let off = model.offset(forKeyId: "A")
+        #expect(abs(off.dx - 0.15) < 0.02)
+        #expect(abs(off.dy - -0.10) < 0.02)
+    }
+
+    @Test func sparseKeyIsShrunkTowardSurface() {
+        var model = TouchOffsetModel(regime: oneThumb)
+        // One sample with a strong mean → heavily shrunk (n=1, κ=8).
+        model.learn(keyId: "A", posU: 0.5, posV: 0.5, sampleX: 0.30, sampleY: 0)
+        #expect(magnitude(model.offset(forKeyId: "A")) < 0.15)
+    }
+
+    @Test func offsetIsClamped() {
+        var model = TouchOffsetModel(regime: oneThumb)
+        for _ in 0 ..< 500 {
+            model.learn(keyId: "A", posU: 0.5, posV: 0.5, sampleX: 0.5, sampleY: 0.5)
+        }
+        let m = magnitude(model.offset(forKeyId: "A"))
+        #expect(m <= TouchOffsetConfig.default.clampFraction + 1e-6)
+        #expect(m > 0.25) // it did grow substantially before clamping
+    }
+
+    @Test func clampMagnitudeStaticScalesDown() {
+        let clamped = TouchOffsetModel.clampMagnitude(CGVector(dx: 0.5, dy: 0.5), maxMagnitude: 0.35)
+        #expect(abs(magnitude(clamped) - 0.35) < 1e-9)
+    }
+
+    @Test func splitSurfaceKeepsHalvesIndependent() {
+        var model = TouchOffsetModel(regime: twoThumb)
+        for _ in 0 ..< 300 {
+            model.learn(keyId: "L", posU: 0.2, posV: 0.5, sampleX: 0.20, sampleY: 0)
+            model.learn(keyId: "R", posU: 0.8, posV: 0.5, sampleX: -0.20, sampleY: 0)
+        }
+        let offsets = model.allOffsets()
+        #expect((offsets["L"]?.dx ?? 0) > 0.1)
+        #expect((offsets["R"]?.dx ?? 0) < -0.1)
+    }
+
+    @Test func repeatedApplicationDoesNotDrift() {
+        // Pure model learns against the supplied (fixed-geometry) sample, so a
+        // constant sample converges and stays — no self-reinforcement (§4.1).
+        var model = TouchOffsetModel(regime: oneThumb)
+        for _ in 0 ..< 500 {
+            model.learn(keyId: "A", posU: 0.5, posV: 0.5, sampleX: 0.10, sampleY: 0.10)
+        }
+        let off = model.offset(forKeyId: "A")
+        #expect(abs(off.dx - 0.10) < 0.02)
+        #expect(abs(off.dy - 0.10) < 0.02)
+    }
+}

--- a/wurstfingerTests/TouchOffsetStoreTests.swift
+++ b/wurstfingerTests/TouchOffsetStoreTests.swift
@@ -1,0 +1,99 @@
+//
+//  TouchOffsetStoreTests.swift
+//  WurstfingerTests
+//
+//  Tests for touch-offset persistence (spec §7): round-trip, schema
+//  invalidation, partial pruning, reset, model bridge.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct TouchOffsetStoreTests {
+    private func freshDefaults(_ suite: String) -> UserDefaults {
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        return d
+    }
+
+    private let regime = TouchRegime(orientation: .portrait, posture: .twoThumb)
+
+    private func sampleSnapshot() -> TouchOffsetSnapshot {
+        var model = TouchOffsetModel(regime: regime)
+        for _ in 0 ..< 50 {
+            model.learn(keyId: "A", posU: 0.3, posV: 0.5, sampleX: 0.1, sampleY: -0.05)
+        }
+        return TouchOffsetSnapshot(
+            schemaVersion: TouchOffsetStore.currentSchemaVersion,
+            regimes: [regime.key: model.persistableKeys]
+        )
+    }
+
+    @Test func roundTripsSnapshot() {
+        let store = TouchOffsetStore(defaults: freshDefaults("test.touchoffset.roundtrip"))
+        let snapshot = sampleSnapshot()
+        store.save(snapshot)
+        #expect(store.load() == snapshot)
+    }
+
+    @Test func emptyWhenAbsent() {
+        let store = TouchOffsetStore(defaults: freshDefaults("test.touchoffset.absent"))
+        #expect(store.load().regimes.isEmpty)
+    }
+
+    @Test func schemaMismatchInvalidates() {
+        let defaults = freshDefaults("test.touchoffset.schema")
+        // Write a snapshot stamped with a wrong (future) schema version.
+        var snapshot = sampleSnapshot()
+        snapshot.schemaVersion = TouchOffsetStore.currentSchemaVersion + 99
+        let data = try? JSONEncoder().encode(snapshot)
+        defaults.set(data, forKey: TouchOffsetStore.storageKey)
+
+        let store = TouchOffsetStore(defaults: defaults)
+        #expect(store.load().regimes.isEmpty)
+    }
+
+    @Test func resetRegimeKeepsOthers() {
+        let store = TouchOffsetStore(defaults: freshDefaults("test.touchoffset.resetregime"))
+        var snapshot = sampleSnapshot()
+        snapshot.regimes["landscape.twoThumb"] = ["B": KeyOffsetState(spreadPrior: 0.1, posU: 0.5, posV: 0.5)]
+        store.save(snapshot)
+
+        store.reset(regimeKey: regime.key)
+        let loaded = store.load()
+        #expect(loaded.regimes[regime.key] == nil)
+        #expect(loaded.regimes["landscape.twoThumb"] != nil)
+    }
+
+    @Test func resetAllClears() {
+        let store = TouchOffsetStore(defaults: freshDefaults("test.touchoffset.resetall"))
+        store.save(sampleSnapshot())
+        store.resetAll()
+        #expect(store.load().regimes.isEmpty)
+    }
+
+    @Test func pruneDropsUnknownKeys() {
+        var snapshot = sampleSnapshot()
+        snapshot.regimes[regime.key]?["STALE"] = KeyOffsetState(spreadPrior: 0.1, posU: 0.9, posV: 0.9)
+        snapshot.pruneKeys(in: regime.key, keeping: ["A"])
+        #expect(snapshot.regimes[regime.key]?["A"] != nil)
+        #expect(snapshot.regimes[regime.key]?["STALE"] == nil)
+    }
+
+    @Test func modelBridgeReloadsState() {
+        let store = TouchOffsetStore(defaults: freshDefaults("test.touchoffset.bridge"))
+        // Learn → persist → rebuild model → state survives.
+        var model = TouchOffsetModel(regime: regime)
+        for _ in 0 ..< 100 {
+            model.learn(keyId: "A", posU: 0.3, posV: 0.5, sampleX: 0.12, sampleY: 0)
+        }
+        store.save(TouchOffsetSnapshot(
+            schemaVersion: TouchOffsetStore.currentSchemaVersion,
+            regimes: [regime.key: model.persistableKeys]
+        ))
+
+        let reloaded = TouchOffsetModel(regime: regime, snapshot: store.load())
+        #expect(abs(reloaded.offset(forKeyId: "A").dx - model.offset(forKeyId: "A").dx) < 1e-9)
+    }
+}

--- a/wurstfingerTests/TouchRegimeTests.swift
+++ b/wurstfingerTests/TouchRegimeTests.swift
@@ -1,0 +1,61 @@
+//
+//  TouchRegimeTests.swift
+//  WurstfingerTests
+//
+//  Tests for derivePosture partition + hysteresis (spec §3.1).
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct TouchRegimeTests {
+    private let t = PostureThresholds.default // narrowScale 0.55, offsetMargin 0.18, hysteresis 0.05
+
+    // MARK: - Nominal partition (no hysteresis)
+
+    @Test func wideCenteredIsTwoThumb() {
+        #expect(PostureResolver.derivePosture(scale: 0.70, position: 0.5) == .twoThumb)
+    }
+
+    @Test func narrowLeftIsOneThumbLeft() {
+        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.25) == .oneThumbLeft)
+    }
+
+    @Test func narrowRightIsOneThumbRight() {
+        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.75) == .oneThumbRight)
+    }
+
+    @Test func narrowCenteredDefaultsToTwoThumb() {
+        // The "schmal & mittig" case: Default to twoThumb (hand unknown).
+        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.5) == .twoThumb)
+    }
+
+    // MARK: - Hysteresis
+
+    @Test func hysteresisKeepsCurrentSideNearBoundary() {
+        // pos 0.34 is just right of the nominal left boundary (0.32) → nominally
+        // twoThumb, but staying in oneThumbLeft keeps it left (boundary 0.37).
+        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.34) == .twoThumb)
+        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.34, previous: .oneThumbLeft) == .oneThumbLeft)
+    }
+
+    @Test func hysteresisFlipsOncePastBand() {
+        // pos 0.40 is past the sticky left boundary (0.37) → flips to twoThumb.
+        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.40, previous: .oneThumbLeft) == .twoThumb)
+    }
+
+    @Test func hysteresisResistsEnteringFromTwoThumb() {
+        // pos 0.30 nominally left (< 0.32), but from twoThumb entering requires
+        // clearly past the tightened boundary (0.27) → stays twoThumb.
+        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.30) == .oneThumbLeft)
+        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.30, previous: .twoThumb) == .twoThumb)
+    }
+
+    // MARK: - Regime key
+
+    @Test func regimeKeyIsStable() {
+        let r = TouchRegime(orientation: .portrait, posture: .oneThumbRight)
+        #expect(r.key == "portrait.oneThumbRight")
+    }
+}

--- a/wurstfingerTests/TouchRegimeTests.swift
+++ b/wurstfingerTests/TouchRegimeTests.swift
@@ -2,7 +2,7 @@
 //  TouchRegimeTests.swift
 //  WurstfingerTests
 //
-//  Tests for derivePosture partition + hysteresis (spec §3.1).
+//  Tests for the explicit posture setting mapping + regime key (spec §3.1/§6.3).
 //
 
 import Foundation
@@ -10,46 +10,29 @@ import Testing
 @testable import WurstfingerApp
 
 struct TouchRegimeTests {
-    private let t = PostureThresholds.default // narrowScale 0.55, offsetMargin 0.18, hysteresis 0.05
+    // MARK: - Explicit posture from the stored setting
 
-    // MARK: - Nominal partition (no hysteresis)
-
-    @Test func wideCenteredIsTwoThumb() {
-        #expect(PostureResolver.derivePosture(scale: 0.70, position: 0.5) == .twoThumb)
+    @Test func missingSettingFallsBackToDefault() {
+        #expect(PostureClass(settingValue: nil) == .oneThumbRight)
+        #expect(PostureClass.defaultDeclared == .oneThumbRight)
     }
 
-    @Test func narrowLeftIsOneThumbLeft() {
-        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.25) == .oneThumbLeft)
+    @Test func unknownSettingFallsBackToDefault() {
+        #expect(PostureClass(settingValue: "garbage") == .oneThumbRight)
     }
 
-    @Test func narrowRightIsOneThumbRight() {
-        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.75) == .oneThumbRight)
+    @Test func storedValueRoundTrips() {
+        for posture in PostureClass.allCases {
+            #expect(PostureClass(settingValue: posture.rawValue) == posture)
+        }
     }
 
-    @Test func narrowCenteredDefaultsToTwoThumb() {
-        // The "schmal & mittig" case: Default to twoThumb (hand unknown).
-        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.5) == .twoThumb)
-    }
+    // MARK: - Split-surface flag (§3.2)
 
-    // MARK: - Hysteresis
-
-    @Test func hysteresisKeepsCurrentSideNearBoundary() {
-        // pos 0.34 is just right of the nominal left boundary (0.32) → nominally
-        // twoThumb, but staying in oneThumbLeft keeps it left (boundary 0.37).
-        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.34) == .twoThumb)
-        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.34, previous: .oneThumbLeft) == .oneThumbLeft)
-    }
-
-    @Test func hysteresisFlipsOncePastBand() {
-        // pos 0.40 is past the sticky left boundary (0.37) → flips to twoThumb.
-        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.40, previous: .oneThumbLeft) == .twoThumb)
-    }
-
-    @Test func hysteresisResistsEnteringFromTwoThumb() {
-        // pos 0.30 nominally left (< 0.32), but from twoThumb entering requires
-        // clearly past the tightened boundary (0.27) → stays twoThumb.
-        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.30) == .oneThumbLeft)
-        #expect(PostureResolver.derivePosture(scale: 0.40, position: 0.30, previous: .twoThumb) == .twoThumb)
+    @Test func onlyTwoThumbUsesSplitSurface() {
+        #expect(PostureClass.twoThumb.usesSplitSurface)
+        #expect(!PostureClass.oneThumbLeft.usesSplitSurface)
+        #expect(!PostureClass.oneThumbRight.usesSplitSurface)
     }
 
     // MARK: - Regime key

--- a/wurstfingerUITests/KeyboardResizingTests.swift
+++ b/wurstfingerUITests/KeyboardResizingTests.swift
@@ -1,0 +1,95 @@
+//
+//  KeyboardResizingTests.swift
+//  wurstfingerUITests
+//
+//  End-to-end validation of Key-Target-Resizing (spec §5.5/§11.6): with a
+//  hardcoded offset on the center column, a FIXED screen point just inside the
+//  right column is reassigned to the center key. Proven by coordinate taps —
+//  the touch frame, not the drawn key, decides assignment. This is the
+//  automated form of the P3.5 device spike.
+//
+
+import XCTest
+
+final class KeyboardResizingTests: XCTestCase {
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    private func launch(spike: Bool) {
+        app = UITestApp.make(["SCREENSHOT_MODE"])
+        app.launchEnvironment["TYPING_TEST"] = "1"
+        app.launchEnvironment["FORCE_LANGUAGE"] = "de_DE"
+        app.launchEnvironment["FORCE_LAYER"] = "lower"
+        app.launchEnvironment["FORCE_APPEARANCE"] = "light"
+        if spike { app.launchEnvironment["TOUCH_OFFSET_SPIKE"] = "1" }
+        app.launch()
+        XCTAssertTrue(app.buttons["center"].waitForExistence(timeout: 5), "Keyboard not loaded")
+        XCTAssertTrue(app.staticTexts["typedText"].waitForExistence(timeout: 2), "Typing harness missing")
+    }
+
+    private func typedText() -> String {
+        (app.staticTexts["typedText"].value as? String) ?? ""
+    }
+
+    private func tapAbsolute(_ point: CGPoint) {
+        app.coordinate(withNormalizedOffset: .zero)
+            .withOffset(CGVector(dx: point.x, dy: point.y))
+            .tap()
+    }
+
+    private func waitText(_ expected: String) -> Bool {
+        let predicate = NSPredicate { _, _ in self.typedText() == expected }
+        return XCTWaiter.wait(
+            for: [XCTNSPredicateExpectation(predicate: predicate, object: nil)], timeout: 3
+        ) == .completed
+    }
+
+    /// With the center column's hit cells shifted right, a fixed point that lies
+    /// in the right key's territory when off lands in the center key when on.
+    @MainActor
+    func testResizingReassignsBoundaryTap() {
+        // OFF: measure the nominal center|right boundary and the two characters.
+        launch(spike: false)
+        let centerFrameOff = app.buttons["center"].frame
+        let centerChar = app.buttons["center"].label
+        let rightChar = app.buttons["midRight"].label
+        let boundaryOff = app.buttons["midRight"].frame.minX
+        let rowY = centerFrameOff.midY
+        XCTAssertNotEqual(centerChar, rightChar, "Center and right keys must differ for a meaningful test")
+        app.terminate()
+
+        // ON: the center column extended right → the boundary moved right.
+        launch(spike: true)
+        let centerFrameOn = app.buttons["center"].frame
+        let boundaryOn = app.buttons["midRight"].frame.minX
+        XCTAssertGreaterThan(
+            boundaryOn, boundaryOff + 1,
+            "Resizing should move the center|right hit boundary right (off \(boundaryOff), on \(boundaryOn))"
+        )
+        XCTAssertGreaterThan(
+            centerFrameOn.maxX, centerFrameOff.maxX + 1,
+            "The center key's touch frame should extend right"
+        )
+
+        // A point between the old and new boundary: right of the OFF boundary
+        // (so OFF → right key), left of the ON boundary (so ON → center key).
+        let probe = CGPoint(x: (boundaryOff + boundaryOn) / 2, y: rowY)
+        tapAbsolute(probe)
+        XCTAssertTrue(
+            waitText(centerChar),
+            "ON: the reassigned point should produce the center char '\(centerChar)', got '\(typedText())'"
+        )
+        app.terminate()
+
+        // OFF control: the very same point produces the right key's char.
+        launch(spike: false)
+        tapAbsolute(probe)
+        XCTAssertTrue(
+            waitText(rightChar),
+            "OFF: the same point should produce the right char '\(rightChar)', got '\(typedText())'"
+        )
+    }
+}

--- a/wurstfingerUITests/TouchOffsetSettingsUITests.swift
+++ b/wurstfingerUITests/TouchOffsetSettingsUITests.swift
@@ -52,8 +52,8 @@ final class TouchOffsetSettingsUITests: XCTestCase {
         XCTAssertTrue(statsLink.waitForExistence(timeout: 3), "Statistics link missing")
         statsLink.tap()
         XCTAssertTrue(
-            app.staticTexts["Does it help?"].waitForExistence(timeout: 3),
-            "A/B statistics missing on the subpage"
+            app.staticTexts["Error rate"].waitForExistence(timeout: 3),
+            "Error-rate statistics missing on the subpage"
         )
         app.navigationBars.buttons.element(boundBy: 0).tap()
 

--- a/wurstfingerUITests/TouchOffsetSettingsUITests.swift
+++ b/wurstfingerUITests/TouchOffsetSettingsUITests.swift
@@ -3,8 +3,8 @@
 //  wurstfingerUITests
 //
 //  Verifies the Touch Correction settings page (spec §6) is reachable and
-//  shows its core controls: the toggle, the learned-offset visualization and
-//  the reset controls.
+//  shows its core controls: the toggle, the explicit hand-posture choice
+//  (§6.3), the learned-offset visualization and the reset controls.
 //
 
 import XCTest
@@ -40,6 +40,16 @@ final class TouchOffsetSettingsUITests: XCTestCase {
             app.buttons["Reset everything"].waitForExistence(timeout: 3),
             "Reset control missing"
         )
+
+        // The posture is an explicit choice, not a view filter: the three
+        // options are present and selectable (order: right, left, both).
+        let rightThumb = app.staticTexts["One hand — right thumb"]
+        XCTAssertTrue(rightThumb.waitForExistence(timeout: 3), "Posture choice missing")
+        XCTAssertTrue(app.staticTexts["One hand — left thumb"].exists, "Left-thumb option missing")
+        let twoThumbs = app.staticTexts["Two thumbs"]
+        XCTAssertTrue(twoThumbs.exists, "Two-thumbs option missing")
+        // Selecting a different posture must be possible.
+        twoThumbs.tap()
 
         // The toggle is interactive.
         app.switches["Correct my typing"].tap()

--- a/wurstfingerUITests/TouchOffsetSettingsUITests.swift
+++ b/wurstfingerUITests/TouchOffsetSettingsUITests.swift
@@ -41,17 +41,24 @@ final class TouchOffsetSettingsUITests: XCTestCase {
             "Reset control missing"
         )
 
-        // The posture is an explicit choice, not a view filter: the three
-        // options are present and selectable (order: right, left, both).
-        let rightThumb = app.staticTexts["One hand — right thumb"]
-        XCTAssertTrue(rightThumb.waitForExistence(timeout: 3), "Posture choice missing")
-        XCTAssertTrue(app.staticTexts["One hand — left thumb"].exists, "Left-thumb option missing")
-        let twoThumbs = app.staticTexts["Two thumbs"]
-        XCTAssertTrue(twoThumbs.exists, "Two-thumbs option missing")
-        // Selecting a different posture must be possible.
-        twoThumbs.tap()
+        // The posture is an explicit choice presented as a compact picker.
+        XCTAssertTrue(
+            app.staticTexts["How do you type?"].waitForExistence(timeout: 3),
+            "Posture picker missing"
+        )
+
+        // Statistics live on their own subpage now.
+        let statsLink = app.buttons["Statistics"]
+        XCTAssertTrue(statsLink.waitForExistence(timeout: 3), "Statistics link missing")
+        statsLink.tap()
+        XCTAssertTrue(
+            app.staticTexts["Does it help?"].waitForExistence(timeout: 3),
+            "A/B statistics missing on the subpage"
+        )
+        app.navigationBars.buttons.element(boundBy: 0).tap()
 
         // The toggle is interactive.
+        XCTAssertTrue(app.switches["Correct my typing"].waitForExistence(timeout: 3), "Toggle missing after back")
         app.switches["Correct my typing"].tap()
     }
 }

--- a/wurstfingerUITests/TouchOffsetSettingsUITests.swift
+++ b/wurstfingerUITests/TouchOffsetSettingsUITests.swift
@@ -1,0 +1,47 @@
+//
+//  TouchOffsetSettingsUITests.swift
+//  wurstfingerUITests
+//
+//  Verifies the Touch Correction settings page (spec §6) is reachable and
+//  shows its core controls: the toggle, the learned-offset visualization and
+//  the reset controls.
+//
+
+import XCTest
+
+final class TouchOffsetSettingsUITests: XCTestCase {
+    @MainActor
+    func testTouchCorrectionPageShowsControls() {
+        // Force English so the assertions are locale-independent (the simulator
+        // may be German, where the tabs read "Einstellungen" etc.). The factory
+        // also redirects the shared store, so toggling the setting below cannot
+        // reach the app group the user's own keyboard reads.
+        let app = UITestApp.make(UITestApp.englishLocaleArguments)
+        app.launchEnvironment["FORCE_APPEARANCE"] = "light"
+        app.launch()
+
+        let settingsTab = app.tabBars.buttons["Settings"]
+        XCTAssertTrue(settingsTab.waitForExistence(timeout: 5), "Settings tab missing")
+        settingsTab.tap()
+
+        let row = app.staticTexts["Touch Correction"]
+        XCTAssertTrue(row.waitForExistence(timeout: 5), "Touch Correction row missing")
+        row.tap()
+
+        XCTAssertTrue(
+            app.switches["Correct my typing"].waitForExistence(timeout: 5),
+            "Master toggle missing"
+        )
+        XCTAssertTrue(
+            app.staticTexts["Learned adjustments"].waitForExistence(timeout: 3),
+            "Visualization section missing"
+        )
+        XCTAssertTrue(
+            app.buttons["Reset everything"].waitForExistence(timeout: 3),
+            "Reset control missing"
+        )
+
+        // The toggle is interactive.
+        app.switches["Correct my typing"].tap()
+    }
+}


### PR DESCRIPTION
**Status: WIP / Draft — not ready for merge.** Feature is default-off and opt-in; opened early for review of the approach.

## What this does
Learns each user's systematic touch offset (people don't tap key centers) per key and per posture, and shifts the **hit-target boundaries** to match — the visible keys never move. Data-driven, on-device, private.

## Algorithm (short)
Per **regime** = (orientation × explicitly-chosen hand posture):
- **Learn** (per accepted tap): sample `e = touchdown − center`; gated by an acceptance filter (Baldwin-style self-labeling: not deleted within a veto window) + an interior gate (anti-drift). Bounded-influence running mean (Welford + Huber clip) with an EW-MAD outlier gate.
- **Shrink**: per-key mean is pulled toward a fitted **reach surface** prior (Empirical-Bayes / James-Stein), `offset = prior + (mean − prior)·n/(n+κ)`. Surface = ridge-WLS (bilinear one-thumb; left/right split for two-thumb). Magnitude clamped so cells never invert.
- **Apply** (Key-Target-Resizing): shift touch-cell grid lines (separable → valid tiling), compensate the visible key back so nothing moves on screen. Gated on regime maturity.

## Phases (P0–P9, all landed on the branch)
Model core + regime + persistence → touchdown plumbing → learning → apply with invisible compensation → settings UI → gesture telemetry → counterfactual benefit metric.

## Review focus / open questions
- **Posture is an explicit user choice** (not auto-detected) — a wrong split can actively mis-correct, and derivation misclassified in practice.
- **Counterfactual benefit metric**: per tap we know the assigned key and the key the raw touchdown would have hit unshifted (`p = touchdown + offset`, flip when it leaves [0,1]); kept flip = *caught*, deleted flip = *caused* → error rate **with** vs **without** correction, self-populating (no A/B toggle dance).
- Honest caveats: self-labeled via backspace (Baldwin 2012) — not ground truth; smooth-field approximation for the flip edge.

## Still open (tracked, not blocking review)
- Localize new English strings (app is 12-language).
- Remove the DEBUG spike hook.
- Visually confirm the invisible compensation on device.
- Dwell-gate (§4.3) and hyperparameter/threshold calibration on device.

## Testing
Unit tests green (model, regime/posture mapping, learning, telemetry + counterfactual math, geometry). The settings UI test compiles but can't run in this local sim (runner-launch flake); it runs in CI.

Spec, literature review and implementation plan live in `docs/touch-offset-correction*.md`.