### PR TITLE
Fix Host App Preview Wiring, Settings Copy, and Screenshot Language Persistence

### DIFF
--- a/wurstfinger/AppStoreScreenshotView.swift
+++ b/wurstfinger/AppStoreScreenshotView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct AppStoreScreenshotView: View {
     @StateObject private var viewModel = KeyboardViewModel(shouldPersistSettings: false)
-    @StateObject private var languageSettings = LanguageSettings.shared
     @State private var colorScheme: ColorScheme?
 
     // Sample text to display - can be overridden via environment
@@ -164,19 +163,13 @@ struct AppStoreScreenshotView: View {
     private func configureFromEnvironment() {
         let env = ProcessInfo.processInfo.environment
 
-        // Default to English for App Store screenshots
-        languageSettings.selectedLanguageId = "en_US"
-
         // Use full-size keyboard for screenshots (no scaling)
         viewModel.keyboardScale = 1.0
 
-        // Override language if specified
-        if let forcedLanguage = env["FORCE_LANGUAGE"] {
-            languageSettings.selectedLanguageId = forcedLanguage
-        }
-
-        // Load definition for the selected language
-        viewModel.loadDefinition(for: languageSettings.selectedLanguageId)
+        // Load the forced language (default: English for App Store screenshots)
+        // on the view model only — the screenshot view must never persist into
+        // the real shared app-group store (`shouldPersistSettings: false`).
+        viewModel.loadDefinition(for: env["FORCE_LANGUAGE"] ?? "en_US")
 
         // Set keyboard mode
         if let forcedLayer = env["FORCE_LAYER"] {

--- a/wurstfinger/ExpertSettingsView.swift
+++ b/wurstfinger/ExpertSettingsView.swift
@@ -49,6 +49,20 @@ struct ExpertSettingsView: View {
     @AppStorage(GestureClassificationThresholds.minOrientedCompactnessKey, store: SharedDefaults.store)
     private var minOrientedCompactness = Double(GestureClassificationThresholds.defaultMinOrientedCompactness)
 
+    // MARK: - Layout Settings (read-only, for the key-height indicator)
+
+    @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
+    private var keyAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
+
+    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
+    private var keyboardScale = DeviceLayoutUtils.defaultKeyboardScale
+
+    /// The key height the user actually sees, derived from the shared layout
+    /// calculation and the stored scale.
+    private var effectiveKeyHeight: Double {
+        KeyboardConstants.Calculations.keyHeight(aspectRatio: keyAspectRatio) * keyboardScale
+    }
+
     var body: some View {
         Form {
             warningSection
@@ -208,11 +222,11 @@ struct ExpertSettingsView: View {
 
             // Visual indicator
             HStack {
-                Text("Key height: 54pt")
+                Text("Key height: \(Int(effectiveKeyHeight.rounded()))pt")
                     .font(.caption)
                     .foregroundColor(.secondary)
                 Spacer()
-                Text("Threshold: \(Int(minSwipeLength / 54 * 100))% of key")
+                Text("Threshold: \(Int(minSwipeLength / effectiveKeyHeight * 100))% of key")
                     .font(.caption)
                     .foregroundColor(.orange)
             }

--- a/wurstfinger/GesturePlaygroundView.swift
+++ b/wurstfinger/GesturePlaygroundView.swift
@@ -15,14 +15,17 @@ struct GesturePlaygroundView: View {
     @State private var detectedGesture: GestureType = .tap
     @State private var isCircularCW: Bool?
 
-    @AppStorage("keyAspectRatio", store: SharedDefaults.store)
-    private var keyAspectRatio = 1.5
+    @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
+    private var keyAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 
-    // Key dimensions for the input area (simulating a standard key)
-    private let keyHeight: CGFloat = KeyboardConstants.KeyDimensions.height
+    // Key dimensions for the input area (simulating a standard key),
+    // derived from the shared layout calculation.
+    private var keyHeight: CGFloat {
+        KeyboardConstants.Calculations.keyHeight(aspectRatio: keyAspectRatio)
+    }
 
     private var keyWidth: CGFloat {
-        KeyboardConstants.KeyDimensions.height * CGFloat(keyAspectRatio)
+        keyHeight * CGFloat(keyAspectRatio)
     }
 
     @State private var isDragging = false

--- a/wurstfinger/InteractiveKeyboardPreview.swift
+++ b/wurstfinger/InteractiveKeyboardPreview.swift
@@ -60,18 +60,15 @@ struct InteractiveKeyboardPreview: View {
     }
 
     private var previewHeight: CGFloat {
-        // Calculate preview height based on aspect ratio and scale
-        let baseHeight = KeyboardConstants.Calculations.baseHeight(aspectRatio: previewViewModel.keyAspectRatio)
-        let scaledHeight = baseHeight * scale
+        // Mirror the real keyboard height: shared base-height formula, scaled.
+        // The bindings drive the preview view model, so they are the
+        // authoritative source for layout inputs here.
+        let scaledHeight = KeyboardConstants.Calculations.baseHeight(aspectRatio: aspectRatio) * scale
 
-        // Determine height constraints based on usage
-        if scale < 0.99 {
-            return min(KeyboardConstants.Preview.maxHeight, max(KeyboardConstants.Preview.minHeight, scaledHeight))
-        } else {
-            let keyHeight = 54.0 * (1.5 / aspectRatio)
-            let totalHeight = (keyHeight * 4) + (8 * 3) + (10 * 2)
-            return min(400, max(200, totalHeight))
-        }
+        // Near full scale the preview reserves more minimum room so the
+        // keyboard is never squeezed below its natural size.
+        let minHeight: CGFloat = scale < 0.99 ? KeyboardConstants.Preview.minHeight : 200
+        return min(KeyboardConstants.Preview.maxHeight, max(minHeight, scaledHeight))
     }
 
     var body: some View {
@@ -106,12 +103,11 @@ struct InteractiveKeyboardPreview: View {
                     .cornerRadius(8)
             }
 
-            GeometryReader { _ in
+            GeometryReader { proxy in
                 ZStack(alignment: .top) {
                     Color(.systemGray6)
 
-                    DataDrivenKeyboardRootView(viewModel: previewViewModel)
-
+                    DataDrivenKeyboardRootView(viewModel: previewViewModel, overrideWidth: proxy.size.width)
                         .onChange(of: aspectRatio) { _, newValue in
                             previewViewModel.keyAspectRatio = newValue
                         }

--- a/wurstfinger/KeyboardShowcaseView.swift
+++ b/wurstfinger/KeyboardShowcaseView.swift
@@ -73,7 +73,6 @@ private class ActionCountTarget: TextInputTarget, ObservableObject {
 
 struct KeyboardShowcaseView: View {
     @StateObject private var viewModel = KeyboardViewModel(shouldPersistSettings: false)
-    @StateObject private var languageSettings = LanguageSettings.shared
     @StateObject private var actionTarget = ActionCountTarget(
         capturesText: ProcessInfo.processInfo.environment["TYPING_TEST"] != nil
     )
@@ -115,18 +114,19 @@ struct KeyboardShowcaseView: View {
         .preferredColorScheme(colorScheme)
         .statusBar(hidden: true)
         .onAppear {
-            // Set language from environment if specified (for UI tests)
-            if let forcedLanguage = ProcessInfo.processInfo.environment["FORCE_LANGUAGE"] {
-                languageSettings.selectedLanguageId = forcedLanguage
-            }
-
             // Wire up the capturing target for dead-zone and typing tests
             if isDeadZoneTest || isTypingTest {
                 viewModel.bindTextInputTarget(actionTarget)
             }
 
-            // Load definition
-            viewModel.loadDefinition(for: languageSettings.selectedLanguageId)
+            // Load the definition for the forced language (UI tests) or the
+            // stored selection. The forced id is applied to the view model
+            // only — the showcase must never persist into the real shared
+            // app-group store (`shouldPersistSettings: false`).
+            let languageId = ProcessInfo.processInfo.environment["FORCE_LANGUAGE"]
+                ?? SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue)
+                ?? LanguageSettings.detectSystemLanguage()
+            viewModel.loadDefinition(for: languageId)
 
             // Set keyboard mode from environment if specified (for UI tests)
             if let forcedLayer = ProcessInfo.processInfo.environment["FORCE_LAYER"] {

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -3745,83 +3745,83 @@
       },
       "comment": "Header for keyboard visual style options"
     },
-    "Liquid Glass requires iOS 26 or later. The classic style will be used on this device.": {
+    "Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass erfordert iOS 26 oder neuer. Auf diesem Gerät wird der klassische Stil verwendet."
+            "value": "Liquid Glass ist für iOS 26 und neuer ausgelegt. Auf älteren Versionen wird ein vereinfachter durchscheinender Stil verwendet."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass nécessite iOS 26 ou une version ultérieure. Le style classique sera utilisé sur cet appareil."
+            "value": "Liquid Glass est conçu pour iOS 26 et versions ultérieures. Sur les versions antérieures, un style translucide simplifié est utilisé."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass requiere iOS 26 o posterior. En este dispositivo se usará el estilo clásico."
+            "value": "Liquid Glass está diseñado para iOS 26 y posteriores. En versiones anteriores se usa un estilo translúcido simplificado."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass richiede iOS 26 o versioni successive. Su questo dispositivo verrà usato lo stile classico."
+            "value": "Liquid Glass è progettato per iOS 26 e versioni successive. Nelle versioni precedenti viene usato uno stile traslucido semplificato."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass требует iOS 26 или новее. На этом устройстве будет использоваться классический стиль."
+            "value": "Liquid Glass разработан для iOS 26 и новее. В более ранних версиях используется упрощённый полупрозрачный стиль."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass wymaga iOS 26 lub nowszego. Na tym urządzeniu zostanie użyty styl klasyczny."
+            "value": "Liquid Glass jest zaprojektowany dla iOS 26 i nowszych. W starszych wersjach używany jest uproszczony półprzezroczysty styl."
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass kräver iOS 26 eller senare. Den klassiska stilen används på den här enheten."
+            "value": "Liquid Glass är utformat för iOS 26 och senare. På äldre versioner används en förenklad halvgenomskinlig stil."
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass vaatii iOS 26:n tai uudemman. Tässä laitteessa käytetään klassista tyyliä."
+            "value": "Liquid Glass on suunniteltu iOS 26:lle ja uudemmille. Vanhemmissa versioissa käytetään yksinkertaistettua läpikuultavaa tyyliä."
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass zahtijeva iOS 26 ili noviji. Na ovom će se uređaju koristiti klasični stil."
+            "value": "Liquid Glass je osmišljen za iOS 26 i novije. Na starijim verzijama koristi se pojednostavljeni poluprozirni stil."
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass דורש iOS 26 ואילך. הסגנון הקלאסי ישמש במכשיר זה."
+            "value": "Liquid Glass מיועד ל‑iOS 26 ואילך. בגרסאות קודמות נעשה שימוש בסגנון שקוף למחצה ופשוט יותר."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass yêu cầu iOS 26 trở lên. Kiểu cổ điển sẽ được dùng trên thiết bị này."
+            "value": "Liquid Glass được thiết kế cho iOS 26 trở lên. Trên các phiên bản cũ hơn, một kiểu trong mờ đơn giản hóa sẽ được dùng."
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kailangan ng Liquid Glass ang iOS 26 o mas bago. Gagamitin ang klasikong estilo sa device na ito."
+            "value": "Ang Liquid Glass ay idinisenyo para sa iOS 26 pataas. Sa mas lumang bersyon, gagamitin ang pinasimpleng translucent na estilo."
           }
         }
       },
-      "comment": "Warning note; 'Liquid Glass' is a style name (keep)"
+      "comment": "Note shown on pre-iOS-26 devices; 'Liquid Glass' is a style name (keep)"
     },
     "Enable or disable all haptic feedback vibrations.": {
       "extractionState": "manual",
@@ -8346,6 +8346,318 @@
         }
       },
       "comment": "Label visibility list item"
+    },
+    "Show Letters": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buchstaben anzeigen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher les lettres"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar letras"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra lettere"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать буквы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokazuj litery"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visa bokstäver"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näytä kirjaimet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prikaži slova"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הצגת אותיות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiện chữ cái"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ipakita ang mga letra"
+          }
+        }
+      },
+      "comment": "Label visibility toggle"
+    },
+    "Show Standard Symbols": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standardsymbole anzeigen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher les symboles standard"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar símbolos estándar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra simboli standard"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать стандартные символы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokazuj symbole standardowe"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visa standardsymboler"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näytä vakiosymbolit"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prikaži standardne simbole"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הצגת סמלים רגילים"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiện ký hiệu chuẩn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ipakita ang mga karaniwang simbolo"
+          }
+        }
+      },
+      "comment": "Label visibility toggle"
+    },
+    "Show Extra Symbols": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zusatzsymbole anzeigen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher les symboles supplémentaires"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar símbolos adicionales"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra simboli extra"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать дополнительные символы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokazuj symbole dodatkowe"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visa extra symboler"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näytä lisäsymbolit"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prikaži dodatne simbole"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הצגת סמלים נוספים"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiện ký hiệu bổ sung"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ipakita ang mga dagdag na simbolo"
+          }
+        }
+      },
+      "comment": "Label visibility toggle"
+    },
+    "Hide labels to practice the layout from memory. Numbers and control keys are always visible.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blende Beschriftungen aus, um das Layout aus dem Gedächtnis zu üben. Zahlen und Steuertasten sind immer sichtbar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masquez les étiquettes pour vous exercer à la disposition de mémoire. Les chiffres et les touches de contrôle restent toujours visibles."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oculta las etiquetas para practicar la disposición de memoria. Los números y las teclas de control siempre están visibles."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nascondi le etichette per esercitarti con il layout a memoria. I numeri e i tasti di controllo restano sempre visibili."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скройте подписи, чтобы тренировать раскладку по памяти. Цифры и служебные клавиши всегда видны."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ukryj etykiety, aby ćwiczyć układ z pamięci. Cyfry i klawisze sterujące są zawsze widoczne."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dölj etiketter för att öva på layouten ur minnet. Siffror och kontrolltangenter är alltid synliga."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piilota merkinnät harjoitellaksesi asettelua muistista. Numerot ja ohjausnäppäimet ovat aina näkyvissä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sakrij oznake da vježbaš raspored napamet. Brojevi i upravljačke tipke uvijek su vidljivi."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הסתר תוויות כדי לתרגל את הפריסה מהזיכרון. הספרות ומקשי הבקרה תמיד גלויים."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ẩn nhãn để luyện tập bố cục theo trí nhớ. Số và các phím điều khiển luôn hiển thị."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Itago ang mga label para masanay sa layout mula sa memorya. Laging nakikita ang mga numero at control key."
+          }
+        }
+      },
+      "comment": "Label visibility footer"
     },
     "Classic": {
       "extractionState": "manual",

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -40,7 +40,7 @@ struct StyleSettingsView: View {
 
                         if keyboardStyleRaw == KeyboardStyle.liquidGlass.rawValue {
                             if #unavailable(iOS 26.0) {
-                                Text("Liquid Glass requires iOS 26 or later. The classic style will be used on this device.")
+                                Text("Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.")
                                     .font(.caption)
                                     .foregroundColor(.orange)
                                     .padding(.horizontal, 16)

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -266,7 +266,7 @@ enum CursorMovementStyle: String, CaseIterable {
 /// Visual style for the keyboard appearance
 enum KeyboardStyle: String, CaseIterable {
     case classic // Traditional opaque key backgrounds
-    case liquidGlass // iOS 26+ Liquid Glass effect (falls back to classic on older iOS)
+    case liquidGlass // iOS 26+ Liquid Glass effect (renders as a simplified translucent style on older iOS)
 
     var displayName: String {
         switch self {


### PR DESCRIPTION
Fixes the host-app findings M6, M9, M10 and the host-app items of L20 from the full codebase review 2026-07-07.

## M9 — Interactive preview never wired `overrideWidth`

`InteractiveKeyboardPreview` discarded its `GeometryReader` proxy, so `DataDrivenKeyboardRootView` always laid out against the full `UIScreen` width while the preview container is `screenWidth − 32`. Near scale 1.0 the outer key columns were cropped by the clip shape, and the horizontal-position preview was computed against the wrong width. The preview now passes `overrideWidth: proxy.size.width` — the parameter that was declared for exactly this call site but had zero callers.

## L20 — Preview height formula had drifted

The ≥ 0.99-scale branch of `previewHeight` hardcoded spacing 8 and padding 10+10 (and read the aspect ratio from a second source), while the real keyboard uses `KeyboardConstants.Calculations.baseHeight` (spacing 5×3, padding 4+10). Both branches now share the same calculation and one input source (the bindings); only the minimum-height clamp still differs by scale, as before.

## M6 — Liquid Glass settings copy overpromised (text-only fix, owner decision)

The pre-iOS-26 note claimed "The classic style will be used on this device", but no fallback exists — there is no `#available` gate in the extension, and on iOS 17–25 the selection renders as a translucent `.bar` material. Per owner decision this PR does **not** implement a fallback; it corrects the copy to "Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used." (translated for all 12 languages) and fixes the stale `KeyboardStyle` enum comment.

## M10 — Label Visibility screen was entirely unlocalized

`Show Letters`, `Show Standard Symbols`, `Show Extra Symbols` and the footer were missing from `Localizable.xcstrings` (the navigation title `Label Visibility` was already in the catalog). All four keys added with translations for the 12 catalog languages, reusing the terminology from the existing `letters` / `standard symbols` / `extra symbols` entries.

> **Note for reviewers:** `LocalizationCompletenessTests` intentionally forbids `needs_review` states, so all new translations are marked `translated`. The **he / vi / fil** translations of the new strings are low-confidence and would benefit from a native-speaker pass:
> - the new Liquid Glass note
> - the three `Show …` toggles and the practice-mode footer

## L20 — Expert tools used hardcoded/wrong layout constants

- `ExpertSettingsView`: "Key height: 54pt" was hardcoded; the actual height is `Calculations.keyHeight(aspectRatio:) × scale` (up to ~33 % off). The indicator and the threshold percentage are now derived from the shared calculation and the stored settings. The new indicator string stays unlocalized like the rest of the expert screen (deliberate scope cut).
- `GesturePlaygroundView`: used the raw string key `"keyAspectRatio"` with a wrong fallback default of 1.5 (the real default is `DeviceLayoutUtils.defaultKeyAspectRatio` = 1.0). Now uses `SettingsKey.keyAspectRatio.rawValue`, the real default, and bases the simulated key size on the shared `Calculations.keyHeight`.

## L20 — Screenshot/showcase views persisted the forced language

`AppStoreScreenshotView` and `KeyboardShowcaseView` wrote `FORCE_LANGUAGE` through `LanguageSettings.shared`, whose `didSet` persists into the real shared app-group store — contradicting their `shouldPersistSettings: false` design and leaking screenshot/UI-test state into the user's actual keyboard language. The forced language is now applied to the view model only via `loadDefinition(for:)`; the rendered keyboard reads exclusively from the loaded definition (with the existing English fallback for stale ids), so launch-argument-driven forcing still reaches it.

## Testing

- `xcodebuild build` (scheme `Wurstfinger`, iPhone 17 Pro simulator): succeeded.
- `xcodebuild test -only-testing:WurstfingerTests`: **TEST SUCCEEDED**, 889 test cases passed, 0 failed. (A first run failed only in `LocalizationCompletenessTests`, which forbids `needs_review` states — resolved by marking the new strings `translated`, see the reviewer note above.)
- SwiftFormat + SwiftLint (`--strict`) clean on all touched files.
- **UI tests (`WurstfingerUITests`) were not run** — TypingTests/DeadZoneTests and screenshot generation drive the showcase views, so a UI-test pass before merging would be a useful extra check for the language-forcing change.

Part of full codebase review 2026-07-07, findings M6/M9/M10/L20.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new label-visibility options and helper text for practice mode.
  * Improved keyboard previews and showcase views to better match the selected language and screen size.
  * Keyboard sizing now uses shared layout settings for more consistent display across views.

* **Bug Fixes**
  * Refined language selection so screenshot and test views use the expected language without affecting saved app settings.
  * Updated Liquid Glass wording for supported and unsupported iOS versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->