### PR TITLE
Add Arabic, Persian, and Urdu keyboard layouts (RTL)

### DIFF
--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -47,6 +47,7 @@ enum GridKeyboardFactory {
         composeRuleOverrides: ComposeRuleSet? = nil,
         supportsCapitalization: Bool = true,
         numericBackToAlphaLabel: String = NumericLayouts.defaultBackToAlphaLabel,
+        numericDigits: [String] = NumericLayouts.westernDigits,
         inputMethod: InputMethodKind = .direct
     ) -> KeyboardDefinition {
         precondition(
@@ -136,7 +137,9 @@ enum GridKeyboardFactory {
         )
 
         var modes: [String: KeyboardMode] = [
-            ModeNames.numeric: NumericLayouts.phone(backToAlphaLabel: numericBackToAlphaLabel),
+            ModeNames.numeric: NumericLayouts.phone(
+                digits: numericDigits, backToAlphaLabel: numericBackToAlphaLabel
+            ),
         ]
 
         if supportsCapitalization {
@@ -177,7 +180,8 @@ enum GridKeyboardFactory {
                 composeRuleOverrides: composeRuleOverrides,
                 inputMethod: inputMethod
             ),
-            numericBackToAlphaLabel: numericBackToAlphaLabel
+            numericBackToAlphaLabel: numericBackToAlphaLabel,
+            numericDigits: numericDigits
         )
     }
 }

