### PR TITLE
Fix Error Handling in Release Scripts and CI Keychain Cleanup

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,11 @@
 default_platform(:ios)
 
+# Single CI predicate — GitHub Actions sets CI="true"; a bare truthy check
+# would also fire on CI="false" or CI="".
+def ci?
+  ENV["CI"] == "true"
+end
+
 platform :ios do
   # Shared context for both lanes: validated environment plus an ASC API key.
   private_lane :asc_context do
@@ -38,7 +44,7 @@ platform :ios do
     )
 
     # Create temporary keychain for CI
-    if ENV["CI"]
+    if ci?
       create_keychain(
         name: "fastlane_tmp_keychain",
         password: "temp_password_123",
@@ -51,10 +57,10 @@ platform :ios do
 
     match(
       type: "appstore",
-      readonly: ENV["CI"] == "true",
+      readonly: ci?,
       app_identifier: [app_id, "#{app_id}.keyboard"],
-      keychain_name: ENV["CI"] ? "fastlane_tmp_keychain" : "login.keychain",
-      keychain_password: ENV["CI"] ? "temp_password_123" : nil
+      keychain_name: ci? ? "fastlane_tmp_keychain" : "login.keychain",
+      keychain_password: ci? ? "temp_password_123" : nil
     )
 
     # Update signing for main app target
@@ -83,12 +89,31 @@ platform :ios do
       export_method: "app-store",
       include_symbols: true,
       include_bitcode: false,
-      xcargs: ENV["CI"] ? "OTHER_CODE_SIGN_FLAGS='--keychain fastlane_tmp_keychain'" : nil
+      xcargs: ci? ? "OTHER_CODE_SIGN_FLAGS='--keychain fastlane_tmp_keychain'" : nil
     )
   end
 
   private_lane :cleanup_ci_keychain do
-    delete_keychain(name: "fastlane_tmp_keychain") if ENV["CI"]
+    next unless ci?
+
+    # Only delete when the keychain actually exists — the lane may fail
+    # before create_keychain ran, and delete_keychain raises otherwise.
+    keychain = "fastlane_tmp_keychain"
+    exists = ["#{keychain}-db", keychain].any? do |name|
+      File.exist?(File.expand_path("~/Library/Keychains/#{name}"))
+    end
+    delete_keychain(name: keychain) if exists
+  end
+
+  # Runs after any lane failure. Without this, a failed match/build/upload
+  # leaves fastlane_tmp_keychain in place *and* set as the default keychain
+  # on the runner. Guarded so cleanup problems never mask the original error.
+  error do |_lane, _exception|
+    begin
+      cleanup_ci_keychain
+    rescue => cleanup_error
+      UI.important("CI keychain cleanup failed: #{cleanup_error.message}")
+    end
   end
 
   desc "Build & upload to TestFlight on develop merges"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,6 +6,11 @@ def ci?
   ENV["CI"] == "true"
 end
 
+# Shared by create_keychain, match, the build xcargs, and cleanup — a rename
+# in one place without the others would silently break signing or cleanup.
+CI_KEYCHAIN_NAME = "fastlane_tmp_keychain"
+CI_KEYCHAIN_PASSWORD = "temp_password_123"
+
 platform :ios do
   # Shared context for both lanes: validated environment plus an ASC API key.
   private_lane :asc_context do
@@ -46,8 +51,8 @@ platform :ios do
     # Create temporary keychain for CI
     if ci?
       create_keychain(
-        name: "fastlane_tmp_keychain",
-        password: "temp_password_123",
+        name: CI_KEYCHAIN_NAME,
+        password: CI_KEYCHAIN_PASSWORD,
         default_keychain: true,
         unlock: true,
         timeout: 3600,
@@ -59,8 +64,8 @@ platform :ios do
       type: "appstore",
       readonly: ci?,
       app_identifier: [app_id, "#{app_id}.keyboard"],
-      keychain_name: ci? ? "fastlane_tmp_keychain" : "login.keychain",
-      keychain_password: ci? ? "temp_password_123" : nil
+      keychain_name: ci? ? CI_KEYCHAIN_NAME : "login.keychain",
+      keychain_password: ci? ? CI_KEYCHAIN_PASSWORD : nil
     )
 
     # Update signing for main app target
@@ -89,7 +94,7 @@ platform :ios do
       export_method: "app-store",
       include_symbols: true,
       include_bitcode: false,
