### PR TITLE
Fix Keyboard Width Squeeze From Keyboard-Sized Window Bounds

### DIFF
--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -59,12 +59,14 @@ final class KeyboardViewModel: ObservableObject {
     /// Updated by the controller in `viewWillLayoutSubviews()` so that
     /// SwiftUI re-evaluates layout after orientation changes.
     @Published private(set) var viewWidth: CGFloat = UIScreen.main.bounds.width
-    /// Shortest side of the hosting window, used to cap the keyboard width so
-    /// it keeps its portrait width in landscape. Measured from the actual
-    /// window (not the full screen) so sizing stays correct in Split View and
-    /// Stage Manager; falls back to the device screen until a window is
-    /// attached.
-    @Published private(set) var windowShortestSide: CGFloat = min(
+    /// Width cap for the keyboard so it keeps its portrait width in
+    /// landscape and follows narrow panes (Slide Over, Stage Manager).
+    /// Derived from the hosting window's *width* — the keyboard's own window
+    /// is only as tall as the keyboard itself, so its height carries no
+    /// container information — bounded by the screen's shortest side, which
+    /// keeps landscape at the portrait width. Falls back to the screen until
+    /// a window is attached.
+    @Published private(set) var keyboardWidthCap: CGFloat = min(
         DeviceLayoutUtils.screenBounds.width, DeviceLayoutUtils.screenBounds.height
     )
     /// The currently active keyboard mode.
@@ -216,11 +218,18 @@ final class KeyboardViewModel: ObservableObject {
     /// Updates the tracked window bounds. Called by the controller in
     /// `viewWillLayoutSubviews()` with the hosting window's bounds; a nil
     /// window (not yet attached) falls back to the device screen.
+    ///
+    /// Only the window's *width* is meaningful: the keyboard extension's
+    /// window is merely keyboard-sized, so `min(width, height)` would return
+    /// the keyboard height (~300 pt) and squeeze the keys horizontally while
+    /// the height constraint stays — visibly breaking the key aspect ratio.
     func updateWindowBounds(_ bounds: CGRect?) {
-        let reference = bounds ?? DeviceLayoutUtils.screenBounds
-        let shortestSide = min(reference.width, reference.height)
-        guard shortestSide > 0, shortestSide != windowShortestSide else { return }
-        windowShortestSide = shortestSide
+        let screenShortestSide = min(
+            DeviceLayoutUtils.screenBounds.width, DeviceLayoutUtils.screenBounds.height
+        )
+        let cap = bounds.map { min($0.width, screenShortestSide) } ?? screenShortestSide
+        guard cap > 0, cap != keyboardWidthCap else { return }
+        keyboardWidthCap = cap
     }
 
     // MARK: - Arrangement Selection

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -22,9 +22,8 @@ struct DataDrivenKeyboardRootView: View {
     private var keyboardStyle: KeyboardStyle = .classic
 
     var body: some View {
-        let containerShortestSide = viewModel.windowShortestSide
         let currentWidth = overrideWidth ?? viewModel.viewWidth
-        let baseWidth = min(currentWidth, containerShortestSide)
+        let baseWidth = min(currentWidth, viewModel.keyboardWidthCap)
         let scaledWidth = baseWidth * viewModel.keyboardScale
         let availableSpace = currentWidth - scaledWidth
         let horizontalOffset = availableSpace * (viewModel.keyboardHorizontalPosition - 0.5)

--- a/wurstfingerTests/OrientationLayoutTests.swift
+++ b/wurstfingerTests/OrientationLayoutTests.swift
@@ -54,30 +54,48 @@ struct OrientationLayoutTests {
 
     // MARK: - Window bounds (Split View / Stage Manager, issue #116)
 
-    @Test("Window bounds publish their shortest side")
-    func windowBoundsPublishShortestSide() {
+    private var screenShortestSide: CGFloat {
+        min(DeviceLayoutUtils.screenBounds.width, DeviceLayoutUtils.screenBounds.height)
+    }
+
+    @Test("Keyboard-sized window keeps the screen's portrait width")
+    func keyboardSizedWindowKeepsPortraitWidth() {
         let viewModel = KeyboardViewModel(shouldPersistSettings: false)
 
-        // Landscape Split View pane: height is the shortest side.
-        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 507, height: 834))
-        #expect(viewModel.windowShortestSide == 507)
+        // The extension's window is only as tall as the keyboard itself
+        // (issue behind #219's regression): its height must never cap the
+        // width. Portrait: window spans the screen width, keyboard-height tall.
+        viewModel.updateWindowBounds(
+            CGRect(x: 0, y: 0, width: DeviceLayoutUtils.screenBounds.width, height: 300)
+        )
+        #expect(viewModel.keyboardWidthCap == screenShortestSide)
 
-        // Portrait pane: width is the shortest side.
-        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 320, height: 1180))
-        #expect(viewModel.windowShortestSide == 320)
+        // Landscape: window is screen-height wide; the screen's shortest
+        // side still caps the keyboard at its portrait width.
+        viewModel.updateWindowBounds(
+            CGRect(x: 0, y: 0, width: DeviceLayoutUtils.screenBounds.height, height: 250)
+        )
+        #expect(viewModel.keyboardWidthCap == screenShortestSide)
+    }
+
+    @Test("Narrow pane window caps the keyboard width")
+    func narrowPaneWindowCapsWidth() {
+        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+
+        // Slide Over / narrow Split View pane: the window width is the
+        // available container width and wins over the screen.
+        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 320, height: 300))
+        #expect(viewModel.keyboardWidthCap == 320)
     }
 
     @Test("Nil window falls back to the device screen")
     func nilWindowFallsBackToScreen() {
         let viewModel = KeyboardViewModel(shouldPersistSettings: false)
-        let screenShortestSide = min(
-            DeviceLayoutUtils.screenBounds.width, DeviceLayoutUtils.screenBounds.height
-        )
 
-        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 507, height: 834))
+        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 320, height: 300))
         viewModel.updateWindowBounds(nil)
 
