### PR TITLE
Polish Pipeline and Definition Layer (Review Findings L7-L11, L13, L16, L17)

### DIFF
--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -131,8 +131,7 @@ enum GridKeyboardFactory {
             name: ModeNames.main,
             keys: allKeys,
             arrangements: arrangements,
-            autoTransitions: [:],
-            doubleTapMode: nil
+            autoTransitions: [:]
         )
 
         var modes: [String: KeyboardMode] = [

--- a/wurstfingerKeyboard/Definition/Language/KeyboardMode+Shifted.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardMode+Shifted.swift
@@ -37,8 +37,7 @@ extension KeyboardMode {
             name: ModeNames.shifted,
             keys: shiftedKeys,
             arrangements: arrangements,
-            autoTransitions: [:],
-            doubleTapMode: nil
+            autoTransitions: [:]
         )
     }
 }

--- a/wurstfingerKeyboard/Definition/Language/KeyboardMode.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardMode.swift
@@ -26,12 +26,10 @@ struct KeyboardMode: Codable, Equatable {
     /// Automatic mode transitions after input of a certain category.
     /// e.g. in "shifted" mode: [.letter: "main"] → after letter back to main.
     /// Empty dictionary = mode stays active (like caps lock or numeric).
+    ///
+    /// Note: double-tap-shift → caps lock is not a mode property; it is
+    /// implemented by rebinding shift-up in `GridKeyboardFactory`.
     let autoTransitions: [KeyCategory: String]
-
-    /// Double-tap on the switchMode key that leads to this mode → switch here.
-    /// e.g. shifted.doubleTapMode = "capsLock" → double-tap shift → caps lock.
-    /// nil = no double-tap behavior.
-    let doubleTapMode: String?
 
     // MARK: - Convenience
 
@@ -52,15 +50,13 @@ struct KeyboardMode: Codable, Equatable {
     /// Creates a copy with changed state machine properties.
     func with(
         name: String? = nil,
-        autoTransitions: [KeyCategory: String]? = nil,
-        doubleTapMode: String?? = nil
+        autoTransitions: [KeyCategory: String]? = nil
     ) -> KeyboardMode {
         KeyboardMode(
             name: name ?? self.name,
             keys: keys,
             arrangements: arrangements,
-            autoTransitions: autoTransitions ?? self.autoTransitions,
-            doubleTapMode: doubleTapMode ?? self.doubleTapMode
+            autoTransitions: autoTransitions ?? self.autoTransitions
         )
     }
 
@@ -78,7 +74,7 @@ struct KeyboardMode: Codable, Equatable {
         updatedKeys[keyId] = key
         return KeyboardMode(
             name: name, keys: updatedKeys, arrangements: arrangements,
-            autoTransitions: autoTransitions, doubleTapMode: doubleTapMode
+            autoTransitions: autoTransitions
         )
     }
 
@@ -103,7 +99,7 @@ struct KeyboardMode: Codable, Equatable {
         updatedKeys[GridSlot.midRight] = midRight
         return KeyboardMode(
             name: name, keys: updatedKeys, arrangements: arrangements,
-            autoTransitions: autoTransitions, doubleTapMode: doubleTapMode
+            autoTransitions: autoTransitions
         )
     }
 }

--- a/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
+++ b/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
@@ -228,8 +228,7 @@ enum NumericLayouts {
             name: ModeNames.numeric,
             keys: allKeys,
             arrangements: StandardArrangements.numeric3x3,
-            autoTransitions: [:],
-            doubleTapMode: nil
+            autoTransitions: [:]
         )
     }
 }

--- a/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
+++ b/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
@@ -120,10 +120,10 @@ enum NumericLayouts {
             label: "¼", action: .commitText("¼"), category: nil,
             returnAction: nil, accessibilityLabel: nil
         ),
