### PR TITLE
Fix Gesture Edge Cases: Return-Up Hijack, ProMotion Buffer, Aspect-Ratio Guard

### DIFF
--- a/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
@@ -149,14 +149,18 @@ struct GesturePreprocessorConfig {
         return value.isFinite ? value : defaultValue
     }
 
-    /// Creates a config with custom aspect ratio
+    /// Creates a config with custom aspect ratio.
+    /// Non-finite or non-positive values (the ratio reaches this via a raw
+    /// `@AppStorage` read) fall back to 1.0 — `normalizeAspectRatio` divides
+    /// by the ratio, and dividing by zero/NaN would poison the whole pipeline
+    /// so that every gesture classifies as `.swipeRight`.
     func with(aspectRatio: CGFloat) -> GesturePreprocessorConfig {
         GesturePreprocessorConfig(
             jitterThreshold: jitterThreshold,
             maxJumpDistance: maxJumpDistance,
             smoothingWindow: smoothingWindow,
             smoothingOrder: smoothingOrder,
-            aspectRatio: aspectRatio
+            aspectRatio: aspectRatio.isFinite && aspectRatio > 0 ? aspectRatio : 1.0
         )
     }
 }

--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -49,7 +49,11 @@ struct SlideGestureState {
     }
 
     /// Processes one `onChanged` sample.