--- a/wurstfingerKeyboard/Definition/Language/KeyboardDefinition.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardDefinition.swift
@@ -39,6 +39,12 @@ struct KeyboardDefinition: Codable, Equatable {
     /// re-deriving the per-language label.
     let numericBackToAlphaLabel: String
 
+    /// Digit set (indexed by value 0–9) for the numeric layer. Retained on the
+    /// definition — like `numericBackToAlphaLabel` — so a numpad-style swap
+    /// rebuilds the numeric mode with the correct script digits instead of
+    /// falling back to Western ASCII. Defaults to `NumericLayouts.westernDigits`.
+    let numericDigits: [String]
+
     init(
         title: String,
         id: String,
@@ -46,7 +52,8 @@ struct KeyboardDefinition: Codable, Equatable {
         modes: [String: KeyboardMode],
         defaultMode: String,
         settings: KeyboardDefinitionSettings,
-        numericBackToAlphaLabel: String = NumericLayouts.defaultBackToAlphaLabel
+        numericBackToAlphaLabel: String = NumericLayouts.defaultBackToAlphaLabel,
+        numericDigits: [String] = NumericLayouts.westernDigits
     ) {
         self.title = title
         self.id = id
@@ -55,6 +62,7 @@ struct KeyboardDefinition: Codable, Equatable {
         self.defaultMode = defaultMode
         self.settings = settings
         self.numericBackToAlphaLabel = numericBackToAlphaLabel
+        self.numericDigits = numericDigits
     }
 
     /// Convenience: Mode lookup
@@ -70,7 +78,8 @@ struct KeyboardDefinition: Codable, Equatable {
         return KeyboardDefinition(
             title: title, id: id, localeIdentifier: localeIdentifier,
             modes: updated, defaultMode: defaultMode, settings: settings,
-            numericBackToAlphaLabel: numericBackToAlphaLabel
+            numericBackToAlphaLabel: numericBackToAlphaLabel,
+            numericDigits: numericDigits
         )
     }
 }

--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
@@ -624,19 +624,23 @@ extension LanguageDefinitions {
                 ["η", "ο", "ρ"],
                 ["τ", "ε", "σ"],
             ],
+            // MessagEase's generic Latin accent ring (ô â ä í î ç ø é ü) is
+            // dropped here: it is noise on a Greek keyboard and would override
+            // the default punctuation/symbol swipes. Greek tonos/dialytika
+            // belong in compose rules, not as primary swipes.
             directionalOverrides: [
-                GridSlot.topLeft: [.swipeUp: "ô", .swipeUpRight: "â", .swipeLeft: "ä", .swipeDownRight: "ω"],
+                GridSlot.topLeft: [.swipeDownRight: "ω"],
                 GridSlot.topCenter: [.swipeDown: "λ"],
-                GridSlot.topRight: [.swipeUpLeft: "í", .swipeRight: "î", .swipeDownLeft: "χ"],
-                GridSlot.midLeft: [.swipeUp: "ç", .swipeRight: "κ", .swipeDown: "ø"],
+                GridSlot.topRight: [.swipeDownLeft: "χ"],
+                GridSlot.midLeft: [.swipeRight: "κ"],
                 GridSlot.center: [
                     .swipeUpLeft: "θ", .swipeUp: "υ", .swipeUpRight: "π",
                     .swipeRight: "β", .swipeDownRight: "ς", .swipeDown: "δ",
                     .swipeDownLeft: "γ", .swipeLeft: "ξ",
                 ],
                 GridSlot.midRight: [.swipeLeft: "μ"],
-                GridSlot.bottomLeft: [.swipeUpRight: "ψ", .swipeDown: "ü"],
-                GridSlot.bottomCenter: [.swipeUp: "ω", .swipeLeft: "é", .swipeRight: "ζ"],
+                GridSlot.bottomLeft: [.swipeUpRight: "ψ"],
+                GridSlot.bottomCenter: [.swipeUp: "ω", .swipeRight: "ζ"],
                 GridSlot.bottomRight: [.swipeUpLeft: "φ"],
             ],
             numericBackToAlphaLabel: "αβγ"
@@ -660,10 +664,14 @@ extension LanguageDefinitions {
                 ["t", "e", "s"],
             ],
             directionalOverrides: [
+                // Portuguese keeps its own accents (â ã õ ô á í ó ú ç ê é);
+                // MessagEase's foreign ring extras — ñ (Spanish) and ü
+                // (dropped from Portuguese in the 1990 orthographic reform) —
+                // are removed.
                 GridSlot.topLeft: [.swipeUp: "ô", .swipeUpRight: "â", .swipeLeft: "ã", .swipeDown: "á", .swipeDownRight: "v"],
-                GridSlot.topCenter: [.swipeUp: "ñ", .swipeDown: "l"],
+                GridSlot.topCenter: [.swipeDown: "l"],
                 GridSlot.topRight: [.swipeUpLeft: "í", .swipeRight: "õ", .swipeDownLeft: "x"],
-                GridSlot.midLeft: [.swipeUp: "ü", .swipeRight: "k", .swipeDown: "ç"],
+                GridSlot.midLeft: [.swipeRight: "k", .swipeDown: "ç"],
                 GridSlot.center: [
                     .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
                     .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "h",

--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
@@ -568,16 +568,16 @@ enum LanguageDefinitions {
     ].sorted { $0.title < $1.title }
 }
 
-// MARK: - Additional MessagEase Layouts
+// MARK: - Additional Layouts
 
-/// Layouts ported 1:1 from the decompiled MessagEase reference. Kept in a
+/// Additional language layouts. Kept in a
 /// separate extension so the primary `LanguageDefinitions` body stays within
 /// SwiftLint's `type_body_length` limit.
 extension LanguageDefinitions {
     // MARK: Ukrainian
 
-    /// Ukrainian reuses the Russian Cyrillic layout with MessagEase's four
-    /// letter substitutions (ъёэы → ґїєі), matching the decompiled reference.
+    /// Ukrainian reuses the Russian Cyrillic layout with four letter
+    /// substitutions (ъёэы → ґїєі).
     static let ukrainian = LanguageDescriptor(
         id: "uk_UA",
         title: "Українська (Ukrainian)",
@@ -627,7 +627,7 @@ extension LanguageDefinitions {
                 ["η", "ο", "ρ"],
                 ["τ", "ε", "σ"],
             ],
-            // MessagEase's generic Latin accent ring (ô â ä í î ç ø é ü) is
+            // The generic Latin accent ring (ô â ä í î ç ø é ü) is
             // dropped here: it is noise on a Greek keyboard and would override
             // the default punctuation/symbol swipes. Greek tonos/dialytika
             // belong in compose rules, not as primary swipes.
@@ -668,7 +668,7 @@ extension LanguageDefinitions {
             ],
             directionalOverrides: [
                 // Portuguese keeps its own accents (â ã õ ô á í ó ú ç ê é);
-                // MessagEase's foreign ring extras — ñ (Spanish) and ü
+                // The foreign ring extras — ñ (Spanish) and ü
                 // (dropped from Portuguese in the 1990 orthographic reform) —
                 // are removed.
                 GridSlot.topLeft: [.swipeUp: "ô", .swipeUpRight: "â", .swipeLeft: "ã", .swipeDown: "á", .swipeDownRight: "v"],

--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
@@ -545,6 +545,7 @@ enum LanguageDefinitions {
     /// `LanguageDescriptor.makeDefinition()` (see `KeyboardRegistry`).
     static let all: [LanguageDescriptor] = [
         spanishCatalan,
+        arabic,
         croatian,
         english,
         estonianFinnish,
@@ -554,6 +555,7 @@ enum LanguageDefinitions {
         greek,
         hebrew,
         italian,
+        persian,
         polish,
         portuguese,
         russian,
@@ -561,6 +563,7 @@ enum LanguageDefinitions {
         swedish,
         tagalog,
         ukrainian,
+        urdu,
         vietnamese,
     ].sorted { $0.title < $1.title }
 }
@@ -682,6 +685,179 @@ extension LanguageDefinitions {
                 GridSlot.bottomCenter: [.swipeUp: "w", .swipeLeft: "é", .swipeRight: "z"],
                 GridSlot.bottomRight: [.swipeUpLeft: "f"],
             ]
+        )
+    }
+
+    // MARK: Arabic script (RTL)
+
+    static let arabic = LanguageDescriptor(
+        id: "ar",
+        title: "العربية (Arabic)",
+        localeIdentifier: "ar"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["ه", "ب", "م"],
+                ["ي", "ا", "ر"],
+                ["و", "ن", "د"],
+            ],
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeRight: "ـ", .swipeDown: "ة", .swipeDownRight: "ق"],
+                GridSlot.topCenter: [
+                    .swipeUp: "ُ", .swipeUpLeft: "ِ", .swipeUpRight: "َ",
+                    .swipeDown: "خ", .swipeDownLeft: "ض",
+                ],
+                GridSlot.topRight: [.swipeDownLeft: "إ"],
+                GridSlot.midLeft: [
+                    .swipeUpRight: "ص", .swipeRight: "ح", .swipeDown: "ى",
+                    .swipeDownRight: "ط",
+                ],
+                GridSlot.center: [
+                    .swipeUp: "ج", .swipeUpLeft: "ف", .swipeUpRight: "ش",
+                    .swipeLeft: "س", .swipeRight: "آ", .swipeDown: "ت",
+                    .swipeDownLeft: "ل", .swipeDownRight: "ك",
+                ],
+                GridSlot.midRight: [.swipeUpLeft: "ٰ", .swipeLeft: "ز", .swipeDownLeft: "ع"],
+                GridSlot.bottomLeft: [.swipeUp: "ّ", .swipeUpLeft: "ٓ", .swipeUpRight: "ؤ"],
+                GridSlot.bottomCenter: [
+                    .swipeUp: "ث", .swipeUpLeft: "ظ", .swipeUpRight: "غ",
+                    .swipeLeft: "ء", .swipeRight: "أ", .swipeDownRight: "ئ",
+                ],
+                GridSlot.bottomRight: [
+                    .swipeUp: "ً", .swipeUpLeft: "ۋ", .swipeUpRight: "ْ",
+                    .swipeLeft: "ذ",
+                ],
+            ],
+            returnOverrides: [
+                GridSlot.topCenter: [.swipeUp: "ٌ", .swipeUpLeft: "ٍ", .swipeUpRight: "ً"],
+                GridSlot.midLeft: [.swipeDown: "ئ"],
+                GridSlot.bottomCenter: [.swipeRight: "إ"],
+                GridSlot.bottomRight: [.swipeUpLeft: "گ"],
+            ],
+            numericBackToAlphaLabel: "ابت",
+            numericDigits: NumericLayouts.arabicIndicDigits
+        )
+    }
+
+    static let persian = LanguageDescriptor(
+        id: "fa_IR",
+        title: "فارسی (Persian)",
+        localeIdentifier: "fa_IR"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["ه", "ب", "م"],
+                ["ی", "ا", "ر"],
+                ["و", "ن", "د"],
+            ],
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeRight: "ـ", .swipeDown: "ۀ", .swipeDownRight: "ق"],
+                GridSlot.topCenter: [
+                    .swipeUp: "ُ", .swipeUpLeft: "ِ", .swipeUpRight: "َ",
+                    .swipeDown: "خ", .swipeDownLeft: "ض", .swipeDownRight: "پ",
+                ],
+                GridSlot.topRight: [.swipeDownLeft: "چ"],
+                GridSlot.midLeft: [.swipeUpRight: "ص", .swipeRight: "ش", .swipeDownRight: "ط"],
+                GridSlot.center: [
+                    .swipeUp: "ح", .swipeUpLeft: "ف", .swipeUpRight: "ج",
+                    .swipeLeft: "س", .swipeRight: "آ", .swipeDown: "ت",
+                    .swipeDownLeft: "ل", .swipeDownRight: "ک",
+                ],
+                GridSlot.midRight: [.swipeUpLeft: "ژ", .swipeLeft: "ز", .swipeDownLeft: "ع"],
+                GridSlot.bottomLeft: [.swipeUp: "ّ", .swipeUpLeft: "ٓ", .swipeUpRight: "ؤ"],
+                GridSlot.bottomCenter: [
+                    .swipeUp: "ث", .swipeUpLeft: "ظ", .swipeUpRight: "غ",
+                    .swipeLeft: "ء", .swipeRight: "أ", .swipeDownRight: "ئ",
+                ],
+                GridSlot.bottomRight: [
+                    .swipeUp: "ً", .swipeUpLeft: "گ", .swipeUpRight: "ْ",
+                    .swipeLeft: "ذ",
+                ],
+            ],
+            returnOverrides: [
+                GridSlot.topLeft: [.swipeDown: "ة", .swipeDownRight: "ف"],
+                GridSlot.topCenter: [
+                    .swipeUp: "ٌ", .swipeUpLeft: "ٍ", .swipeUpRight: "ً",
+                    .swipeDown: "ح", .swipeDownLeft: "ص", .swipeDownRight: "ب",
+                ],
+                GridSlot.topRight: [.swipeDownLeft: "ج"],
+                GridSlot.midLeft: [.swipeUpRight: "ض", .swipeRight: "س", .swipeDownRight: "ظ"],
+                GridSlot.center: [
+                    .swipeUp: "خ", .swipeUpLeft: "ق", .swipeUpRight: "چ",
+                    .swipeLeft: "ش", .swipeRight: "ا", .swipeDown: "ث",
+                    .swipeDownRight: "گ",
+                ],
+                GridSlot.midRight: [.swipeLeft: "ر", .swipeDownLeft: "غ"],
+                GridSlot.bottomCenter: [
+                    .swipeUp: "ت", .swipeUpLeft: "ط", .swipeUpRight: "ع",
+                    .swipeRight: "إ",
+                ],
+                GridSlot.bottomRight: [.swipeUpLeft: "ک", .swipeLeft: "د"],
+            ],
+            numericBackToAlphaLabel: "ابپ",
+            numericDigits: NumericLayouts.persianDigits
+        )
+    }
+
+    static let urdu = LanguageDescriptor(
+        id: "ur",
+        title: "اردو (Urdu)",
+        localeIdentifier: "ur"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["ه", "ب", "م"],
+                ["ی", "ا", "ر"],
+                ["و", "ن", "د"],
+            ],
+            directionalOverrides: [
+                GridSlot.topLeft: [
+                    .swipeUp: "ٹ", .swipeRight: "ـ", .swipeDown: "ۀ",
+                    .swipeDownRight: "ق",
+                ],
+                GridSlot.topCenter: [
+                    .swipeUp: "ُ", .swipeUpLeft: "ِ", .swipeUpRight: "َ",
+                    .swipeDown: "خ", .swipeDownLeft: "ض", .swipeDownRight: "پ",
+                ],
+                GridSlot.topRight: [.swipeDownLeft: "چ"],
+                GridSlot.midLeft: [
+                    .swipeUp: "ۓ", .swipeUpRight: "ص", .swipeRight: "ح",
+                    .swipeDown: "ے", .swipeDownRight: "ط",
+                ],
+                GridSlot.center: [
+                    .swipeUp: "ج", .swipeUpLeft: "ف", .swipeUpRight: "ش",
+                    .swipeLeft: "س", .swipeRight: "آ", .swipeDown: "ت",
+                    .swipeDownLeft: "ل", .swipeDownRight: "ک",
+                ],
+                GridSlot.midRight: [
+                    .swipeUp: "ڑ", .swipeUpLeft: "ژ", .swipeLeft: "ز",
+                    .swipeDown: "ڈ", .swipeDownLeft: "ع",
+                ],
+                GridSlot.bottomLeft: [.swipeUp: "ّ", .swipeUpLeft: "ٓ", .swipeUpRight: "ؤ"],
+                GridSlot.bottomCenter: [
+                    .swipeUp: "ث", .swipeUpLeft: "ظ", .swipeUpRight: "غ",
+                    .swipeLeft: "ء", .swipeRight: "ں", .swipeDownRight: "ئ",
+                ],
+                GridSlot.bottomRight: [
+                    .swipeUp: "ً", .swipeUpLeft: "گ", .swipeUpRight: "ْ",
+                    .swipeLeft: "ذ",
+                ],
+            ],
+            returnOverrides: [
+                GridSlot.topLeft: [.swipeDown: "ة"],
+                GridSlot.topCenter: [.swipeUp: "ٌ", .swipeUpLeft: "ٍ", .swipeUpRight: "ً"],
+            ],
+            numericBackToAlphaLabel: "ابپ",
+            numericDigits: NumericLayouts.persianDigits
         )
     }
 }

