### PR TITLE
Add Optional Long-Press to Type Numbers

### DIFF
--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -40,6 +40,9 @@ struct SettingsView: View {
     @AppStorage(SettingsKey.autoCapitalizeEnabled.rawValue, store: SharedDefaults.store)
     private var autoCapitalizeEnabled = false
 
+    @AppStorage(SettingsKey.longPressNumbersEnabled.rawValue, store: SharedDefaults.store)
+    private var longPressNumbersEnabled = false
+
     private let licenseURL = URL(string: "https://github.com/cl445/wurstfinger/blob/main/LICENSE")!
 
     @AppStorage(SettingsKey.expertModeEnabled.rawValue, store: SharedDefaults.store)
@@ -88,6 +91,14 @@ struct SettingsView: View {
                     icon: "textformat.size.larger", color: .teal,
                     title: "Auto-Capitalize",
                     subtitle: String(localized: "Capitalize after sentence-ending punctuation")
+                )
+            }
+
+            Toggle(isOn: $longPressNumbersEnabled) {
+                SettingsRow(
+                    icon: "123.rectangle", color: .pink,
+                    title: "Type Numbers by Holding",
+                    subtitle: String(localized: "Hold a letter key to type its digit")
                 )
             }
 

--- a/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
+++ b/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
@@ -82,6 +82,14 @@ enum CommonKeys {
                 label: "␣", action: .space, category: .utility,
                 returnAction: nil, accessibilityLabel: String(localized: "Space")
             ),
+            // MessagEase pairs the hold-for-digit feature with 0 on the space
+            // bar (no letter-layer slot maps to 0 otherwise). Long presses
+            // only occur with the opt-in setting enabled, so this is inert by
+            // default; .longPress has no hint alignment, so nothing renders.
+            .longPress: KeyBinding(
+                label: "0", action: .commitText("0"),
+                category: .digit, returnAction: nil, accessibilityLabel: nil
+            ),
         ],
         swipeMode: .none,
         slideType: .moveCursor,

--- a/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
+++ b/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
@@ -82,8 +82,8 @@ enum CommonKeys {
                 label: "␣", action: .space, category: .utility,
                 returnAction: nil, accessibilityLabel: String(localized: "Space")
             ),
-            // MessagEase pairs the hold-for-digit feature with 0 on the space
-            // bar (no letter-layer slot maps to 0 otherwise). Long presses
+            // The hold-for-digit feature pairs 0 with the space bar (no
+            // letter-layer slot maps to 0 otherwise). Long presses
             // only occur with the opt-in setting enabled, so this is inert by
             // default; .longPress has no hint alignment, so nothing renders.
             .longPress: KeyBinding(

--- a/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
+++ b/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
@@ -62,6 +62,10 @@ enum NumericLayouts {
                 label: "0", action: .commitText("0"),
                 category: .digit, returnAction: nil, accessibilityLabel: nil
             ),
+            .longPress: KeyBinding(
+                label: "0", action: .commitText("0"),
+                category: .digit, returnAction: nil, accessibilityLabel: nil
+            ),
         ],
         swipeMode: .none,
         slideType: .none,
@@ -204,11 +208,17 @@ enum NumericLayouts {
                     bindings[.circularCounterclockwise] = circBinding
                 }
 
