### PR TITLE
Bump Version to 1.3.1 and Update Release Notes

### DIFF
--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,12 +1,16 @@
-Version 1.3.0
+Version 1.3.1
 
 Neu:
-• Sprache direkt auf der Tastatur wechseln — mit einem Wisch über die Globus-Taste durch deine aktivierten Sprachen
-• Cursor-Steuerung — wählen, wie sich der Cursor per Leertaste bewegt: stufenlos oder schrittweise, auch wortweise
-• Label-Sichtbarkeit — Buchstaben, Standard- oder Extra-Symbole einzeln ausblenden
-• Die App ist jetzt in 12 Sprachen verfügbar
-• Neue vietnamesische Telex-Eingabe
+• Überarbeitete Haptik — genau ein Impuls pro Anschlag und ein deutlich breiterer Intensitätsbereich
+• Label-Sichtbarkeit direkt per Geste auf der Leertaste umschalten
+• Compose-Hinweise (kleine Akzent-Labels) lassen sich jetzt ausblenden
+• Hebräisch: Endbuchstaben per Rück-Wisch
 
 Zuverlässigkeit:
-• Die Tastatur öffnet jetzt zuverlässiger
-• Tote Bereiche zwischen den Tasten im Liquid-Glass-Stil behoben
+• Doppelte Vibration pro Tastendruck behoben
+• Tastatur nutzt wieder die volle Bildschirmbreite
+• Cursor-Bewegung über Emoji korrigiert
+• Schnelle Wischgesten werden zuverlässiger erkannt
+• Automatische Großschreibung greift jetzt in den richtigen Momenten
+• Deaktivierte Sprachen bleiben deaktiviert
+• Vietnamesische Tonzeichen-Regeln wirken nicht mehr in andere Sprachen hinein

--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -8,7 +8,6 @@ Neu:
 
 Zuverlässigkeit:
 • Doppelte Vibration pro Tastendruck behoben
-• Tastatur nutzt wieder die volle Bildschirmbreite
 • Cursor-Bewegung über Emoji korrigiert
 • Schnelle Wischgesten werden zuverlässiger erkannt
 • Automatische Großschreibung greift jetzt in den richtigen Momenten

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -8,7 +8,6 @@ New:
 
 Reliability:
 • Fixed double vibration per key press
-• The keyboard uses the full screen width again
 • Fixed cursor movement across emoji
 • Fast swipe gestures are recognized more reliably
 • Auto-capitalization now engages at the right moments

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,12 +1,16 @@
-Version 1.3.0
+Version 1.3.1
 
 New:
-• Switch languages right from the keyboard — cycle through your enabled languages with a swipe on the globe key
-• Cursor control — choose how the space-bar cursor moves: continuous drag or step-by-step, including word-by-word
-• Label visibility — hide letters, standard symbols, or extra symbols independently
-• The app is now available in 12 languages
-• New Vietnamese Telex input
+• Reworked haptics — exactly one pulse per keystroke and a much wider intensity range
+• Toggle label visibility directly with a gesture on the space bar
+• Compose hints (small accent labels) can now be hidden
+• Hebrew: final letters via return swipes
 
 Reliability:
-• The keyboard now opens more reliably
-• Fixed dead zones between keys in the Liquid Glass style
+• Fixed double vibration per key press
+• The keyboard uses the full screen width again
+• Fixed cursor movement across emoji
+• Fast swipe gestures are recognized more reliably
+• Auto-capitalization now engages at the right moments
+• Disabled languages stay disabled
+• Vietnamese tone rules no longer leak into other languages

--- a/wurstfinger.xcodeproj/project.pbxproj
+++ b/wurstfinger.xcodeproj/project.pbxproj
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfinger;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -580,7 +580,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfinger;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -598,7 +598,7 @@
 				CURRENT_PROJECT_VERSION = 2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfingerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -616,7 +616,7 @@
 				CURRENT_PROJECT_VERSION = 2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfingerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -632,7 +632,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfingerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -648,7 +648,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfingerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -676,7 +676,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfinger.keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -705,7 +705,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfinger.keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary
- Bump `MARKETING_VERSION` from 1.3.0 to 1.3.1 across all build configurations (`CURRENT_PROJECT_VERSION` is left untouched — the release lane pulls the build number from App Store Connect and increments it)
- Rewrite `fastlane/metadata/{de-DE,en-US}/release_notes.txt` for 1.3.1, describing the delta against the shipped 1.3.0

## Release scope (vs. shipped v1.3.0)
Reliability fixes from the review-fix series #205–#216 plus #217–#220, #223, and the haptics rework #222.

## Merge order
⚠️ Merge **after** #222 (haptics rework) — the release notes already mention it.

Once merged, publishing a GitHub release `v1.3.1` triggers `appstore-release.yml` (build, upload, metadata). Submission for review in App Store Connect remains manual (`submit_for_review: false`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated release notes to highlight new typing experience improvements, including refined haptics, spacebar gesture label visibility, hidden compose hints, and Hebrew swipe behavior updates.
* **Bug Fixes**
  * Updated release notes to mention reliability improvements such as removing double vibration, better cursor movement with emoji, improved quick swipe recognition, corrected auto-capitalization timing, keeping disabled languages disabled, and preventing Vietnamese tone rules from affecting other languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->