### PR TITLE
Fix One-Shot Shift Semantics, Spanish Auto-Cap, and Caseless Hebrew

### DIFF
--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -117,7 +117,13 @@ enum GridKeyboardFactory {
             }
         }
 
-        // 2. Merge utility keys
+        // 2. Merge utility keys — the slot-id sets must be disjoint or the
+        // merge would silently swallow a utility key (same invariant as
+        // `NumericLayouts.buildMode`).
+        precondition(
+            Set(letterKeys.keys).isDisjoint(with: CommonKeys.allUtilityKeys.keys),
+            "letter and utility key IDs must not overlap"
+        )
         let allKeys = letterKeys.merging(CommonKeys.allUtilityKeys) { letter, _ in letter }
 
         // 3. Build base mode with all keys (includes shift-down on midRight)

--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -26,6 +26,10 @@ enum GridKeyboardFactory {
     ///   - composeRuleOverrides: Language-specific compose rules merged over the
     ///     global base rules at runtime (override wins for the same trigger +
     ///     base character). Defaults to nil (global rules only).
+    ///   - supportsCapitalization: Whether the script distinguishes letter case.
+    ///     Caseless scripts (Hebrew) pass `false`: the layout then has no
+    ///     shifted/capsLock modes, no shift binding on the midRight key, and
+    ///     auto-capitalization is disabled in the definition settings.
     ///   - numericBackToAlphaLabel: Label shown on the symbols key in numeric
     ///     mode that switches back to the main (alphabetic) layer. Defaults to
     ///     the Latin "abc"; non-Latin layouts (Hebrew, Russian, …) should
@@ -41,6 +45,7 @@ enum GridKeyboardFactory {
         directionalOverrides: [String: [GestureType: String]] = [:],
         returnOverrides: [String: [GestureType: String]] = [:],
         composeRuleOverrides: ComposeRuleSet? = nil,
+        supportsCapitalization: Bool = true,
         numericBackToAlphaLabel: String = NumericLayouts.defaultBackToAlphaLabel,
         inputMethod: InputMethodKind = .direct
     ) -> KeyboardDefinition {
@@ -124,37 +129,45 @@ enum GridKeyboardFactory {
             doubleTapMode: nil
         )
 
-        // Generate the shifted base once and derive both shifted + caps lock.
-        let shiftedBase = baseMode.generateShifted(locale: locale)
+        var modes: [String: KeyboardMode] = [
+            ModeNames.numeric: NumericLayouts.phone(backToAlphaLabel: numericBackToAlphaLabel),
+        ]
 
-        // 4. Shifted — shift-up points directly to capsLock (label stays ⇧).
-        let shiftedMode = shiftedBase
-            .with(autoTransitions: [.letter: ModeNames.main])
-            .replacingShiftUpBinding(label: "⇧", action: .switchMode(ModeNames.capsLock))
+        if supportsCapitalization {
+            // Generate the shifted base once and derive both shifted + caps lock.
+            let shiftedBase = baseMode.generateShifted(locale: locale)
 
-        // 5. Caps lock — shift-up is no-op (stays in capsLock), label shows ⇪.
-        let capsLockMode = shiftedBase
-            .with(name: ModeNames.capsLock)
-            .replacingShiftUpBinding(label: "⇪", action: .switchMode(ModeNames.capsLock))
+            // 4. Shifted — shift-up points directly to capsLock (label stays ⇧).
+            modes[ModeNames.shifted] = shiftedBase
+                .with(autoTransitions: [.letter: ModeNames.main])
+                .replacingShiftUpBinding(label: "⇧", action: .switchMode(ModeNames.capsLock))
 
-        // 6. Main mode — remove shift-down hint from midRight (only shown in shifted/capsLock).
-        let mainMode = baseMode
-            .removingBinding(keyId: GridSlot.midRight, gesture: .swipeDown)
+            // 5. Caps lock — shift-up is no-op (stays in capsLock), label shows ⇪.
+            modes[ModeNames.capsLock] = shiftedBase
+                .with(name: ModeNames.capsLock)
+                .replacingShiftUpBinding(label: "⇪", action: .switchMode(ModeNames.capsLock))
+
+            // 6. Main mode — remove shift-down hint from midRight (only shown in shifted/capsLock).
+            modes[ModeNames.main] = baseMode
+                .removingBinding(keyId: GridSlot.midRight, gesture: .swipeDown)
+        } else {
+            // Caseless script: no shifted/capsLock modes and no shift
+            // affordance on the midRight key (neither the ⇧ shift-up
+            // binding nor the ⇩ back-to-main hint).
+            modes[ModeNames.main] = baseMode
+                .removingBinding(keyId: GridSlot.midRight, gesture: .swipeUp)
+                .removingBinding(keyId: GridSlot.midRight, gesture: .swipeDown)
+        }
 
         // 7. Assemble definition
         return KeyboardDefinition(
             title: title,
             id: id,
             localeIdentifier: localeIdentifier,
-            modes: [
-                ModeNames.main: mainMode,
-                ModeNames.shifted: shiftedMode,
-                ModeNames.capsLock: capsLockMode,
-                ModeNames.numeric: NumericLayouts.phone(backToAlphaLabel: numericBackToAlphaLabel),
-            ],
+            modes: modes,
             defaultMode: ModeNames.main,
             settings: KeyboardDefinitionSettings(
-                autoCapitalize: true,
+                autoCapitalize: supportsCapitalization,
                 composeRuleOverrides: composeRuleOverrides,
                 inputMethod: inputMethod
             ),

--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
@@ -256,6 +256,9 @@ enum LanguageDefinitions {
                     .swipeUpRight: "ף", .swipeDown: "ן", .swipeDownLeft: "ך",
                 ],
             ],
+            // Hebrew is caseless: no shift key, no shifted/capsLock modes,
+            // no auto-capitalization.
+            supportsCapitalization: false,
             numericBackToAlphaLabel: "אבג"
         )
     }

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -221,9 +221,14 @@ extension KeyboardViewModel {
         guard currentDefinition?.settings.autoCapitalize == true,
               sharedDefaults.bool(forKey: SettingsKey.autoCapitalizeEnabled.rawValue)
         else { return nil }
-        return AutoCapitalization.shouldCapitalize(
-            context: textInputTarget?.documentContextBeforeInput
-        )
+        let context = textInputTarget?.documentContextBeforeInput
+        // Sentence-opening punctuation (Spanish ¿/¡) capitalizes the letter
+        // that immediately follows it, matching iOS system keyboards.
+        if let last = context?.last,
+           AutoCapitalization.shouldCapitalizeImmediately(after: String(last)) {
+            return true
+        }
+        return AutoCapitalization.shouldCapitalize(context: context)
     }
 
     /// Engages the shifted layer for the next key. Only fires from `main`:

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -167,7 +167,16 @@ extension KeyboardViewModel {
         middlewares.append(AutoCapitalizationMiddleware(
             evaluate: { [weak self] in self?.evaluateAutoCapitalization() },
             onCapitalize: { [weak self] in self?.engageAutoCapitalization() },
-            onReleaseCapitalize: { [weak self] in self?.releaseAutoCapitalization() }
+            onReleaseCapitalize: { [weak self] in
+                // Mirror `refreshAutoCapitalization`: only an *auto-engaged*
+                // shift may be released when the context stops calling for
+                // capitalization. A manually tapped shift is one-shot and is
+                // consumed exclusively by letters (via the shifted mode's
+                // auto-transition) — never dropped by delete, symbols,
+                // paste, or cut — matching iOS system shift behavior.
+                guard let self, shiftEngagedByAutoCapitalization else { return }
+                releaseAutoCapitalization()
+            }
         ))
 
         // 8. Mode transitions (auto-transitions from key category)

--- a/wurstfingerKeyboard/Runtime/Pipeline/ModeTransitionMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/ModeTransitionMiddleware.swift
@@ -24,10 +24,26 @@ struct ModeTransitionMiddleware: ActionMiddleware {
     func process(_ context: ActionContext, next: (ActionContext) -> Void) {
         next(context)
         guard let currentMode = definition.modes[context.mode] else { return }
-        let category = context.binding?.resolvedCategory
-            ?? context.action.inferredCategory
+        let category = Self.transitionCategory(for: context)
         guard let nextMode = currentMode.nextMode(after: category) else { return }
         guard nextMode != context.mode else { return }
         onModeChange(nextMode)
+    }
+
+    /// Category driving the auto-transition lookup.
+    ///
+    /// Normally the binding's resolved category. Compose bindings are the
+    /// exception: `ComposeMiddleware` rewrites their action before it gets
+    /// here (`.compose("´")` → `.commitText("á")`), and the transition must
+    /// follow the *result* — a composed letter consumes a one-shot shift
+    /// exactly like a plain letter, while a compose trigger that merely
+    /// commits its trigger character behaves like a symbol and keeps shift
+    /// engaged (matching iOS system shift semantics).
+    static func transitionCategory(for context: ActionContext) -> KeyCategory {
+        guard let binding = context.binding else { return context.action.inferredCategory }
+        if binding.resolvedCategory == .compose, context.action != binding.action {
+            return context.action.inferredCategory
+        }
+        return binding.resolvedCategory
     }
 }

--- a/wurstfingerTests/AutoCapitalizationTests.swift
+++ b/wurstfingerTests/AutoCapitalizationTests.swift
@@ -306,6 +306,91 @@ struct AutoCapitalizationTests {
         #expect(vm.activeModeName == ModeNames.numeric)
     }
 
+    // MARK: - One-shot shift semantics (manual vs. auto-engaged)
+
+    // Policy (matching iOS system keyboards): a manually tapped shift is
+    // consumed ONLY by letters. Delete, symbols, paste, and cut must not
+    // drop it — even while the auto-capitalization setting is on. Only an
+    // auto-engaged shift may be released when the context stops calling
+    // for capitalization.
+
+    @Test func manualShiftSurvivesDeleteThroughPipeline() {
+        let (vm, target) = makeAutoCapViewModel()
+        // Mid-sentence context: auto-capitalization evaluates to false.
+        target.documentContextBeforeInput = "Hello wor"
+
+        // User taps shift manually, then deletes a typo.
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.shifted)
+        vm.handleGesture(.tap, keyId: UtilitySlot.delete, isReturn: false)
+
+        #expect(
+            vm.activeModeName == ModeNames.shifted,
+            "Delete must not drop a manually engaged shift"
+        )
+    }
+
+    @Test func manualShiftSurvivesSymbolThroughPipeline() {
+        let (vm, target) = makeAutoCapViewModel()
+        target.documentContextBeforeInput = "Hello wor"
+
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.shifted)
+        // "-" on topLeft swipeRight is a symbol binding (unchanged in shifted).
+        vm.handleGesture(.swipeRight, keyId: GridSlot.topLeft, isReturn: false)
+
+        #expect(target.events.contains(.insertText("-")))
+        #expect(
+            vm.activeModeName == ModeNames.shifted,
+            "A symbol must not consume a manually engaged shift"
+        )
+    }
+
+    @Test func manualShiftSurvivesPasteThroughPipeline() {
+        let (vm, target) = makeAutoCapViewModel()
+        target.documentContextBeforeInput = "Hello wor"
+
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.shifted)
+        vm.dispatchAction(.paste)
+
+        #expect(
+            vm.activeModeName == ModeNames.shifted,
+            "Paste must not drop a manually engaged shift"
+        )
+    }
+
+    @Test func manualShiftIsConsumedByLetter() {
+        let (vm, target) = makeAutoCapViewModel()
+        target.documentContextBeforeInput = "Hello "
+
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.shifted)
+        vm.handleGesture(.tap, keyId: GridSlot.topLeft, isReturn: false)
+
+        #expect(target.events.contains(.insertText("A")))
+        #expect(
+            vm.activeModeName == ModeNames.main,
+            "A letter must consume the one-shot shift"
+        )
+    }
+
+    @Test func autoEngagedShiftIsStillReleasedByDelete() {
+        let (vm, target) = makeAutoCapViewModel()
+        target.documentContextBeforeInput = "Hello"
+
+        // Sentence ender auto-engages shift…
+        vm.dispatchAction(.commitText(". "))
+        #expect(vm.activeModeName == ModeNames.shifted)
+
+        // …deleting back into the sentence must release it again.
+        vm.dispatchAction(.deleteBackward)
+        #expect(
+            vm.activeModeName == ModeNames.main,
+            "An auto-engaged shift must be released when the context no longer calls for it"
+        )
+    }
+
     // MARK: - Definition-level enablement
 
     @Test func definitionWithoutAutoCapitalizeDisablesEngagement() throws {

--- a/wurstfingerTests/AutoCapitalizationTests.swift
+++ b/wurstfingerTests/AutoCapitalizationTests.swift
@@ -391,6 +391,47 @@ struct AutoCapitalizationTests {
         )
     }
 
