### PR TITLE
Fix Unreliable Space-Bar Label Toggle Swipes

### DIFF
--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -59,7 +59,13 @@ struct SlideGestureState {
         let currentX = translation.width
         upwardPeakY = min(upwardPeakY, translation.height)
 
-        if !isSliding, abs(currentX) >= activationThreshold {
+        // Activate only while the horizontal axis dominates: crossing the
+        // (small) horizontal threshold during a mostly-vertical movement must
+        // not latch the slide, or an upward label-toggle swipe with a few
+        // points of sideways drift turns into a cursor slide and the vertical
+        // classification in `handleEnded` becomes unreachable. Once latched,
+        // the slide stays tolerant of vertical drift as before.
+        if !isSliding, abs(currentX) >= activationThreshold, abs(currentX) > abs(translation.height) {
             isSliding = true
             // Anchor at the threshold crossing (not the full translation) so
             // the travel beyond the threshold is reported on the same tick
@@ -94,12 +100,16 @@ struct SlideGestureState {
         // must precede the tap check: a return-up swipe ends near its origin
         // and would otherwise be classified as a tap.
         if -upwardPeakY >= swipeUpThreshold {
-            // Mirror the discrete horizontal classification: a final position
-            // close to the origin relative to the peak means the finger
-            // returned. Downward peaks are never tracked, so down-swipes
-            // still fall through and stay ignored.
-            let ratio = abs(translation.height) / abs(upwardPeakY)
-            return .swipeUp(isReturn: ratio < KeyboardConstants.SpaceGestures.returnSwipeThreshold)
+            // The finger "returned" when it came back at least
+            // (1 - returnSwipeThreshold) of the way from the peak toward the
+            // origin. Compared signed (peak is negative, y grows downward) so
+            // overshooting past the origin still counts as a return — fast
+            // return swipes routinely end below their starting point, and an
+            // absolute-distance ratio would misread them as plain up-swipes.
+            // Downward peaks are never tracked, so down-swipes still fall
+            // through and stay ignored.
+            let returnBoundary = upwardPeakY * KeyboardConstants.SpaceGestures.returnSwipeThreshold
+            return .swipeUp(isReturn: translation.height >= returnBoundary)
         }
         // A tap must stay near its origin on *both* axes. Gating on
         // horizontal travel alone would classify a vertical flick (e.g.

--- a/wurstfingerTests/SlideGestureStateTests.swift
+++ b/wurstfingerTests/SlideGestureStateTests.swift
@@ -120,6 +120,67 @@ struct SlideGestureStateTests {
         #expect(phase == .swipeUp(isReturn: true))
     }
 
+    @Test func upSwipeWithHorizontalDriftStaysAnUpSwipe() {
+        var state = SlideGestureState()
+        // A natural upward flick drifts sideways beyond the (small) slide
+        // threshold. While the vertical axis dominates, the cursor slide must
+        // not latch — previously this became a cursor slide and the toggle
+        // never fired.
+        let drift = threshold + 4
+        let first = state.handleChanged(
+            translation: CGSize(width: drift, height: -drift - 6), activationThreshold: threshold
+        )
+        #expect(first.phases.isEmpty)
+        let second = state.handleChanged(
+            translation: CGSize(width: drift, height: -upThreshold - 20),
+            activationThreshold: threshold
+        )
+        #expect(second.phases.isEmpty)
+        let phase = state.handleEnded(
+            translation: CGSize(width: drift, height: -upThreshold - 20),
+            activationThreshold: threshold
+        )
+        #expect(phase == .swipeUp(isReturn: false))
+    }
+
+    @Test func horizontalDominanceStillActivatesSlideAfterVerticalWobble() {
+        var state = SlideGestureState()
+        // Contact wobble where the vertical axis briefly dominates must not
+        // block a genuine cursor slide once the horizontal axis takes over.
+        let wobble = state.handleChanged(
+            translation: CGSize(width: threshold, height: -threshold - 2),
+            activationThreshold: threshold
+        )
+        #expect(wobble.phases.isEmpty)
+        let sliding = state.handleChanged(
+            translation: CGSize(width: threshold * 3, height: -threshold - 2),
+            activationThreshold: threshold
+        )
+        #expect(sliding.phases.first == .began)
+        let phase = state.handleEnded(
+            translation: CGSize(width: threshold * 3, height: -threshold - 2),
+            activationThreshold: threshold
+        )
+        #expect(phase == .ended)
+    }
+
+    @Test func returnUpSwipeOvershootingOriginIsStillAReturn() {
+        var state = SlideGestureState()
+        // Fast return swipes routinely overshoot past the starting point.
+        // Measured as absolute distance from the origin this looked like a
+        // plain up-swipe and toggled the wrong label group.
+        _ = state.handleChanged(
+            translation: CGSize(width: 0, height: -upThreshold - 10), activationThreshold: threshold
+        )
+        _ = state.handleChanged(
+            translation: CGSize(width: 0, height: 20), activationThreshold: threshold
+        )
+        let phase = state.handleEnded(
+            translation: CGSize(width: 0, height: 20), activationThreshold: threshold
+        )
+        #expect(phase == .swipeUp(isReturn: true))
+    }
+
     @Test func upSwipeBelowThresholdIsIgnored() {
         var state = SlideGestureState()
         let translation = CGSize(width: 0, height: -upThreshold + 4)


### PR DESCRIPTION
## Problem
The space-bar label-visibility swipes introduced in #220 fire unreliably. Two classification issues in `SlideGestureState`:

1. **The cursor slide steals the up-swipe.** The horizontal slide latched as soon as translation exceeded 8 pt on the x-axis at *any* sample, regardless of vertical movement — and once latched, `handleEnded` always returns `.ended`, so the vertical classification is unreachable. Since the up-swipe needs 30 pt of upward travel, the finger had to stay inside a 16 pt wide corridor for the whole gesture. A natural upward thumb flick almost always drifts more than 8 pt sideways, so instead of toggling labels it moved the cursor.
2. **Return detection breaks on overshoot.** Return-up was classified via `abs(final.y) / abs(peak.y) < 0.3`. Fast return swipes routinely overshoot past the starting point, making the absolute final distance large again — the gesture was then read as a plain up-swipe and toggled the wrong label group.

## Fix
- Latch the horizontal slide only while the horizontal axis dominates (`abs(x) >= threshold && abs(x) > abs(y)`). Once latched, the slide stays tolerant of vertical drift exactly as before, so both cursor-movement styles keep their behavior. The dominance gate also applies to the delete key, where a mostly-vertical flick no longer starts slide-deletion.
- Classify the return signed instead of by absolute distance: the finger returned when it came back at least 70% of the way from the peak toward the origin, with overshoot past the origin still counting as a return.

## Tests
- `upSwipeWithHorizontalDriftStaysAnUpSwipe` — diagonal up-flick with sideways drift beyond the slide threshold classifies as `.swipeUp`, no cursor phases emitted
- `returnUpSwipeOvershootingOriginIsStillAReturn` — overshooting return swipe keeps `isReturn: true`
- `horizontalDominanceStillActivatesSlideAfterVerticalWobble` — regression guard: cursor slide still latches after a brief vertical contact wobble

Both new bug tests verified to fail against the previous handler; full `SlideGestureStateTests` + `SpaceLabelTogglePipelineTests` pass with the fix.

## Note
Candidate for 1.3.1 (#224) — the release notes advertise this feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gesture recognition so mostly vertical finger movement no longer incorrectly starts a horizontal slide.
  * Refined upward swipe handling to correctly detect return swipes even when the finger overshoots past the starting point.

* **Tests**
  * Added coverage for upward swipes with horizontal drift, slide activation after vertical wobble, and return swipes that end beyond the origin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->