### PR TITLE
Fix Utility-Left Layout to Move Only Utility Keys

### DIFF
--- a/wurstfingerKeyboard/Definition/Layout/GridArrangement.swift
+++ b/wurstfingerKeyboard/Definition/Layout/GridArrangement.swift
@@ -22,11 +22,15 @@ struct GridArrangement: Codable, Equatable {
 // MARK: - Transformations
 
 extension GridArrangement {
-    /// Mirrors each row horizontally (utility left ↔ right).
-    func mirroredHorizontally() -> GridArrangement {
+    /// Moves the placements with the given key IDs to the leading edge of their
+    /// row while preserving the relative order of all other placements
+    /// (utility column left ↔ right without mirroring the letter grid).
+    func movingToLeading(keyIds: Set<String>) -> GridArrangement {
         GridArrangement(
             columns: columns,
-            rows: rows.map { $0.reversed() }
+            rows: rows.map { row in
+                row.filter { keyIds.contains($0.keyId) } + row.filter { !keyIds.contains($0.keyId) }
+            }
         )
     }
 

--- a/wurstfingerKeyboard/Definition/Layout/StandardArrangements.swift
+++ b/wurstfingerKeyboard/Definition/Layout/StandardArrangements.swift
@@ -101,21 +101,35 @@ enum StandardArrangements {
         ]
     )
 
+    // MARK: - Utility-Left Variants
+
+    /// The utility keys that move to the leading edge when "Utility Keys on
+    /// Left" is enabled: globe, symbols, delete, and return — in the same
+    /// top-to-bottom order as the trailing column. The space bar and all
+    /// letter/digit keys keep their original left-to-right order.
+    static let leadingUtilityKeys: Set<String> = [
+        UtilitySlot.globe, UtilitySlot.symbols, UtilitySlot.delete, UtilitySlot.return,
+    ]
+
+    private static func utilityLeft(_ arrangement: GridArrangement) -> GridArrangement {
+        arrangement.movingToLeading(keyIds: leadingUtilityKeys)
+    }
+
     // MARK: - All 4 Contexts
 
     /// All 4 arrangement contexts for 3x3 grid layouts.
     static let grid3x3: [ArrangementContext: GridArrangement] = [
         .portrait: portrait,
-        .portraitUtilityLeft: portrait.mirroredHorizontally(),
+        .portraitUtilityLeft: utilityLeft(portrait),
         .landscape: landscape,
-        .landscapeUtilityLeft: landscape.mirroredHorizontally(),
+        .landscapeUtilityLeft: utilityLeft(landscape),
     ]
 
     /// Numeric mode: same as grid3x3 but with an extra "0" key in the bottom row.
     static let numeric3x3: [ArrangementContext: GridArrangement] = [
         .portrait: numericPortrait,
-        .portraitUtilityLeft: numericPortrait.mirroredHorizontally(),
+        .portraitUtilityLeft: utilityLeft(numericPortrait),
         .landscape: numericLandscape,
-        .landscapeUtilityLeft: numericLandscape.mirroredHorizontally(),
+        .landscapeUtilityLeft: utilityLeft(numericLandscape),
     ]
 }

--- a/wurstfingerTests/CommonKeysFactoryTests.swift
+++ b/wurstfingerTests/CommonKeysFactoryTests.swift
@@ -118,16 +118,71 @@ struct StandardArrangementsTests {
         #expect(landscape.rows.count == 3)
     }
 
-    @Test func portraitUtilityLeftIsMirroredPortrait() throws {
-        let portrait = try #require(StandardArrangements.grid3x3[.portrait])
-        let utilityLeft = try #require(StandardArrangements.grid3x3[.portraitUtilityLeft])
-        #expect(utilityLeft == portrait.mirroredHorizontally())
+    /// Key IDs of a row without the relocated utility keys (letters, digits, space).
+    private func nonUtilityIds(_ row: [KeyPlacement]) -> [String] {
+        row.map(\.keyId).filter { !StandardArrangements.leadingUtilityKeys.contains($0) }
     }
 
-    @Test func landscapeUtilityLeftIsMirroredLandscape() throws {
-        let landscape = try #require(StandardArrangements.grid3x3[.landscape])
+    @Test(arguments: [StandardArrangements.grid3x3, StandardArrangements.numeric3x3])
+    func utilityLeftKeepsNonUtilityKeyOrder(_ arrangements: [ArrangementContext: GridArrangement]) throws {
+        // The "Utility Keys on Left" variants must not mirror the letter grid:
+        // per row, everything except the utility column keeps its order.
+        for (base, utilityLeft) in [
+            (ArrangementContext.portrait, ArrangementContext.portraitUtilityLeft),
+            (ArrangementContext.landscape, ArrangementContext.landscapeUtilityLeft),
+        ] {
+            let baseRows = try #require(arrangements[base]).rows
+            let utilityLeftRows = try #require(arrangements[utilityLeft]).rows
+            #expect(baseRows.count == utilityLeftRows.count)
+            for (baseRow, utilityLeftRow) in zip(baseRows, utilityLeftRows) {
+                #expect(nonUtilityIds(baseRow) == nonUtilityIds(utilityLeftRow))
+            }
+        }
+    }
+
+    @Test(arguments: [StandardArrangements.grid3x3, StandardArrangements.numeric3x3])
+    func utilityLeftMovesUtilityKeysToLeadingEdge(_ arrangements: [ArrangementContext: GridArrangement]) throws {
+        // In the utility-left variants every relocated utility key sits at the
+        // start of its row, before all letter/digit keys.
+        for context in [ArrangementContext.portraitUtilityLeft, .landscapeUtilityLeft] {
+            for row in try #require(arrangements[context]).rows {
+                let ids = row.map(\.keyId)
+                let utilityCount = ids.count(where: { StandardArrangements.leadingUtilityKeys.contains($0) })
+                #expect(
+                    Array(ids.prefix(utilityCount)).allSatisfy { StandardArrangements.leadingUtilityKeys.contains($0) },
+                    "Utility keys must lead row \(ids) in \(context)"
+                )
+            }
+        }
+    }
+
+    @Test func portraitUtilityLeftUtilityColumnOrderMatchesTrailingColumn() throws {
+        // Leading utility column reads globe/symbols/delete/return top-to-bottom,
+        // the same order as the trailing column in the default portrait layout.
+        let utilityLeft = try #require(StandardArrangements.grid3x3[.portraitUtilityLeft])
+        let firstColumn = utilityLeft.rows.map { $0[0].keyId }
+        #expect(firstColumn == [UtilitySlot.globe, UtilitySlot.symbols, UtilitySlot.delete, UtilitySlot.return])
+    }
+
+    @Test func landscapeUtilityLeftSolvesWithReturnSpanInsideGrid() throws {
+        // The relocated return key still spans two rows and every cell stays
+        // within the 5-column grid.
         let utilityLeft = try #require(StandardArrangements.grid3x3[.landscapeUtilityLeft])
-        #expect(utilityLeft == landscape.mirroredHorizontally())
+        let cells = GridLayoutSolver.solve(utilityLeft)
+        let returnCell = try #require(cells.first { $0.keyId == UtilitySlot.return })
+        #expect(returnCell.rowSpan == 2)
+        for cell in cells {
+            #expect(cell.column + cell.columnSpan <= utilityLeft.columns)
+        }
+        // No two cells overlap.
+        var covered = Set<[Int]>()
+        for cell in cells {
+            for row in cell.row ..< (cell.row + cell.rowSpan) {
+                for column in cell.column ..< (cell.column + cell.columnSpan) {
+                    #expect(covered.insert([row, column]).inserted, "Overlap at \(row),\(column)")
+                }
+            }
+        }
     }
 
     @Test func portraitFirstRowContainsGridAndGlobe() throws {

--- a/wurstfingerTests/GridTypeTests.swift
+++ b/wurstfingerTests/GridTypeTests.swift
@@ -73,33 +73,37 @@ struct GridArrangementTests {
         ]
     )
 
-    @Test func mirroredHorizontallyReversesEachRow() {
-        let mirrored = Self.portrait.mirroredHorizontally()
+    static let utilityKeys: Set<String> = ["globe", "symbols", "delete", "return"]
 
-        #expect(mirrored.columns == 4)
-        #expect(mirrored.rows.count == 4)
+    @Test func movingToLeadingMovesOnlyUtilityKeys() {
+        let moved = Self.portrait.movingToLeading(keyIds: Self.utilityKeys)
 
-        // First row: globe should now be first
-        #expect(mirrored.rows[0][0].keyId == "globe")
-        #expect(mirrored.rows[0][1].keyId == "topRight")
-        #expect(mirrored.rows[0][2].keyId == "topCenter")
-        #expect(mirrored.rows[0][3].keyId == "topLeft")
+        #expect(moved.columns == 4)
+        #expect(moved.rows.count == 4)
 
-        // Last row: return first, space second
-        #expect(mirrored.rows[3][0].keyId == "return")
-        #expect(mirrored.rows[3][1].keyId == "space")
+        // Utility key leads each row; letters keep their original order.
+        #expect(moved.rows[0].map(\.keyId) == ["globe", "topLeft", "topCenter", "topRight"])
+        #expect(moved.rows[1].map(\.keyId) == ["symbols", "midLeft", "center", "midRight"])
+        #expect(moved.rows[2].map(\.keyId) == ["delete", "bottomLeft", "bottomCenter", "bottomRight"])
+        #expect(moved.rows[3].map(\.keyId) == ["return", "space"])
     }
 
-    @Test func mirroredHorizontallyPreservesMultipliers() throws {
-        let mirrored = Self.portrait.mirroredHorizontally()
+    @Test func movingToLeadingPreservesMultipliers() throws {
+        let moved = Self.portrait.movingToLeading(keyIds: Self.utilityKeys)
         // Space should keep its widthMultiplier
-        let spacePlacement = try #require(mirrored.rows[3].first { $0.keyId == "space" })
+        let spacePlacement = try #require(moved.rows[3].first { $0.keyId == "space" })
         #expect(spacePlacement.widthMultiplier == 3)
     }
 
-    @Test func doubleMirrorIsIdentity() {
-        let doubleMirrored = Self.portrait.mirroredHorizontally().mirroredHorizontally()
-        #expect(doubleMirrored == Self.portrait)
+    @Test func movingToLeadingIsIdempotent() {
+        let once = Self.portrait.movingToLeading(keyIds: Self.utilityKeys)
+        let twice = once.movingToLeading(keyIds: Self.utilityKeys)
+        #expect(twice == once)
+    }
+
+    @Test func movingToLeadingWithNoMatchesIsIdentity() {
+        let moved = Self.portrait.movingToLeading(keyIds: ["nonexistent"])
+        #expect(moved == Self.portrait)
     }
 
     @Test func resizedAdjustsTargetKey() throws {

--- a/wurstfingerTests/LanguageDefinitionTests.swift
+++ b/wurstfingerTests/LanguageDefinitionTests.swift
@@ -85,6 +85,23 @@ struct GermanLayoutTests {
     @Test func localeIsGerman() {
         #expect(Self.german.localeIdentifier == "de_DE")
     }
+
+    @Test func utilityLeftKeepsGermanLetterOrder() throws {
+        // "Utility Keys on Left" must not mirror the letter grid:
+        // the letters still read a n i / h d r / t e s left-to-right.
+        let main = try #require(Self.german.modes[ModeNames.main])
+        let arrangement = try #require(main.arrangements[.portraitUtilityLeft])
+        let letterRows = arrangement.rows.map { row in
+            row.compactMap { main.keys[$0.keyId]?.bindings[.tap]?.action }
+                .compactMap { action -> String? in
+                    if case let .commitText(text) = action { return text }
+                    return nil
+                }
+        }
+        #expect(letterRows[0] == ["a", "n", "i"])
+        #expect(letterRows[1] == ["h", "d", "r"])
+        #expect(letterRows[2] == ["t", "e", "s"])
+    }
 }
 
 // MARK: - NumericLayouts Tests


### PR DESCRIPTION
## Problem

The **"Utility Keys on Left"** toggle built its arrangements via `GridArrangement.mirroredHorizontally()`, which reverses **every** row — so the whole letter grid flipped along with the utility column. For German portrait, `a n i / h d r / t e s` rendered as `i n a / r d h / s e t`. The settings UI promises only: *"Places globe, symbols, delete and return on the left"* — nothing about mirroring letters.

Decision (project owner): **the settings text is correct; the behavior is wrong.** With the toggle on, only the utility keys move to the leading side; all letter/digit keys keep their original left-to-right order.

Fixes finding **H2** of the full codebase review 2026-07-07 (`docs/code-review-develop-2026-07-07.md`).

## Fix

`mirroredHorizontally()` is replaced by `GridArrangement.movingToLeading(keyIds:)`: per row, placements whose key ID is in the given set move to the front (keeping their relative order), everything else follows in its original order. `StandardArrangements` applies it with `leadingUtilityKeys = {globe, symbols, delete, return}` to **all** utility-left variants (grid3x3 and numeric3x3, portrait and landscape — landscape is currently unreachable but kept consistent). The space bar stays with the letter/digit keys, and the leading utility column reads globe/symbols/delete/return top-to-bottom — the same order as the trailing column in the default layout. The relocated landscape return key still spans two rows; `GridLayoutSolver` and validation are position-independent, so no runtime changes were needed.

## Before / After (German portrait, utility left)

| Before (mirrored) | After |
|---|---|
| `i n a 🌐` | `🌐 a n i` |
| `r d h 123` | `123 h d r` |
| `s e t ⌫` | `⌫ t e s` |
| `⏎ [space]` | `⏎ [space]` |

## Tests

- Removed: `portraitUtilityLeftIsMirroredPortrait`, `landscapeUtilityLeftIsMirroredLandscape`, `mirroredHorizontallyReversesEachRow`, `mirroredHorizontallyPreservesMultipliers`, `doubleMirrorIsIdentity` (they codified the old mirroring; `mirroredHorizontally()` itself is removed as unused).
- Added `GridArrangementTests`: `movingToLeading` moves only the given keys, preserves multipliers, is idempotent, and is the identity for non-matching IDs.
- Added `StandardArrangementsTests` (parameterized over grid3x3 and numeric3x3, portrait and landscape): non-utility key order is identical between base and utility-left variants; utility keys lead each row; the portrait leading column reads globe/symbols/delete/return; the landscape utility-left variant solves with the 2-row return span and no cell overlap.
- Added `GermanLayoutTests.utilityLeftKeepsGermanLetterOrder`: end-to-end check that the utility-left arrangement still reads `a n i / h d r / t e s`.
- Language definition validation (`LanguageDefinitionValidationTests`) still passes for all languages.

Full `WurstfingerTests` run: **895 passed, 0 failed** (one earlier run tripped the known `KeyboardRegistryTests` shared-cache race, review finding H5 — unrelated; clean on re-run).

## Note

This is a visual change — a simulator screenshot of the utility-left layout will follow in review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Utility-key layouts now place selected keys on the leading edge of each row instead of fully reversing the keyboard.
  * Added support for left-oriented utility-key arrangements in multiple keyboard layouts.

* **Bug Fixes**
  * Preserved the original ordering of normal keys when shifting utility keys.
  * Kept key sizing and grid behavior consistent in the updated layouts.
  * Improved layout handling for languages so letter order remains unchanged in utility-left views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->