-        #expect(viewModel.windowShortestSide == screenShortestSide)
+        #expect(viewModel.keyboardWidthCap == screenShortestSide)
     }
 
     @Test("Same window bounds do not trigger redundant publish")
@@ -85,12 +103,12 @@ struct OrientationLayoutTests {
         let viewModel = KeyboardViewModel(shouldPersistSettings: false)
 
         var publishCount = 0
-        let cancellable = viewModel.$windowShortestSide
+        let cancellable = viewModel.$keyboardWidthCap
             .dropFirst()
             .sink { _ in publishCount += 1 }
 
-        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 507, height: 834))
-        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 507, height: 834))
+        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 320, height: 300))
+        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 320, height: 300))
 
         #expect(publishCount == 1, "Same bounds should not publish again")
         _ = cancellable
@@ -100,9 +118,9 @@ struct OrientationLayoutTests {
     func degenerateWindowBoundsIgnored() {
         let viewModel = KeyboardViewModel(shouldPersistSettings: false)
 
-        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 507, height: 834))
-        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 0, height: 834))
+        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 320, height: 300))
+        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 0, height: 300))
 
-        #expect(viewModel.windowShortestSide == 507, "Zero-sized bounds must not be adopted")
+        #expect(viewModel.keyboardWidthCap == 320, "Zero-sized bounds must not be adopted")
     }
 }


### PR DESCRIPTION
## Problem

Since #219, the keyboard renders far too narrow on iPhone (~160 pt instead of ~270 pt), horizontally squeezing every key while the height constraint stays — visibly breaking the key aspect ratio.

**Root cause:** #219 capped the keyboard width at `min(window.width, window.height)`. But the keyboard extension's window is not the app window — it is only as tall as the keyboard itself. Measured live in the extension (simulator, iPhone 17 Pro portrait):

```
viewBounds={{0, 0}, {402, 237}}  windowBounds={{0, 0}, {402, 237}}  screen={{0, 0}, {402, 874}}
```

So the "shortest side" resolves to the keyboard height (237 pt) instead of the portrait screen width (402 pt): `min(402, 237) × scale 0.67 ≈ 159 pt`. #219's unit tests fed synthetic full-pane rects (e.g. 507×834), which the real input window never has, so they missed it.

## Fix

Only the window's **width** carries container information (that's what shrinks in Slide Over / narrow Stage Manager panes); the height must never enter the calculation. The screen's shortest side still caps landscape at the portrait width (preserving #197):

- `windowShortestSide` → `keyboardWidthCap = min(window.width, screenShortestSide)`, falling back to the screen when no window is attached.
- Tests rewritten around real window shapes: keyboard-sized portrait/landscape windows keep the portrait width; a narrow 320 pt pane caps at 320 pt; nil/degenerate bounds and redundant-publish behavior unchanged.

## Verification

- Reproduced the squeezed rendering with the real keyboard extension in the iPhone 17 Pro simulator (enabled via Settings, opened in a host text field), then confirmed the fix restores the correct ~270 pt width and square keys. Before/after screenshots below.
- Full `WurstfingerTests` target passes (serial run).
- SwiftFormat + SwiftLint (`--strict`) clean.

| Before (#219) | After |
|---|---|
| keys squeezed to ~40% width | correct 67% width, square keys |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard sizing so height-constrained windows no longer squeeze keys or distort their shape.
  * Keyboard width now respects the available window width, with sensible fallback behavior when no window bounds are available.
  * Reduced unnecessary size updates, helping keep keyboard layout more stable during orientation and window changes.

* **Tests**
  * Updated layout coverage to verify portrait, landscape, narrow-pane, and edge-case sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->