-        // Intentional MessagEase parity: the original's layout maps the
-        // numeric center key's circle gesture to a plain lowercase "a"
-        // ('5' circle → 'a' in the decompiled reference), even though every
-        // sibling is a math/superscript symbol. Do not "fix" this to "ª".
+        // Intentional: the numeric center key's circle gesture types a
+        // plain lowercase "a" (the long-established convention for this
+        // key in this layout family), even though every sibling is a
+        // math/superscript symbol. Do not "fix" this to "ª".
         GridSlot.center: KeyBinding(
             label: "a", action: .commitText("a"), category: nil,
             returnAction: nil, accessibilityLabel: nil

--- a/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
+++ b/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
@@ -120,6 +120,10 @@ enum NumericLayouts {
             label: "¼", action: .commitText("¼"), category: nil,
             returnAction: nil, accessibilityLabel: nil
         ),
+        // Intentional MessagEase parity: the original's layout maps the
+        // numeric center key's circle gesture to a plain lowercase "a"
+        // ('5' circle → 'a' in the decompiled reference), even though every
+        // sibling is a math/superscript symbol. Do not "fix" this to "ª".
         GridSlot.center: KeyBinding(
             label: "a", action: .commitText("a"), category: nil,
             returnAction: nil, accessibilityLabel: nil

--- a/wurstfingerKeyboard/Definition/Model/ValidationError.swift
+++ b/wurstfingerKeyboard/Definition/Model/ValidationError.swift
@@ -140,11 +140,6 @@ extension KeyboardDefinition {
             for (_, targetMode) in mode.autoTransitions where modes[targetMode] == nil {
                 errors.append(.missingMode(targetMode))
             }
-
-            // All doubleTapMode targets must exist
-            if let doubleTap = mode.doubleTapMode, modes[doubleTap] == nil {
-                errors.append(.missingMode(doubleTap))
-            }
         }
 
         // Validate each mode individually

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -20,11 +20,14 @@ enum KeyboardHapticEvent {
     /// silence. Text actions are silent here: their haptic already fired on
     /// touch-down, and firing again on dispatch would double every keystroke.
     /// Only actions that change keyboard or system state get a distinct
-    /// confirmation tick.
+    /// confirmation tick. Clipboard actions are silent here too: whether
+    /// copy/cut/paste actually does anything is only known inside
+    /// `AdvancedTextMiddleware` (full access, non-empty selection or
+    /// pasteboard), so their tick fires from its success paths instead.
     static func forPipelineAction(_ action: KeyAction) -> KeyboardHapticEvent? {
         switch action {
         case .switchMode, .switchToNextLanguage, .advanceToNextInputMode,
-             .dismissKeyboard, .copy, .cut, .paste:
+             .dismissKeyboard:
             .stateChange
         default:
             nil

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -307,7 +307,10 @@ final class KeyboardViewModel: ObservableObject {
         let currentId = currentDefinition?.id
             ?? sharedDefaults.string(forKey: SettingsKey.selectedLanguageId.rawValue)
             ?? "en_US"
-        let nextId = LanguageSettings(userDefaults: sharedDefaults).nextLanguageId(after: currentId)
+        // Static lookup on the already-normalized enabled list: constructing
+        // a throwaway LanguageSettings here would re-run init normalization
+        // (an app-group read/write cycle) on every globe swipe.
+        let nextId = LanguageSettings.nextLanguageId(after: currentId, in: enabledLanguageIds)
 
         if nextId != currentId {
             sharedDefaults.set(nextId, forKey: SettingsKey.selectedLanguageId.rawValue)

--- a/wurstfingerKeyboard/Runtime/Pipeline/AdvancedTextMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/AdvancedTextMiddleware.swift
@@ -18,10 +18,16 @@ import UIKit
 struct AdvancedTextMiddleware: ActionMiddleware {
     private let targetProvider: () -> TextInputTarget?
     private let localeProvider: () -> Locale
+    private let onClipboardSuccess: () -> Void
 
-    init(target: @escaping () -> TextInputTarget?, locale: @escaping () -> Locale) {
+    init(
+        target: @escaping () -> TextInputTarget?,
+        locale: @escaping () -> Locale,
+        onClipboardSuccess: @escaping () -> Void = {}
+    ) {
         targetProvider = target
         localeProvider = locale
+        self.onClipboardSuccess = onClipboardSuccess
     }
 
     func process(_ context: ActionContext, next: (ActionContext) -> Void) {
@@ -86,17 +92,26 @@ struct AdvancedTextMiddleware: ActionMiddleware {
 
     // MARK: - Clipboard
 
+    // The clipboard confirmation tick fires from the success paths below —
+    // not from the haptic middleware — so a guarded no-op (no full access,
+    // empty selection/pasteboard) stays silent, mirroring how mode and
+    // language switches only tick on an actual change.
+
     private func handleCopy(target: TextInputTarget) {
         guard target.hasFullAccess else { return }
         if let selected = target.selectedText, !selected.isEmpty {
             UIPasteboard.general.string = selected
+            onClipboardSuccess()
         }
     }
 
     private func handlePaste(target: TextInputTarget) {
         guard target.hasFullAccess else { return }
         if let text = UIPasteboard.general.string, !text.isEmpty {
-            target.insertText(text)
+            // Cap pasted text so a multi-MB pasteboard cannot blow the
+            // keyboard extension's jetsam memory budget. Truncates silently.
+            target.insertText(Self.cappedForInsertion(text))
+            onClipboardSuccess()
         }
     }
 
@@ -105,6 +120,28 @@ struct AdvancedTextMiddleware: ActionMiddleware {
         if let selected = target.selectedText, !selected.isEmpty {
             UIPasteboard.general.string = selected
             target.deleteBackward()
+            onClipboardSuccess()
         }
+    }
+
+    /// Returns `text` capped at `KeyboardConstants.TextInput.maxPasteUTF16Length`
+    /// UTF-16 code units, cut at a grapheme-cluster boundary so no emoji or
+    /// combining sequence is ever split. The cheap `utf16.count` check makes
+    /// the common (small) case allocation-free; the truncating path walks at
+    /// most the capped prefix, so the memory bound holds for the copy too.
+    static func cappedForInsertion(
+        _ text: String,
+        maxUTF16Length: Int = KeyboardConstants.TextInput.maxPasteUTF16Length
+    ) -> String {
+        guard text.utf16.count > maxUTF16Length else { return text }
+        var usedUTF16 = 0
+        var end = text.startIndex
+        while end < text.endIndex {
+            let next = text.index(after: end)
+            usedUTF16 += text[end].utf16.count
+            if usedUTF16 > maxUTF16Length { break }
+            end = next
+        }
+        return String(text[..<end])
     }
 }

--- a/wurstfingerKeyboard/Runtime/Pipeline/ComposeMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/ComposeMiddleware.swift
@@ -11,7 +11,8 @@ import Foundation
 ///
 /// - `.compose(trigger)`: checks `ComposeEngine` for a rule combining the
 ///   previous character with the trigger. Inserts the trigger as plain text
-///   when no rule matches.
+///   when no rule matches or when the previous character is a space (the
+///   space is never consumed — MessagEase parity).
 /// - `.cycleAccents`: cycles through accent variants of the previous character.
 ///
 /// All other actions pass through untouched.
@@ -40,11 +41,16 @@ struct ComposeMiddleware: ActionMiddleware {
         case let .compose(trigger):
             var transformed = context
             let previous = previousCharacter()
-            if !previous.isEmpty, let replacement = compose(previous, trigger) {
+            // MessagEase parity: the original never combines across a space —
+            // its combine table has no space rules, so "hello " + ´ yields
+            // "hello ´" with the space preserved. The rule set inherits
+            // space-consuming " " + x fallback rows from Thumb-Key, so the
+            // lookup is skipped entirely when a space precedes the cursor.
+            if !previous.isEmpty, previous != " ", let replacement = compose(previous, trigger) {
                 deletePreviousCharacter()
                 transformed.action = .commitText(replacement)
             } else {
-                // No rule — insert the trigger as plain text.
+                // No rule (or preceding space) — insert the trigger as plain text.
                 transformed.action = .commitText(trigger)
             }
             next(transformed)

--- a/wurstfingerKeyboard/Runtime/Pipeline/ComposeMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/ComposeMiddleware.swift
@@ -12,7 +12,7 @@ import Foundation
 /// - `.compose(trigger)`: checks `ComposeEngine` for a rule combining the
 ///   previous character with the trigger. Inserts the trigger as plain text
 ///   when no rule matches or when the previous character is a space (the
-///   space is never consumed — MessagEase parity).
+///   space is never consumed).
 /// - `.cycleAccents`: cycles through accent variants of the previous character.
 ///
 /// All other actions pass through untouched.
@@ -41,11 +41,11 @@ struct ComposeMiddleware: ActionMiddleware {
         case let .compose(trigger):
             var transformed = context
             let previous = previousCharacter()
-            // MessagEase parity: the original never combines across a space —
-            // its combine table has no space rules, so "hello " + ´ yields
-            // "hello ´" with the space preserved. The rule set inherits
-            // space-consuming " " + x fallback rows from Thumb-Key, so the
-            // lookup is skipped entirely when a space precedes the cursor.
+            // Combining across a space is never wanted: "hello " + ´ must
+            // yield "hello ´" with the space preserved. The rule set
+            // inherits space-consuming " " + x fallback rows from
+            // Thumb-Key, so the lookup is skipped entirely when a space
+            // precedes the cursor.
             if !previous.isEmpty, previous != " ", let replacement = compose(previous, trigger) {
                 deletePreviousCharacter()
                 transformed.action = .commitText(replacement)

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -322,7 +322,10 @@ extension KeyboardViewModel {
               text.first?.isLetter == true
         else { return false }
         let locale = pipelineLocale ?? Locale.current
-        let uppercased = text.uppercased(with: locale)
+        // keyboardUppercased (not plain uppercased) keeps ß → ẞ as a single
+        // character, matching the shifted-layer generation in the definition
+        // layer — a layout with ß on a tap position must not expand to "SS".
+        let uppercased = text.keyboardUppercased(with: locale)
         dispatchAction(.commitText(uppercased))
         return true
     }

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -146,10 +146,14 @@ extension KeyboardViewModel {
             }
         ))
 
-        // 4. Advanced text (delete-forward, capitalize, clipboard)
+        // 4. Advanced text (delete-forward, capitalize, clipboard). The
+        //    clipboard confirmation tick fires from the middleware's success
+        //    paths (not upfront in the haptic middleware) so guarded no-ops
+        //    stay silent.
         middlewares.append(AdvancedTextMiddleware(
             target: { [weak self] in self?.textInputTarget },
-            locale: { [weak self] in self?.pipelineLocale ?? Locale.current }
+            locale: { [weak self] in self?.pipelineLocale ?? Locale.current },
+            onClipboardSuccess: { [weak self] in self?.feedbackStateChange() }
         ))
 
         // 5. Basic text input (commitText, deleteBackward, space, newline, moveCursor)

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -258,6 +258,12 @@ struct KeyView: View {
         case .copy: "doc.on.doc"
         case .paste: "doc.on.clipboard"
         case .cut: "scissors"
+        // Note: on the globe key `hintOverlay` renders the current-language
+        // label (e.g. "DE") for this action instead — both occupy the same
+        // directional slot, so the more informative label wins there. The
+        // icon keeps the action→icon mapping complete for any other render
+        // of a language-switch binding.
+        case .switchToNextLanguage: "globe.badge.chevron.backward"
         default: nil
         }
     }

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -178,6 +178,16 @@ enum KeyboardConstants {
         static let repeatDelay: TimeInterval = 0.35
     }
 
+    // MARK: - Text Input
+
+    enum TextInput {
+        /// Maximum size of a pasted string in UTF-16 code units (~200 KB as
+        /// NSString storage). The pasteboard is the one unbounded external
+        /// input in the jetsam-constrained keyboard extension; longer text is
+        /// silently truncated at a grapheme boundary before insertion.
+        static let maxPasteUTF16Length = 200_000
+    }
+
     // MARK: - Preview Settings
 
     enum Preview {

--- a/wurstfingerKeyboard/Settings/LanguageSettings.swift
+++ b/wurstfingerKeyboard/Settings/LanguageSettings.swift
@@ -49,16 +49,26 @@ class LanguageSettings: ObservableObject {
         let state = Self.loadNormalizedState(from: defaults)
         selectedLanguageId = state.selected
         enabledLanguageIds = state.enabled
-        pinnedLanguageId = state.pinned
+        // Initialize the backing wrapper directly: the Optional property gets
+        // an implicit `nil` default, so a plain assignment here would run the
+        // setter — and its `didSet` persists to the app group on every
+        // construction, even when nothing changed.
+        _pinnedLanguageId = Published(initialValue: state.pinned)
 
         // `didSet` does not fire inside `init`, so persist the normalized
         // values explicitly — otherwise a corrected inconsistency (e.g. a
         // reselected language) would be re-read in its broken form next launch.
+        // Every write is change-guarded: an unguarded app-group write fires
+        // `UserDefaults.didChangeNotification` on each construction, which
+        // makes the keyboard's observer reload settings for nothing.
         if state.selected != defaults.string(forKey: SettingsKey.selectedLanguageId.rawValue) {
             defaults.set(state.selected, forKey: SettingsKey.selectedLanguageId.rawValue)
         }
-        Self.saveEnabledLanguageIds(state.enabled, to: defaults)
-        if state.pinned == nil {
+        if state.enabled != Self.loadEnabledLanguageIds(from: defaults) {
+            Self.saveEnabledLanguageIds(state.enabled, to: defaults)
+        }
+        if state.pinned == nil,
+           defaults.string(forKey: SettingsKey.pinnedLanguageId.rawValue) != nil {
             defaults.removeObject(forKey: SettingsKey.pinnedLanguageId.rawValue)
         }
     }

--- a/wurstfingerTests/ActionPipelineTests.swift
+++ b/wurstfingerTests/ActionPipelineTests.swift
@@ -65,8 +65,7 @@ private enum PipelineFixtures {
                     rows: [[KeyPlacement(keyId: keys.first?.id ?? "x")]]
                 ),
             ],
-            autoTransitions: autoTransitions,
-            doubleTapMode: nil
+            autoTransitions: autoTransitions
         )
     }
 

--- a/wurstfingerTests/ActionPipelineTests.swift
+++ b/wurstfingerTests/ActionPipelineTests.swift
@@ -223,6 +223,61 @@ struct ComposeMiddlewareTests {
         #expect(deleted == 0, "No rule → no previous-character deletion")
     }
 
+    /// MessagEase parity: the original never combines across a space. The
+    /// rule set carries Thumb-Key's space-consuming " " + x fallback rows,
+    /// but the middleware must skip them: "hello " + ´ → "hello ´".
+    @Test func preservesSpaceAndCommitsTriggerAfterSpace() {
+        let middleware = ComposeMiddleware(
+            compose: { previous, _ in
+                Issue.record("compose lookup must be skipped after a space")
+                return previous == " " ? "'" : nil
+            },
+            cycleAccent: { _ in nil },
+            previousCharacter: { " " },
+            deletePreviousCharacter: { Issue.record("Space must never be consumed by compose") }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .compose(trigger: "´")))
+
+        #expect(sink.received.first?.action == .commitText("´"))
+    }
+
+    @Test func stillComposesAfterLetterDespiteSpaceGuard() {
+        var deleted = 0
+        let middleware = ComposeMiddleware(
+            compose: { previous, trigger in
+                (previous == "e" && trigger == "´") ? "é" : nil
+            },
+            cycleAccent: { _ in nil },
+            previousCharacter: { "e" },
+            deletePreviousCharacter: { deleted += 1 }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .compose(trigger: "´")))
+
+        #expect(sink.received.first?.action == .commitText("é"))
+        #expect(deleted == 1)
+    }
+
+    @Test func commitsTriggerAtDocumentStart() {
+        let middleware = ComposeMiddleware(
+            compose: { _, _ in Issue.record("compose must not run at document start"); return nil },
+            cycleAccent: { _ in nil },
+            previousCharacter: { "" },
+            deletePreviousCharacter: { Issue.record("Must not delete at document start") }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .compose(trigger: "´")))
+
+        #expect(sink.received.first?.action == .commitText("´"))
+    }
+
     @Test func insertsTriggerWhenNoPreviousCharacter() {
         let middleware = ComposeMiddleware(
             compose: { _, _ in "should not run" },

--- a/wurstfingerTests/ActionPipelineTests.swift
+++ b/wurstfingerTests/ActionPipelineTests.swift
@@ -223,9 +223,9 @@ struct ComposeMiddlewareTests {
         #expect(deleted == 0, "No rule → no previous-character deletion")
     }
 
-    /// MessagEase parity: the original never combines across a space. The
-    /// rule set carries Thumb-Key's space-consuming " " + x fallback rows,
-    /// but the middleware must skip them: "hello " + ´ → "hello ´".
+    /// Composing never combines across a space. The rule set carries
+    /// Thumb-Key's space-consuming " " + x fallback rows, but the
+    /// middleware must skip them: "hello " + ´ → "hello ´".
     @Test func preservesSpaceAndCommitsTriggerAfterSpace() {
         let middleware = ComposeMiddleware(
             compose: { previous, _ in

--- a/wurstfingerTests/AdvancedTextMiddlewareTests.swift
+++ b/wurstfingerTests/AdvancedTextMiddlewareTests.swift
@@ -23,11 +23,13 @@ private enum AdvancedTextFixtures {
     /// the app's default uppercasing behaviour, e.g. `ß → SS`).
     static func middleware(
         target: MockTextTarget,
-        localeId: String = "de_DE"
+        localeId: String = "de_DE",
+        onClipboardSuccess: @escaping () -> Void = {}
     ) -> AdvancedTextMiddleware {
         AdvancedTextMiddleware(
             target: { target },
-            locale: { Locale(identifier: localeId) }
+            locale: { Locale(identifier: localeId) },
+            onClipboardSuccess: onClipboardSuccess
         )
     }
 }
@@ -251,12 +253,14 @@ final class AdvancedTextMiddlewareClipboardTests {
         target.hasFullAccess = true
         target.selectedText = "copied-\(UUID().uuidString)"
         let expected = target.selectedText
-        let middleware = AdvancedTextFixtures.middleware(target: target)
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(target: target) { successTicks += 1 }
 
         middleware.process(AdvancedTextFixtures.context(.copy)) { _ in }
 
         #expect(UIPasteboard.general.string == expected)
         #expect(target.events.isEmpty) // copy must not mutate the document
+        #expect(successTicks == 1)
     }
 
     @Test func copyIsNoopWithoutFullAccess() {
@@ -266,11 +270,29 @@ final class AdvancedTextMiddlewareClipboardTests {
         let target = MockTextTarget()
         target.hasFullAccess = false
         target.selectedText = "secret"
-        let middleware = AdvancedTextFixtures.middleware(target: target)
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(target: target) { successTicks += 1 }
 
         middleware.process(AdvancedTextFixtures.context(.copy)) { _ in }
 
         #expect(UIPasteboard.general.string == marker) // unchanged
+        #expect(successTicks == 0, "A guarded no-op must not fire a success tick")
+    }
+
+    @Test func copyIsNoopWhenNothingSelected() {
+        let marker = "untouched-\(UUID().uuidString)"
+        UIPasteboard.general.string = marker
+
+        let target = MockTextTarget()
+        target.hasFullAccess = true
+        target.selectedText = nil
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(target: target) { successTicks += 1 }
+
+        middleware.process(AdvancedTextFixtures.context(.copy)) { _ in }
+
+        #expect(UIPasteboard.general.string == marker) // unchanged
+        #expect(successTicks == 0, "A guarded no-op must not fire a success tick")
     }
 
     @Test func pasteInsertsClipboardTextWithFullAccess() {
@@ -279,11 +301,13 @@ final class AdvancedTextMiddlewareClipboardTests {
 
         let target = MockTextTarget()
         target.hasFullAccess = true
-        let middleware = AdvancedTextFixtures.middleware(target: target)
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(target: target) { successTicks += 1 }
 
         middleware.process(AdvancedTextFixtures.context(.paste)) { _ in }
 
         #expect(target.events == [.insertText(text)])
+        #expect(successTicks == 1)
     }
 
     @Test func pasteIsNoopWithoutFullAccess() {
@@ -291,11 +315,44 @@ final class AdvancedTextMiddlewareClipboardTests {
 
         let target = MockTextTarget()
         target.hasFullAccess = false
-        let middleware = AdvancedTextFixtures.middleware(target: target)
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(target: target) { successTicks += 1 }
 
         middleware.process(AdvancedTextFixtures.context(.paste)) { _ in }
 
         #expect(target.events.isEmpty)
+        #expect(successTicks == 0, "A guarded no-op must not fire a success tick")
+    }
+
+    @Test func pasteIsNoopWhenPasteboardEmpty() {
+        UIPasteboard.general.items = []
+
+        let target = MockTextTarget()
+        target.hasFullAccess = true
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(target: target) { successTicks += 1 }
+
+        middleware.process(AdvancedTextFixtures.context(.paste)) { _ in }
+
+        #expect(target.events.isEmpty)
+        #expect(successTicks == 0, "A guarded no-op must not fire a success tick")
+    }
+
+    @Test func pasteTruncatesOversizedPasteboardText() {
+        // 250k UTF-16 units — above the 200k cap. ASCII, so units == Characters.
+        let oversized = String(repeating: "a", count: 250_000)
+        UIPasteboard.general.string = oversized
+
+        let target = MockTextTarget()
+        target.hasFullAccess = true
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(target: target) { successTicks += 1 }
+
+        middleware.process(AdvancedTextFixtures.context(.paste)) { _ in }
+
+        let expected = String(repeating: "a", count: KeyboardConstants.TextInput.maxPasteUTF16Length)
+        #expect(target.events == [.insertText(expected)])
+        #expect(successTicks == 1, "A truncated paste still inserts text and ticks")
     }
 
     @Test func cutCopiesSelectionAndDeletes() {
@@ -303,12 +360,14 @@ final class AdvancedTextMiddlewareClipboardTests {
         target.hasFullAccess = true
         target.selectedText = "cut-\(UUID().uuidString)"
         let expected = target.selectedText
-        let middleware = AdvancedTextFixtures.middleware(target: target)
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(target: target) { successTicks += 1 }
 
         middleware.process(AdvancedTextFixtures.context(.cut)) { _ in }
 
         #expect(UIPasteboard.general.string == expected)
         #expect(target.events == [.deleteBackward])
+        #expect(successTicks == 1)
     }
 
     @Test func cutIsNoopWithoutFullAccess() {
@@ -318,12 +377,14 @@ final class AdvancedTextMiddlewareClipboardTests {
         let target = MockTextTarget()
         target.hasFullAccess = false
         target.selectedText = "secret"
-        let middleware = AdvancedTextFixtures.middleware(target: target)
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(target: target) { successTicks += 1 }
 
         middleware.process(AdvancedTextFixtures.context(.cut)) { _ in }
 
         #expect(target.events.isEmpty)
         #expect(UIPasteboard.general.string == marker) // pasteboard untouched
+        #expect(successTicks == 0, "A guarded no-op must not fire a success tick")
     }
 
     @Test func cutIsNoopWhenNothingSelected() {
@@ -333,11 +394,52 @@ final class AdvancedTextMiddlewareClipboardTests {
         let target = MockTextTarget()
         target.hasFullAccess = true
         target.selectedText = nil
-        let middleware = AdvancedTextFixtures.middleware(target: target)
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(target: target) { successTicks += 1 }
 
         middleware.process(AdvancedTextFixtures.context(.cut)) { _ in }
 
         #expect(target.events.isEmpty)
         #expect(UIPasteboard.general.string == marker) // pasteboard untouched
+        #expect(successTicks == 0, "A guarded no-op must not fire a success tick")
+    }
+}
+
+// MARK: - Paste size cap
+
+/// `cappedForInsertion` is pure, so the truncation semantics are tested
+/// directly with small caps; the 200k production cap is exercised once via
+/// the pasteboard in `pasteTruncatesOversizedPasteboardText` above.
+struct AdvancedTextPasteCapTests {
+    @Test func returnsShortTextUnchanged() {
+        let text = "hello wörld 👍🏽"
+        #expect(AdvancedTextMiddleware.cappedForInsertion(text) == text)
+    }
+
+    @Test func returnsTextExactlyAtCapUnchanged() {
+        let text = "abc"
+        #expect(AdvancedTextMiddleware.cappedForInsertion(text, maxUTF16Length: 3) == "abc")
+    }
+
+    @Test func truncatesToCapInUTF16Units() {
+        let text = "abcdef"
+        #expect(AdvancedTextMiddleware.cappedForInsertion(text, maxUTF16Length: 4) == "abcd")
+    }
+
+    @Test func neverSplitsAGraphemeCluster() {
+        // 👍🏽 = base + skin tone = 4 UTF-16 units. A cap that lands inside the
+        // cluster must round down to the previous boundary.
+        let text = "a👍🏽b"
+        #expect(AdvancedTextMiddleware.cappedForInsertion(text, maxUTF16Length: 3) == "a")
+        #expect(AdvancedTextMiddleware.cappedForInsertion(text, maxUTF16Length: 4) == "a")
+        #expect(AdvancedTextMiddleware.cappedForInsertion(text, maxUTF16Length: 5) == "a👍🏽")
+    }
+
+    @Test func neverSplitsAZWJFamilySequence() {
+        // 👨‍👩‍👧‍👦 = ZWJ family sequence = 11 UTF-16 units.
+        let family = "👨‍👩‍👧‍👦"
+        let text = "ab" + family
+        #expect(AdvancedTextMiddleware.cappedForInsertion(text, maxUTF16Length: 12) == "ab")
+        #expect(AdvancedTextMiddleware.cappedForInsertion(text, maxUTF16Length: 13) == text)
     }
 }

--- a/wurstfingerTests/CircularGesturePipelineTests.swift
+++ b/wurstfingerTests/CircularGesturePipelineTests.swift
@@ -79,4 +79,52 @@ struct CircularGesturePipelineTests {
 
         #expect(target.events.isEmpty)
     }
+
+    /// The uppercase fallback must route through `keyboardUppercased` so a
+    /// layout with ß on a tap position yields the capital sharp S (ẞ) instead
+    /// of the plain-`uppercased` two-letter "SS" expansion — matching the
+    /// shifted-layer generation in the definition layer. No shipped layout
+    /// carries ß on tap today, so the definition is injected directly.
+    @Test func circularOnSharpSKeyInsertsCapitalSharpS() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+
+        let sharpSKey = KeyConfig(
+            id: "sz",
+            bindings: [
+                .tap: KeyBinding(
+                    label: "ß", action: .commitText("ß"), category: .letter,
+                    returnAction: nil, accessibilityLabel: nil
+                ),
+            ],
+            swipeMode: .eightWay, slideType: .none,
+            style: .primary, tapCycleActions: nil
+        )
+        let mainMode = KeyboardMode(
+            name: ModeNames.main,
+            keys: [sharpSKey.id: sharpSKey],
+            arrangements: [
+                .portrait: GridArrangement(
+                    columns: 1,
+                    rows: [[KeyPlacement(keyId: sharpSKey.id)]]
+                ),
+            ],
+            autoTransitions: [:]
+        )
+        vm.currentDefinition = KeyboardDefinition(
+            title: "Fixture", id: "fixture", localeIdentifier: "de_DE",
+            modes: [ModeNames.main: mainMode], defaultMode: ModeNames.main,
+            settings: KeyboardDefinitionSettings(
+                autoCapitalize: false, composeRuleOverrides: nil
+            )
+        )
+        vm.activeModeName = ModeNames.main
+        vm.currentMode = mainMode
+        vm.pipelineLocale = Locale(identifier: "de_DE")
+        vm.rebuildResolverChain()
+        vm.rebuildPipeline()
+
+        vm.handleGesture(.circularClockwise, keyId: sharpSKey.id, isReturn: false)
+
+        #expect(target.events == [.insertText("ẞ")])
+    }
 }

--- a/wurstfingerTests/CommonKeysFactoryTests.swift
+++ b/wurstfingerTests/CommonKeysFactoryTests.swift
@@ -280,7 +280,6 @@ struct GridKeyboardFactoryTests {
     @Test func capsLockHasNoAutoTransitions() throws {
         let capsLock = try #require(Self.testLayout.modes[ModeNames.capsLock])
         #expect(capsLock.autoTransitions.isEmpty)
-        #expect(capsLock.doubleTapMode == nil)
     }
 
     @Test func mainModeShiftLabelIsUpArrow() throws {

--- a/wurstfingerTests/GestureResolverTests.swift
+++ b/wurstfingerTests/GestureResolverTests.swift
@@ -36,8 +36,7 @@ private enum Fixtures {
             name: name,
             keys: Dictionary(uniqueKeysWithValues: keys.map { ($0.id, $0) }),
             arrangements: [.portrait: GridArrangement(columns: 1, rows: [[KeyPlacement(keyId: keys.first?.id ?? "x")]])],
-            autoTransitions: [:],
-            doubleTapMode: nil
+            autoTransitions: [:]
         )
     }
 

--- a/wurstfingerTests/HapticFeedbackTests.swift
+++ b/wurstfingerTests/HapticFeedbackTests.swift
@@ -64,11 +64,19 @@ struct PipelineHapticEventTests {
         #expect(KeyboardHapticEvent.forPipelineAction(.none) == nil)
     }
 
+    /// Clipboard actions must not tick upfront: whether copy/cut/paste
+    /// actually does anything is only known inside AdvancedTextMiddleware,
+    /// which fires the confirmation tick from its success paths.
+    @Test func clipboardActionsAreSilentInThePipelineMapping() {
+        #expect(KeyboardHapticEvent.forPipelineAction(.copy) == nil)
+        #expect(KeyboardHapticEvent.forPipelineAction(.cut) == nil)
+        #expect(KeyboardHapticEvent.forPipelineAction(.paste) == nil)
+    }
+
     @Test func stateChangingActionsGetConfirmationTick() {
         let actions: [KeyAction] = [
             .switchMode("numeric"), .switchToNextLanguage,
             .advanceToNextInputMode, .dismissKeyboard,
-            .copy, .cut, .paste,
         ]
         for action in actions {
             #expect(KeyboardHapticEvent.forPipelineAction(action) == .stateChange)

--- a/wurstfingerTests/KeyboardGridRenderingTests.swift
+++ b/wurstfingerTests/KeyboardGridRenderingTests.swift
@@ -72,8 +72,7 @@ struct KeyboardViewModelContextTests {
                 .portrait: utilityRightArrangement,
                 .portraitUtilityLeft: utilityLeftArrangement,
             ],
-            autoTransitions: [:],
-            doubleTapMode: nil
+            autoTransitions: [:]
         )
 
         let viewModel = makeViewModel(utilityLeft: false)

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -874,3 +874,89 @@ struct LanguageSettingsStalenessTests {
         #expect(settings.pinnedLanguageId == "de_DE")
     }
 }
+
+// MARK: - Init Write Hygiene
+
+/// In-memory defaults that records every mutating call. Used to prove that
+/// constructing `LanguageSettings` on an already-normalized store performs
+/// no write at all — an unguarded app-group write would fire
+/// `UserDefaults.didChangeNotification` and make the keyboard extension
+/// reload its settings on every construction.
+private final class WriteRecordingDefaults: UserDefaults {
+    private var storage: [String: Any] = [:]
+    private(set) var writtenKeys: [String] = []
+
+    convenience init() {
+        self.init(suiteName: nil)!
+    }
+
+    override func object(forKey defaultName: String) -> Any? {
+        storage[defaultName]
+    }
+
+    override func set(_ value: Any?, forKey defaultName: String) {
+        writtenKeys.append(defaultName)
+        storage[defaultName] = value
+    }
+
+    override func removeObject(forKey defaultName: String) {
+        writtenKeys.append(defaultName)
+        storage[defaultName] = nil
+    }
+
+    override func string(forKey defaultName: String) -> String? {
+        object(forKey: defaultName) as? String
+    }
+
+    override func stringArray(forKey defaultName: String) -> [String]? {
+        object(forKey: defaultName) as? [String]
+    }
+
+    /// Seeds the store without recording the writes.
+    func seed(_ value: Any?, forKey key: String) {
+        storage[key] = value
+    }
+}
+
+struct LanguageSettingsInitWriteHygieneTests {
+    @Test("Init on an already-normalized store performs no write")
+    func initOnNormalizedStoreIsWriteFree() {
+        let defaults = WriteRecordingDefaults()
+        defaults.seed("en_US", forKey: SettingsKey.selectedLanguageId.rawValue)
+        defaults.seed(["en_US", "de_DE"], forKey: SettingsKey.enabledLanguageIds.rawValue)
+
+        _ = LanguageSettings(userDefaults: defaults)
+
+        #expect(defaults.writtenKeys.isEmpty)
+    }
+
+    @Test("Init on a normalized store with a valid pin performs no write")
+    func initWithValidPinIsWriteFree() {
+        let defaults = WriteRecordingDefaults()
+        defaults.seed("en_US", forKey: SettingsKey.selectedLanguageId.rawValue)
+        defaults.seed(["en_US", "de_DE"], forKey: SettingsKey.enabledLanguageIds.rawValue)
+        defaults.seed("de_DE", forKey: SettingsKey.pinnedLanguageId.rawValue)
+
+        _ = LanguageSettings(userDefaults: defaults)
+
+        #expect(defaults.writtenKeys.isEmpty)
+    }
+
+    @Test("Init still persists corrections for an inconsistent store")
+    func initPersistsNormalizationWhenStoreIsInconsistent() {
+        let defaults = WriteRecordingDefaults()
+        // Stale enabled entry + selection outside the enabled list + dangling pin.
+        defaults.seed("de_DE", forKey: SettingsKey.selectedLanguageId.rawValue)
+        defaults.seed(["en_US", "zz_ZZ"], forKey: SettingsKey.enabledLanguageIds.rawValue)
+        defaults.seed("zz_ZZ", forKey: SettingsKey.pinnedLanguageId.rawValue)
+
+        let settings = LanguageSettings(userDefaults: defaults)
+
+        #expect(settings.selectedLanguageId == "en_US")
+        #expect(settings.enabledLanguageIds == ["en_US"])
+        #expect(settings.pinnedLanguageId == nil)
+        #expect(defaults.writtenKeys.contains(SettingsKey.selectedLanguageId.rawValue))
+        #expect(defaults.writtenKeys.contains(SettingsKey.enabledLanguageIds.rawValue))
+        #expect(defaults.writtenKeys.contains(SettingsKey.pinnedLanguageId.rawValue))
+    }
+}

--- a/wurstfingerTests/ModeDefinitionValidationTests.swift
+++ b/wurstfingerTests/ModeDefinitionValidationTests.swift
@@ -30,8 +30,7 @@ private func utilityKey(_ id: String, action: KeyAction) -> KeyConfig {
 /// Minimal valid mode with 4 keys and a portrait arrangement
 private func minimalMode(
     name: String = "main",
-    autoTransitions: [KeyCategory: String] = [:],
-    doubleTapMode: String? = nil
+    autoTransitions: [KeyCategory: String] = [:]
 ) -> KeyboardMode {
     let keys: [String: KeyConfig] = [
         "a": letterKey("a", "a"),
@@ -46,8 +45,7 @@ private func minimalMode(
     return KeyboardMode(
         name: name, keys: keys,
         arrangements: [.portrait: arrangement],
-        autoTransitions: autoTransitions,
-        doubleTapMode: doubleTapMode
+        autoTransitions: autoTransitions
     )
 }
 
@@ -96,8 +94,7 @@ struct KeyboardModeTests {
                 .portrait: #require(minimalMode().arrangements[.portrait]),
                 .landscape: landscapeArrangement,
             ],
-            autoTransitions: [:],
-            doubleTapMode: nil
+            autoTransitions: [:]
         )
         let result = mode.arrangement(for: .landscape)
         #expect(result == landscapeArrangement)
@@ -139,20 +136,8 @@ struct KeyboardModeTests {
         #expect(modified.keys == mode.keys)
     }
 
-    @Test func withChangesDoubleTapMode() {
-        let mode = minimalMode()
-        let modified = mode.with(doubleTapMode: "capsLock")
-        #expect(modified.doubleTapMode == "capsLock")
-    }
-
-    @Test func withClearsDoubleTapMode() {
-        let mode = minimalMode(doubleTapMode: "capsLock")
-        let modified = mode.with(doubleTapMode: .some(nil))
-        #expect(modified.doubleTapMode == nil)
-    }
-
     @Test func codableRoundtrip() throws {
-        let mode = minimalMode(autoTransitions: [.letter: "main"], doubleTapMode: "capsLock")
+        let mode = minimalMode(autoTransitions: [.letter: "main"])
         let data = try JSONEncoder().encode(mode)
         let decoded = try JSONDecoder().decode(KeyboardMode.self, from: data)
         #expect(decoded == mode)
@@ -207,7 +192,7 @@ struct ValidationTests {
             name: "test",
             keys: ["a": letterKey("a", "a")],
             arrangements: [.portrait: arrangement],
-            autoTransitions: [:], doubleTapMode: nil
+            autoTransitions: [:]
         )
         let errors = mode.validate()
         #expect(errors.contains(.missingKey(keyId: "nonexistent", context: .portrait)))
@@ -237,7 +222,7 @@ struct ValidationTests {
         let arrangement = GridArrangement(columns: 2, rows: [
             [KeyPlacement(keyId: "a"), KeyPlacement(keyId: "shift")],
         ])
-        let mode = KeyboardMode(name: "main", keys: keys, arrangements: [.portrait: arrangement], autoTransitions: [:], doubleTapMode: nil)
+        let mode = KeyboardMode(name: "main", keys: keys, arrangements: [.portrait: arrangement], autoTransitions: [:])
         let def = minimalDefinition(modes: [ModeNames.main: mode])
         let errors = def.validate()
         #expect(errors.contains(.missingMode("nonexistent")))
@@ -256,7 +241,7 @@ struct ValidationTests {
             swipeMode: .none, slideType: .none, style: .utility, tapCycleActions: nil
         )
         let arrangement = GridArrangement(columns: 1, rows: [[KeyPlacement(keyId: "shift")]])
-        let mode = KeyboardMode(name: "main", keys: ["shift": key], arrangements: [.portrait: arrangement], autoTransitions: [:], doubleTapMode: nil)
+        let mode = KeyboardMode(name: "main", keys: ["shift": key], arrangements: [.portrait: arrangement], autoTransitions: [:])
         let def = minimalDefinition(modes: [ModeNames.main: mode])
         #expect(def.validate().contains(.missingMode("nonexistent")))
     }
@@ -272,20 +257,13 @@ struct ValidationTests {
             tapCycleActions: [.commitText("c"), .switchMode("nonexistent")]
         )
         let arrangement = GridArrangement(columns: 1, rows: [[KeyPlacement(keyId: "cycle")]])
-        let mode = KeyboardMode(name: "main", keys: ["cycle": key], arrangements: [.portrait: arrangement], autoTransitions: [:], doubleTapMode: nil)
+        let mode = KeyboardMode(name: "main", keys: ["cycle": key], arrangements: [.portrait: arrangement], autoTransitions: [:])
         let def = minimalDefinition(modes: [ModeNames.main: mode])
         #expect(def.validate().contains(.missingMode("nonexistent")))
     }
 
     @Test func missingAutoTransitionTarget() {
         let mode = minimalMode(autoTransitions: [.letter: "nonexistent"])
-        let def = minimalDefinition(modes: [ModeNames.main: mode])
-        let errors = def.validate()
-        #expect(errors.contains(.missingMode("nonexistent")))
-    }
-
-    @Test func missingDoubleTapModeTarget() {
-        let mode = minimalMode(doubleTapMode: "nonexistent")
         let def = minimalDefinition(modes: [ModeNames.main: mode])
         let errors = def.validate()
         #expect(errors.contains(.missingMode("nonexistent")))
@@ -301,7 +279,7 @@ struct ValidationTests {
             name: "test",
             keys: ["a": letterKey("a", "a"), "b": letterKey("b", "b")],
             arrangements: [.portrait: arrangement],
-            autoTransitions: [:], doubleTapMode: nil
+            autoTransitions: [:]
         )
         let errors = mode.validate()
         #expect(errors.contains(.columnMismatch(row: 0, context: .portrait, expected: 3, got: 2)))
@@ -320,7 +298,7 @@ struct ValidationTests {
             name: "test",
             keys: ["a": letterKey("a", "a"), "b": letterKey("b", "b"), "c": letterKey("c", "c")],
             arrangements: [.portrait: arrangement],
-            autoTransitions: [:], doubleTapMode: nil
+            autoTransitions: [:]
         )
         #expect(mode.validate().filter { if case .columnMismatch = $0 { true } else { false } }.isEmpty)
     }
@@ -339,7 +317,7 @@ struct ValidationTests {
                 "c": letterKey("c", "c"), "d": letterKey("d", "d"),
             ],
             arrangements: [.portrait: arrangement],
-            autoTransitions: [:], doubleTapMode: nil
+            autoTransitions: [:]
         )
         let errors = mode.validate()
         #expect(errors.contains(.columnMismatch(row: 1, context: .portrait, expected: 2, got: 3)))
@@ -354,7 +332,7 @@ struct ValidationTests {
             name: "test",
             keys: ["a": letterKey("a", "a"), "b": letterKey("b", "b")],
             arrangements: [.portrait: arrangement],
-            autoTransitions: [:], doubleTapMode: nil
+            autoTransitions: [:]
         )
         let errors = mode.validate()
         #expect(errors.contains(.rowSpanOutOfBounds(keyId: "a", context: .portrait)))
@@ -370,7 +348,7 @@ struct ValidationTests {
             name: "test",
             keys: ["a": letterKey("a", "a")],
             arrangements: [.portrait: arrangement],
-            autoTransitions: [:], doubleTapMode: nil
+            autoTransitions: [:]
         )
         let errors = mode.validate()
         #expect(errors.contains(.duplicateKeyId("a")))
@@ -383,7 +361,7 @@ struct ValidationTests {
         let mode = KeyboardMode(
             name: "test", keys: [:],
             arrangements: [.portrait: arrangement],
-            autoTransitions: [:], doubleTapMode: nil
+            autoTransitions: [:]
         )
         let errors = mode.validate()
         #expect(errors.contains(.emptyKeyPool))
@@ -399,7 +377,7 @@ struct ValidationTests {
             name: "test",
             keys: ["a": letterKey("a", "a"), "b": letterKey("b", "b")],
             arrangements: [.landscape: arrangement], // No portrait!
-            autoTransitions: [:], doubleTapMode: nil
+            autoTransitions: [:]
         )
         let errors = mode.validate()
         #expect(errors.contains(.noPortraitArrangement))

--- a/wurstfingerTests/SlotFactoryShiftedTests.swift
+++ b/wurstfingerTests/SlotFactoryShiftedTests.swift
@@ -273,7 +273,7 @@ struct GenerateShiftedTests {
         return KeyboardMode(
             name: ModeNames.main, keys: keys,
             arrangements: [.portrait: arrangement],
-            autoTransitions: [:], doubleTapMode: nil
+            autoTransitions: [:]
         )
     }
 
@@ -322,15 +322,13 @@ struct GenerateShiftedTests {
 
         // Default: empty autoTransitions (stays active like caps lock)
         #expect(shifted.autoTransitions.isEmpty)
-        #expect(shifted.doubleTapMode == nil)
     }
 
     @Test func generateShiftedWithPostConfiguration() {
         let main = Self.sampleMode()
         let shifted = main.generateShifted(locale: Locale(identifier: "de_DE"))
-            .with(autoTransitions: [.letter: ModeNames.main], doubleTapMode: ModeNames.capsLock)
+            .with(autoTransitions: [.letter: ModeNames.main])
 
         #expect(shifted.autoTransitions[.letter] == ModeNames.main)
-        #expect(shifted.doubleTapMode == ModeNames.capsLock)
     }
 }


### PR DESCRIPTION
Implements eight small fixes from the full codebase review 2026-07-07 (findings L7, L8, L9, L10, L11, L13, L16, L17).

## Changes

### L9 — Compose after a space no longer consumes the space
Combining across a space is never what the user wants: `"hello "` + accent gesture should yield `"hello ´"` with the space preserved. The space-consuming `" " + x → x` fallback rows in our rule set are Thumb-Key heritage. `ComposeMiddleware` now skips the compose lookup when the previous character is a space and commits the trigger character after it. The rule set itself is untouched (an unmatched previous already falls through to committing the trigger, so the guard is the minimal change). Composing after letters and at document start is unchanged — all three cases covered by new middleware tests.

### L7 — Clipboard haptic ticks only on success
`KeyboardHapticEvent.forPipelineAction` returned `.stateChange` for `.copy/.cut/.paste` unconditionally, while the actual operation is gated later in `AdvancedTextMiddleware` on full access and a non-empty selection/pasteboard — a success tick with nothing happening. The tick now fires from the middleware's success paths via an injected `onClipboardSuccess` callback (wired to the same `feedbackStateChange()` mode/language switches use), and the upfront mapping is silent for clipboard actions.

### L16 — Pasted text capped at ~200 KB
Paste inserted the full pasteboard string unbounded — the one unbounded allocation in the jetsam-constrained extension. Inserted text is now silently truncated at `KeyboardConstants.TextInput.maxPasteUTF16Length` (200,000 UTF-16 units), cut at a grapheme-cluster boundary so emoji/ZWJ sequences are never split. The cheap `utf16.count` check keeps the common case allocation-free; the truncation walk is bounded by the cap.

### L8 — Removed dead `KeyboardMode.doubleTapMode`
Only read by validation; the real double-tap-shift → caps-lock is implemented via shift-up rebinding in the factory. Field, validation rule, initializer arguments, and related tests removed.
**Scope note:** this required removing the `doubleTapMode: nil` argument from the `KeyboardMode` initializer call in `GridKeyboardFactory.swift` (one line, in the `baseMode` construction next to `autoTransitions`) — flagged here because a concurrent branch also touches that file.

### L10 — Hint icon mapping for `.switchToNextLanguage`
`hintIcon(for:)` had no case for the action, violating the documented "keep hintIcon in sync" convention. Added `globe.badge.chevron.backward` (available since iOS 15; deployment target is 17.0). **Collision note:** on the globe key the swipe-right hint slot is already occupied by the current-language label overlay (`languageLabel`, e.g. "DE"), which renders whenever more than one language is enabled — so the gesture is discoverable there today, and that branch keeps precedence to avoid rendering icon and label on top of each other. With a single enabled language the gesture is a no-op and deliberately stays hint-free. The icon therefore completes the convention/mapping rather than changing the globe key's current rendering.

### L11 — Guard comment for the numeric center circle binding
The plain lowercase `a` on the numeric center key's circle gesture is the long-established convention for this layout family, even though every other position pairs circle with an ordinal/uppercase variant. Documented as intentional so nobody "fixes" it to `ª`.

### L13 — Circular-gesture uppercasing preserves ß → ẞ
`tryCircularUppercase` used plain `uppercased(with:)`, which would expand ß → SS if a layout ever put ß on a tap position. Now routes through `keyboardUppercased(with:)` like the definition layer's shifted generation. Covered by a pipeline test with an injected ß-on-tap definition.

### L17 — `LanguageSettings.init` writes change-guarded; no throwaway instance per globe swipe
Every construction persisted the enabled list unconditionally (app-group write → `didChangeNotification` → `reloadSettings()`), and the test for this surfaced a second hidden write: the Optional `@Published var pinnedLanguageId` gets an implicit `nil` default, so the assignment in `init` ran the setter and its persisting `didSet` on every construction. Both are fixed (change-guarded enabled/pinned persists; backing-wrapper initialization for the pin), and `switchToNextLanguage` now uses the static `nextLanguageId(after:in:)` with the view model's already-normalized `enabledLanguageIds`. New tests prove init on a normalized store performs zero writes while still persisting corrections for inconsistent stores.

## Testing
- `xcodebuild test -only-testing:WurstfingerTests` on a fresh `iPhone 17 Pro` simulator: 901 passed, 1 failed — `KeyboardRegistryTests/loadCachesResult` (known flaky under parallel load: another suite populates the shared registry cache); green when run isolated.
- SwiftFormat and SwiftLint `--strict`: clean.

Full codebase review 2026-07-07, findings L7/L8/L9/L10/L11/L13/L16/L17.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clipboard actions now provide success feedback, and pasted text is safely limited to a maximum size.
  * Circular gesture uppercase handling now preserves language-specific characters like sharp S.

* **Bug Fixes**
  * Compose actions now skip lookup after spaces, keeping spacing intact.
  * Keyboard language switching and haptic feedback behavior were refined for more consistent results.

* **Chores**
  * Improved language settings initialization to avoid unnecessary saves and normalize stored preferences more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->