### PR TITLE
Fix Test Hygiene Findings From Full Codebase Review (M12/H5/L20)

### DIFF
--- a/wurstfingerTests/ActionPipelineTests.swift
+++ b/wurstfingerTests/ActionPipelineTests.swift
@@ -341,70 +341,48 @@ struct ComposeMiddlewareTests {
 
 // MARK: - TextInputMiddleware
 
-private final class MockTextInputTarget: TextInputTarget {
-    enum Event: Equatable {
-        case insertText(String)
-        case deleteBackward
-        case adjustCursor(Int)
-    }
-
-    var events: [Event] = []
-    var documentContextBeforeInput: String?
-    var documentContextAfterInput: String?
-    var selectedText: String?
-    var hasFullAccess: Bool = false
-
-    func insertText(_ text: String) {
-        events.append(.insertText(text))
-    }
-
-    func deleteBackward() {
-        events.append(.deleteBackward)
-    }
-
-    func adjustTextPosition(byCharacterOffset offset: Int) {
-        events.append(.adjustCursor(offset))
-    }
-}
+// These tests use the shared `MockTextTarget` (TestHelpers.swift). A private
+// event-only mock used to live here; it drifted from the shared one (no
+// document context / UTF-16 semantics), so it was removed (review M12).
 
 struct TextInputMiddlewareTests {
-    private func pipeline(target: MockTextInputTarget) -> ActionPipeline {
+    private func pipeline(target: MockTextTarget) -> ActionPipeline {
         let middleware = TextInputMiddleware(target: { target })
         return ActionPipeline(middlewares: [middleware])
     }
 
     @Test func commitTextInsertsText() {
-        let target = MockTextInputTarget()
+        let target = MockTextTarget()
         pipeline(target: target).process(PipelineFixtures.context(action: .commitText("hi")))
         #expect(target.events == [.insertText("hi")])
     }
 
     @Test func deleteBackwardDeletes() {
-        let target = MockTextInputTarget()
+        let target = MockTextTarget()
         pipeline(target: target).process(PipelineFixtures.context(action: .deleteBackward))
         #expect(target.events == [.deleteBackward])
     }
 
     @Test func spaceInsertsSpaceCharacter() {
-        let target = MockTextInputTarget()
+        let target = MockTextTarget()
         pipeline(target: target).process(PipelineFixtures.context(action: .space))
         #expect(target.events == [.insertText(" ")])
     }
 
     @Test func newlineInsertsLineBreak() {
-        let target = MockTextInputTarget()
+        let target = MockTextTarget()
         pipeline(target: target).process(PipelineFixtures.context(action: .newline))
         #expect(target.events == [.insertText("\n")])
     }
 
     @Test func moveCursorAdjustsPosition() {
-        let target = MockTextInputTarget()
+        let target = MockTextTarget()
         pipeline(target: target).process(PipelineFixtures.context(action: .moveCursor(offset: -3)))
         #expect(target.events == [.adjustCursor(-3)])
     }
 
     @Test func nonTextActionsAreIgnored() {
-        let target = MockTextInputTarget()
+        let target = MockTextTarget()
         let sink = RecordingMiddleware()
         let middleware = TextInputMiddleware(target: { target })
         let pipe = ActionPipeline(middlewares: [middleware, sink])
@@ -788,7 +766,7 @@ struct PipelineIntegrationTests {
     @Test func composeThenTextInputProducesCommittedCharacter() {
         // ComposeMiddleware rewrites the action; TextInputMiddleware then
         // inserts the rewritten text into the target.
-        let target = MockTextInputTarget()
+        let target = MockTextTarget()
         var deleted = 0
         let compose = ComposeMiddleware(
             compose: { prev, trig in (prev == "a" && trig == "¨") ? "ä" : nil },
@@ -807,7 +785,7 @@ struct PipelineIntegrationTests {
 
     @Test func fullPipelineRunsAllMiddlewaresInOrder() {
         var steps: [String] = []
-        let target = MockTextInputTarget()
+        let target = MockTextTarget()
         let compose = ComposeMiddleware(
             compose: { _, _ in nil },
             cycleAccent: { _ in nil },

--- a/wurstfingerTests/CursorMovementTests.swift
+++ b/wurstfingerTests/CursorMovementTests.swift
@@ -9,29 +9,11 @@ import Foundation
 import Testing
 @testable import WurstfingerApp
 
-struct DiscreteGestureClassificationTests {
-    @Test func returnRatioBelowThresholdIsReturnSwipe() {
-        // finalX near zero, maxDisplacement large -> return swipe
-        let maxDisplacement: CGFloat = 50
-        let finalX: CGFloat = 5
-        let ratio = abs(finalX) / abs(maxDisplacement)
-        #expect(ratio < KeyboardConstants.SpaceGestures.returnSwipeThreshold)
-    }
-
-    @Test func returnRatioAboveThresholdIsRegularSwipe() {
-        // finalX close to maxDisplacement -> regular swipe
-        let maxDisplacement: CGFloat = 50
-        let finalX: CGFloat = 45
-        let ratio = abs(finalX) / abs(maxDisplacement)
-        #expect(ratio >= KeyboardConstants.SpaceGestures.returnSwipeThreshold)
-    }
-
-    @Test func returnSwipeThresholdIsReasonable() {
-        let threshold = KeyboardConstants.SpaceGestures.returnSwipeThreshold
-        #expect(threshold > 0)
-        #expect(threshold < 1)
-    }
-}
+// Note: a `DiscreteGestureClassificationTests` suite used to live here. Its
+// tests recomputed the production return-ratio formula inside the test (or
+// asserted a constant lies in (0, 1)), so they could never catch a
+// classification regression. The actual return-vs-regular swipe behavior is
+// exercised end-to-end by `DiscreteCursorMovementTests` below (review L20).
 
 @Suite(.serialized)
 struct CursorMovementPipelineTests {
@@ -112,7 +94,7 @@ struct CursorMovementPipelineTests {
 @Suite(.serialized)
 struct DiscreteCursorMovementTests {
     private func makeDiscreteViewModel() -> (KeyboardViewModel, MockTextTarget) {
-        let defaults = UserDefaults(suiteName: "test.\(UUID().uuidString)")!
+        let defaults = InMemoryUserDefaults()
         defaults.set(
             CursorMovementStyle.discrete.rawValue,
             forKey: SettingsKey.cursorMovementStyle.rawValue

--- a/wurstfingerTests/KeyboardGridRenderingTests.swift
+++ b/wurstfingerTests/KeyboardGridRenderingTests.swift
@@ -18,7 +18,7 @@ struct KeyboardViewModelContextTests {
     /// Builds a ViewModel with a deterministic utility-column setting. We use an
     /// in-memory UserDefaults so the suite never touches the shared store.
     private func makeViewModel(utilityLeft: Bool) -> KeyboardViewModel {
-        let defaults = UserDefaults(suiteName: "test.\(UUID().uuidString)")!
+        let defaults = InMemoryUserDefaults()
         let viewModel = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
         viewModel.utilityColumnLeading = utilityLeft
         return viewModel

--- a/wurstfingerTests/KeyboardRegistryTests.swift
+++ b/wurstfingerTests/KeyboardRegistryTests.swift
@@ -28,6 +28,18 @@ struct KeyboardInfoTests {
 
 // MARK: - KeyboardRegistry
 
+/// `KeyboardRegistry.cache` is a process-global static shared with every other
+/// suite in the test run (~11 suites load the same ids in parallel).
+/// `.serialized` only orders tests *within* this suite, so these tests must
+/// never assert that an id is globally *absent* from the cache after an evict:
+/// any concurrent `load(id:)` re-caches it and flips the assertion (the
+/// documented cause of the intermittent `loadCachesResult` failures, review
+/// H5). Presence is safe to assert — no other suite evicts.
+///
+/// Tests below therefore only assert presence and load/evict/reload round-trip
+/// behavior. Residual risk: "evict actually removes the entry" is only
+/// observable via global absence and stays untested until the registry becomes
+/// injectable (owner decision deferred, see the 2026-07-07 review, H5).
 @Suite(.serialized)
 struct KeyboardRegistryTests {
     @Test func availableContainsAllLanguages() {
@@ -44,7 +56,6 @@ struct KeyboardRegistryTests {
     }
 
     @Test func loadReturnsCorrectDefinition() {
-        KeyboardRegistry.evictAll()
         let definition = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
         #expect(definition != nil)
         #expect(definition?.id == LanguageDefinitions.german.id)
@@ -52,8 +63,9 @@ struct KeyboardRegistryTests {
     }
 
     @Test func loadCachesResult() {
-        KeyboardRegistry.evictAll()
-        #expect(!KeyboardRegistry.isCached(id: LanguageDefinitions.german.id))
+        // Presence-only round trip: after a load the id is cached and repeated
+        // loads return an equal definition. (Asserting absence after evictAll
+        // here raced with parallel suites loading German — see suite comment.)
         let first = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
         #expect(first != nil)
         #expect(KeyboardRegistry.isCached(id: LanguageDefinitions.german.id))
@@ -63,17 +75,22 @@ struct KeyboardRegistryTests {
 
     @Test func loadNonexistentReturnsNil() {
         #expect(KeyboardRegistry.load(id: "nonexistent_layout") == nil)
+        // Stable absence assertion: an unknown id can never be cached, so no
+        // parallel suite can flip this.
+        #expect(!KeyboardRegistry.isCached(id: "nonexistent_layout"))
     }
 
-    @Test func evictRemovesFromCache() {
-        KeyboardRegistry.evictAll()
-        _ = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
-        #expect(KeyboardRegistry.isCached(id: LanguageDefinitions.german.id))
+    @Test func evictedDefinitionReloads() {
+        // The evict → absent transition is unobservable race-free (a parallel
+        // load may re-cache immediately); what we can pin is that evicting
+        // never breaks the registry: a subsequent load rebuilds an equal
+        // definition from the descriptor.
+        let before = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
         KeyboardRegistry.evict(id: LanguageDefinitions.german.id)
-        #expect(!KeyboardRegistry.isCached(id: LanguageDefinitions.german.id))
-        // After evict, load should still work (rebuilds from LanguageDefinitions)
         let reloaded = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
         #expect(reloaded != nil)
+        #expect(reloaded == before)
+        #expect(KeyboardRegistry.isCached(id: LanguageDefinitions.german.id))
     }
 
     /// Regression test: the registry cache used to be an unsynchronized
@@ -81,11 +98,17 @@ struct KeyboardRegistryTests {
     /// `Dictionary._Variant.setValue` when parallel test suites called
     /// `load(id:)` concurrently. Hammering the cache from multiple tasks
     /// documents the thread-safety contract (and trips TSan without the lock).
+    ///
+    /// The hammer is limited to two rarely-loaded ids: evicting German/English
+    /// (or all languages) in a tight loop forced every concurrent suite into
+    /// repeated full definition rebuilds — a contributor to the known
+    /// `LanguageDefinitionValidationTests` timeout flakiness under full
+    /// parallelism + coverage (review H5). Two ids still exercise every code
+    /// path the lock guards (hit, miss+build, evict, query).
     @Test func concurrentLoadEvictAndQueryDoesNotCrash() async {
-        KeyboardRegistry.evictAll()
-        let ids = KeyboardRegistry.available.map(\.id)
+        let ids = [LanguageDefinitions.hebrew.id, LanguageDefinitions.tagalog.id]
         await withTaskGroup(of: Void.self) { group in
-            for _ in 0 ..< 4 {
+            for _ in 0 ..< 16 {
                 for id in ids {
                     group.addTask {
                         _ = KeyboardRegistry.load(id: id)
@@ -102,14 +125,16 @@ struct KeyboardRegistryTests {
         }
     }
 
-    @Test func evictAllClearsCache() {
-        // Load a few definitions
+    @Test func evictAllKeepsRegistryFunctional() {
+        // See suite comment: post-evictAll absence cannot be asserted against
+        // the shared static cache. Pin the behavioral contract instead —
+        // evictAll never breaks subsequent loads, and loading re-caches.
         _ = KeyboardRegistry.load(id: LanguageDefinitions.german.id)
         _ = KeyboardRegistry.load(id: LanguageDefinitions.english.id)
+        KeyboardRegistry.evictAll()
+        #expect(KeyboardRegistry.load(id: LanguageDefinitions.german.id) != nil)
+        #expect(KeyboardRegistry.load(id: LanguageDefinitions.english.id) != nil)
         #expect(KeyboardRegistry.isCached(id: LanguageDefinitions.german.id))
         #expect(KeyboardRegistry.isCached(id: LanguageDefinitions.english.id))
-        KeyboardRegistry.evictAll()
-        #expect(!KeyboardRegistry.isCached(id: LanguageDefinitions.german.id))
-        #expect(!KeyboardRegistry.isCached(id: LanguageDefinitions.english.id))
     }
 }

--- a/wurstfingerTests/LanguageSettingsTests.swift
+++ b/wurstfingerTests/LanguageSettingsTests.swift
@@ -172,104 +172,11 @@ struct LanguageSettingsTests {
     }
 }
 
-// MARK: - Primary Language Resolution Tests
-
-/// Tests the logic that resolves a language ID from UserDefaults into a locale identifier,
-/// matching the primaryLanguage getter in KeyboardViewController.
-struct PrimaryLanguageResolutionTests {
-    /// Helper that mirrors the primaryLanguage getter logic:
-    /// read language ID from UserDefaults → resolve to LanguageConfig → return locale identifier
-    private func resolvePrimaryLanguage(from defaults: UserDefaults) -> String {
-        let languageId = defaults.string(forKey: SettingsKey.selectedLanguageId.rawValue)
-        let config = languageId.flatMap { LanguageConfig.language(withId: $0) } ?? .english
-        return config.locale.identifier
-    }
-
-    private func createTestDefaults() -> (UserDefaults, String) {
-        let suiteName = "test.primaryLanguage.\(UUID().uuidString)"
-        return (UserDefaults(suiteName: suiteName)!, suiteName)
-    }
-
-    @Test("Returns German locale when German is selected")
-    func resolveGerman() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
-
-        defaults.set("de_DE", forKey: SettingsKey.selectedLanguageId.rawValue)
-        #expect(resolvePrimaryLanguage(from: defaults) == "de_DE")
-    }
-
-    @Test("Returns French locale when French is selected")
-    func resolveFrench() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
-
-        defaults.set("fr_FR", forKey: SettingsKey.selectedLanguageId.rawValue)
-        #expect(resolvePrimaryLanguage(from: defaults) == "fr_FR")
-    }
-
-    @Test("Returns Russian locale when Russian is selected")
-    func resolveRussian() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
-
-        defaults.set("ru_RU", forKey: SettingsKey.selectedLanguageId.rawValue)
-        #expect(resolvePrimaryLanguage(from: defaults) == "ru_RU")
-    }
-
-    @Test("Falls back to English when no language is stored")
-    func fallbackWhenNoLanguageStored() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
-
-        // Don't set any value — should fall back to English
-        #expect(resolvePrimaryLanguage(from: defaults) == "en_US")
-    }
-
-    @Test("Falls back to English for unknown language ID")
-    func fallbackForUnknownLanguageId() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
-
-        defaults.set("xx_XX", forKey: SettingsKey.selectedLanguageId.rawValue)
-        #expect(resolvePrimaryLanguage(from: defaults) == "en_US")
-    }
-
-    @Test("Picks up language change from UserDefaults without restart")
-    func picksUpLanguageChange() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
-
-        defaults.set("de_DE", forKey: SettingsKey.selectedLanguageId.rawValue)
-        #expect(resolvePrimaryLanguage(from: defaults) == "de_DE")
-
-        // Simulate host app changing language
-        defaults.set("fr_FR", forKey: SettingsKey.selectedLanguageId.rawValue)
-        #expect(resolvePrimaryLanguage(from: defaults) == "fr_FR")
-    }
-
-    @Test("All supported languages resolve to valid locale identifiers")
-    func allLanguagesResolveToValidLocale() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
-
-        for language in LanguageConfig.allLanguages {
-            defaults.set(language.id, forKey: SettingsKey.selectedLanguageId.rawValue)
-            let resolved = resolvePrimaryLanguage(from: defaults)
-            #expect(
-                resolved == language.locale.identifier,
-                "Language \(language.name) (\(language.id)) should resolve to \(language.locale.identifier), got \(resolved)"
-            )
-        }
-    }
-}
-
 // MARK: - Multi-Language Settings Tests
 
 struct MultiLanguageSettingsTests {
-    private func createTestDefaults() -> (UserDefaults, String) {
-        let suiteName = "test.multiLang.\(UUID().uuidString)"
-        return (UserDefaults(suiteName: suiteName)!, suiteName)
+    private func createTestDefaults() -> UserDefaults {
+        InMemoryUserDefaults()
     }
 
     private func createSettings(defaults: UserDefaults, selectedId: String = "en_US", enabledIds: [String]? = nil) -> LanguageSettings {
@@ -282,8 +189,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Migration: no enabled list seeds from selected language")
     func migrationSeedsFromSelected() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "de_DE")
         #expect(settings.enabledLanguageIds == ["de_DE"])
@@ -292,8 +198,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Loads existing enabled list from UserDefaults")
     func loadsEnabledList() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU", "de_DE"])
         #expect(settings.enabledLanguageIds == ["en_US", "ru_RU", "de_DE"])
@@ -301,8 +206,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Toggle enables a language")
     func toggleEnablesLanguage() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
         settings.toggleLanguage(.russian)
@@ -312,8 +216,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Toggle disables an enabled language")
     func toggleDisablesLanguage() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU", "de_DE"])
         let result = settings.toggleLanguage(.russian)
@@ -324,8 +227,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Cannot disable last remaining language")
     func cannotDisableLastLanguage() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
         let result = settings.toggleLanguage(.english)
@@ -335,8 +237,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Disabling selected language switches to first enabled")
     func disablingSelectedSwitchesToFirst() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "ru_RU", enabledIds: ["en_US", "ru_RU", "de_DE"])
         settings.toggleLanguage(.russian)
@@ -345,8 +246,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Selecting a language adds it to enabled if not present")
     func selectAddsToEnabled() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
         settings.selectLanguage(.russian)
@@ -356,8 +256,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Next language cycles through enabled list with 2 languages")
     func nextLanguageCyclesTwoLanguages() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
         #expect(settings.nextLanguageId(after: "en_US") == "ru_RU")
@@ -366,8 +265,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Next language cycles through enabled list with 3 languages")
     func nextLanguageCyclesThreeLanguages() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU", "de_DE"])
         #expect(settings.nextLanguageId(after: "en_US") == "ru_RU")
@@ -377,8 +275,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Next language cycles through many enabled languages")
     func nextLanguageCyclesManyLanguages() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let ids = ["en_US", "ru_RU", "de_DE", "fr_FR", "es_ES"]
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ids)
@@ -391,8 +288,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Next language returns same when only one enabled")
     func nextLanguageSingleLanguage() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
         #expect(settings.nextLanguageId(after: "en_US") == "en_US")
@@ -400,8 +296,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Next language falls back to first when current not in list")
     func nextLanguageFallsBackWhenNotInList() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
         #expect(settings.nextLanguageId(after: "de_DE") == "en_US")
@@ -409,8 +304,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("hasMultipleLanguages reflects enabled count")
     func hasMultipleLanguagesFlag() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let single = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
         #expect(single.hasMultipleLanguages == false)
@@ -421,8 +315,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("currentLanguageLabel returns uppercase language code")
     func languageLabelUppercase() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let enSettings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US"])
         #expect(enSettings.currentLanguageLabel == "EN")
@@ -436,8 +329,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("enabledLanguages returns resolved LanguageConfig objects")
     func enabledLanguagesResolved() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU", "de_DE"])
         let configs = settings.enabledLanguages
@@ -449,8 +341,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Stale IDs in enabled list are filtered out on load")
     func staleIdsFiltered() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "zz_ZZ", "ru_RU"])
         #expect(settings.enabledLanguageIds == ["en_US", "ru_RU"])
@@ -458,8 +349,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Init reselects the first enabled language when selected is not enabled")
     func selectedNotEnabledReselectsFirstEnabled() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         // Selected is ru_RU but enabled list only has en_US — this state arises
         // when the language was disabled elsewhere; the disable must win, so the
@@ -473,8 +363,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("Enabled list persistence round-trips through JSON")
     func enabledListPersistence() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let ids = ["en_US", "ru_RU", "de_DE", "fr_FR"]
         LanguageSettings.saveEnabledLanguageIds(ids, to: defaults)
@@ -484,8 +373,7 @@ struct MultiLanguageSettingsTests {
 
     @Test("isLanguageEnabled reflects enabled state")
     func isLanguageEnabledCheck() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
         #expect(settings.isLanguageEnabled(.english) == true)
@@ -497,9 +385,8 @@ struct MultiLanguageSettingsTests {
 // MARK: - Pinned Default Language Tests
 
 struct PinnedLanguageTests {
-    private func createTestDefaults() -> (UserDefaults, String) {
-        let suiteName = "test.pinned.\(UUID().uuidString)"
-        return (UserDefaults(suiteName: suiteName)!, suiteName)
+    private func createTestDefaults() -> UserDefaults {
+        InMemoryUserDefaults()
     }
 
     private func createSettings(
@@ -516,8 +403,7 @@ struct PinnedLanguageTests {
 
     @Test("Pin a language sets pinnedLanguageId")
     func pinSetsId() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"])
         settings.pinLanguage(.russian)
@@ -526,8 +412,7 @@ struct PinnedLanguageTests {
 
     @Test("Unpin by tapping the same language")
     func unpinSameLanguage() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
         settings.pinLanguage(.russian)
@@ -536,8 +421,7 @@ struct PinnedLanguageTests {
 
     @Test("Pin a different language replaces the previous pin")
     func pinDifferentLanguage() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "en_US")
         settings.pinLanguage(.russian)
@@ -546,8 +430,7 @@ struct PinnedLanguageTests {
 
     @Test("Pinning a disabled language enables it first")
     func pinDisabledLanguageEnablesIt() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, enabledIds: ["en_US"])
         settings.pinLanguage(.russian)
@@ -557,8 +440,7 @@ struct PinnedLanguageTests {
 
     @Test("Disabling the pinned language clears the pin")
     func disablingPinnedLanguageClearsPin() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
         settings.toggleLanguage(.russian)
@@ -567,8 +449,7 @@ struct PinnedLanguageTests {
 
     @Test("startupLanguageId returns pinned when set")
     func startupReturnsPinned() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
         #expect(settings.startupLanguageId == "ru_RU")
@@ -576,8 +457,7 @@ struct PinnedLanguageTests {
 
     @Test("startupLanguageId returns selectedLanguageId when no pin")
     func startupReturnsSelectedWhenNoPin() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
         #expect(settings.startupLanguageId == "en_US")
@@ -585,8 +465,7 @@ struct PinnedLanguageTests {
 
     @Test("applyStartupLanguage makes the pinned language the active selection")
     func applyStartupHonorsPin() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
         settings.applyStartupLanguage()
@@ -599,8 +478,7 @@ struct PinnedLanguageTests {
 
     @Test("applyStartupLanguage leaves the selection unchanged when no pin")
     func applyStartupNoPinKeepsSelection() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, selectedId: "en_US", enabledIds: ["en_US", "ru_RU"])
         settings.applyStartupLanguage()
@@ -610,8 +488,7 @@ struct PinnedLanguageTests {
 
     @Test("Stale pinned ID is cleared on load")
     func stalePinnedIdCleared() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "zz_ZZ")
         #expect(settings.pinnedLanguageId == nil)
@@ -619,8 +496,7 @@ struct PinnedLanguageTests {
 
     @Test("Pinned ID not in enabled list is cleared on load")
     func pinnedNotInEnabledCleared() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, enabledIds: ["en_US"], pinnedId: "ru_RU")
         #expect(settings.pinnedLanguageId == nil)
@@ -628,8 +504,7 @@ struct PinnedLanguageTests {
 
     @Test("pinnedLanguage returns resolved LanguageConfig")
     func pinnedLanguageResolved() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
         #expect(settings.pinnedLanguage?.id == "ru_RU")
@@ -637,8 +512,7 @@ struct PinnedLanguageTests {
 
     @Test("pinnedLanguage is nil when no pin")
     func pinnedLanguageNilWhenNoPin() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"])
         #expect(settings.pinnedLanguage == nil)
@@ -646,8 +520,7 @@ struct PinnedLanguageTests {
 
     @Test("Pin persists to UserDefaults")
     func pinPersists() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"])
         settings.pinLanguage(.russian)
@@ -657,8 +530,7 @@ struct PinnedLanguageTests {
 
     @Test("Unpin persists nil to UserDefaults")
     func unpinPersistsNil() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         let settings = createSettings(defaults: defaults, enabledIds: ["en_US", "ru_RU"], pinnedId: "ru_RU")
         settings.pinLanguage(.russian)
@@ -668,8 +540,7 @@ struct PinnedLanguageTests {
 
     @Test("KeyboardViewModel boots with pinned language, not selected")
     func viewModelBootsWithPinnedLanguage() {
-        let (defaults, suite) = createTestDefaults()
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = createTestDefaults()
 
         defaults.set("en_US", forKey: SettingsKey.selectedLanguageId.rawValue)
         LanguageSettings.saveEnabledLanguageIds(["en_US", "ru_RU"], to: defaults)
@@ -732,33 +603,61 @@ struct ResolvedLanguageIdTests {
     func fallsBackForNil() {
         #expect(LanguageSettings.resolvedLanguageId(nil) == LanguageSettings.detectSystemLanguage())
     }
+
+    @Test("Keeps every known language id")
+    func keepsAllKnownIds() {
+        for language in LanguageConfig.allLanguages {
+            #expect(LanguageSettings.resolvedLanguageId(language.id) == language.id)
+        }
+    }
+
+    /// Pins the contract `KeyboardViewController.primaryLanguage` relies on:
+    /// whatever `resolvedLanguageId` returns must be resolvable via the
+    /// lightweight `KeyboardRegistry.available` metadata, so the controller's
+    /// locale lookup never has to hit its English fallback for a resolved id.
+    ///
+    /// Conscious gap: the controller property itself (SharedDefaults read +
+    /// registry lookup + fallback) is not directly testable until the registry
+    /// and shared store are injectable — see the deferred injectable-registry
+    /// decision from the 2026-07-07 code review (H5/M12).
+    @Test("Resolved ids always have registry metadata with a matching locale")
+    func resolvedIdsAlwaysHaveRegistryMetadata() {
+        let metadataByID = Dictionary(
+            uniqueKeysWithValues: KeyboardRegistry.available.map { ($0.id, $0) }
+        )
+        let storedCandidates: [String?] = [nil, "", "xx_XX", "de_DE", "en_US", "vi_VN"]
+        for stored in storedCandidates {
+            let resolved = LanguageSettings.resolvedLanguageId(stored)
+            let info = metadataByID[resolved]
+            #expect(info != nil, "Resolved id \(resolved) (from \(stored ?? "nil")) missing in registry metadata")
+            let expectedLocale = LanguageConfig.language(withId: resolved)?.locale.identifier
+            #expect(info?.localeIdentifier == expectedLocale)
+        }
+    }
 }
 
 // MARK: - normalizedEnabledLanguageIds
 
 struct NormalizedEnabledLanguageIdsTests {
-    private func makeDefaults(selected: String, enabled: [String]?) -> (UserDefaults, String) {
-        let suite = "test.normalized.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
+    private func makeDefaults(selected: String, enabled: [String]?) -> UserDefaults {
+        let defaults = InMemoryUserDefaults()
         defaults.set(selected, forKey: SettingsKey.selectedLanguageId.rawValue)
         if let enabled {
             LanguageSettings.saveEnabledLanguageIds(enabled, to: defaults)
         }
-        return (defaults, suite)
+        return defaults
     }
 
     @Test("Filters out stale/unknown enabled IDs")
     func filtersStaleIds() {
-        let (defaults, suite) = makeDefaults(selected: "de_DE", enabled: ["de_DE", "zz_ZZ", "en_US"])
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = makeDefaults(selected: "de_DE", enabled: ["de_DE", "zz_ZZ", "en_US"])
 
         #expect(LanguageSettings.normalizedEnabledLanguageIds(from: defaults) == ["de_DE", "en_US"])
     }
 
     @Test("Falls back to the selected language when the stored list is empty")
     func emptyFallsBackToSelected() {
-        let (defaults, suite) = makeDefaults(selected: "ru_RU", enabled: [])
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = makeDefaults(selected: "ru_RU", enabled: [])
 
         #expect(LanguageSettings.normalizedEnabledLanguageIds(from: defaults) == ["ru_RU"])
     }
@@ -768,16 +667,14 @@ struct NormalizedEnabledLanguageIdsTests {
         // selected = de_DE with de_DE absent from the enabled list means the
         // host app disabled German after the keyboard selected it — treating it
         // as enabled again would resurrect a language the user turned off.
-        let (defaults, suite) = makeDefaults(selected: "de_DE", enabled: ["en_US"])
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = makeDefaults(selected: "de_DE", enabled: ["en_US"])
 
         #expect(LanguageSettings.normalizedEnabledLanguageIds(from: defaults) == ["en_US"])
     }
 
     @Test("Does not persist — leaves the stored list untouched")
     func doesNotPersist() {
-        let (defaults, suite) = makeDefaults(selected: "de_DE", enabled: ["de_DE", "zz_ZZ"])
-        defer { defaults.removePersistentDomain(forName: suite) }
+        let defaults = makeDefaults(selected: "de_DE", enabled: ["de_DE", "zz_ZZ"])
 
         _ = LanguageSettings.normalizedEnabledLanguageIds(from: defaults)
         #expect(LanguageSettings.loadEnabledLanguageIds(from: defaults) == ["de_DE", "zz_ZZ"])

--- a/wurstfingerTests/OrientationLayoutTests.swift
+++ b/wurstfingerTests/OrientationLayoutTests.swift
@@ -21,7 +21,7 @@ struct OrientationLayoutTests {
     /// in viewWillLayoutSubviews(), so SwiftUI re-evaluates the layout.
     @Test("viewWidth publishes changes for orientation handling")
     func viewWidthPublishesChanges() {
-        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        let viewModel = KeyboardViewModel(userDefaults: InMemoryUserDefaults(), shouldPersistSettings: false)
 
         var observedWidths: [CGFloat] = []
         let cancellable = viewModel.$viewWidth
@@ -38,7 +38,7 @@ struct OrientationLayoutTests {
 
     @Test("Same viewWidth does not trigger redundant publish")
     func sameViewWidthNoRedundantPublish() {
-        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        let viewModel = KeyboardViewModel(userDefaults: InMemoryUserDefaults(), shouldPersistSettings: false)
 
         var publishCount = 0
         let cancellable = viewModel.$viewWidth
@@ -60,7 +60,7 @@ struct OrientationLayoutTests {
 
     @Test("Keyboard-sized window keeps the screen's portrait width")
     func keyboardSizedWindowKeepsPortraitWidth() {
-        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        let viewModel = KeyboardViewModel(userDefaults: InMemoryUserDefaults(), shouldPersistSettings: false)
 
         // The extension's window is only as tall as the keyboard itself
         // (issue behind #219's regression): its height must never cap the
@@ -80,7 +80,7 @@ struct OrientationLayoutTests {
 
     @Test("Narrow pane window caps the keyboard width")
     func narrowPaneWindowCapsWidth() {
-        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        let viewModel = KeyboardViewModel(userDefaults: InMemoryUserDefaults(), shouldPersistSettings: false)
 
         // Slide Over / narrow Split View pane: the window width is the
         // available container width and wins over the screen.
@@ -90,7 +90,7 @@ struct OrientationLayoutTests {
 
     @Test("Nil window falls back to the device screen")
     func nilWindowFallsBackToScreen() {
-        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        let viewModel = KeyboardViewModel(userDefaults: InMemoryUserDefaults(), shouldPersistSettings: false)
 
         viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 320, height: 300))
         viewModel.updateWindowBounds(nil)
@@ -100,7 +100,7 @@ struct OrientationLayoutTests {
 
     @Test("Same window bounds do not trigger redundant publish")
     func sameWindowBoundsNoRedundantPublish() {
-        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        let viewModel = KeyboardViewModel(userDefaults: InMemoryUserDefaults(), shouldPersistSettings: false)
 
         var publishCount = 0
         let cancellable = viewModel.$keyboardWidthCap
@@ -116,7 +116,7 @@ struct OrientationLayoutTests {
 
     @Test("Degenerate window bounds are ignored")
     func degenerateWindowBoundsIgnored() {
-        let viewModel = KeyboardViewModel(shouldPersistSettings: false)
+        let viewModel = KeyboardViewModel(userDefaults: InMemoryUserDefaults(), shouldPersistSettings: false)
 
         viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 320, height: 300))
         viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: 0, height: 300))

--- a/wurstfingerTests/TestHelpers.swift
+++ b/wurstfingerTests/TestHelpers.swift
@@ -89,6 +89,26 @@ final class InMemoryUserDefaults: UserDefaults {
         storage[defaultName] = value
     }
 
+    // Typed setters route into the in-memory storage as well: without these
+    // overrides, a statically-typed call like `set(0.3, forKey:)` resolves to
+    // the non-overridden `set(Double,forKey:)` and silently writes to the real
+    // standard domain instead.
+    override func set(_ value: Double, forKey defaultName: String) {
+        set(value as NSNumber, forKey: defaultName)
+    }
+
+    override func set(_ value: Float, forKey defaultName: String) {
+        set(value as NSNumber, forKey: defaultName)
+    }
+
+    override func set(_ value: Int, forKey defaultName: String) {
+        set(value as NSNumber, forKey: defaultName)
+    }
+
+    override func set(_ value: Bool, forKey defaultName: String) {
+        set(value as NSNumber, forKey: defaultName)
+    }
+
     override func removeObject(forKey defaultName: String) {
         lock.lock(); defer { lock.unlock() }
         storage[defaultName] = nil

--- a/wurstfingerTests/wurstfingerTests.swift
+++ b/wurstfingerTests/wurstfingerTests.swift
@@ -117,28 +117,20 @@ struct wurstfingerTests {
 
     // MARK: - Haptic Persistence Tests
 
-    @Test @MainActor func hapticIntensitiesPersistToDefaults() throws {
-        let suite = "group.de.akator.wurstfinger.tests.hapticsPersist"
-        let defaults = try #require(UserDefaults(suiteName: suite))
-        defaults.removePersistentDomain(forName: suite)
-        defer { defaults.removePersistentDomain(forName: suite) }
+    @Test @MainActor func hapticIntensitiesPersistToDefaults() {
+        let defaults = InMemoryUserDefaults()
 
         let viewModel = KeyboardViewModel(userDefaults: defaults)
         viewModel.hapticIntensityTap = 0.8
         viewModel.hapticIntensityDrag = 1.1
-
-        defaults.synchronize()
 
         #expect(defaults.double(forKey: KeyboardViewModel.hapticTapIntensityKey) == 0.8)
         let dragDefault = defaults.double(forKey: KeyboardViewModel.hapticDragIntensityKey)
         #expect(abs(dragDefault - 1.0) < 0.0001)
     }
 
-    @Test @MainActor func previewViewModelDoesNotPersist() throws {
-        let suite = "group.de.akator.wurstfinger.tests.preview"
-        let defaults = try #require(UserDefaults(suiteName: suite))
-        defaults.removePersistentDomain(forName: suite)
-        defer { defaults.removePersistentDomain(forName: suite) }
+    @Test @MainActor func previewViewModelDoesNotPersist() {
+        let defaults = InMemoryUserDefaults()
 
         defaults.set(0.3, forKey: KeyboardViewModel.hapticTapIntensityKey)
 
@@ -150,11 +142,8 @@ struct wurstfingerTests {
         #expect(abs(persistedTap - 0.3) < 0.0001)
     }
 
-    @Test @MainActor func hapticIntensityClampsWithinBounds() throws {
-        let suite = "group.de.akator.wurstfinger.tests.clamp"
-        let defaults = try #require(UserDefaults(suiteName: suite))
-        defaults.removePersistentDomain(forName: suite)
-        defer { defaults.removePersistentDomain(forName: suite) }
+    @Test @MainActor func hapticIntensityClampsWithinBounds() {
+        let defaults = InMemoryUserDefaults()
 
         let viewModel = KeyboardViewModel(userDefaults: defaults)
 

--- a/wurstfingerUITests/wurstfingerUITests.swift
+++ b/wurstfingerUITests/wurstfingerUITests.swift
@@ -13,6 +13,12 @@ final class wurstfingerUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
+        // The suite queries localized display text ("Settings", "Language", …),
+        // so pin the app to English regardless of the simulator's locale.
+        app.launchArguments = [
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_US",
+        ]
         app.launch()
     }
 
@@ -67,31 +73,51 @@ final class wurstfingerUITests: XCTestCase {
         let toggles = app.switches
         XCTAssertTrue(toggles.count >= 3, "Should have at least 3 setup step toggles")
 
-        // Toggle the first switch
-        if let firstToggle = toggles.allElementsBoundByIndex.first {
-            let initialValue = firstToggle.value as? String
-            firstToggle.tap()
-            let newValue = firstToggle.value as? String
-            XCTAssertNotEqual(initialValue, newValue, "Toggle value should change after tap")
-        }
+        // Toggle the first switch — unconditionally, so this fails loudly if
+        // the control vanishes instead of silently passing.
+        let firstToggle = toggles.element(boundBy: 0)
+        XCTAssertTrue(firstToggle.exists, "First setup step toggle must exist")
+
+        let initialValue = firstToggle.value as? String
+        firstToggle.tap()
+        let newValue = firstToggle.value as? String
+        XCTAssertNotEqual(initialValue, newValue, "Toggle value should change after tap")
+
+        // The setup steps persist to the shared app-group store — restore the
+        // original state so the test leaves no trace on the device/simulator.
+        firstToggle.tap()
+        let restoredValue = firstToggle.value as? String
+        XCTAssertEqual(initialValue, restoredValue, "Toggle must be restored to its original state")
     }
 
     // MARK: - Settings Tests
+
+    /// Scrolls the current screen until `element` exists. SwiftUI `List` rows
+    /// are created lazily, so rows below the fold don't exist in the
+    /// accessibility hierarchy until scrolled into view.
+    @MainActor
+    private func scrollToElement(_ element: XCUIElement, maxSwipes: Int = 6) {
+        for _ in 0 ..< maxSwipes {
+            if element.exists { return }
+            app.swipeUp()
+        }
+    }
 
     @MainActor
     func testSettingsViewShowsMainOptions() {
         app.tabBars.buttons["Settings"].tap()
 
-        // Check main settings rows exist
-        XCTAssertTrue(app.staticTexts["Language"].waitForExistence(timeout: 2), "Language row missing")
+        // Check main settings rows exist (scrolling for lazily-created rows).
+        XCTAssertTrue(app.staticTexts["Languages"].waitForExistence(timeout: 2), "Languages row missing")
+
+        scrollToElement(app.staticTexts["Key Aspect Ratio"])
         XCTAssertTrue(app.staticTexts["Key Aspect Ratio"].exists, "Key Aspect Ratio row missing")
+
+        scrollToElement(app.staticTexts["Haptic Feedback"])
         XCTAssertTrue(app.staticTexts["Haptic Feedback"].exists, "Haptic Feedback row missing")
 
         // Version is in the About section at the bottom — scroll until visible
-        for _ in 0 ..< 5 {
-            if app.staticTexts["Version"].exists { break }
-            app.swipeUp()
-        }
+        scrollToElement(app.staticTexts["Version"])
         XCTAssertTrue(app.staticTexts["Version"].waitForExistence(timeout: 2), "Version row missing")
     }
 
@@ -99,11 +125,13 @@ final class wurstfingerUITests: XCTestCase {
     func testSettingsLanguageNavigation() {
         app.tabBars.buttons["Settings"].tap()
 
-        // Tap on Language row
-        app.staticTexts["Language"].tap()
+        // Tap on Languages row
+        let languagesRow = app.staticTexts["Languages"]
+        XCTAssertTrue(languagesRow.waitForExistence(timeout: 2), "Languages row missing")
+        languagesRow.tap()
 
-        // Should navigate to language selection (title is "Keyboard Language")
-        XCTAssertTrue(app.navigationBars["Keyboard Language"].waitForExistence(timeout: 2))
+        // Should navigate to language selection
+        XCTAssertTrue(app.navigationBars["Languages"].waitForExistence(timeout: 2))
 
         // Go back
         app.navigationBars.buttons.element(boundBy: 0).tap()
@@ -114,30 +142,61 @@ final class wurstfingerUITests: XCTestCase {
     func testSettingsHapticFeedbackNavigation() {
         app.tabBars.buttons["Settings"].tap()
 
-        // Tap on Haptic Feedback row
-        app.staticTexts["Haptic Feedback"].tap()
+        // The Feedback section sits below the fold — scroll it into view first.
+        let hapticRow = app.staticTexts["Haptic Feedback"]
+        scrollToElement(hapticRow)
+        XCTAssertTrue(hapticRow.exists, "Haptic Feedback row missing")
+        hapticRow.tap()
 
         // Should navigate to haptic settings (title is "Haptics")
         XCTAssertTrue(app.navigationBars["Haptics"].waitForExistence(timeout: 2))
 
-        // Without Full Access: shows a disabled toggle and warning text
-        // With Full Access: shows sliders for intensity control
-        // Either way, the Haptic Feedback toggle should be visible
-        XCTAssertTrue(app.switches["Haptic Feedback"].exists, "Should show the haptic feedback toggle")
+        // The master toggle was removed with the per-event intensity rework;
+        // the screen now shows one control per haptic event instead.
+        XCTAssertTrue(app.staticTexts["Tap Feedback"].exists, "Tap Feedback control missing")
+        XCTAssertTrue(app.staticTexts["Drag Feedback"].exists, "Drag Feedback control missing")
     }
 
     @MainActor
     func testSettingsUtilityKeysToggle() {
         app.tabBars.buttons["Settings"].tap()
 
-        // Find the "Utility Keys on Left" toggle
-        let utilityToggle = app.switches["Utility Keys on Left"]
-        if utilityToggle.exists {
-            let initialValue = utilityToggle.value as? String
-            utilityToggle.tap()
-            let newValue = utilityToggle.value as? String
-            XCTAssertNotEqual(initialValue, newValue, "Toggle should change state")
+        // Find the "Utility Keys on Left" toggle. The row has no stable
+        // accessibility identifier (adding one would be a production change,
+        // out of scope here), so match on the pinned-English label. The
+        // SwiftUI Toggle label combines title + subtitle, hence CONTAINS
+        // rather than an exact subscript match.
+        let utilityToggle = app.switches
+            .matching(NSPredicate(format: "label CONTAINS %@", "Utility Keys on Left"))
+            .firstMatch
+        XCTAssertTrue(
+            utilityToggle.waitForExistence(timeout: 2),
+            "Utility Keys on Left toggle must exist in Settings"
+        )
+
+        // SwiftUI exposes the whole row as the switch element; tapping its
+        // center hits the label, not the UISwitch. Tap the nested switch when
+        // present, otherwise the trailing edge where the UISwitch sits.
+        func flip() {
+            let inner = utilityToggle.switches.firstMatch
+            if inner.exists {
+                inner.tap()
+            } else {
+                utilityToggle
+                    .coordinate(withNormalizedOffset: CGVector(dx: 0.93, dy: 0.5))
+                    .tap()
+            }
         }
+
+        let initialValue = utilityToggle.value as? String
+        flip()
+        let newValue = utilityToggle.value as? String
+        XCTAssertNotEqual(initialValue, newValue, "Toggle should change state")
+
+        // The toggle writes to the real shared app-group store — restore it.
+        flip()
+        let restoredValue = utilityToggle.value as? String
+        XCTAssertEqual(initialValue, restoredValue, "Toggle must be restored to its original state")
     }
 
     // MARK: - Test Area Tests
@@ -161,9 +220,14 @@ final class wurstfingerUITests: XCTestCase {
         // Home should be the default tab
         XCTAssertTrue(app.navigationBars["Wurstfinger"].waitForExistence(timeout: 2))
 
-        // Check for some expected content
-        let hasContent = app.staticTexts.count > 0
-        XCTAssertTrue(hasContent, "Home view should display content")
+        // Assert the actual Home content: app title, tagline, and quick links.
+        XCTAssertTrue(app.staticTexts["Wurstfinger"].exists, "App title missing on Home")
+        XCTAssertTrue(
+            app.staticTexts["The Keyboard for Fat Fingers"].exists,
+            "Tagline missing on Home"
+        )
+        XCTAssertTrue(app.buttons["Setup Instructions"].exists, "Setup Instructions link missing")
+        XCTAssertTrue(app.buttons["GitHub"].exists, "GitHub link missing")
     }
 
     // MARK: - Performance Tests


### PR DESCRIPTION
Implements the decided test-hygiene fixes from the full codebase review 2026-07-07 (findings M12, H5, and the test items in L20). Test code only — no production changes. Making `KeyboardRegistry` injectable is explicitly deferred (owner decision pending); this PR applies only the test-side mitigation.

## M12a — Delete the drifted `primaryLanguage` reimplementation
`LanguageSettingsTests` contained a `PrimaryLanguageResolutionTests` suite whose helper mirrored an outdated version of `KeyboardViewController.primaryLanguage` (`languageId → LanguageConfig ?? .english`). Production resolves via `LanguageSettings.resolvedLanguageId` (system-language fallback *before* English) plus `KeyboardRegistry.available` metadata, so those ~7 tests would have kept passing with the real getter broken. Deleted; `ResolvedLanguageIdTests` now covers the full fallback chain (valid id kept for every known language, stale/nil → system language → English) and pins the invariant the controller relies on: every resolved id has registry metadata with a matching locale. **Conscious gap** (documented in a comment): the controller property itself (SharedDefaults read + fallback) stays untested until the registry/shared store become injectable.

## M12b — Unify the duplicated text-target mock
Deleted the private `MockTextInputTarget` in `ActionPipelineTests` (event-only, no document context / UTF-16 semantics) and migrated its tests to the shared `MockTextTarget`, which records the same events. No shared-helper extension was needed for event assertions.

## M12c — Replace on-disk `UserDefaults(suiteName:)!` with `InMemoryUserDefaults`
Mechanical substitution at all remaining sites (`CursorMovementTests`, `KeyboardGridRenderingTests` — whose "in-memory" comment is now actually true — `LanguageSettingsTests`, `wurstfingerTests`). None of the call sites relied on cross-instance persistence. While migrating, `InMemoryUserDefaults` gained typed `set(Double/Float/Int/Bool, forKey:)` overrides: statically-typed writes like `set(0.3, forKey:)` resolved to the non-overridden typed overloads and would silently bypass the in-memory storage.

## L20 — Tautological tests
Deleted `DiscreteGestureClassificationTests`: two tests recomputed the production return-ratio formula inside the test, the third asserted a constant lies in (0, 1). None exercised production code; the real behavior is covered end-to-end by `DiscreteCursorMovementTests`.

## L20 — OrientationLayoutTests read the real app-group store
All seven `KeyboardViewModel(shouldPersistSettings: false)` constructions now inject `userDefaults: InMemoryUserDefaults()` like every other suite, so the tests no longer read the developer machine's shared suite or register observers on it.

## H5 (test-side mitigation) — KeyboardRegistry cache races
`KeyboardRegistry.cache` is a process-global static; ~11 parallel suites load the same ids while `KeyboardRegistryTests` evicts and asserts global absence — the documented cause of the intermittent `loadCachesResult` failures. Custom ids cannot be registered and definitions are value types (no identity), so absence-after-evict is not observable race-free. The suite now:
- asserts **presence and round-trip behavior only** (presence is stable — no other suite evicts),
- keeps a stable absence assertion on an unloadable id (`nonexistent_layout`),
- limits the concurrency hammer to two rarely-loaded languages (Hebrew, Tagalog) with more iterations, so it stops forcing full definition rebuilds across concurrent suites — a contributor to the known `LanguageDefinitionValidationTests` timeout flakiness,
- documents the residual gap ("evict actually removes the entry" untestable) with a reference to the deferred injectable-registry decision.

## L20 — Host-app UI test hygiene
- `setUp` pins `-AppleLanguages (en)` / `-AppleLocale en_US` (same pattern as `DeadZoneTests`), so localized text queries are deterministic.
- `testOnboardingCheckboxesAreToggleable` and `testSettingsUtilityKeysToggle` now assert control existence unconditionally (no more silently-passing `if exists` blocks) and toggle back to restore the persisted app-group settings they flip.
- `testHomeViewShowsAppInfo` asserts the actual title, tagline, and quick links instead of `staticTexts.count > 0`.
- Repaired three tests that were already failing on develop due to stale queries: the Settings row is now titled "Languages" (destination title "Languages"), the "Haptic Feedback" row sits below the fold of a lazy `List` and needs scrolling before it exists in the hierarchy, and the haptics master toggle was replaced by per-event intensity controls in the haptics rework.
- Settings rows have no stable accessibility identifiers; adding them would be a production change and is out of scope — noted, queries match pinned-English labels instead.

## Verification
- `xcodebuild build-for-testing` (app + both test targets): succeeded.
- Full `WurstfingerTests` unit target: green (3 full runs).
- `KeyboardRegistryTests` in isolation: 7/7 consecutive green runs.
- Full `wurstfingerUITests` class (host-app UI tests) on a dedicated simulator: all 10 tests green, including the three repaired pre-existing failures (verified failing on unmodified develop first).
- SwiftFormat + SwiftLint `--strict`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of language, keyboard layout, haptics, and cursor-related behavior by tightening test coverage around real app flows.
  - Settings persistence is now exercised more consistently, helping prevent issues where preferences could be saved or restored incorrectly.
  - UI interactions in setup and settings are verified more deterministically, reducing locale- and scrolling-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->