--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
@@ -551,13 +551,129 @@ enum LanguageDefinitions {
         finnish,
         french,
         german,
+        greek,
         hebrew,
         italian,
         polish,
+        portuguese,
         russian,
         spanish,
         swedish,
         tagalog,
+        ukrainian,
         vietnamese,
     ].sorted { $0.title < $1.title }
+}
+
+// MARK: - Additional MessagEase Layouts
+
+/// Layouts ported 1:1 from the decompiled MessagEase reference. Kept in a
+/// separate extension so the primary `LanguageDefinitions` body stays within
+/// SwiftLint's `type_body_length` limit.
+extension LanguageDefinitions {
+    // MARK: Ukrainian
+
+    /// Ukrainian reuses the Russian Cyrillic layout with MessagEase's four
+    /// letter substitutions (ъёэы → ґїєі), matching the decompiled reference.
+    static let ukrainian = LanguageDescriptor(
+        id: "uk_UA",
+        title: "Українська (Ukrainian)",
+        localeIdentifier: "uk_UA"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["с", "и", "т"],
+                ["в", "о", "а"],
+                ["е", "р", "н"],
+            ],
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeDown: "ц", .swipeDownRight: "п"],
+                GridSlot.topCenter: [.swipeUp: "й", .swipeDown: "к"],
+                GridSlot.topRight: [.swipeDownLeft: "ь"],
+                GridSlot.midLeft: [.swipeUp: "б", .swipeDown: "ґ", .swipeRight: "і"],
+                GridSlot.center: [
+                    .swipeUpLeft: "ч", .swipeUp: "м", .swipeUpRight: "х",
+                    .swipeRight: "г", .swipeDownRight: "ш", .swipeDown: "я",
+                    .swipeDownLeft: "щ", .swipeLeft: "ж",
+                ],
+                GridSlot.midRight: [.swipeLeft: "л"],
+                GridSlot.bottomLeft: [.swipeUp: "ї", .swipeRight: "є", .swipeUpRight: "д"],
+                GridSlot.bottomCenter: [.swipeUp: "у", .swipeRight: "з", .swipeLeft: "ю"],
+                GridSlot.bottomRight: [.swipeUpLeft: "ф"],
+            ],
+            numericBackToAlphaLabel: "абв"
+        )
+    }
+
+    // MARK: Greek
+
+    static let greek = LanguageDescriptor(
+        id: "el_GR",
+        title: "Ελληνικά (Greek)",
+        localeIdentifier: "el_GR"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["α", "ν", "ι"],
+                ["η", "ο", "ρ"],
+                ["τ", "ε", "σ"],
+            ],
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeUp: "ô", .swipeUpRight: "â", .swipeLeft: "ä", .swipeDownRight: "ω"],
+                GridSlot.topCenter: [.swipeDown: "λ"],
+                GridSlot.topRight: [.swipeUpLeft: "í", .swipeRight: "î", .swipeDownLeft: "χ"],
+                GridSlot.midLeft: [.swipeUp: "ç", .swipeRight: "κ", .swipeDown: "ø"],
+                GridSlot.center: [
+                    .swipeUpLeft: "θ", .swipeUp: "υ", .swipeUpRight: "π",
+                    .swipeRight: "β", .swipeDownRight: "ς", .swipeDown: "δ",
+                    .swipeDownLeft: "γ", .swipeLeft: "ξ",
+                ],
+                GridSlot.midRight: [.swipeLeft: "μ"],
+                GridSlot.bottomLeft: [.swipeUpRight: "ψ", .swipeDown: "ü"],
+                GridSlot.bottomCenter: [.swipeUp: "ω", .swipeLeft: "é", .swipeRight: "ζ"],
+                GridSlot.bottomRight: [.swipeUpLeft: "φ"],
+            ],
+            numericBackToAlphaLabel: "αβγ"
+        )
+    }
+
+    // MARK: Portuguese
+
+    static let portuguese = LanguageDescriptor(
+        id: "pt_PT",
+        title: "Português (Portuguese)",
+        localeIdentifier: "pt_PT"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["a", "n", "i"],
+                ["d", "o", "r"],
+                ["t", "e", "s"],
+            ],
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeUp: "ô", .swipeUpRight: "â", .swipeLeft: "ã", .swipeDown: "á", .swipeDownRight: "v"],
+                GridSlot.topCenter: [.swipeUp: "ñ", .swipeDown: "l"],
+                GridSlot.topRight: [.swipeUpLeft: "í", .swipeRight: "õ", .swipeDownLeft: "x"],
+                GridSlot.midLeft: [.swipeUp: "ü", .swipeRight: "k", .swipeDown: "ç"],
+                GridSlot.center: [
+                    .swipeUpLeft: "q", .swipeUp: "u", .swipeUpRight: "p",
+                    .swipeRight: "b", .swipeDownRight: "j", .swipeDown: "h",
+                    .swipeDownLeft: "g", .swipeLeft: "c",
+                ],
+                GridSlot.midRight: [.swipeLeft: "m"],
+                GridSlot.bottomLeft: [.swipeUp: "ú", .swipeUpRight: "y", .swipeRight: "ê", .swipeDown: "ó"],
+                GridSlot.bottomCenter: [.swipeUp: "w", .swipeLeft: "é", .swipeRight: "z"],
+                GridSlot.bottomRight: [.swipeUpLeft: "f"],
+            ]
+        )
+    }
 }