-    mutating func handleChanged(translation: CGSize, activationThreshold: CGFloat) -> Update {
+    mutating func handleChanged(
+        translation: CGSize,
+        activationThreshold: CGFloat,
+        swipeUpThreshold: CGFloat = KeyboardConstants.SpaceGestures.swipeUpActivationThreshold
+    ) -> Update {
         var update = Update()
         if !dragStarted {
             dragStarted = true
@@ -65,7 +69,18 @@ struct SlideGestureState {
         // points of sideways drift turns into a cursor slide and the vertical
         // classification in `handleEnded` becomes unreachable. Once latched,
         // the slide stays tolerant of vertical drift as before.
-        if !isSliding, abs(currentX) >= activationThreshold, abs(currentX) > abs(translation.height) {
+        //
+        // Instantaneous dominance alone is not enough: on the return leg of a
+        // return-up swipe the vertical translation shrinks through ~0 while
+        // sideways drift stays, so a lift-off sample like (10, -6) would
+        // latch the slide even though the peak committed the up-swipe long
+        // ago. Once the upward peak crossed the up-swipe threshold, the
+        // gesture belongs to `handleEnded`'s vertical classification and must
+        // never latch.
+        if !isSliding,
+           -upwardPeakY < swipeUpThreshold,
+           abs(currentX) >= activationThreshold,
+           abs(currentX) > abs(translation.height) {
             isSliding = true
             // Anchor at the threshold crossing (not the full translation) so
             // the travel beyond the threshold is reported on the same tick

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -118,8 +118,13 @@ enum KeyboardConstants {
         static let finalOffsetMultiplier: CGFloat = 0.71
 
         /// Number of touch points to buffer for gesture analysis.
-        /// 60 points at 60Hz = 1 second of touch history.
-        static let positionBufferSize: Int = 60
+        /// SwiftUI's DragGesture delivers samples at display refresh rate, so
+        /// the buffer is sized for the fastest shipping display: 120 points
+        /// hold 1 second of history at 120Hz (ProMotion) and 2 seconds at
+        /// 60Hz. A smaller buffer evicts the outbound leg of slow return
+        /// swipes, which then misclassify as plain swipes after
+        /// origin-anchoring (see `KeyGestureRecognizer.anchoringOrigin`).
+        static let positionBufferSize: Int = 120
     }
 
     // MARK: - Space Key Gestures

--- a/wurstfingerTests/GesturePreprocessorRobustnessTests.swift
+++ b/wurstfingerTests/GesturePreprocessorRobustnessTests.swift
@@ -68,10 +68,25 @@ struct GesturePreprocessorRobustnessTests {
     }
 
     @Test func pathLongerThanPositionBufferStaysClassifiable() {
-        // More samples than KeyboardConstants.Gesture.positionBufferSize (60),
-        // a straight rightward drag — must still classify as a right swipe.
+        // More samples than KeyboardConstants.Gesture.positionBufferSize
+        // (120), a straight rightward drag — must still classify as a right
+        // swipe.
         let points = (0 ... 500).map { CGPoint(x: CGFloat($0), y: 0) }
         #expect(classify(points) == .swipeRight)
+    }
+
+    @Test(arguments: [CGFloat.zero, -2, .nan, .infinity])
+    func invalidAspectRatioFallsBackInsteadOfPoisoningClassification(aspectRatio: CGFloat) {
+        // The aspect ratio reaches the preprocessor via a raw @AppStorage
+        // read; a zero/non-finite stored value used to turn normalization
+        // into NaN so that every gesture classified as .swipeRight. It must
+        // fall back to 1.0 and classify this clean up-swipe correctly.
+        let config = GesturePreprocessorConfig.default.with(aspectRatio: aspectRatio)
+        let points = (0 ... 15).map { CGPoint(x: 0, y: CGFloat($0) * -4) }
+        let result = KeyGestureRecognizer.classify(
+            positions: points, config: config, thresholds: .default
+        )
+        #expect(result.gesture == .swipeUp)
     }
 
     @Test func preprocessHandlesDegenerateInput() {

--- a/wurstfingerTests/OriginAnchoringTests.swift
+++ b/wurstfingerTests/OriginAnchoringTests.swift
@@ -59,6 +59,31 @@ struct OriginAnchoringTests {
         #expect(classification.gesture == .swipeRight)
     }
 
+    @Test func slowReturnSwipeAtProMotionSampleRateKeepsItsOutboundLeg() {
+        // SwiftUI's DragGesture samples at display refresh rate: at 120Hz a
+        // ~0.85s return swipe produces ~100 samples. With the old 60-sample
+        // buffer the outbound leg was evicted; after origin re-anchoring the
+        // displacement peak sat at the start of the retained window
+        // (progress ~ 0, outside returnDisplacementRange) and the gesture
+        // committed as a plain right swipe instead of the return alternate.
+        var buffer = RingBuffer<CGPoint>(capacity: KeyboardConstants.Gesture.positionBufferSize)
+        buffer.append(.zero)
+        for i in 1 ... 50 {
+            buffer.append(CGPoint(x: CGFloat(i) * 1.2, y: 0))
+        }
+        for i in 1 ... 50 {
+            buffer.append(CGPoint(x: 60 - CGFloat(i) * 1.2, y: 0))
+        }
+
+        let classification = KeyGestureRecognizer.classify(
+            positions: KeyGestureRecognizer.anchoringOrigin(buffer.elements),
+            config: .default,
+            thresholds: .default
+        )
+        #expect(classification.gesture == .swipeRight)
+        #expect(classification.isReturn)
+    }
+
     @Test func longDragWithFarOutRetainedWindowClassifiesAsSwipe() {
         // A long slow drag overflowed the ring buffer and the retained
         // window sits entirely beyond maxJumpDistance (50pt) from the

--- a/wurstfingerTests/SlideGestureStateTests.swift
+++ b/wurstfingerTests/SlideGestureStateTests.swift
@@ -197,6 +197,29 @@ struct SlideGestureStateTests {
         #expect(phase == nil)
     }
 
+    @Test func returnUpSwipeWithDriftAtLiftOffStaysAReturnUpSwipe() {
+        var state = SlideGestureState()
+        // Return leg of a return-up swipe: the vertical component shrinks
+        // through ~0 while sideways drift stays above the (small) slide
+        // threshold. The committed up-swipe peak (-45, beyond the 30 pt
+        // up-swipe threshold) must keep the slide from latching on the
+        // lift-off samples — previously (10, -6) latched it (10 >= 8 and
+        // 10 > 6), losing the label toggle and jumping the cursor.
+        let samples: [CGSize] = [
+            CGSize(width: 6, height: -45),
+            CGSize(width: 9, height: -15),
+            CGSize(width: 10, height: -6),
+        ]
+        for sample in samples {
+            let update = state.handleChanged(translation: sample, activationThreshold: threshold)
+            #expect(update.phases.isEmpty)
+        }
+        let phase = state.handleEnded(
+            translation: CGSize(width: 10, height: -6), activationThreshold: threshold
+        )
+        #expect(phase == .swipeUp(isReturn: true))
+    }
+
     @Test func upSwipeAfterHorizontalActivationEndsAsSlide() {
         var state = SlideGestureState()
         // Horizontal slide activates first, then the finger drifts far up:


### PR DESCRIPTION
Implements findings M1, M2, and L3 from the full codebase review 2026-07-07.

## M1 — Return-up swipe on the space bar hijacked into a cursor slide by lift-off drift

`SlideGestureState.handleChanged` latched the cursor slide on *instantaneous* cumulative translation (`abs(x) >= threshold && abs(x) > abs(y)`). On the return leg of a return-up swipe the vertical component shrinks through ~0 while sideways drift stays, so a sample sequence like `(6,-45) -> (9,-15) -> (10,-6)` latched the slide on the last sample (10 >= 8 and 10 > 6) even though `upwardPeakY = -45` had long committed the up-swipe (30 pt threshold). `handleEnded` then short-circuited to `.ended`: the label-toggle return-up swipe was lost and the cursor jumped by the drift delta.

**Fix:** once the upward peak has crossed the up-swipe threshold, the latch is refused (`-upwardPeakY < swipeUpThreshold` added to the latch condition; the threshold is passed into `handleChanged` with the same default `handleEnded` already uses). Existing behavior is preserved: `horizontalDominanceStillActivatesSlideAfterVerticalWobble` (peak 10 < 30) and `upSwipeAfterHorizontalActivationEndsAsSlide` (latches on its first sample at peak 0) stay green. New regression test `returnUpSwipeWithDriftAtLiftOffStaysAReturnUpSwipe` feeds exactly the drift-at-lift-off sequence above and asserts `.swipeUp(isReturn: true)`.

## M2 — Position buffer held only ~0.5 s of history on ProMotion (120 Hz) devices

`positionBufferSize = 60` was documented as "1 second at 60Hz", but SwiftUI `DragGesture` delivers samples at display refresh rate — 120 Hz on ProMotion iPhones. A return swipe slower than ~0.5 s lost its outbound leg to ring-buffer eviction; `anchoringOrigin` restores only the origin, so the displacement peak sat at the start of the retained window (progress ~ 0, outside `returnDisplacementRange 0.2...0.8`) and the gesture committed as a plain directional swipe instead of the return alternate.

**Fix:** buffer sized to 120 samples (1 s at 120 Hz, 2 s at 60 Hz; ~1 KB extra per key), comment updated to match reality. New regression test `slowReturnSwipeAtProMotionSampleRateKeepsItsOutboundLeg` pushes a 101-sample slow return swipe through a `RingBuffer` at the production capacity and asserts it classifies as a return swipe — verified to fail with the old capacity of 60.

## L3 — `normalizeAspectRatio` divided by an unvalidated aspect ratio

The key aspect ratio reaches `GesturePreprocessorConfig` via a raw `@AppStorage` read (`KeyView`), with no finiteness/positivity guard on the path. `normalizeAspectRatio` divides X coordinates by it, so a zero or non-finite stored value turned the whole pipeline into NaN and every gesture classified as `.swipeRight`.

**Fix:** `with(aspectRatio:)` — the single funnel through which the raw value enters the config — falls back to 1.0 for non-finite or non-positive values, consistent with the file's existing `finiteCGFloat` hygiene for the other stored parameters. New parameterized robustness test (`0`, `-2`, `.nan`, `.infinity`) asserts a clean up-swipe still classifies as `.swipeUp`.

## Testing

- Full `WurstfingerTests` unit suite on iPhone 17 Pro simulator: 894 passed, 0 failed.
- SwiftFormat and SwiftLint (`--strict`) clean on all touched files.
- Both M1 and M2 regression tests were confirmed to fail against the pre-fix behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gesture recognition reliability for swipe up and swipe right interactions.
  * Fixed cases where invalid gesture settings could cause incorrect swipe classification.
  * Better preserves gesture history on high-refresh-rate devices, reducing missed return swipes.
  * More accurately distinguishes slides from upward swipes when lifting or drifting during the gesture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->