### PR TITLE
WIP: Swipe-sector bias correction (learned angular offset)

### DIFF
--- a/docs/touch-offset-correction.md
+++ b/docs/touch-offset-correction.md
@@ -902,3 +902,76 @@ Zusätzlich:
 
 v1: **erheben + anzeigen**. **Keine** Schwellen-/Feature-Anpassung zur Laufzeit. Adaption (kern-
 verankert, geclampt, reversibel, default-aus; Winkel-Offset zuerst) ist ein eigener späterer Track.
+
+## 14. Swipe-Sektor-Bias-Korrektur (Winkel-Offset pro Richtung)
+
+**Status:** implementiert als Folge-Feature der Tap-Offset-Korrektur — der in §13 als „sauberster
+erster Kandidat" benannte per-Richtung-Winkel-Offset, jetzt mit *Anwendung* (nicht nur Erhebung).
+Eigener Toggle (`swipeBiasEnabled`, default aus), eigener Store, eigene Reset-Semantik.
+
+### 14.1 Lernen (Self-Labeling, analog §4.1)
+
+Die 8 Swipe-Sektoren sind 45°-Keile um die Mittelwinkel `i·45°` (Koordinaten wie `atan2`, y nach
+unten; `KeyGestureRecognizer.angleToGestureType`). Ein **akzeptierter** Swipe (nicht im Veto-Fenster
+gelöscht) liefert:
+
+```
+Label   = final klassifizierter Sektor S (Intent unter Self-Labeling)
+Sample  = Δθ = wrap(maxDisplacementAngle_roh − Mittelwinkel(S))   ∈ (−π, π]
+```
+
+Das Residual wird **immer gegen den rohen Messwinkel** gebildet — auch während eine Korrektur
+aktiv ist —, damit das gelernte Mittel den *unkorrigierten* Bias schätzt (kein Feedback-Drift).
+Return-Swipes nutzen dieselbe Winkel→Sektor-Abbildung und werden mitgelernt.
+
+**Gemeinsames Acceptance-Fenster:** Taps (§4.1) und Swipes teilen sich *ein* Veto-Fenster
+(`AcceptanceTracker<PendingSample>`), damit ein Delete den *jüngsten Commit* vetot, egal welcher
+Art — ein Delete nach Tap-dann-Swipe darf nicht den unschuldigen Tap treffen.
+
+**Zensur:** Fehlklassifizierte Swipes werden gelöscht/vetoed und fehlen im Sample — die Verteilung
+ist bei ±22,5° trunkiert, das Mittel unterschätzt den Bias betragsmäßig. Gleiches Argument wie bei
+Taps (§4.1): das Vorzeichen stimmt, die Korrektur konvergiert iterativ.
+
+### 14.2 Schätzer & Shrinkage
+
+Pro `(Regime, Sektor)` ein `RunningOffset` (derselbe robuste Schätzer wie §4.2 Step 1: Huber-Clip,
+EW-MAD-Gate, `nMax`-Plastizität — Einheiten hier Radiant, `spreadPrior ≈ 12°`). Empirical-Bayes-
+Shrinkage gegen den **zählungsgewichteten Regime-Globalbias** g (statt einer Reach-Surface — der
+Bias ist primär biomechanisch pro Richtung, 8 Zellen sind klein genug):
+
+```
+b_S = clamp(g + (m_S − g)·n_S/(n_S + κ),  ±clampRadians)
+```
+
+Residuen leben in (−22,5°, 22,5°] plus geclampter Korrektur — weit weg vom ±180°-Wrap, daher sind
+gewöhnliche (nicht-zirkuläre) Mittel exakt.
+
+### 14.3 Anwendung
+
+Rein numerisch im View-Model (`handleGesture`), **vor** Resolver und Telemetrie — kein Frame-
+Resizing, keine Invisible Compensation:
+
+```
+S_roh   = angleToGestureType(θ)
+S_final = angleToGestureType(θ − b_{S_roh})
+```
+
+Ein Lookup-Schritt genügt, weil `clampRadians` (15°) deutlich unter der halben Sektorbreite
+(22,5°) liegt. Gate: Toggle an **und** Regime-Reife `Σ n_S ≥ applyOn`.
+
+### 14.4 Persistenz / UI / Reset
+
+- Eigener Store (`swipeBias.snapshot`, eigene Schema-Version), nur Aggregate `{m_S, n_S, s_S}` —
+  keine Rohwinkel (§7-Datenschutz). Lernen ist inert, solange der Toggle aus ist.
+- Settings: Toggle „Correct my swipes" auf der Touch-Correction-Seite; beide Reset-Pfade
+  (Posture/alles) löschen auch den Swipe-Store.
+
+### 14.5 Telemetrie / Diagnose
+
+`sectorResidual` (Radiant) als zusätzliches Feature-Stat pro Gestenklasse in der P6-Telemetrie:
+Mittel deutlich ≠ 0 ⇒ systematischer Bias (Rotation hilft); Mittel ≈ 0 bei hoher Streuung ⇒ die
+Misses sind Varianz (dann wären Hysterese/Sektor-Gewichtung das Mittel, nicht Rotation).
+
+**Offen (Folge-Track):** Counterfactual-Metrik für Swipes (analog §8: „hat die Rotation den Sektor
+geflippt, und wurde das Ergebnis behalten?"); per-Key-Verfeinerung des Bias, falls die Daten sie
+hergeben; Tap↔Swipe-Schwellen-Adaption bleibt §13.

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -22603,6 +22603,143 @@
           }
         }
       }