--- a/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
+++ b/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
@@ -16,14 +16,32 @@ enum NumericLayouts {
     /// script-appropriate label via `phone(backToAlphaLabel:)`.
     static let defaultBackToAlphaLabel = "abc"
 
+    /// Western (ASCII) digits, indexed by value 0–9. The default digit set.
+    static let westernDigits = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+
+    /// Arabic-Indic digits (U+0660–0669), used by the Arabic layout.
+    static let arabicIndicDigits = ["٠", "١", "٢", "٣", "٤", "٥", "٦", "٧", "٨", "٩"]
+
+    /// Extended Arabic-Indic (Persian) digits (U+06F0–06F9), used by the
+    /// Persian and Urdu layouts.
+    static let persianDigits = ["۰", "۱", "۲", "۳", "۴", "۵", "۶", "۷", "۸", "۹"]
+
     /// Phone-style layout (1-2-3 in top row).
-    static func phone(backToAlphaLabel: String = defaultBackToAlphaLabel) -> KeyboardMode {
+    ///
+    /// - Parameter digits: Digit set indexed by value (0–9). Non-Latin layouts
+    ///   (Arabic, Persian, …) pass their script-specific digits; both the tap
+    ///   output and the key label use the supplied glyphs.
+    static func phone(
+        digits: [String] = westernDigits,
+        backToAlphaLabel: String = defaultBackToAlphaLabel
+    ) -> KeyboardMode {
         buildMode(
             centerDigits: [
-                ["1", "2", "3"],
-                ["4", "5", "6"],
-                ["7", "8", "9"],
+                [digits[1], digits[2], digits[3]],
+                [digits[4], digits[5], digits[6]],
+                [digits[7], digits[8], digits[9]],
             ],
+            zeroDigit: digits[0],
             // Phone layout swaps digits but keeps circular gestures at their
             // physical positions.
             circularOverrides: phoneCircularOverrides,
@@ -32,13 +50,17 @@ enum NumericLayouts {
     }
 
     /// Classic calculator style (7-8-9 in top row).
-    static func classic(backToAlphaLabel: String = defaultBackToAlphaLabel) -> KeyboardMode {
+    static func classic(
+        digits: [String] = westernDigits,
+        backToAlphaLabel: String = defaultBackToAlphaLabel
+    ) -> KeyboardMode {
         buildMode(
             centerDigits: [
-                ["7", "8", "9"],
-                ["4", "5", "6"],
-                ["1", "2", "3"],
+                [digits[7], digits[8], digits[9]],
+                [digits[4], digits[5], digits[6]],
+                [digits[1], digits[2], digits[3]],
             ],
+            zeroDigit: digits[0],
             circularOverrides: classicCircularOverrides,
             backToAlphaLabel: backToAlphaLabel
         )
@@ -55,28 +77,30 @@ enum NumericLayouts {
     }
 
     /// Standalone "0" digit key in the bottom row.
-    private static let zeroKey = KeyConfig(
-        id: GridSlot.zero,
-        bindings: [
-            .tap: KeyBinding(
-                label: "0", action: .commitText("0"),
-                category: .digit, returnAction: nil, accessibilityLabel: nil
-            ),
-        ],
-        swipeMode: .none,
-        slideType: .none,
-        style: .primary,
-        tapCycleActions: nil
-    )
+    private static func zeroKey(digit: String) -> KeyConfig {
+        KeyConfig(
+            id: GridSlot.zero,
+            bindings: [
+                .tap: KeyBinding(
+                    label: digit, action: .commitText(digit),
+                    category: .digit, returnAction: nil, accessibilityLabel: nil
+                ),
+            ],
+            swipeMode: .none,
+            slideType: .none,
+            style: .primary,
+            tapCycleActions: nil
+        )
+    }
 
-    private static func utilityKeys(backToAlphaLabel: String) -> [String: KeyConfig] {
+    private static func utilityKeys(zeroDigit: String, backToAlphaLabel: String) -> [String: KeyConfig] {
         [
             UtilitySlot.globe: CommonKeys.globe,
             UtilitySlot.delete: CommonKeys.delete,
             UtilitySlot.return: CommonKeys.return,
             UtilitySlot.symbols: backToMain(label: backToAlphaLabel),
             UtilitySlot.space: CommonKeys.spacebar,
-            GridSlot.zero: zeroKey,
+            GridSlot.zero: zeroKey(digit: zeroDigit),
         ]
     }
 
@@ -168,6 +192,7 @@ enum NumericLayouts {
 
     private static func buildMode(
         centerDigits: [[String]],
+        zeroDigit: String,
         circularOverrides: [String: KeyBinding],
         backToAlphaLabel: String
     ) -> KeyboardMode {
@@ -217,7 +242,7 @@ enum NumericLayouts {
             }
         }
 
-        let utilities = utilityKeys(backToAlphaLabel: backToAlphaLabel)
+        let utilities = utilityKeys(zeroDigit: zeroDigit, backToAlphaLabel: backToAlphaLabel)
         precondition(
             Set(digitKeys.keys).isDisjoint(with: utilities.keys),
             "digit and utility key IDs must not overlap"

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -53,6 +53,7 @@ extension KeyboardViewModel {
         let style = raw.flatMap(NumpadStyle.init(rawValue:)) ?? .phone
         guard style == .classic else { return definition }
         let classicNumeric = NumericLayouts.classic(
+            digits: definition.numericDigits,
             backToAlphaLabel: definition.numericBackToAlphaLabel
         )
         return definition.replacingMode(ModeNames.numeric, with: classicNumeric)

--- a/wurstfingerTests/ModeDefinitionValidationTests.swift
+++ b/wurstfingerTests/ModeDefinitionValidationTests.swift
@@ -248,6 +248,14 @@ struct NativeDigitLayerTests {
         #expect(def.numericDigits == NumericLayouts.westernDigits)
         #expect(digitTap(def.mode(ModeNames.numeric), GridSlot.topLeft) == "1")
     }
+
+    @Test func rtlLanguagesShipNativeDigits() {
+        #expect(LanguageDefinitions.arabic.makeDefinition().numericDigits == NumericLayouts.arabicIndicDigits)
+        #expect(LanguageDefinitions.persian.makeDefinition().numericDigits == NumericLayouts.persianDigits)
+        #expect(LanguageDefinitions.urdu.makeDefinition().numericDigits == NumericLayouts.persianDigits)
+        // The new non-Arabic-script languages keep Western digits.
+        #expect(LanguageDefinitions.greek.makeDefinition().numericDigits == NumericLayouts.westernDigits)
+    }
 }
 
 // MARK: - Validation Tests

--- a/wurstfingerTests/ModeDefinitionValidationTests.swift
+++ b/wurstfingerTests/ModeDefinitionValidationTests.swift
@@ -182,6 +182,74 @@ struct KeyboardDefinitionTests {
     }
 }
 
+// MARK: - Native Digit Layer Tests
+
+/// Covers the per-language numeric digit set (Arabic-Indic / Persian) plumbed
+/// through `NumericLayouts`, `GridKeyboardFactory`, and `KeyboardDefinition`.
+struct NativeDigitLayerTests {
+    /// Reads the tap output of a numeric-mode key.
+    private func digitTap(_ mode: KeyboardMode?, _ slot: String) -> String? {
+        guard case let .commitText(text)? = mode?.keys[slot]?.bindings[.tap]?.action else { return nil }
+        return text
+    }
+
+    @Test func phoneDefaultsToWesternDigits() {
+        let mode = NumericLayouts.phone()
+        #expect(digitTap(mode, GridSlot.topLeft) == "1")
+        #expect(digitTap(mode, GridSlot.zero) == "0")
+    }
+
+    @Test func phoneUsesSuppliedNativeDigits() {
+        let mode = NumericLayouts.phone(digits: NumericLayouts.arabicIndicDigits)
+        #expect(digitTap(mode, GridSlot.topLeft) == "١") // value 1
+        #expect(digitTap(mode, GridSlot.center) == "٥") // value 5
+        #expect(digitTap(mode, GridSlot.zero) == "٠") // value 0
+    }
+
+    @Test func classicUsesSuppliedNativeDigits() {
+        let mode = NumericLayouts.classic(digits: NumericLayouts.persianDigits)
+        #expect(digitTap(mode, GridSlot.topLeft) == "۷") // classic top-left is value 7
+        #expect(digitTap(mode, GridSlot.zero) == "۰")
+    }
+
+    @Test func factoryThreadsDigitsIntoDefinitionAndNumericMode() {
+        let def = GridKeyboardFactory.layout(
+            id: "test_ar", title: "Test", localeIdentifier: "ar",
+            centerCharacters: [["ا", "ب", "ت"], ["ث", "ج", "ح"], ["خ", "د", "ذ"]],
+            numericDigits: NumericLayouts.arabicIndicDigits
+        )
+        #expect(def.numericDigits == NumericLayouts.arabicIndicDigits)
+        #expect(digitTap(def.mode(ModeNames.numeric), GridSlot.zero) == "٠")
+    }
+
+    @Test func numericDigitsSurviveNumpadStyleSwap() {
+        let def = GridKeyboardFactory.layout(
+            id: "test_ar", title: "Test", localeIdentifier: "ar",
+            centerCharacters: [["ا", "ب", "ت"], ["ث", "ج", "ح"], ["خ", "د", "ذ"]],
+            numericDigits: NumericLayouts.arabicIndicDigits
+        )
+        // Mirror KeyboardViewModel+Pipeline.applyNumpadStyle's classic rebuild.
+        let swapped = def.replacingMode(
+            ModeNames.numeric,
+            with: NumericLayouts.classic(
+                digits: def.numericDigits,
+                backToAlphaLabel: def.numericBackToAlphaLabel
+            )
+        )
+        #expect(swapped.numericDigits == NumericLayouts.arabicIndicDigits)
+        #expect(digitTap(swapped.mode(ModeNames.numeric), GridSlot.zero) == "٠")
+    }
+
+    @Test func defaultDefinitionKeepsWesternDigits() {
+        let def = GridKeyboardFactory.layout(
+            id: "test_en", title: "Test", localeIdentifier: "en_US",
+            centerCharacters: [["a", "n", "i"], ["h", "o", "r"], ["t", "e", "s"]]
+        )
+        #expect(def.numericDigits == NumericLayouts.westernDigits)
+        #expect(digitTap(def.mode(ModeNames.numeric), GridSlot.topLeft) == "1")
+    }
+}
+
 // MARK: - Validation Tests
 
 struct ValidationTests {


### PR DESCRIPTION
## What

Adds three right-to-left keyboard layouts:

| Language | ID | Digits |
|---|---|---|
| العربية (Arabic) | `ar` | Arabic-Indic ٠-٩ |
| فارسی (Persian) | `fa_IR` | Persian ۰-۹ |
| اردو (Urdu) | `ur` | Persian ۰-۹ |

## Stacking ⚠️

Stacked on **#241** (native digit layer) and **#243** (Greek/PT/Ukrainian). The net-new change is the last commit (`Add Arabic, Persian, and Urdu…`). **Merge #241 and #243 first, then retarget this PR's base to `develop` before squash-merge.**

## How

- Letters + harakat (ـ ة ق … + ُ ِ َ ّ) on primary swipes.
- Alternate letter forms — hamza variants (ا→أ, ي→ئ), tanwin, and Persian related-letter cycling — use the existing `returnOverrides` mechanism.
- Native digits via the per-language digit layer from #241.
- **RTL needs no code** — handled by iOS/`UITextView`, exactly like the existing Hebrew layout. The generic Latin accent ring is omitted (consistent with the curated layouts).

## Tests

Parameterized `LanguageDefinitionTests` / `LayoutValidationTests` cover all three; new `rtlLanguagesShipNativeDigits` asserts each carries the correct script digits. Build + tests green on iPhone 17 Pro sim.

## Verification still open (best on device)

- RTL entry: cursor behaviour and character order when typing Arabic/Persian/Urdu into a real field.
- Native numeric layer renders ٠-٩ / ۰-۹ and survives the phone↔classic numpad swap.
- Spot-check letters + return-swipe hamza/alternate forms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for localized number keys in numeric keyboard layouts, including Western, Arabic-Indic, and Persian digit sets.
  * Expanded language support with additional layouts such as Arabic, Greek, Persian, Ukrainian, Portuguese, and Urdu.
  * Numeric keyboards now keep the correct digit style when switching or rebuilding layouts.

* **Bug Fixes**
  * Fixed numeric layouts so the displayed digits match the selected language/keyboard configuration more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->