+    // MARK: - Spanish inverted punctuation (¿ / ¡)
+
+    @Test func invertedQuestionMarkEngagesShiftThroughPipeline() {
+        let (vm, target) = makeAutoCapViewModel()
+        target.documentContextBeforeInput = "Hola "
+
+        // ¿ is the return swipe of "?" (topRight swipeLeft).
+        vm.handleGesture(.swipeLeft, keyId: GridSlot.topRight, isReturn: true)
+
+        #expect(target.events.contains(.insertText("¿")))
+        #expect(
+            vm.activeModeName == ModeNames.shifted,
+            "¿ must capitalize the immediately following letter"
+        )
+    }
+
+    @Test func invertedExclamationMarkEngagesShiftThroughPipeline() {
+        let (vm, target) = makeAutoCapViewModel()
+        target.documentContextBeforeInput = "Hola "
+
+        vm.dispatchAction(.commitText("¡"))
+        #expect(vm.activeModeName == ModeNames.shifted)
+    }
+
+    @Test func invertedPunctuationEngagesShiftViaRefresh() {
+        let (vm, target) = makeAutoCapViewModel()
+        // Caret lands right after an opener (host-side change).
+        target.documentContextBeforeInput = "¿"
+
+        vm.refreshAutoCapitalization()
+        #expect(vm.activeModeName == ModeNames.shifted)
+    }
+
+    @Test func invertedPunctuationDoesNothingWhenSettingDisabled() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+        target.documentContextBeforeInput = "Hola "
+
+        vm.dispatchAction(.commitText("¿"))
+        #expect(vm.activeModeName == ModeNames.main)
+    }
+
     // MARK: - Definition-level enablement
 
     @Test func definitionWithoutAutoCapitalizeDisablesEngagement() throws {

--- a/wurstfingerTests/LanguageDefinitionTests.swift
+++ b/wurstfingerTests/LanguageDefinitionTests.swift
@@ -26,9 +26,16 @@ struct LanguageDefinitionValidationTests {
     func layoutHasRequiredModes(descriptor: LanguageDescriptor) {
         let layout = descriptor.makeDefinition()
         #expect(layout.modes[ModeNames.main] != nil, "\(layout.id) missing main mode")
-        #expect(layout.modes[ModeNames.shifted] != nil, "\(layout.id) missing shifted mode")
-        #expect(layout.modes[ModeNames.capsLock] != nil, "\(layout.id) missing capsLock mode")
         #expect(layout.modes[ModeNames.numeric] != nil, "\(layout.id) missing numeric mode")
+        // Caseless scripts (Hebrew) carry no shift affordance at all; every
+        // other layout must have both shifted and capsLock.
+        if CaselessLanguages.ids.contains(layout.id) {
+            #expect(layout.modes[ModeNames.shifted] == nil, "\(layout.id) must not have a shifted mode")
+            #expect(layout.modes[ModeNames.capsLock] == nil, "\(layout.id) must not have a capsLock mode")
+        } else {
+            #expect(layout.modes[ModeNames.shifted] != nil, "\(layout.id) missing shifted mode")
+            #expect(layout.modes[ModeNames.capsLock] != nil, "\(layout.id) missing capsLock mode")
+        }
     }
 
     @Test func allLanguagesAreResolvableViaLanguageConfig() {
@@ -101,6 +108,79 @@ struct GermanLayoutTests {
         #expect(letterRows[0] == ["a", "n", "i"])
         #expect(letterRows[1] == ["h", "d", "r"])
         #expect(letterRows[2] == ["t", "e", "s"])
+    }
+}
+
+// MARK: - Caseless Script Tests (Hebrew)
+
+/// Hebrew is caseless: the layout must carry no shift affordance at all
+/// (no shifted/capsLock modes, no ⇧/⇩ bindings on midRight) and must opt
+/// out of auto-capitalization. All other languages keep the full shift
+/// machinery.
+struct CaselessScriptTests {
+    static let hebrew = LanguageDefinitions.hebrew.makeDefinition()
+
+    @Test func hebrewHasNoShiftedOrCapsLockModes() {
+        #expect(Self.hebrew.modes[ModeNames.shifted] == nil)
+        #expect(Self.hebrew.modes[ModeNames.capsLock] == nil)
+        #expect(Self.hebrew.modes[ModeNames.main] != nil)
+        #expect(Self.hebrew.modes[ModeNames.numeric] != nil)
+    }
+
+    @Test func hebrewMainModeHasNoShiftBindings() throws {
+        let main = try #require(Self.hebrew.modes[ModeNames.main])
+        let midRight = try #require(main.keys[GridSlot.midRight])
+        #expect(midRight.bindings[.swipeUp] == nil, "shift-up binding must be absent")
+        #expect(midRight.bindings[.swipeDown] == nil, "shift-down hint must be absent")
+    }
+
+    @Test func hebrewDisablesAutoCapitalization() {
+        #expect(!Self.hebrew.settings.autoCapitalize)
+    }
+
+    @Test func hebrewHasNoSwitchModeToShiftedAnywhere() {
+        for (modeName, mode) in Self.hebrew.modes {
+            for (keyId, key) in mode.keys {
+                for (gesture, binding) in key.bindings {
+                    #expect(
+                        binding.action != .switchMode(ModeNames.shifted)
+                            && binding.action != .switchMode(ModeNames.capsLock),
+                        "Dangling shift switchMode in \(modeName)/\(keyId)/\(gesture)"
+                    )
+                    #expect(
+                        binding.returnAction != .switchMode(ModeNames.shifted)
+                            && binding.returnAction != .switchMode(ModeNames.capsLock),
+                        "Dangling shift return switchMode in \(modeName)/\(keyId)/\(gesture)"
+                    )
+                }
+            }
+        }
+    }
+
+    @Test func hebrewAutoCapitalizationNeverEngages() {
+        let (vm, target) = makeViewModel(languageId: "he_IL")
+        vm.sharedDefaults.set(true, forKey: SettingsKey.autoCapitalizeEnabled.rawValue)
+
+        // Neither an empty field nor a sentence ender may switch modes —
+        // the definition opts out even with the user setting on.
+        target.documentContextBeforeInput = nil
+        vm.refreshAutoCapitalization()
+        #expect(vm.activeModeName == ModeNames.main)
+
+        vm.dispatchAction(.commitText("שלום. "))
+        #expect(vm.activeModeName == ModeNames.main)
+    }
+
+    @Test(arguments: LanguageDefinitions.all.filter { !CaselessLanguages.ids.contains($0.id) })
+    func casedLanguagesKeepShiftAndAutoCapitalization(descriptor: LanguageDescriptor) throws {
+        let layout = descriptor.makeDefinition()
+        #expect(layout.settings.autoCapitalize, "\(layout.id) must keep autoCapitalize")
+        let main = try #require(layout.modes[ModeNames.main])
+        let midRight = try #require(main.keys[GridSlot.midRight])
+        #expect(
+            midRight.bindings[.swipeUp]?.action == .switchMode(ModeNames.shifted),
+            "\(layout.id) must keep the shift-up binding on midRight"
+        )
     }
 }
 