-      xcargs: ci? ? "OTHER_CODE_SIGN_FLAGS='--keychain fastlane_tmp_keychain'" : nil
+      xcargs: ci? ? "OTHER_CODE_SIGN_FLAGS='--keychain #{CI_KEYCHAIN_NAME}'" : nil
     )
   end
 
@@ -98,7 +103,7 @@ platform :ios do
 
     # Only delete when the keychain actually exists — the lane may fail
     # before create_keychain ran, and delete_keychain raises otherwise.
-    keychain = "fastlane_tmp_keychain"
+    keychain = CI_KEYCHAIN_NAME
     exists = ["#{keychain}-db", keychain].any? do |name|
       File.exist?(File.expand_path("~/Library/Keychains/#{name}"))
     end

--- a/scripts/generate-appstore-screenshots.sh
+++ b/scripts/generate-appstore-screenshots.sh
@@ -21,7 +21,6 @@ set -e
 # Colors for output
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
-YELLOW='\033[0;33m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 
@@ -116,11 +115,17 @@ for target in "${TARGETS[@]}"; do
         -derivedDataPath "$DERIVED_DATA" \
         CODE_SIGNING_ALLOWED=NO \
         2>&1 | if command -v xcpretty >/dev/null; then xcpretty --color; else cat; fi
-    TEST_RESULT=$?
+    # $? after a pipe is the formatter's exit code (always 0); we need xcodebuild's.
+    TEST_RESULT=${PIPESTATUS[0]}
     set -e
 
-    if [ $TEST_RESULT -ne 0 ]; then
-        echo -e "${YELLOW}⚠️  Tests may have issues, checking for screenshots...${NC}"
+    if [ "$TEST_RESULT" -ne 0 ]; then
+        # These screenshots ship to the App Store (deliver uploads with
+        # overwrite_screenshots: true), so a partial set from a failed run
+        # must never be used silently.
+        echo -e "${RED}❌ Screenshot tests failed on $DEVICE_NAME (exit code: $TEST_RESULT)${NC}"
+        echo -e "${RED}   Refusing to continue — a partial screenshot set must not ship.${NC}"
+        exit 1
     fi
 
     # Find and extract screenshots from xcresult

--- a/scripts/generate-screenshots.sh
+++ b/scripts/generate-screenshots.sh
@@ -60,6 +60,10 @@ for runtime_devices in devices.values():
 raise SystemExit(1)
 " 2>/dev/null || true)
 