+    },
+    "Correct my swipes": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصحيح تمريراتي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meine Wischgesten korrigieren"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διόρθωση των σαρώσεών μου"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corregir mis deslizamientos"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اصلاح کشیدن‌های من"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korjaa pyyhkäisyjäni"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Itama ang mga swipe ko"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corriger mes balayages"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תיקון ההחלקות שלי"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मेरे स्वाइप सुधारें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ispravljaj moje prijelaze"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correggi i miei scorrimenti"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スワイプを補正する"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내 스와이프 보정"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koryguj moje przesunięcia"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corrigir os meus deslizes"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Корректировать мои свайпы"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korrigera mina svep"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปรับแก้การปัดของฉัน"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Коригувати мої свайпи"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "میرے سوائپ درست کریں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiệu chỉnh cử chỉ vuốt của tôi"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/wurstfinger/TouchOffsetSettingsView.swift
+++ b/wurstfinger/TouchOffsetSettingsView.swift
@@ -21,10 +21,14 @@ struct TouchOffsetSettingsView: View {
     /// active learning regime, not just a view filter (§3.1/§6.3).
     @AppStorage(SettingsKey.touchOffsetPosture.rawValue, store: SharedDefaults.store)
     private var posture: PostureClass = .oneThumbRight
+    @AppStorage(SettingsKey.swipeBiasEnabled.rawValue, store: SharedDefaults.store)
+    private var swipeEnabled = false
     @State private var snapshot: TouchOffsetSnapshot = .empty(schemaVersion: TouchOffsetStore.currentSchemaVersion)
+    @State private var swipeSnapshot: SwipeBiasSnapshot = .empty(schemaVersion: SwipeBiasStore.currentSchemaVersion)
     @State private var showResetDialog = false
 
     private let store = TouchOffsetStore(defaults: SharedDefaults.store)
+    private let swipeStore = SwipeBiasStore(defaults: SharedDefaults.store)
     private let telemetryStore = GestureTelemetryStore(defaults: SharedDefaults.store)
     private let arrangement = StandardArrangements.grid3x3[.portrait]
 
@@ -40,6 +44,10 @@ struct TouchOffsetSettingsView: View {
         regimeKeys.values.reduce(0) { $0 + $1.count }
     }
 
+    private var totalSwipeSamples: Int {
+        (swipeSnapshot.regimes[regime.key] ?? [:]).values.reduce(0) { $0 + $1.count }
+    }
+
     var body: some View {
         Form {
             Section {
@@ -53,6 +61,16 @@ struct TouchOffsetSettingsView: View {
                     "Learns where you tend to tap each key and quietly adjusts the touch targets to match. Everything is learned **on this device** and never leaves it."
                 )
                 // swiftlint:enable line_length
+            }
+
+            Section {
+                Toggle("Correct my swipes", isOn: $swipeEnabled)
+            } footer: {
+                Text(("Learns the angle your swipes tend to drift by and compensates it, "
+                        + "so a swipe near a direction boundary lands in the direction you meant. ")
+                    + (totalSwipeSamples > 0
+                        ? "\(totalSwipeSamples) swipes learned for this posture."
+                        : "No swipe data yet for this posture."))
             }
 
             Section {
@@ -100,9 +118,10 @@ struct TouchOffsetSettingsView: View {
             Section {
                 Button("Reset this posture", role: .destructive) {
                     store.reset(regimeKey: regime.key)
+                    swipeStore.reset(regimeKey: regime.key)
                     reload()
                 }
-                .disabled(totalSamples == 0)
+                .disabled(totalSamples == 0 && totalSwipeSamples == 0)
                 Button("Reset everything", role: .destructive) {
                     showResetDialog = true
                 }
@@ -114,6 +133,7 @@ struct TouchOffsetSettingsView: View {
         .confirmationDialog("Reset all learned corrections?", isPresented: $showResetDialog, titleVisibility: .visible) {
             Button("Reset everything", role: .destructive) {
                 store.resetAll()
+                swipeStore.resetAll()
                 telemetryStore.reset()
                 reload()
             }
@@ -131,6 +151,7 @@ struct TouchOffsetSettingsView: View {
 
     private func reload() {
         snapshot = store.load()
+        swipeSnapshot = swipeStore.load()
     }
 }
 

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -158,12 +158,15 @@ final class KeyboardViewModel: ObservableObject {
     private var userDefaultsObserver: NSObjectProtocol?
     private var settingsCancellables = Set<AnyCancellable>()
 
-    /// Learns and (P7) applies per-key touch-offset correction (spec §4.1, §5).
-    /// Inert unless the feature toggle is on. Lazy so its closures can capture
-    /// `self` after initialization.
+    /// Learns and (P7) applies per-key touch-offset correction (spec §4.1, §5)
+    /// and per-sector swipe bias (§14). Each track is inert unless its feature
+    /// toggle is on. Lazy so its closures can capture `self` after
+    /// initialization.
     lazy var touchLearning: TouchLearningController = .init(
         store: TouchOffsetStore(defaults: sharedDefaults),
+        swipeStore: SwipeBiasStore(defaults: sharedDefaults),
         isEnabled: { [weak self] in self?.isTouchOffsetEnabled ?? false },
+        isSwipeBiasEnabled: { [weak self] in self?.isSwipeBiasEnabled ?? false },
         currentRegime: { [weak self] in
             self?.currentTouchRegime ?? TouchRegime(orientation: .portrait, posture: .twoThumb)
         },

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -345,6 +345,22 @@ extension KeyboardViewModel {
         return model.allOffsets()
     }
 
+    /// Whether the learned swipe-sector bias correction is enabled (§14.4).
+    var isSwipeBiasEnabled: Bool {
+        sharedDefaults.bool(forKey: SettingsKey.swipeBiasEnabled.rawValue)
+    }
+
+    /// Re-maps a directional swipe through the learned angular-bias rotation
+    /// (§14.3): the measured angle minus the measured sector's bias, looked up
+    /// again. Identity for non-swipes, missing features, a disabled toggle, or
+    /// an immature regime.
+    func correctedSwipeGesture(_ gesture: GestureType, features: GestureFeatures?) -> GestureType {
+        guard gesture.isDirectionalSwipe, let features, isSwipeBiasEnabled else { return gesture }
+        let model = touchLearning.swipeModel(for: currentTouchRegime)
+        guard model.maturity >= model.config.applyOn else { return gesture }
+        return model.correctedGesture(measuredAngle: features.maxDisplacementAngle)
+    }
+
     /// Normalized center position of a key in the current arrangement (`[0,1]²`),
     /// used as the reach-surface input (§5.2). `nil` if the key is not placed.
     func normalizedKeyPosition(_ keyId: String) -> CGPoint? {
@@ -383,6 +399,11 @@ extension KeyboardViewModel {
     ) -> Bool {
         guard let mode = activeModeFromDefinition else { return false }
 
+        // Swipe-sector bias correction (§14.3): rotate the measured angle by
+        // the learned bias and re-map the sector before resolving, so telemetry
+        // and dispatch both see the corrected direction.
+        let gesture = correctedSwipeGesture(gesture, features: features)
+
         // Telemetry (§13) + A/B proxy metric (§8): record every classified
         // gesture (all classes, incl. circular below).
         telemetry.recordGesture(gesture, isReturn: isReturn, features: features)
@@ -397,8 +418,8 @@ extension KeyboardViewModel {
         guard let binding = chain?.resolve(keyId: keyId, gesture: gesture, in: mode) else { return false }
 
         // Touch-offset learning (§4.1): record real taps (with a touchdown) for
-        // the acceptance filter. Swipes/returns are excluded; user deletes are
-        // observed by TouchLearningMiddleware. Inert unless the feature is on.
+        // the acceptance filter. User deletes are observed by
+        // TouchLearningMiddleware. Inert unless the feature is on.
         if gesture == .tap, !isReturn, let touchdown {
             touchLearning.recordTap(keyId: keyId, touchdown: touchdown)
             // Counterfactual benefit (§8): did the applied correction change which
@@ -410,6 +431,16 @@ extension KeyboardViewModel {
                     isFlip: TelemetryController.isFlip(touchdown: touchdown, offset: offset)
                 )
             }
+        }
+
+        // Swipe-bias learning (§14.1): the resolved sector is the intent label;
+        // the sample is the raw angle's residual against it. Return swipes share
+        // the sector semantics, so they are learned too. Inert unless enabled.
+        if gesture.isDirectionalSwipe, let features {
+            touchLearning.recordSwipe(
+                sector: gesture,
+                measuredAngle: Double(features.maxDisplacementAngle)
+            )
         }
 
         // Mode and language switches bypass the pipeline, so their

--- a/wurstfingerKeyboard/Runtime/TouchModel/AcceptanceTracker.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/AcceptanceTracker.swift
@@ -2,12 +2,16 @@
 //  AcceptanceTracker.swift
 //  Wurstfinger
 //
-//  Self-labeling acceptance filter (spec §4.1): holds recently committed taps
-//  in a small veto window. A user delete vetoes the most recent pending tap(s)
-//  (immediate + short-burst correction); taps that age out of the window are
-//  "accepted" and returned for learning. Only user deletes (the `.deleteBackward`
-//  KeyAction in the pipeline) reach this — compose/Telex internal deletes bypass
-//  the pipeline and are correctly ignored.
+//  Self-labeling acceptance filter (spec §4.1): holds recently committed
+//  samples in a small veto window. A user delete vetoes the most recent pending
+//  sample(s) (immediate + short-burst correction); samples that age out of the
+//  window are "accepted" and returned for learning. Only user deletes (the
+//  `.deleteBackward` KeyAction in the pipeline) reach this — compose/Telex
+//  internal deletes bypass the pipeline and are correctly ignored.
+//
+//  Taps (§4.1) and directional swipes (§14.1) share **one** window so a delete
+//  vetoes the most recent commit regardless of kind — a delete after
+//  tap-then-swipe must not veto the innocent tap.
 //
 
 import CoreGraphics
@@ -21,21 +25,38 @@ struct PendingTap: Equatable {
     let regime: TouchRegime
 }
 
-/// Ring of pending taps with a veto window. Not thread-safe (main-thread use).
-final class AcceptanceTracker {
-    /// How many of the most recent taps remain vetoable. Older taps are
-    /// confirmed (returned for learning) on the next tap.
+/// A committed directional swipe awaiting acceptance confirmation (§14.1).
+struct PendingSwipe: Equatable {
+    /// The final classified sector — the intent label under self-labeling.
+    let sector: GestureType
+    /// Angular residual `measuredAngle − sectorCenter(sector)`, radians,
+    /// wrapped to (−π, π]. Measured from the *raw* angle so the learned mean
+    /// stays the raw bias even while a correction is being applied.
+    let residual: Double
+    let regime: TouchRegime
+}
+
+/// A committed sample of either kind, sharing the acceptance window.
+enum PendingSample: Equatable {
+    case tap(PendingTap)
+    case swipe(PendingSwipe)
+}
+
+/// Ring of pending samples with a veto window. Not thread-safe (main-thread use).
+final class AcceptanceTracker<Sample> {
+    /// How many of the most recent samples remain vetoable. Older samples are
+    /// confirmed (returned for learning) on the next record.
     private let window: Int
-    private var pending: [PendingTap] = []
+    private var pending: [Sample] = []
 
     init(window: Int = 3) {
         self.window = max(1, window)
     }
 
-    /// Records a tap and returns any taps that just aged out of the veto window
-    /// (now accepted → learn them).
-    func recordTap(_ tap: PendingTap) -> [PendingTap] {
-        pending.append(tap)
+    /// Records a sample and returns any samples that just aged out of the veto
+    /// window (now accepted → learn them).
+    func record(_ sample: Sample) -> [Sample] {
+        pending.append(sample)
         guard pending.count > window else { return [] }
         let overflow = pending.count - window
         let confirmed = Array(pending.prefix(overflow))
@@ -43,19 +64,19 @@ final class AcceptanceTracker {
         return confirmed
     }
 
-    /// A user delete: veto the most recent `count` pending taps (a burst deletes
-    /// several). They were corrected, so they are never learned.
+    /// A user delete: veto the most recent `count` pending samples (a burst
+    /// deletes several). They were corrected, so they are never learned.
     func recordUserDelete(count: Int = 1) {
         pending.removeLast(min(max(count, 0), pending.count))
     }
 
     /// Confirms and returns everything still pending (e.g. on teardown).
-    func flush() -> [PendingTap] {
+    func flush() -> [Sample] {
         defer { pending.removeAll() }
         return pending
     }
 
-    /// Number of taps currently awaiting confirmation (for tests/diagnostics).
+    /// Number of samples currently awaiting confirmation (for tests/diagnostics).
     var pendingCount: Int {
         pending.count
     }

--- a/wurstfingerKeyboard/Runtime/TouchModel/RunningOffset.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/RunningOffset.swift
@@ -10,6 +10,22 @@
 
 import Foundation
 
+/// The estimator hyperparameters `RunningOffset` needs. Shared by the 2D
+/// touch-offset model (samples in pitch fractions) and the swipe-bias model
+/// (samples in radians) — the estimator itself is unit-agnostic.
+protocol RunningEstimatorConfig {
+    /// Plasticity cap: above this the running mean behaves like an EMA.
+    var nMax: Int { get }
+    /// Huber clip factor (× spread): bounds a single sample's influence.
+    var huberC: Double { get }
+    /// Outlier-gate threshold (× spread); rejects samples beyond it after warmup.
+    var kGate: Double { get }
+    /// EW-MAD rate for the robust spread estimate.
+    var betaMad: Double { get }
+    /// Samples before the variance-based outlier gate becomes active.
+    var warmup: Int { get }
+}
+
 /// One axis (x or y) of a key's offset estimate, in key-pitch fractions.
 struct RunningOffset: Codable, Equatable {
     /// Bounded-influence running mean of the offset (`m_k`).
@@ -30,7 +46,7 @@ struct RunningOffset: Codable, Equatable {
     /// - Returns: `true` if the sample was used, `false` if rejected by the
     ///   variance outlier gate (only active after `warmup`).
     @discardableResult
-    mutating func update(sample s: Double, config: TouchOffsetConfig) -> Bool {
+    mutating func update(sample s: Double, config: some RunningEstimatorConfig) -> Bool {
         // Variance outlier gate — only after enough samples for a stable spread.
         if count >= config.warmup, abs(s - mean) > config.kGate * spread {
             return false

--- a/wurstfingerKeyboard/Runtime/TouchModel/SwipeBiasConfig.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/SwipeBiasConfig.swift
@@ -1,0 +1,51 @@
+//
+//  SwipeBiasConfig.swift
+//  Wurstfinger
+//
+//  Hyperparameters for the swipe-sector bias model (spec §14). All angular
+//  quantities are in **radians**. Defaults are starting values; final tuning
+//  happens on device (§10).
+//
+
+import Foundation
+
+struct SwipeBiasConfig: Equatable, RunningEstimatorConfig {
+    // MARK: Estimator (shared shape with §4.2 Step 1)
+
+    /// Plasticity cap: above this the running mean behaves like an EMA with
+    /// α = 1/nMax (recency / self-healing), decoupled from shrinkage.
+    let nMax: Int
+    /// Huber clip factor (× spread): bounds a single sample's influence.
+    let huberC: Double
+    /// Outlier-gate threshold (× spread); rejects samples beyond it after warmup.
+    let kGate: Double
+    /// EW-MAD rate for the robust spread estimate.
+    let betaMad: Double
+    /// Samples before the variance-based outlier gate becomes active.
+    let warmup: Int
+    /// Initial robust spread of the angular residual (≈ 12°).
+    let spreadPrior: Double
+
+    // MARK: Shrinkage & application (§14.2)
+
+    /// Shrinkage strength (prior pseudo-counts): a sector needs ≈ κ samples to
+    /// be half-trusted vs. the regime-global bias.
+    let kappa: Double
+    /// Max magnitude of the applied rotation — kept well below the 22.5°
+    /// half-sector width so the one-step sector lookup stays valid (§14.3).
+    let clampRadians: Double
+    /// Regime maturity (Σ n_s) at which the rotation starts being applied.
+    let applyOn: Int
+
+    static let `default` = SwipeBiasConfig(
+        nMax: 150,
+        huberC: 2.0,
+        kGate: 3.5,
+        betaMad: 0.05,
+        warmup: 8,
+        spreadPrior: 12 * .pi / 180,
+        kappa: 8.0,
+        clampRadians: 15 * .pi / 180,
+        applyOn: 16
+    )
+}

--- a/wurstfingerKeyboard/Runtime/TouchModel/SwipeBiasModel.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/SwipeBiasModel.swift
@@ -1,0 +1,131 @@
+//
+//  SwipeBiasModel.swift
+//  Wurstfinger
+//
+//  Per-regime Empirical-Bayes model of the systematic **angular bias** of
+//  directional swipes (spec §14). Analogous to `TouchOffsetModel`, but 1D and
+//  per swipe *sector* instead of per key: an accepted swipe's classified sector
+//  is its intent label (§4.1 self-labeling), and the sample is the angular
+//  residual `measuredAngle − sectorCenter`. The applied correction rotates the
+//  measured angle by the learned bias before the sector lookup, recentering
+//  swipes in their sectors and rescuing near-boundary misses.
+//
+//  Residuals live in (−22.5°, 22.5°] plus a clamped correction — far from the
+//  ±180° wrap — so plain (non-circular) means are exact.
+//
+
+import CoreGraphics
+import Foundation
+
+// MARK: - Sector geometry
+
+extension GestureType {
+    /// The eight directional swipe types, ordered by sector center angle in the
+    /// classifier's coordinate system (`atan2`, y down): index × 45°, starting
+    /// at 0° = right. Matches `KeyGestureRecognizer.angleToGestureType`.
+    static let directionalSwipes: [GestureType] = [
+        .swipeRight, .swipeDownRight, .swipeDown, .swipeDownLeft,
+        .swipeLeft, .swipeUpLeft, .swipeUp, .swipeUpRight,
+    ]
+
+    var isDirectionalSwipe: Bool {
+        Self.directionalSwipes.contains(self)
+    }
+
+    /// Center angle of this swipe's 45° sector, radians in [0, 2π).
+    /// `nil` for non-directional gesture types.
+    var sectorCenterAngle: Double? {
+        guard let index = Self.directionalSwipes.firstIndex(of: self) else { return nil }
+        return Double(index) * .pi / 4
+    }
+}
+
+// MARK: - Model
+
+struct SwipeBiasModel {
+    let regime: TouchRegime
+    let config: SwipeBiasConfig
+    /// `GestureType.rawValue` of the sector → running residual estimate.
+    private(set) var sectors: [String: RunningOffset]
+
+    init(regime: TouchRegime, config: SwipeBiasConfig = .default, sectors: [String: RunningOffset] = [:]) {
+        self.regime = regime
+        self.config = config
+        self.sectors = sectors
+    }
+
+    // MARK: - Angle helpers
+
+    /// Wraps an angle to (−π, π].
+    static func wrappedAngle(_ angle: Double) -> Double {
+        var a = angle.truncatingRemainder(dividingBy: 2 * .pi)
+        if a <= -.pi { a += 2 * .pi }
+        if a > .pi { a -= 2 * .pi }
+        return a
+    }
+
+    /// Angular residual of a measured swipe angle relative to `sector`'s center,
+    /// wrapped to (−π, π]. `nil` for non-directional sectors.
+    static func residual(measuredAngle: Double, sector: GestureType) -> Double? {
+        guard let center = sector.sectorCenterAngle else { return nil }
+        return wrappedAngle(measuredAngle - center)
+    }
+
+    // MARK: - Learning (§14.1)
+
+    /// Folds one accepted swipe's angular residual into the model.
+    mutating func learn(sector: GestureType, residual: Double) {
+        guard sector.isDirectionalSwipe else { return }
+        var state = sectors[sector.rawValue] ?? RunningOffset(spreadPrior: config.spreadPrior)
+        state.update(sample: residual, config: config)
+        sectors[sector.rawValue] = state
+    }
+
+    /// Regime maturity (Σ per-sector counts) — drives the apply gate.
+    var maturity: Int {
+        sectors.values.reduce(0) { $0 + $1.count }
+    }
+
+    // MARK: - Application (§14.2 / §14.3)
+
+    /// Count-weighted mean residual across all sectors — the shrinkage prior.
+    /// A user's global "rotation" shows up here first, so sparse sectors borrow
+    /// strength from well-sampled ones.
+    var globalBias: Double {
+        let total = sectors.values.reduce(0) { $0 + $1.count }
+        guard total > 0 else { return 0 }
+        let weighted = sectors.values.reduce(0.0) { $0 + $1.mean * Double($1.count) }
+        return weighted / Double(total)
+    }
+
+    /// The clamped angular bias to subtract for `sector`: the per-sector mean
+    /// shrunk toward the regime-global bias by κ pseudo-counts.
+    func bias(for sector: GestureType) -> Double {
+        let g = globalBias
+        let raw: Double
+        if let state = sectors[sector.rawValue] {
+            let n = Double(state.count)
+            raw = g + (state.mean - g) * n / (n + config.kappa)
+        } else {
+            raw = g
+        }
+        return clamp(raw, -config.clampRadians, config.clampRadians)
+    }
+
+    /// Rotates a measured swipe angle by the learned bias and returns the
+    /// corrected sector. The bias of the *measured* sector is used; since the
+    /// correction is clamped well below the 22.5° half-sector width, a single
+    /// lookup step is exact enough (§14.3). Non-directional results pass through.
+    func correctedGesture(measuredAngle: CGFloat) -> GestureType {
+        let raw = KeyGestureRecognizer.angleToGestureType(measuredAngle)
+        guard raw.isDirectionalSwipe else { return raw }
+        let corrected = measuredAngle - CGFloat(bias(for: raw))
+        return KeyGestureRecognizer.angleToGestureType(corrected)
+    }
+
+    // MARK: - Reset
+
+    mutating func reset() {
+        sectors.removeAll()
+    }
+}

--- a/wurstfingerKeyboard/Runtime/TouchModel/SwipeBiasStore.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/SwipeBiasStore.swift
@@ -1,0 +1,80 @@
+//
+//  SwipeBiasStore.swift
+//  Wurstfinger
+//
+//  Persistence for the swipe-bias model (spec §14, mirrors §7). Only aggregates
+//  are stored ({m_s, n_s, s_s} per sector, per regime) — never raw angles or
+//  trajectories (privacy). Kept in a separate payload from the touch-offset
+//  snapshot so the two models version and reset independently.
+//
+
+import Foundation
+
+/// The full persisted payload: per regime, a map of sector key → residual state.
+struct SwipeBiasSnapshot: Codable, Equatable {
+    var schemaVersion: Int
+    /// `regime.key` → (`GestureType.rawValue` → state).
+    var regimes: [String: [String: RunningOffset]]
+
+    static func empty(schemaVersion: Int) -> SwipeBiasSnapshot {
+        SwipeBiasSnapshot(schemaVersion: schemaVersion, regimes: [:])
+    }
+}
+
+/// Loads/saves the snapshot from a `UserDefaults` (production: the App-Group
+/// `SharedDefaults.store`; tests inject a throwaway suite).
+final class SwipeBiasStore {
+    static let currentSchemaVersion = 1
+    static let storageKey = "swipeBias.snapshot"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    /// Loads the snapshot, or an empty one if absent / schema-incompatible /
+    /// corrupt (the schema bump invalidates everything at once).
+    func load() -> SwipeBiasSnapshot {
+        guard
+            let data = defaults.data(forKey: Self.storageKey),
+            let snapshot = try? JSONDecoder().decode(SwipeBiasSnapshot.self, from: data),
+            snapshot.schemaVersion == Self.currentSchemaVersion
+        else {
+            return .empty(schemaVersion: Self.currentSchemaVersion)
+        }
+        return snapshot
+    }
+
+    /// Persists the snapshot (stamping the current schema version).
+    func save(_ snapshot: SwipeBiasSnapshot) {
+        var stamped = snapshot
+        stamped.schemaVersion = Self.currentSchemaVersion
+        guard let data = try? JSONEncoder().encode(stamped) else { return }
+        defaults.set(data, forKey: Self.storageKey)
+    }
+
+    /// Clears all learned bias ("reset all").
+    func resetAll() {
+        defaults.removeObject(forKey: Self.storageKey)
+    }
+
+    /// Clears one regime ("reset current regime"), keeping the rest.
+    func reset(regimeKey: String) {
+        var snapshot = load()
+        snapshot.regimes[regimeKey] = nil
+        save(snapshot)
+    }
+}
+
+extension SwipeBiasModel {
+    /// Builds a model for `regime` from a persisted snapshot.
+    init(regime: TouchRegime, config: SwipeBiasConfig = .default, snapshot: SwipeBiasSnapshot) {
+        self.init(regime: regime, config: config, sectors: snapshot.regimes[regime.key] ?? [:])
+    }
+
+    /// The persistable per-sector states for this regime.
+    var persistableSectors: [String: RunningOffset] {
+        sectors
+    }
+}

--- a/wurstfingerKeyboard/Runtime/TouchModel/TelemetryController.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/TelemetryController.swift
@@ -68,6 +68,17 @@ final class TelemetryController {
                 stat.add(value)
                 telemetry.features[name] = stat
             }
+            // §14.5: per-sector angular residual of directional swipes — a mean
+            // clearly ≠ 0 reveals a systematic bias the rotation can correct;
+            // a near-zero mean with high spread says the misses are variance.
+            if let residual = SwipeBiasModel.residual(
+                measuredAngle: Double(features.maxDisplacementAngle),
+                sector: gesture
+            ) {
+                var stat = telemetry.features["sectorResidual"] ?? FeatureStat()
+                stat.add(residual)
+                telemetry.features["sectorResidual"] = stat
+            }
         }
         classes[cls] = telemetry
         snapshot.classes[regimeKey] = classes

--- a/wurstfingerKeyboard/Runtime/TouchModel/TouchLearningController.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/TouchLearningController.swift
@@ -2,12 +2,13 @@
 //  TouchLearningController.swift
 //  Wurstfinger
 //
-//  Orchestrates touch-offset learning (spec §4.1, §5): records taps with their
-//  touchdown, applies the acceptance filter (veto on user delete) and the
-//  interior gate, computes the sample `e = touchdown − center` and folds it into
-//  the per-regime model, persisting periodically. Inert unless the feature is
-//  enabled. Regime, key position and enabled-state are injected so the
-//  controller is testable without a view model.
+//  Orchestrates touch learning (spec §4.1, §5, §14): records taps with their
+//  touchdown and directional swipes with their angular residual, applies the
+//  shared acceptance filter (veto on user delete), computes the samples and
+//  folds them into the per-regime models (offset per key, bias per sector),
+//  persisting periodically. Each track is inert unless its feature is enabled.
+//  Regime, key position and enabled-states are injected so the controller is
+//  testable without a view model.
 //
 
 import CoreGraphics
@@ -15,15 +16,20 @@ import Foundation
 
 final class TouchLearningController {
     private let store: TouchOffsetStore
+    private let swipeStore: SwipeBiasStore
     private let config: TouchOffsetConfig
-    private let tracker: AcceptanceTracker
+    private let swipeConfig: SwipeBiasConfig
+    private let tracker: AcceptanceTracker<PendingSample>
     private let saveEvery: Int
 
     /// In-memory model state (persisted debounced). `private(set)` for tests.
     private(set) var snapshot: TouchOffsetSnapshot
+    private(set) var swipeSnapshot: SwipeBiasSnapshot
 
-    /// Master toggle (§6.1) — learning is inert when this returns `false`.
+    /// Master toggle for tap-offset learning (§6.1) — inert when `false`.
     var isEnabled: () -> Bool
+    /// Toggle for swipe-bias learning (§14.4) — inert when `false`.
+    var isSwipeBiasEnabled: () -> Bool
     /// The active regime at the moment of a tap.
     var currentRegime: () -> TouchRegime
     /// Normalized key position in the keyboard `[0,1]²` (surface-fit input);
@@ -34,19 +40,26 @@ final class TouchLearningController {
 
     init(
         store: TouchOffsetStore,
+        swipeStore: SwipeBiasStore,
         config: TouchOffsetConfig = .default,
+        swipeConfig: SwipeBiasConfig = .default,
         window: Int = 3,
         saveEvery: Int = 8,
         isEnabled: @escaping () -> Bool,
+        isSwipeBiasEnabled: @escaping () -> Bool = { false },
         currentRegime: @escaping () -> TouchRegime,
         keyPosition: @escaping (String) -> CGPoint?
     ) {
         self.store = store
+        self.swipeStore = swipeStore
         self.config = config
+        self.swipeConfig = swipeConfig
         tracker = AcceptanceTracker(window: window)
         self.saveEvery = saveEvery
         snapshot = store.load()
+        swipeSnapshot = swipeStore.load()
         self.isEnabled = isEnabled
+        self.isSwipeBiasEnabled = isSwipeBiasEnabled
         self.currentRegime = currentRegime
         self.keyPosition = keyPosition
     }
@@ -56,16 +69,36 @@ final class TouchLearningController {
     /// Records an accepted-so-far tap (a non-slide tap with a touchdown).
     func recordTap(keyId: String, touchdown: CGPoint) {
         guard isEnabled() else { return }
-        let confirmed = tracker.recordTap(
+        confirm(tracker.record(.tap(
             PendingTap(keyId: keyId, touchdown: touchdown, regime: currentRegime())
-        )
-        confirmed.forEach(learn)
+        )))
     }
 
-    /// A user delete (`.deleteBackward` in the pipeline) — vetoes recent taps.
+    /// Records an accepted-so-far directional swipe (§14.1). The residual is
+    /// computed from the *raw* measured angle against the final sector's center
+    /// so the learned mean estimates the uncorrected bias.
+    func recordSwipe(sector: GestureType, measuredAngle: Double) {
+        guard isSwipeBiasEnabled(),
+              let residual = SwipeBiasModel.residual(measuredAngle: measuredAngle, sector: sector)
+        else { return }
+        confirm(tracker.record(.swipe(
+            PendingSwipe(sector: sector, residual: residual, regime: currentRegime())
+        )))
+    }
+
+    /// A user delete (`.deleteBackward` in the pipeline) — vetoes recent samples.
     func recordUserDelete() {
-        guard isEnabled() else { return }
+        guard isEnabled() || isSwipeBiasEnabled() else { return }
         tracker.recordUserDelete()
+    }
+
+    private func confirm(_ samples: [PendingSample]) {
+        for sample in samples {
+            switch sample {
+            case let .tap(tap): learn(tap)
+            case let .swipe(swipe): learn(swipe)
+            }
+        }
     }
 
     // MARK: - Model access (for UI / P7 application)
@@ -74,20 +107,29 @@ final class TouchLearningController {
         TouchOffsetModel(regime: regime, config: config, keys: snapshot.regimes[regime.key] ?? [:])
     }
 
+    func swipeModel(for regime: TouchRegime) -> SwipeBiasModel {
+        SwipeBiasModel(regime: regime, config: swipeConfig, sectors: swipeSnapshot.regimes[regime.key] ?? [:])
+    }
+
     func resetAll() {
         snapshot = .empty(schemaVersion: TouchOffsetStore.currentSchemaVersion)
+        swipeSnapshot = .empty(schemaVersion: SwipeBiasStore.currentSchemaVersion)
         store.resetAll()
+        swipeStore.resetAll()
         dirtyCount = 0
     }
 
     func reset(regime: TouchRegime) {
         snapshot.regimes[regime.key] = nil
+        swipeSnapshot.regimes[regime.key] = nil
         store.reset(regimeKey: regime.key)
+        swipeStore.reset(regimeKey: regime.key)
     }
 
     /// Forces a persist (call on background/teardown).
     func persist() {
         store.save(snapshot)
+        swipeStore.save(swipeSnapshot)
         dirtyCount = 0
     }
 
@@ -115,7 +157,17 @@ final class TouchLearningController {
             sampleY: ey
         )
         snapshot.regimes[tap.regime.key] = model.persistableKeys
+        markDirty()
+    }
 
+    private func learn(_ swipe: PendingSwipe) {
+        var model = swipeModel(for: swipe.regime)
+        model.learn(sector: swipe.sector, residual: swipe.residual)
+        swipeSnapshot.regimes[swipe.regime.key] = model.persistableSectors
+        markDirty()
+    }
+
+    private func markDirty() {
         dirtyCount += 1
         if dirtyCount >= saveEvery { persist() }
     }

--- a/wurstfingerKeyboard/Runtime/TouchModel/TouchOffsetConfig.swift
+++ b/wurstfingerKeyboard/Runtime/TouchModel/TouchOffsetConfig.swift
@@ -9,7 +9,7 @@
 
 import Foundation
 
-struct TouchOffsetConfig: Equatable {
+struct TouchOffsetConfig: Equatable, RunningEstimatorConfig {
     // MARK: Estimator (§4.2 Step 1)
 
     /// Plasticity cap: above this the running mean behaves like an EMA with

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -69,6 +69,9 @@ enum SettingsKey: String, CaseIterable {
     /// Schema version of the persisted touch-offset model; bump invalidates
     /// incompatible stored state. See §7.
     case touchModelSchemaVersion
+    /// Toggle for the learned swipe-sector bias correction (default off).
+    /// See `docs/touch-offset-correction.md` §14.
+    case swipeBiasEnabled
 }
 
 // MARK: - Haptic Settings

--- a/wurstfingerTests/SwipeBiasModelTests.swift
+++ b/wurstfingerTests/SwipeBiasModelTests.swift
@@ -1,0 +1,168 @@
+//
+//  SwipeBiasModelTests.swift
+//  WurstfingerTests
+//
+//  Tests for the swipe-sector bias model (spec §14): sector geometry consistency
+//  with the classifier, angle wrapping, learning/shrinkage/clamping, and the
+//  corrected sector lookup.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct SwipeSectorGeometryTests {
+    /// Every sector's center angle must map back to that sector through the
+    /// classifier — pins `sectorCenterAngle` to `angleToGestureType`.
+    @Test func sectorCentersMatchClassifier() throws {
+        for sector in GestureType.directionalSwipes {
+            let center = try #require(sector.sectorCenterAngle)
+            #expect(KeyGestureRecognizer.angleToGestureType(CGFloat(center)) == sector)
+            // Just inside both sector boundaries too (±22.5° − ε).
+            let halfWidth = Double.pi / 8 - 0.001
+            #expect(KeyGestureRecognizer.angleToGestureType(CGFloat(center + halfWidth)) == sector)
+            #expect(KeyGestureRecognizer.angleToGestureType(CGFloat(center - halfWidth)) == sector)
+        }
+    }
+
+    @Test func nonDirectionalTypesHaveNoSector() {
+        #expect(GestureType.tap.sectorCenterAngle == nil)
+        #expect(GestureType.circularClockwise.sectorCenterAngle == nil)
+        #expect(GestureType.longPress.sectorCenterAngle == nil)
+        #expect(!GestureType.tap.isDirectionalSwipe)
+        #expect(GestureType.swipeUpLeft.isDirectionalSwipe)
+    }
+
+    @Test func wrappedAngleStaysInHalfOpenPi() {
+        #expect(abs(SwipeBiasModel.wrappedAngle(3 * .pi) - .pi) < 1e-9)
+        #expect(abs(SwipeBiasModel.wrappedAngle(-2 * .pi)) < 1e-9)
+        #expect(abs(SwipeBiasModel.wrappedAngle(0.3) - 0.3) < 1e-9)
+        #expect(SwipeBiasModel.wrappedAngle(-.pi) == .pi)
+    }
+
+    /// `atan2` yields swipe-up angles near −π/2 while the sector center lives at
+    /// 3π/2 — the residual must wrap that distinction away.
+    @Test func residualWrapsAcrossRepresentations() throws {
+        let zero = try #require(SwipeBiasModel.residual(measuredAngle: -.pi / 2, sector: .swipeUp))
+        #expect(abs(zero) < 1e-9)
+        let drift = try #require(SwipeBiasModel.residual(measuredAngle: -.pi / 2 + 0.15, sector: .swipeUp))
+        #expect(abs(drift - 0.15) < 1e-9)
+        #expect(SwipeBiasModel.residual(measuredAngle: 0, sector: .tap) == nil)
+    }
+}
+
+struct SwipeBiasModelTests {
+    private let regime = TouchRegime(orientation: .portrait, posture: .oneThumbRight)
+
+    private func learnedModel(sector: GestureType, residual: Double, count: Int) -> SwipeBiasModel {
+        var model = SwipeBiasModel(regime: regime)
+        for _ in 0 ..< count {
+            model.learn(sector: sector, residual: residual)
+        }
+        return model
+    }
+
+    @Test func learnsConstantResidualExactly() {
+        let model = learnedModel(sector: .swipeRight, residual: 0.15, count: 40)
+        #expect(abs(model.bias(for: .swipeRight) - 0.15) < 0.01)
+        #expect(model.maturity == 40)
+    }
+
+    @Test func biasIsClampedBelowHalfSector() {
+        // A huge (implausible) bias must never exceed the clamp, which itself
+        // stays below the 22.5° half-sector width.
+        let model = learnedModel(sector: .swipeRight, residual: 0.45, count: 200)
+        let bias = model.bias(for: .swipeRight)
+        #expect(bias <= SwipeBiasConfig.default.clampRadians + 1e-9)
+        #expect(SwipeBiasConfig.default.clampRadians < .pi / 8)
+    }
+
+    /// An unseen sector borrows the regime-global bias (shrinkage prior) —
+    /// a user's overall rotation transfers to sparsely used directions.
+    @Test func unseenSectorBorrowsGlobalBias() {
+        let model = learnedModel(sector: .swipeRight, residual: 0.2, count: 100)
+        #expect(abs(model.bias(for: .swipeUp) - 0.2) < 0.02)
+    }
+
+    /// A well-sampled sector overrules a conflicting global mean as counts grow.
+    @Test func sectorMeanDominatesWithEnoughSamples() {
+        var model = learnedModel(sector: .swipeRight, residual: 0.2, count: 100)
+        for _ in 0 ..< 100 {
+            model.learn(sector: .swipeLeft, residual: -0.2)
+        }
+        // Global mean ≈ 0, but each sector sticks near its own residual.
+        #expect(model.bias(for: .swipeRight) > 0.15)
+        #expect(model.bias(for: .swipeLeft) < -0.15)
+    }
+
+    @Test func correctedGestureRescuesBoundaryMiss() {
+        // Learned: swipes drift ~+12° clockwise (y-down: toward down-right).
+        let model = learnedModel(sector: .swipeRight, residual: 12 * .pi / 180, count: 40)
+        // A right-swipe measured at 25° lands in the down-right sector raw…
+        let measured = CGFloat(25 * Double.pi / 180)
+        #expect(KeyGestureRecognizer.angleToGestureType(measured) == .swipeDownRight)
+        // …but the rotation pulls it back into the intended sector.
+        #expect(model.correctedGesture(measuredAngle: measured) == .swipeRight)
+    }
+
+    @Test func correctedGestureIsIdentityWithoutData() {
+        let model = SwipeBiasModel(regime: regime)
+        for sector in GestureType.directionalSwipes {
+            let center = CGFloat(sector.sectorCenterAngle ?? 0)
+            #expect(model.correctedGesture(measuredAngle: center) == sector)
+        }
+    }
+
+    @Test func resetClearsAllSectors() {
+        var model = learnedModel(sector: .swipeRight, residual: 0.2, count: 20)
+        model.reset()
+        #expect(model.maturity == 0)
+        #expect(abs(model.bias(for: .swipeRight)) < 1e-9)
+    }
+}
+
+struct SwipeBiasStoreTests {
+    private let regime = TouchRegime(orientation: .portrait, posture: .twoThumb)
+
+    private func freshDefaults(_ suite: String) -> UserDefaults {
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        return d
+    }
+
+    @Test func roundTripsSnapshot() {
+        let d = freshDefaults("test.swipebias.roundtrip")
+        let store = SwipeBiasStore(defaults: d)
+
+        var model = SwipeBiasModel(regime: regime)
+        for _ in 0 ..< 20 {
+            model.learn(sector: .swipeDown, residual: 0.1)
+        }
+        var snapshot = SwipeBiasSnapshot.empty(schemaVersion: SwipeBiasStore.currentSchemaVersion)
+        snapshot.regimes[regime.key] = model.persistableSectors
+        store.save(snapshot)
+
+        let reloaded = SwipeBiasModel(regime: regime, snapshot: store.load())
+        #expect(abs(reloaded.bias(for: .swipeDown) - model.bias(for: .swipeDown)) < 1e-9)
+        #expect(reloaded.maturity == 20)
+    }
+
+    @Test func resetRegimeKeepsOthers() {
+        let d = freshDefaults("test.swipebias.reset")
+        let store = SwipeBiasStore(defaults: d)
+        let other = TouchRegime(orientation: .portrait, posture: .oneThumbLeft)
+
+        var snapshot = SwipeBiasSnapshot.empty(schemaVersion: SwipeBiasStore.currentSchemaVersion)
+        var state = RunningOffset(spreadPrior: SwipeBiasConfig.default.spreadPrior)
+        state.update(sample: 0.1, config: SwipeBiasConfig.default)
+        snapshot.regimes[regime.key] = [GestureType.swipeUp.rawValue: state]
+        snapshot.regimes[other.key] = [GestureType.swipeDown.rawValue: state]
+        store.save(snapshot)
+
+        store.reset(regimeKey: regime.key)
+        let reloaded = store.load()
+        #expect(reloaded.regimes[regime.key] == nil)
+        #expect(reloaded.regimes[other.key] != nil)
+    }
+}

--- a/wurstfingerTests/TouchLearningTests.swift
+++ b/wurstfingerTests/TouchLearningTests.swift
@@ -16,53 +16,70 @@ struct AcceptanceTrackerTests {
         PendingTap(keyId: id, touchdown: CGPoint(x: 0.5, y: 0.5), regime: regime)
     }
 
+    private func swipe(_ sector: GestureType) -> PendingSwipe {
+        PendingSwipe(sector: sector, residual: 0.1, regime: regime)
+    }
+
     @Test func holdsTapsWithinWindow() {
-        let t = AcceptanceTracker(window: 2)
-        #expect(t.recordTap(tap("A")).isEmpty)
-        #expect(t.recordTap(tap("B")).isEmpty)
+        let t = AcceptanceTracker<PendingTap>(window: 2)
+        #expect(t.record(tap("A")).isEmpty)
+        #expect(t.record(tap("B")).isEmpty)
         #expect(t.pendingCount == 2)
     }
 
     @Test func confirmsOldestOnOverflow() {
-        let t = AcceptanceTracker(window: 1)
-        #expect(t.recordTap(tap("A")).isEmpty)
-        let confirmed = t.recordTap(tap("B"))
+        let t = AcceptanceTracker<PendingTap>(window: 1)
+        #expect(t.record(tap("A")).isEmpty)
+        let confirmed = t.record(tap("B"))
         #expect(confirmed.map(\.keyId) == ["A"])
     }
 
     @Test func userDeleteVetoesMostRecent() {
-        let t = AcceptanceTracker(window: 3)
-        _ = t.recordTap(tap("A"))
-        _ = t.recordTap(tap("B"))
+        let t = AcceptanceTracker<PendingTap>(window: 3)
+        _ = t.record(tap("A"))
+        _ = t.record(tap("B"))
         t.recordUserDelete()
         #expect(t.flush().map(\.keyId) == ["A"]) // B vetoed
     }
 
     @Test func burstDeleteVetoesSeveral() {
-        let t = AcceptanceTracker(window: 5)
-        ["A", "B", "C"].forEach { _ = t.recordTap(tap($0)) }
+        let t = AcceptanceTracker<PendingTap>(window: 5)
+        ["A", "B", "C"].forEach { _ = t.record(tap($0)) }
         t.recordUserDelete(count: 2)
         #expect(t.flush().map(\.keyId) == ["A"]) // B, C vetoed
+    }
+
+    /// Taps and swipes share one window (§14.1): a delete vetoes the most
+    /// recent commit regardless of kind — here the swipe, not the earlier tap.
+    @Test func mixedWindowVetoesMostRecentKind() {
+        let t = AcceptanceTracker<PendingSample>(window: 3)
+        _ = t.record(.tap(tap("A")))
+        _ = t.record(.swipe(swipe(.swipeUp)))
+        t.recordUserDelete()
+        #expect(t.flush() == [.tap(tap("A"))]) // swipe vetoed, tap survives
     }
 }
 
 struct TouchLearningControllerTests {
     private let regime = TouchRegime(orientation: .portrait, posture: .oneThumbLeft)
 
-    private func freshStore(_ suite: String) -> TouchOffsetStore {
+    private func freshDefaults(_ suite: String) -> UserDefaults {
         let d = UserDefaults(suiteName: suite)!
         d.removePersistentDomain(forName: suite)
-        return TouchOffsetStore(defaults: d)
+        return d
     }
 
     private func makeController(
-        suite: String, enabled: Bool = true, window: Int = 1
+        suite: String, enabled: Bool = true, swipeEnabled: Bool = false, window: Int = 1
     ) -> TouchLearningController {
-        TouchLearningController(
-            store: freshStore(suite),
+        let d = freshDefaults(suite)
+        return TouchLearningController(
+            store: TouchOffsetStore(defaults: d),
+            swipeStore: SwipeBiasStore(defaults: d),
             window: window,
             saveEvery: 1,
             isEnabled: { enabled },
+            isSwipeBiasEnabled: { swipeEnabled },
             currentRegime: { regime },
             keyPosition: { _ in CGPoint(x: 0.5, y: 0.5) }
         )
@@ -126,6 +143,59 @@ struct TouchLearningControllerTests {
         let reloaded = TouchOffsetModel(regime: regime, snapshot: TouchOffsetStore(defaults: d).load())
         #expect(abs(reloaded.offset(forKeyId: "A").dx - 0.15) < 0.03)
     }
+
+    // MARK: - Swipe-bias learning (§14.1)
+
+    @Test func learnsSwipeResidual() {
+        let c = makeController(suite: "test.swipe.learn", swipeEnabled: true)
+        // Swipes meant as "up" drift +0.15 rad past the sector center.
+        for _ in 0 ..< 40 {
+            c.recordSwipe(sector: .swipeUp, measuredAngle: -.pi / 2 + 0.15)
+        }
+        #expect(abs(c.swipeModel(for: regime).bias(for: .swipeUp) - 0.15) < 0.01)
+    }
+
+    @Test func swipeLearningDisabledLearnsNothing() {
+        let c = makeController(suite: "test.swipe.disabled", swipeEnabled: false)
+        for _ in 0 ..< 40 {
+            c.recordSwipe(sector: .swipeUp, measuredAngle: -.pi / 2 + 0.15)
+        }
+        #expect(c.swipeModel(for: regime).maturity == 0)
+    }
+
+    @Test func vetoedSwipeIsNotLearned() {
+        let c = makeController(suite: "test.swipe.veto", swipeEnabled: true)
+        // A swipe followed by a user delete is vetoed and never learned.
+        c.recordSwipe(sector: .swipeDown, measuredAngle: .pi / 2 + 0.2)
+        c.recordUserDelete()
+        for _ in 0 ..< 40 {
+            c.recordSwipe(sector: .swipeUp, measuredAngle: -.pi / 2 + 0.1)
+        }
+        let model = c.swipeModel(for: regime)
+        #expect(model.sectors[GestureType.swipeDown.rawValue] == nil)
+        #expect(abs(model.bias(for: .swipeUp) - 0.1) < 0.02)
+    }
+
+    @Test func swipeBiasPersistsAcrossReload() throws {
+        let suite = "test.swipe.persist"
+        let c = makeController(suite: suite, swipeEnabled: true)
+        for _ in 0 ..< 40 {
+            c.recordSwipe(sector: .swipeRight, measuredAngle: 0.12)
+        }
+        c.persist()
+        let d = try #require(UserDefaults(suiteName: suite))
+        let reloaded = SwipeBiasModel(regime: regime, snapshot: SwipeBiasStore(defaults: d).load())
+        #expect(abs(reloaded.bias(for: .swipeRight) - 0.12) < 0.01)
+    }
+
+    @Test func resetAllClearsSwipeModelToo() {
+        let c = makeController(suite: "test.swipe.resetall", swipeEnabled: true)
+        for _ in 0 ..< 40 {
+            c.recordSwipe(sector: .swipeRight, measuredAngle: 0.12)
+        }
+        c.resetAll()
+        #expect(c.swipeModel(for: regime).maturity == 0)
+    }
 }
 
 /// End-to-end through the real view model (gesture path + regime + key position).
@@ -159,6 +229,55 @@ struct TouchLearningViewModelTests {
         }
         let off = vm.touchLearning.model(for: vm.currentTouchRegime).offset(forKeyId: GridSlot.topLeft)
         #expect(magnitude(off) < 1e-9)
+    }
+
+    /// Straight-line features at `angle` (radians) — only `maxDisplacementAngle`
+    /// matters for the sector correction.
+    private func swipeFeatures(angle: Double) -> GestureFeatures {
+        GestureFeatures.extract(from: [
+            .zero,
+            CGPoint(x: 40 * cos(angle), y: 40 * sin(angle)),
+        ])
+    }
+
+    /// The swipe apply-gate (§14.3): the rotation is applied only when enabled
+    /// AND the regime has matured, and then re-maps boundary misses.
+    @Test func swipeCorrectionGateAndRemap() {
+        let (vm, _) = makeViewModel()
+        let drift = 12 * Double.pi / 180
+        let boundaryMiss = swipeFeatures(angle: 25 * Double.pi / 180)
+
+        // Off: identity even with (hypothetical) data.
+        #expect(vm.correctedSwipeGesture(.swipeDownRight, features: boundaryMiss) == .swipeDownRight)
+
+        vm.sharedDefaults.set(true, forKey: SettingsKey.swipeBiasEnabled.rawValue)
+        // Enabled but immature: still identity.
+        #expect(vm.correctedSwipeGesture(.swipeDownRight, features: boundaryMiss) == .swipeDownRight)
+
+        // Learn a consistent clockwise drift on right-swipes.
+        for _ in 0 ..< 40 {
+            vm.touchLearning.recordSwipe(sector: .swipeRight, measuredAngle: drift)
+        }
+        // Mature: the 25° measurement is pulled back into the intended sector.
+        #expect(vm.correctedSwipeGesture(.swipeDownRight, features: boundaryMiss) == .swipeRight)
+        // Non-swipes and missing features pass through untouched.
+        #expect(vm.correctedSwipeGesture(.tap, features: boundaryMiss) == .tap)
+        #expect(vm.correctedSwipeGesture(.swipeDownRight, features: nil) == .swipeDownRight)
+    }
+
+    /// The gesture path feeds swipe learning with the resolved sector (§14.1).
+    @Test func learnsFromSwipesThroughViewModel() {
+        let (vm, _) = makeViewModel()
+        vm.sharedDefaults.set(true, forKey: SettingsKey.swipeBiasEnabled.rawValue)
+        let angle = -Double.pi / 2 + 0.15
+        for _ in 0 ..< 40 {
+            vm.handleGesture(
+                .swipeUp, keyId: GridSlot.center, isReturn: false,
+                features: swipeFeatures(angle: angle)
+            )
+        }
+        let bias = vm.touchLearning.swipeModel(for: vm.currentTouchRegime).bias(for: .swipeUp)
+        #expect(abs(bias - 0.15) < 0.02)
     }
 
     /// The apply-gate (§4.4): correction is exposed only when enabled AND the


### PR DESCRIPTION
## What

Follow-up to #221, extending the learned-correction principle from tap targets to **swipe direction sectors**: swipes that consistently drift by a few degrees often land in the neighboring 45° sector. This PR learns that angular bias per sector and rotates the measured angle back before the sector lookup, rescuing near-boundary misses.

## How it works (spec §14, added in this PR)

- **Self-labeling, same as taps (§4.1):** an accepted swipe's classified sector is its intent label; the sample is the angular residual `measuredAngle − sectorCenter`, always taken from the *raw* angle so the model keeps estimating the uncorrected bias while a correction is active (no feedback drift).
- **Shared acceptance window:** taps and swipes now go through one `AcceptanceTracker<PendingSample>`, so a user delete vetoes the most recent commit regardless of kind (previously a delete after tap-then-swipe would have vetoed the innocent tap).
- **Estimator:** the same robust `RunningOffset` (Huber clip, EW-MAD outlier gate, capped plasticity) via a new `RunningEstimatorConfig` protocol — 1D in radians instead of 2D in pitch fractions. Per-sector means are EB-shrunk toward the count-weighted regime-global bias (κ pseudo-counts) and clamped to ±15°, well below the 22.5° half-sector width, so the one-step sector re-lookup stays valid.
- **Application:** purely numeric in `handleGesture`, before telemetry and resolution — no frame resizing / invisible compensation needed. Return swipes share the angle→sector mapping and are corrected and learned too.
- **Gating:** own toggle (`swipeBiasEnabled`, default off) + regime maturity (`applyOn`). Learning is inert while the toggle is off. Own store (`swipeBias.snapshot`), aggregates only; both reset paths clear it.
- **Telemetry:** a per-class `sectorResidual` stat (radians) — mean clearly ≠ 0 shows a systematic bias worth correcting; mean ≈ 0 with high spread means the misses are variance and rotation won't help.

## Testing

- New suites: `SwipeSectorGeometryTests` (sector centers pinned to `angleToGestureType`, angle wrapping), `SwipeBiasModelTests` (learning, shrinkage, clamp, boundary-miss remap), `SwipeBiasStoreTests`, plus swipe cases in `TouchLearningControllerTests` and `TouchLearningViewModelTests` (apply gate, end-to-end learning through `handleGesture`).
- All new and directly affected suites pass. ⚠️ The full `WurstfingerTests` run intermittently aborts the test runner (SIGABRT), taking out random batches of unrelated tests (0.000s failures in e.g. `Vector2DTests`); a comparison run on the base branch is in progress to determine whether this pre-exists — will follow up in a comment.

## Open / follow-ups

- Counterfactual benefit metric for swipes (analogous to §8: did the rotation flip the sector, and was the result kept?).
- Per-key refinement of the bias if the data supports it.
- On-device verification of the learned bias magnitudes and `applyOn` tuning.