--- a/wurstfingerTests/LayoutValidationTests.swift
+++ b/wurstfingerTests/LayoutValidationTests.swift
@@ -45,16 +45,24 @@ struct LayoutValidationTests {
         }
     }
 
-    @Test func allLanguagesHaveShiftedMode() {
+    @Test func allCasedLanguagesHaveShiftedMode() {
         for info in KeyboardRegistry.available {
             guard let definition = KeyboardRegistry.load(id: info.id) else {
                 Issue.record("Failed to load \(info.id)")
                 continue
             }
-            #expect(
-                definition.mode(ModeNames.shifted) != nil,
-                "Language \(info.id) missing shifted mode"
-            )
+            if CaselessLanguages.ids.contains(info.id) {
+                // Caseless scripts have no shift affordance at all.
+                #expect(
+                    definition.mode(ModeNames.shifted) == nil,
+                    "Caseless language \(info.id) must not have a shifted mode"
+                )
+            } else {
+                #expect(
+                    definition.mode(ModeNames.shifted) != nil,
+                    "Language \(info.id) missing shifted mode"
+                )
+            }
         }
     }
 

--- a/wurstfingerTests/TestHelpers.swift
+++ b/wurstfingerTests/TestHelpers.swift
@@ -115,6 +115,13 @@ final class InMemoryUserDefaults: UserDefaults {
     }
 }
 