-                // Tap → digit
-                bindings[.tap] = KeyBinding(
+                // Tap → digit. The same binding doubles as a long press:
+                // GhostKeyResolver falls back to this layer for gestures the
+                // letter layer leaves unbound, so holding a letter key types
+                // its digit without a mode switch. Long presses only occur
+                // with the opt-in "Type Numbers by Holding" setting enabled.
+                let digitBinding = KeyBinding(
                     label: digit, action: .commitText(digit),
                     category: .digit, returnAction: nil, accessibilityLabel: nil
                 )
+                bindings[.tap] = digitBinding
+                bindings[.longPress] = digitBinding
 
                 digitKeys[slotId] = KeyConfig(
                     id: slotId, bindings: bindings, swipeMode: .eightWay,

--- a/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
@@ -23,6 +23,12 @@ struct GestureClassification {
 struct KeyGestureSequence {
     private var positions: RingBuffer<CGPoint>
 
+    /// Largest distance from the touch-down origin seen so far. Tracked as a
+    /// running maximum (rather than derived from the buffer) so it survives
+    /// ring-buffer eviction and out-and-back paths; used to cancel a pending
+    /// long press once the finger has clearly left its resting position.
+    private(set) var maxDisplacement: CGFloat = 0
+
     init(capacity: Int = KeyboardConstants.Gesture.positionBufferSize) {
         positions = RingBuffer<CGPoint>(capacity: capacity)
     }
@@ -40,12 +46,16 @@ struct KeyGestureSequence {
             positions.append(.zero)
         }
         positions.append(CGPoint(x: translation.width, y: translation.height))
+        maxDisplacement = max(maxDisplacement, hypot(translation.width, translation.height))
         return isTouchDown
     }
 
     /// Records the final sample and classifies the completed sequence.
     mutating func handleEnded(translation: CGSize, aspectRatio: CGFloat) -> GestureClassification {
-        defer { positions.removeAll() }
+        defer {
+            positions.removeAll()
+            maxDisplacement = 0
+        }
         if positions.isEmpty {
             positions.append(.zero)
         }
@@ -62,6 +72,7 @@ struct KeyGestureSequence {
     /// path, misclassifying a tap as the previous gesture's swipe.
     mutating func handleCancelled() {
         positions.removeAll()
+        maxDisplacement = 0
     }
 }
 
@@ -79,7 +90,18 @@ struct KeyGestureRecognizer: ViewModifier {
     /// Key aspect ratio forwarded to the preprocessor for normalization.
     let aspectRatio: CGFloat
 
+    /// Called when the finger has rested on the key for
+    /// `KeyboardConstants.LongPress.duration` without moving beyond
+    /// `movementTolerance`. Returns whether the long press was handled; a
+    /// handled long press consumes the touch, so releasing produces no tap.
+    /// An unhandled one (no long-press binding resolves for the key) leaves
+    /// the touch untouched and it classifies normally on release. `nil`
+    /// disables long-press detection entirely.
+    var onLongPress: (() -> Bool)?
+
     @State private var sequence = KeyGestureSequence()
+    @State private var pendingLongPress: DispatchWorkItem?
+    @State private var longPressConsumedTouch = false
     @Binding var isActive: Bool
 
     /// True while a touch sequence is in flight. Unlike `@State`, SwiftUI
@@ -98,10 +120,24 @@ struct KeyGestureRecognizer: ViewModifier {
                     .onChanged { value in
                         if sequence.handleChanged(translation: value.translation) {
                             onTouchDown()
+                            scheduleLongPress()
+                        } else if pendingLongPress != nil,
+                                  sequence.maxDisplacement > KeyboardConstants.LongPress.movementTolerance {
+                            cancelPendingLongPress()
                         }
                         isActive = true
                     }
                     .onEnded { value in
+                        cancelPendingLongPress()
+                        if longPressConsumedTouch {
+                            // The long press already dispatched its action;
+                            // discard the touch instead of classifying it, so
+                            // releasing doesn't produce a second key event.
+                            longPressConsumedTouch = false
+                            sequence.handleCancelled()
+                            isActive = false
+                            return
+                        }
                         let classification = sequence.handleEnded(
                             translation: value.translation,
                             aspectRatio: aspectRatio
@@ -116,9 +152,39 @@ struct KeyGestureRecognizer: ViewModifier {
                 // cancelled the touches. Discard the partial gesture without
                 // classifying it.
                 guard !inFlight, sequence.isTracking else { return }
+                cancelPendingLongPress()
+                longPressConsumedTouch = false
                 sequence.handleCancelled()
                 isActive = false
             }
+    }
+
+    // MARK: - Long Press
+
+    private func scheduleLongPress() {
+        guard onLongPress != nil else { return }
+        cancelPendingLongPress()
+        let workItem = DispatchWorkItem { fireLongPress() }
+        pendingLongPress = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + KeyboardConstants.LongPress.duration,
+            execute: workItem
+        )
+    }
+
+    private func cancelPendingLongPress() {
+        pendingLongPress?.cancel()
+        pendingLongPress = nil
+    }
+
+    private func fireLongPress() {
+        pendingLongPress = nil
+        // The touch may have ended or been cancelled between scheduling and
+        // firing; a stale fire must not dispatch anything.
+        guard sequence.isTracking,
+              sequence.maxDisplacement <= KeyboardConstants.LongPress.movementTolerance,
+              onLongPress?() == true else { return }
+        longPressConsumedTouch = true
     }
 
     /// Guarantees the touch-down origin `(0,0)` is the first sample.

--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -41,6 +41,10 @@ struct SlideGestureState {
     /// Most-negative vertical translation seen this gesture (SwiftUI's y axis
     /// points down, so upward travel is negative). Peak of the up-swipe.
     private(set) var upwardPeakY: CGFloat = 0
+    /// Largest distance from the touch-down origin seen so far. Mirrors
+    /// `KeyGestureSequence.maxDisplacement`; used to cancel a pending long
+    /// press once the finger has clearly left its resting position.
+    private(set) var maxDisplacement: CGFloat = 0
 
     /// Events produced by a single drag update.
     struct Update: Equatable {
@@ -62,6 +66,7 @@ struct SlideGestureState {
 
         let currentX = translation.width
         upwardPeakY = min(upwardPeakY, translation.height)
+        maxDisplacement = max(maxDisplacement, hypot(translation.width, translation.height))
 
         // Activate only while the horizontal axis dominates: crossing the
         // (small) horizontal threshold during a mostly-vertical movement must
@@ -147,6 +152,7 @@ struct SlideGestureState {
         isSliding = false
         lastTranslationX = 0
         upwardPeakY = 0
+        maxDisplacement = 0
     }
 }
 
@@ -160,9 +166,17 @@ struct SlideGestureHandler: ViewModifier {
     let slideType: SlideType
     let onSlide: (SlidePhase) -> Void
     let onTouchDown: () -> Void
+    /// Same contract as `KeyGestureRecognizer.onLongPress`: fires after the
+    /// finger has rested for `KeyboardConstants.LongPress.duration` without
+    /// sliding or moving beyond the tolerance; returns whether it was
+    /// handled. A handled long press consumes the touch (no tap, no slide
+    /// on release). `nil` disables detection.
+    var onLongPress: (() -> Bool)?
     @Binding var isActive: Bool
 
     @State private var state = SlideGestureState()
+    @State private var pendingLongPress: DispatchWorkItem?
+    @State private var longPressConsumedTouch = false
 
     /// True while a touch sequence is in flight. Unlike `@State`, SwiftUI
     /// guarantees `@GestureState` is reset when the system cancels the
@@ -178,12 +192,24 @@ struct SlideGestureHandler: ViewModifier {
                         inFlight = true
                     }
                     .onChanged { value in
+                        // A fired long press owns the rest of this touch:
+                        // don't feed the state machine, or the movement would
+                        // start a cursor slide after the digit was typed.
+                        if longPressConsumedTouch {
+                            isActive = true
+                            return
+                        }
                         let update = state.handleChanged(
                             translation: value.translation,
                             activationThreshold: activationThreshold
                         )
                         if update.isTouchDown {
                             onTouchDown()
+                            scheduleLongPress()
+                        } else if pendingLongPress != nil,
+                                  state.isSliding
+                                  || state.maxDisplacement > KeyboardConstants.LongPress.movementTolerance {
+                            cancelPendingLongPress()
                         }
                         for phase in update.phases {
                             onSlide(phase)
@@ -191,6 +217,15 @@ struct SlideGestureHandler: ViewModifier {
                         isActive = true
                     }
                     .onEnded { value in
+                        cancelPendingLongPress()
+                        if longPressConsumedTouch {
+                            // Reset silently: no phase is reported, so the
+                            // release produces neither a tap nor a slide end.
+                            longPressConsumedTouch = false
+                            _ = state.handleCancelled()
+                            isActive = false
+                            return
+                        }
                         if let phase = state.handleEnded(
                             translation: value.translation,
                             activationThreshold: activationThreshold
@@ -205,11 +240,41 @@ struct SlideGestureHandler: ViewModifier {
                 // if the sequence stops while a drag is still marked as in
                 // flight, the system cancelled the touches.
                 guard !inFlight else { return }
+                cancelPendingLongPress()
+                longPressConsumedTouch = false
                 if let phase = state.handleCancelled() {
                     onSlide(phase)
                 }
                 isActive = false
             }
+    }
+
+    // MARK: - Long Press
+
+    private func scheduleLongPress() {
+        guard onLongPress != nil else { return }
+        cancelPendingLongPress()
+        let workItem = DispatchWorkItem { fireLongPress() }
+        pendingLongPress = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + KeyboardConstants.LongPress.duration,
+            execute: workItem
+        )
+    }
+
+    private func cancelPendingLongPress() {
+        pendingLongPress?.cancel()
+        pendingLongPress = nil
+    }
+
+    private func fireLongPress() {
+        pendingLongPress = nil
+        // The touch may have ended, slid, or been cancelled between
+        // scheduling and firing; a stale fire must not dispatch anything.
+        guard state.dragStarted, !state.isSliding,
+              state.maxDisplacement <= KeyboardConstants.LongPress.movementTolerance,
+              onLongPress?() == true else { return }
+        longPressConsumedTouch = true
     }
 
     private var activationThreshold: CGFloat {

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -250,17 +250,23 @@ extension KeyboardViewModel {
     // MARK: - Gesture Dispatch
 
     /// Central entry point for the data-driven gesture path.
-    func handleGesture(_ gesture: GestureType, keyId: String, isReturn: Bool) {
-        guard let mode = activeModeFromDefinition else { return }
+    ///
+    /// Returns whether the gesture resolved to a binding and was dispatched.
+    /// The long-press path uses this to decide whether the touch is consumed:
+    /// a key without a long-press binding (e.g. return, globe) must keep its
+    /// normal tap on release instead of being swallowed by the failed hold.
+    @discardableResult
+    func handleGesture(_ gesture: GestureType, keyId: String, isReturn: Bool) -> Bool {
+        guard let mode = activeModeFromDefinition else { return false }
 
         // Circular gestures: try requested direction, fall back to opposite.
         if gesture == .circularClockwise || gesture == .circularCounterclockwise {
             handleCircular(keyId: keyId, in: mode, gesture: gesture)
-            return
+            return true
         }
 
         let chain = isReturn ? returnSwipeResolverChain : resolverChain
-        guard let binding = chain?.resolve(keyId: keyId, gesture: gesture, in: mode) else { return }
+        guard let binding = chain?.resolve(keyId: keyId, gesture: gesture, in: mode) else { return false }
 
         // Mode and language switches bypass the pipeline, so their
         // confirmation tick fires here instead of in the haptic middleware —
@@ -272,7 +278,7 @@ extension KeyboardViewModel {
             if activeModeName != previousMode {
                 feedbackStateChange()
             }
-            return
+            return true
         }
 
         if case .switchToNextLanguage = binding.action {
@@ -281,7 +287,7 @@ extension KeyboardViewModel {
             if currentDefinition?.id != previousLanguage {
                 feedbackStateChange()
             }
-            return
+            return true
         }
 
         let context = ActionContext(
@@ -290,6 +296,7 @@ extension KeyboardViewModel {
             mode: activeModeName
         )
         pipeline?.process(context)
+        return true
     }
 
     /// Handles a circular gesture. Checks for an explicit binding first

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -46,6 +46,9 @@ struct DataDrivenKeyboardRootView: View {
                     onSlide: { key, phase in
                         viewModel.handleSlide(key, phase: phase)
                     },
+                    onLongPress: { key in
+                        viewModel.handleGesture(.longPress, keyId: key.id, isReturn: false)
+                    },
                     languageLabel: viewModel.currentLanguageLabel,
                     showLanguageLabel: viewModel.hasMultipleLanguages
                 )

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -20,6 +20,10 @@ struct KeyView: View {
     let onGesture: (KeyConfig, GestureType, Bool) -> Void
     var onTouchDown: (() -> Void)?
     var onSlide: ((KeyConfig, SlidePhase) -> Void)?
+    /// Handles a long press on this key; returns whether it dispatched an
+    /// action (a handled long press consumes the touch). Long-press detection
+    /// only runs when this is set and the user setting is enabled.
+    var onLongPress: ((KeyConfig) -> Bool)?
     var spanRatio: CGFloat = 1.0
 
     /// Inset between the full touch cell and the key's visible bounds. The cell
@@ -55,6 +59,9 @@ struct KeyView: View {
 
     @AppStorage(SettingsKey.hideExtraSymbols.rawValue, store: SharedDefaults.store)
     private var hideExtraSymbols = false
+
+    @AppStorage(SettingsKey.longPressNumbersEnabled.rawValue, store: SharedDefaults.store)
+    private var longPressNumbersEnabled = false
 
     /// Whether the label of `binding` should be drawn, honouring the user's
     /// label-visibility toggles (numbers and functional keys always show).
@@ -118,6 +125,7 @@ struct KeyView: View {
                 // 1×1, so scale the base aspect ratio by columnSpan/rowSpan
                 // (spanRatio) to classify swipes against the real geometry.
                 aspectRatio: CGFloat(keyAspectRatio) * spanRatio,
+                onLongPress: longPressHandler,
                 isActive: $isActive
             ))
         }
@@ -195,6 +203,13 @@ struct KeyView: View {
     /// gesture classification.
     private var usesSlideGesture: Bool {
         key.slideType != .none
+    }
+
+    /// Long-press handler for the gesture recognizer, or nil when the
+    /// opt-in setting is off or no handler is wired up (preview contexts).
+    private var longPressHandler: (() -> Bool)? {
+        guard longPressNumbersEnabled, let onLongPress else { return nil }
+        return { onLongPress(key) }
     }
 
     // MARK: - View Construction

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -113,6 +113,7 @@ struct KeyView: View {
                 slideType: key.slideType,
                 onSlide: { phase in onSlide?(key, phase) },
                 onTouchDown: { onTouchDown?() },
+                onLongPress: longPressHandler,
                 isActive: $isActive
             ))
         } else {

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -20,6 +20,8 @@ struct KeyboardGridView: View {
     let onGesture: (KeyConfig, GestureType, Bool) -> Void
     var onTouchDown: (() -> Void)?
     var onSlide: ((KeyConfig, SlidePhase) -> Void)?
+    /// Forwarded to `KeyView`; returns whether the long press was handled.
+    var onLongPress: ((KeyConfig) -> Bool)?
     /// Active-language hint for the switch key, supplied by `KeyboardViewModel`
     /// so it reflects the loaded definition rather than re-derived storage.
     var languageLabel: String = ""
@@ -62,6 +64,7 @@ struct KeyboardGridView: View {
                 onGesture: onGesture,
                 onTouchDown: onTouchDown,
                 onSlide: onSlide,
+                onLongPress: onLongPress,
                 spanRatio: CGFloat(cell.columnSpan) / CGFloat(cell.rowSpan),
                 visualInset: visualInset(for: cell, totalRows: totalRows),
                 languageLabel: languageLabel,

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -127,6 +127,20 @@ enum KeyboardConstants {
         static let positionBufferSize: Int = 120
     }
 
+    // MARK: - Long Press
+
+    enum LongPress {
+        /// How long the finger must rest on a key before a long press fires.
+        /// Matches UIKit's `UILongPressGestureRecognizer` default.
+        static let duration: TimeInterval = 0.5
+
+        /// Maximum travel from touch-down before a pending long press is
+        /// cancelled. Matches `UILongPressGestureRecognizer.allowableMovement`
+        /// so natural finger wobble doesn't cancel the hold, while anything
+        /// resembling a swipe does.
+        static let movementTolerance: CGFloat = 10
+    }
+
     // MARK: - Space Key Gestures
 
     enum SpaceGestures {

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -131,8 +131,10 @@ enum KeyboardConstants {
 
     enum LongPress {
         /// How long the finger must rest on a key before a long press fires.
-        /// Matches UIKit's `UILongPressGestureRecognizer` default.
-        static let duration: TimeInterval = 0.5
+        /// Deliberately above UIKit's 0.5s default: hesitating mid-word is
+        /// common on a gesture keyboard, and an accidental digit is worse
+        /// than a slightly slower intentional one (tuned on device).
+        static let duration: TimeInterval = 0.7
 
         /// Maximum travel from touch-down before a pending long press is
         /// cancelled. Matches `UILongPressGestureRecognizer.allowableMovement`

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -36,8 +36,8 @@ enum SettingsKey: String {
     case hideLetters
     case hideStandardSymbols
     case hideExtraSymbols
-    /// MessagEase-style: holding a letter key types the digit that key
-    /// carries on the numeric layer, without switching modes.
+    /// Holding a letter key types the digit that key carries on the
+    /// numeric layer, without switching modes.
     case longPressNumbersEnabled
 }
 

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -36,6 +36,9 @@ enum SettingsKey: String {
     case hideLetters
     case hideStandardSymbols
     case hideExtraSymbols
+    /// MessagEase-style: holding a letter key types the digit that key
+    /// carries on the numeric layer, without switching modes.
+    case longPressNumbersEnabled
 }
 
 // MARK: - Haptic Settings

--- a/wurstfingerTests/KeyGestureSequenceTests.swift
+++ b/wurstfingerTests/KeyGestureSequenceTests.swift
@@ -57,6 +57,29 @@ struct KeyGestureSequenceTests {
         #expect(isTouchDown)
     }
 
+    @Test func maxDisplacementTracksPeakDistanceFromOrigin() {
+        var sequence = KeyGestureSequence()
+        _ = sequence.handleChanged(translation: CGSize(width: 30, height: 40)) // 50pt out …
+        _ = sequence.handleChanged(translation: CGSize(width: 3, height: 4)) // … then back
+        // The running maximum must survive the return leg — a pending long
+        // press stays cancelled after an out-and-back movement.
+        #expect(sequence.maxDisplacement == 50)
+    }
+
+    @Test func maxDisplacementResetsAfterEnd() {
+        var sequence = KeyGestureSequence()
+        feedRightwardSwipe(into: &sequence)
+        _ = sequence.handleEnded(translation: CGSize(width: 60, height: 0), aspectRatio: 1.0)
+        #expect(sequence.maxDisplacement == 0)
+    }
+
+    @Test func maxDisplacementResetsAfterCancellation() {
+        var sequence = KeyGestureSequence()
+        feedRightwardSwipe(into: &sequence)
+        sequence.handleCancelled()
+        #expect(sequence.maxDisplacement == 0)
+    }
+
     @Test func tapAfterCancelledSwipeClassifiesAsTap() {
         var sequence = KeyGestureSequence()
         // A rightward swipe is cancelled by the system mid-gesture …

--- a/wurstfingerTests/LongPressNumberTests.swift
+++ b/wurstfingerTests/LongPressNumberTests.swift
@@ -84,6 +84,29 @@ struct LongPressNumberPipelineTests {
         #expect(target.events.contains(.insertText("0")))
     }
 
+    @Test func longPressOnSpaceBarTypesZero() {
+        let (vm, target) = makeViewModel()
+        let handled = vm.handleGesture(.longPress, keyId: UtilitySlot.space, isReturn: false)
+        #expect(handled)
+        #expect(target.events == [.insertText("0")])
+    }
+
+    @Test func longPressOnSpaceBarTypesZeroInNumericMode() {
+        let (vm, target) = makeViewModel()
+        vm.handleGesture(.tap, keyId: UtilitySlot.symbols, isReturn: false)
+        vm.handleGesture(.longPress, keyId: UtilitySlot.space, isReturn: false)
+        #expect(target.events.contains(.insertText("0")))
+    }
+
+    @Test func longPressOnDeleteReportsUnhandled() {
+        let (vm, target) = makeViewModel()
+        // Delete shares SlideGestureHandler with space but has no long-press
+        // binding; the hold must not be consumed.
+        let handled = vm.handleGesture(.longPress, keyId: UtilitySlot.delete, isReturn: false)
+        #expect(!handled)
+        #expect(target.events.isEmpty)
+    }
+
     @Test func unhandledLongPressReportsFalseAndTypesNothing() {
         let (vm, target) = makeViewModel()
         // Utility keys have no digit on the numeric layer: the long press must

--- a/wurstfingerTests/LongPressNumberTests.swift
+++ b/wurstfingerTests/LongPressNumberTests.swift
@@ -2,7 +2,7 @@
 //  LongPressNumberTests.swift
 //  WurstfingerTests
 //
-//  Tests for the MessagEase-style "type numbers by holding" feature.
+//  Tests for the "type numbers by holding" feature.
 //  A .longPress gesture on a letter key resolves to the digit that key
 //  carries on the numeric layer (via GhostKeyResolver), and handleGesture
 //  reports whether the press was handled so the recognizer only consumes

--- a/wurstfingerTests/LongPressNumberTests.swift
+++ b/wurstfingerTests/LongPressNumberTests.swift
@@ -1,0 +1,101 @@
+//
+//  LongPressNumberTests.swift
+//  WurstfingerTests
+//
+//  Tests for the MessagEase-style "type numbers by holding" feature.
+//  A .longPress gesture on a letter key resolves to the digit that key
+//  carries on the numeric layer (via GhostKeyResolver), and handleGesture
+//  reports whether the press was handled so the recognizer only consumes
+//  touches that actually dispatched an action.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+// MARK: - Definition Layer
+
+struct LongPressBindingTests {
+    @Test func numericLayerExposesDigitsAsLongPress() {
+        for mode in [NumericLayouts.phone(), NumericLayouts.classic()] {
+            for slot in GridSlot.allSlots.flatMap(\.self) {
+                let key = mode.key(for: slot)
+                #expect(key?.bindings[.longPress] != nil, "slot \(slot)")
+                #expect(key?.bindings[.longPress] == key?.bindings[.tap], "slot \(slot)")
+            }
+            #expect(mode.key(for: GridSlot.zero)?.bindings[.longPress]?.action == .commitText("0"))
+        }
+    }
+}
+
+// MARK: - Pipeline (gesture → digit)
+
+@Suite(.serialized)
+struct LongPressNumberPipelineTests {
+    @Test func longPressOnLetterKeyTypesDigit() {
+        let (vm, target) = makeViewModel()
+        // Phone numpad (default): top-left slot carries "1".
+        let handled = vm.handleGesture(.longPress, keyId: GridSlot.topLeft, isReturn: false)
+        #expect(handled)
+        #expect(target.events == [.insertText("1")])
+    }
+
+    @Test func allNineMainSlotsTypeTheirPhoneLayoutDigit() {
+        let slots = GridSlot.allSlots.flatMap(\.self)
+        for (index, slot) in slots.enumerated() {
+            let (vm, target) = makeViewModel()
+            vm.handleGesture(.longPress, keyId: slot, isReturn: false)
+            #expect(target.events == [.insertText("\(index + 1)")], "slot \(slot)")
+        }
+    }
+
+    @Test func longPressFollowsClassicNumpadStyle() {
+        let defaults = InMemoryUserDefaults()
+        defaults.set(NumpadStyle.classic.rawValue, forKey: SettingsKey.numpadStyle.rawValue)
+        let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
+        let target = MockTextTarget()
+        vm.bindTextInputTarget(target)
+        vm.loadDefinition(for: "de_DE")
+
+        vm.handleGesture(.longPress, keyId: GridSlot.topLeft, isReturn: false)
+        #expect(target.events == [.insertText("7")])
+    }
+
+    @Test func longPressWorksInShiftedMode() {
+        let (vm, target) = makeViewModel()
+        vm.handleGesture(.swipeUp, keyId: GridSlot.midRight, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.shifted)
+        vm.handleGesture(.longPress, keyId: GridSlot.center, isReturn: false)
+        #expect(target.events.contains(.insertText("5")))
+    }
+
+    @Test func longPressOnDigitKeyInNumericModeTypesDigit() {
+        let (vm, target) = makeViewModel()
+        vm.handleGesture(.tap, keyId: UtilitySlot.symbols, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.numeric)
+        vm.handleGesture(.longPress, keyId: GridSlot.topLeft, isReturn: false)
+        #expect(target.events.contains(.insertText("1")))
+    }
+
+    @Test func longPressOnZeroKeyTypesZero() {
+        let (vm, target) = makeViewModel()
+        vm.handleGesture(.tap, keyId: UtilitySlot.symbols, isReturn: false)
+        vm.handleGesture(.longPress, keyId: GridSlot.zero, isReturn: false)
+        #expect(target.events.contains(.insertText("0")))
+    }
+
+    @Test func unhandledLongPressReportsFalseAndTypesNothing() {
+        let (vm, target) = makeViewModel()
+        // Utility keys have no digit on the numeric layer: the long press must
+        // report unhandled so the touch is not consumed and the key keeps its
+        // normal tap on release.
+        let handled = vm.handleGesture(.longPress, keyId: UtilitySlot.return, isReturn: false)
+        #expect(!handled)
+        #expect(target.events.isEmpty)
+    }
+
+    @Test func handledGestureReportsTrue() {
+        let (vm, _) = makeViewModel()
+        #expect(vm.handleGesture(.tap, keyId: GridSlot.topLeft, isReturn: false))
+    }
+}

--- a/wurstfingerTests/SlideGestureStateTests.swift
+++ b/wurstfingerTests/SlideGestureStateTests.swift
@@ -332,6 +332,41 @@ struct SlideGestureStateTests {
         #expect(update.isTouchDown)
         #expect(update.phases.isEmpty)
     }
+
+    // MARK: - Long-press displacement tracking
+
+    @Test func maxDisplacementTracksPeakDistanceFromOrigin() {
+        var state = SlideGestureState()
+        _ = state.handleChanged(
+            translation: CGSize(width: 30, height: 40), activationThreshold: threshold
+        ) // 50pt out ...
+        _ = state.handleChanged(
+            translation: CGSize(width: 3, height: 4), activationThreshold: threshold
+        ) // ... then back
+        // The running maximum must survive the return leg - a pending long
+        // press stays cancelled after an out-and-back movement.
+        #expect(state.maxDisplacement == 50)
+    }
+
+    @Test func maxDisplacementResetsAfterEnd() {
+        var state = SlideGestureState()
+        _ = state.handleChanged(
+            translation: CGSize(width: 100, height: 0), activationThreshold: threshold
+        )
+        _ = state.handleEnded(
+            translation: CGSize(width: 100, height: 0), activationThreshold: threshold
+        )
+        #expect(state.maxDisplacement == 0)
+    }
+
+    @Test func maxDisplacementResetsAfterCancellation() {
+        var state = SlideGestureState()
+        _ = state.handleChanged(
+            translation: CGSize(width: 100, height: 0), activationThreshold: threshold
+        )
+        _ = state.handleCancelled()
+        #expect(state.maxDisplacement == 0)
+    }
 }
 
 // MARK: - ViewModel handling of .cancelled


### PR DESCRIPTION
## Summary

Opt-in convenience feature: holding a letter key types the digit that key carries on the numeric layer, and holding the space bar types 0 — without switching modes. Disabled by default; enabled via a new **Type Numbers by Holding** toggle in Settings (General section).

### How it works

- **Detection**: a timer starts on touch-down (only when the setting is enabled) and is cancelled once the finger moves more than 10pt from its origin (matching `UILongPressGestureRecognizer.allowableMovement`) or lifts. After 0.7s of resting, the long press fires (0.5s proved too short on device — it triggered on mid-word hesitation). `KeyGestureRecognizer` handles regular keys; `SlideGestureHandler` gains the same rest-detection for the space bar, additionally cancelling when the cursor slide activates. Both state machines (`KeyGestureSequence`, `SlideGestureState`) track a running `maxDisplacement` so the cancel decision survives out-and-back paths.
- **Resolution**: the numeric layer's digit keys expose their digit as a `.longPress` binding in addition to `.tap`. The existing `GhostKeyResolver` (numeric-layer fallback) therefore resolves a long press on any letter key to the correct digit — in every language, both numpad styles (phone/classic), and shifted mode, with no per-language data changes. The space bar carries its own `.longPress` binding for 0. The previously unused `GestureType.longPress` case is now live.
- **Touch consumption**: `handleGesture` now returns whether a binding was dispatched (`@discardableResult`). A handled long press consumes the touch: releasing produces no tap (and on space, no space character or cursor slide). An unhandled one (e.g. holding return, globe, or delete, which have no digit) leaves the touch untouched and it classifies normally on release.

### Out of scope (possible follow-ups)

- Auto-repeat while continuing to hold
- Configurable hold duration

## Test plan

- [x] New unit tests: numeric-layer `.longPress` bindings (both numpad styles), digit resolution for all nine slots, classic style, shifted mode, numeric mode, zero key, space bar (main + numeric mode), and unhandled-long-press semantics (return, delete)
- [x] New `maxDisplacement` tests for `KeyGestureSequence` and `SlideGestureState` (peak tracking, reset on end/cancel)
- [x] Full `WurstfingerTests` suite green locally (one unrelated flake: `KeyboardRegistryTests/evictAllClearsCache`, shared-global-state race, green in isolation)
- [x] On-device: hold-to-type feel tuned (0.5s → 0.7s), space bar verified
- [ ] On-device re-check after final tuning: swipes/circular gestures/compose unaffected, cursor slide on space unaffected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “Type Numbers by Holding” setting so long-pressing keys can enter digits.
  * Expanded keyboard behavior to support long-press number entry across letter keys, number keys, and select utility keys.
  * Long-press gestures now use consistent timing and movement thresholds for more reliable input.

* **Bug Fixes**
  * Improved gesture handling so held touches are cancelled when the finger moves too far.
  * Fixed gesture state resets after long-press, end, or cancellation to avoid misclassified input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->