+# Marker file so we can count only screenshots created by this run
+# (pre-existing .webp files in $DOCS_DIR must not count as success).
+RUN_MARKER=$(mktemp)
+
 # Ensure cleanup runs on any exit (normal, error, or signal)
 cleanup() {
     echo ""
@@ -68,6 +72,7 @@ cleanup() {
         xcrun simctl status_bar "$TARGET_UDID" clear 2>/dev/null || true
     fi
     rm -rf "$DERIVED_DATA"
+    rm -f "$RUN_MARKER"
 }
 trap cleanup EXIT
 
@@ -101,7 +106,7 @@ xcodebuild test \
 TEST_EXIT_CODE=${PIPESTATUS[0]}
 set -e
 
-if [ $TEST_EXIT_CODE -ne 0 ]; then
+if [ "$TEST_EXIT_CODE" -ne 0 ]; then
   echo -e "${RED}⚠️  UI tests failed (exit code: $TEST_EXIT_CODE), but continuing to check for screenshots...${NC}"
 fi
 
@@ -128,6 +133,7 @@ rm -rf "$TEMP_EXPORT"
 xcrun xcresulttool export attachments --path "$RESULTS_BUNDLE" --output-path "$TEMP_EXPORT"
 
 # Map exported files to proper names based on manifest
+COPIED=0
 if [ -f "$TEMP_EXPORT/manifest.json" ]; then
     # Parse manifest, crop, and convert to WebP
     export TEMP_EXPORT
@@ -261,19 +267,21 @@ for test_result in manifest:
             print(f"  ✓ Created {base_name}.webp ({img.width}x{img.height})")
 EOF
 
-    # Count created files
-    COPIED=$(ls -1 "$DOCS_DIR"/*.webp 2>/dev/null | wc -l | tr -d ' ')
+    # Count only files created (or overwritten) by this run
+    COPIED=$(find "$DOCS_DIR" -maxdepth 1 -name "*.webp" -type f -newer "$RUN_MARKER" | wc -l | tr -d ' ')
+else
+    echo -e "${RED}❌ No manifest.json in exported attachments — nothing was extracted${NC}"
 fi
 
 # Clean up temp export
 rm -rf "$TEMP_EXPORT"
 
 echo ""
-if [ $COPIED -gt 0 ]; then
+if [ "${COPIED:-0}" -gt 0 ]; then
   echo -e "${GREEN}✅ Success! Created $COPIED WebP screenshot(s) in $DOCS_DIR${NC}"
   echo ""
   echo -e "${BLUE}📝 Generated screenshots:${NC}"
-  ls -1 "$DOCS_DIR"/*.webp 2>/dev/null | while read -r f; do echo "    - $(basename "$f")"; done
+  find "$DOCS_DIR" -maxdepth 1 -name "*.webp" -type f -newer "$RUN_MARKER" | sort | while read -r f; do echo "    - $(basename "$f")"; done
 else
   echo -e "${RED}❌ No screenshots found${NC}"
   echo ""


### PR DESCRIPTION
Implements findings **M11** and the script/Fastfile items in **L20** from the full codebase review 2026-07-07 (`docs/code-review-develop-2026-07-07.md`).

## M11 — `scripts/generate-appstore-screenshots.sh`: test failures were invisible

`TEST_RESULT=$?` after `xcodebuild test ... | xcpretty` captured the *formatter's* exit code, which is effectively always 0 — a failing screenshot test run was never detected. Since a run that fails after producing *some* screenshots leaves a partial set in `fastlane/screenshots/`, and `deliver` uploads that directory with `overwrite_screenshots: true`, an incomplete set could silently ship to the App Store.

- Capture `TEST_RESULT=${PIPESTATUS[0]}` (matching the sibling `generate-screenshots.sh`).
- Tightened the downstream fallback: instead of "tests may have issues, checking for screenshots anyway", the script now **fails hard** on a non-zero test exit. For App-Store-bound screenshots, a partial set must never be used.
- Removed the now-unused `YELLOW` color variable (its only use was the removed soft warning).

## L20 — `scripts/generate-screenshots.sh`: unset `$COPIED` and false success

Two failure modes:
1. `COPIED` was only assigned inside `if [ -f "$TEMP_EXPORT/manifest.json" ]`. With the manifest missing, `[ $COPIED -gt 0 ]` expanded to `[ -gt 0 ]` → "unary operator expected", and `set -e` killed the script *before its own troubleshooting help text printed*.
2. `COPIED` counted **all** `.webp` files in `docs/images/`, including pre-existing ones — a run producing zero new screenshots still reported success.

Fixes: initialize `COPIED=0` before the block, quote the comparison (`[ "${COPIED:-0}" -gt 0 ]`), print an explicit error when the manifest is missing, and count only files newer than a marker file created at script start (`find -newer`), so only this run's output counts. Also quoted `$TEST_EXIT_CODE` in the same script (same shellcheck class, SC2086).

## L20 — `fastlane/Fastfile`: temp CI keychain leaked on failure + inconsistent CI predicates

`cleanup_ci_keychain` only ran as the last statement of the `beta`/`release` lanes. Any failure in match/build/upload left `fastlane_tmp_keychain` in place **and set as the default keychain** on the runner.

- Added an `error do |_lane, _exception|` block that runs the cleanup on any lane failure, wrapped in `begin/rescue` so a cleanup problem can never mask the original error.
- `cleanup_ci_keychain` now checks that the keychain file actually exists before calling `delete_keychain` (the lane may fail before `create_keychain` ran, and `delete_keychain` raises on a missing keychain).
- Unified CI detection: the file mixed truthy `ENV["CI"]` with `ENV["CI"] == "true"`. All sites now use a single `ci?` helper (`ENV["CI"] == "true"`), so `CI=false` or `CI=""` no longer flips some branches but not others.

## Verification

- `bash -n` on both scripts: clean.
- `shellcheck` on both scripts: clean (the two findings it raised were caused by / adjacent to this change and are fixed; no other pre-existing warnings remain in these files).
- `ruby -c fastlane/Fastfile`: Syntax OK.
- `fastlane lanes` (standalone, without bundler — the project bundle is not installed on this machine): Fastfile parses and both lanes (`beta`, `release`) are listed, which validates the `error` block and `ci?` helper against the real lane DSL. The lanes themselves were not executed (they require signing credentials/CI env).

Refs: full codebase review 2026-07-07, findings M11/L20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability for app signing by only creating/using temporary keychains in CI and making keychain cleanup safer when lanes fail.
  * Screenshot generation now captures the true `xcodebuild` exit code through piped output and exits immediately on failure to avoid partial results.
  * Screenshot export counting now limits success metrics to images created or updated during the current run, using a per-run marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->