+/// Language ids whose script is caseless. These layouts have no shift
+/// affordance (no shifted/capsLock modes, no shift binding) and
+/// auto-capitalization disabled in their definition settings.
+enum CaselessLanguages {
+    static let ids: Set<String> = ["he_IL"]
+}
+
 /// Creates a KeyboardViewModel wired to a MockTextTarget for testing.
 func makeViewModel(
     languageId: String = "de_DE",

--- a/wurstfingerTests/wurstfingerTests.swift
+++ b/wurstfingerTests/wurstfingerTests.swift
@@ -292,6 +292,50 @@ struct wurstfingerTests {
         #expect(allInserts.last == "Á", "Compose should produce Á after uppercase A, got \(allInserts.last ?? "nil")")
     }
 
+    @Test func composeAsFirstActionInShiftedModeConsumesShift() {
+        // Auto-capitalization is off here (default in makeViewModel), so the
+        // shift release must come from the mode transition itself, not from
+        // an auto-cap side effect.
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+
+        // Type "a", then engage shift manually.
+        vm.handleGesture(.tap, keyId: GridSlot.topLeft, isReturn: false)
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.shifted)
+
+        // Compose as the FIRST action in shifted mode: ´ + a → á.
+        vm.handleGesture(.swipeUpRight, keyId: GridSlot.topCenter, isReturn: false)
+
+        let inserts = target.events.compactMap { if case let .insertText(t) = $0 { t } else { nil } }
+        #expect(inserts.last == "á", "Compose should produce á, got \(inserts.last ?? "nil")")
+        #expect(
+            vm.activeModeName == ModeNames.main,
+            "A composed letter must consume the one-shot shift exactly like a plain letter"
+        )
+    }
+
+    @Test func composeTriggerWithoutRuleKeepsShiftEngaged() {
+        // Deliberate policy: when the compose gesture finds no rule (no
+        // preceding character) it merely commits the trigger character —
+        // a symbol, not a letter. Per the iOS-style one-shot shift
+        // semantics, symbols must NOT consume shift, so the keyboard stays
+        // shifted until an actual letter is produced.
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.shifted)
+
+        // Empty document: ´ has nothing to compose with and commits "´".
+        vm.handleGesture(.swipeUpRight, keyId: GridSlot.topCenter, isReturn: false)
+
+        let inserts = target.events.compactMap { if case let .insertText(t) = $0 { t } else { nil } }
+        #expect(inserts.last == "´", "Trigger should commit literally, got \(inserts.last ?? "nil")")
+        #expect(
+            vm.activeModeName == ModeNames.shifted,
+            "A committed trigger character is a symbol and must not consume shift"
+        )
+    }
+
     // MARK: - Asterisk Regression (Vietnamese tone rules must not be global)
 
     @Test func asteriskInsertsLiterallyAfterVowel() {


### PR DESCRIPTION
Implements four decided fixes from the full codebase review 2026-07-07 (findings M3, L5, L4, L12, L14).

## Shift policy (owner decision)

One-shot shift follows iOS system behavior: a **manually tapped shift is consumed only by letters** — including composed/accented letters — and is never dropped by delete, symbols, punctuation, paste, or cut. An **auto-engaged shift** (auto-capitalization) may still be released when the context no longer calls for capitalization.

## M3 — Pipeline no longer drops a manually engaged shift

`KeyboardViewModel+Pipeline` wired the auto-capitalization middleware's release callback to an unconditional `releaseAutoCapitalization()`. With auto-cap on, tapping shift manually and then hitting delete (or a symbol/paste/cut) silently dropped the shift before the intended capital letter. The release is now gated on `shiftEngagedByAutoCapitalization`, mirroring the already-correct `refreshAutoCapitalization` path. Pipeline tests cover: manual shift survives delete/symbol/paste, manual shift is consumed by a letter, and an auto-engaged shift is still released by delete.

## L5 — Composed letters consume the one-shot shift

`ModeTransitionMiddleware` used the original binding's category, so a compose binding (`.compose`) never matched the shifted mode's `.letter → main` auto-transition even after `ComposeMiddleware` rewrote it to `.commitText("Á")` — the keyboard stayed stuck in shifted when auto-cap was off. The middleware now falls back to the transformed action's inferred category when a compose binding's action was rewritten.

Deliberate policy detail: a compose **trigger** that finds no rule and merely commits its trigger character (e.g. `´` on an empty document) is a symbol commit and does **not** consume shift — consistent with the decided shift policy. Encoded in `composeTriggerWithoutRuleKeepsShiftEngaged`; the composed-letter-as-first-action case is covered by `composeAsFirstActionInShiftedModeConsumesShift`.

## L4 — Spanish inverted punctuation capitalizes the next letter

`AutoCapitalization.shouldCapitalizeImmediately` (¿/¡) had zero production callers. It is now wired into `evaluateAutoCapitalization()`, so both the pipeline and the host-refresh path engage shift right after an opener — matching iOS system keyboards. Active only when the auto-capitalization setting and the definition's `autoCapitalize` flag are on.

## L12 — Hebrew: no shift key, no auto-capitalization (owner decision)

Hebrew is caseless, so the shift affordance was meaningless and auto-cap churned mode state every sentence. `GridKeyboardFactory` gains `supportsCapitalization: Bool = true`; when `false` the layout is built without shifted/capsLock modes, without the ⇧ shift-up binding and ⇩ hint on midRight, and with `autoCapitalize: false`. Hebrew opts out; all other languages are unchanged (asserted by a parameterized test). Hebrew final forms (return-swipe overrides) are unaffected, and `validate()` passes with no dangling `switchMode` targets (dedicated test).

## L14 — Slot-id collision precondition in the factory merge

The letter/utility key merge silently preferred the letter key on a slot-id collision, swallowing a utility key while validation still passed. The merge is now guarded by the same disjointness `precondition` that `NumericLayouts.buildMode` uses.

## Testing

- `xcodebuild test -only-testing:WurstfingerTests` on iPhone 17 Pro simulator: all tests pass (the known-flaky `KeyboardRegistryTests/loadCachesResult` failed once under full parallel load and passes isolated).
- New coverage: one-shot shift semantics through the pipeline, compose-in-shifted-mode transitions, ¿/¡ capitalization, Hebrew caseless structure and behavior, cased-language regression guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for layouts that do not use capitalization, with shift/caps-lock behavior automatically hidden where not needed.
  * Improved auto-capitalization for Spanish inverted punctuation, so text after `¿` and `¡` can capitalize correctly.

* **Bug Fixes**
  * Shift now stays active more reliably during deletes, paste, and symbol actions until a letter is entered.
  * Composition-related input now preserves or clears shift state more consistently, improving keyboard behavior across layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->