### PR TITLE
Add Thai keyboard layout

### DIFF
--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
@@ -952,6 +952,7 @@ extension LanguageDefinitions {
                 GridSlot.bottomCenter: [.swipeUp: "ๆ", .swipeRight: "ํ"],
                 GridSlot.bottomRight: [.swipeUp: "ฌ", .swipeRight: "ซ", .swipeDownLeft: "ำ"],
             ],
+            supportsCapitalization: false,
             numericBackToAlphaLabel: "กขค",
             numericDigits: NumericLayouts.thaiDigits
         )

--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
@@ -562,6 +562,7 @@ enum LanguageDefinitions {
         spanish,
         swedish,
         tagalog,
+        thai,
         ukrainian,
         urdu,
         vietnamese,
@@ -861,6 +862,98 @@ extension LanguageDefinitions {
             supportsCapitalization: false,
             numericBackToAlphaLabel: "ابپ",
             numericDigits: NumericLayouts.persianDigits
+        )
+    }
+
+    // MARK: Thai
+
+    static let thai = LanguageDescriptor(
+        id: "th_TH",
+        title: "ไทย (Thai)",
+        localeIdentifier: "th_TH"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["า", "น", "ั"],
+                ["ก", "อ", "ร"],
+                ["ม", "เ", "ง"],
+            ],
+            directionalOverrides: [
+                GridSlot.topLeft: [
+                    .swipeUp: "ุ", .swipeUpRight: "ิ", .swipeLeft: "ฝ",
+                    .swipeDown: "ู", .swipeDownLeft: "ฟ", .swipeDownRight: "ี",
+                ],
+                GridSlot.topCenter: [
+                    .swipeUp: "ณ", .swipeUpLeft: "็", .swipeUpRight: "์",
+                    .swipeDown: "ล", .swipeDownRight: "ข",
+                ],
+                GridSlot.topRight: [
+                    .swipeUpLeft: "ฮ", .swipeRight: "ฐ", .swipeDown: "ะ",
+                    .swipeDownLeft: "ๆ", .swipeDownRight: "ภ",
+                ],
+                GridSlot.midLeft: [
+                    .swipeUp: "ื", .swipeUpLeft: "ึ", .swipeUpRight: "โ",
+                    .swipeRight: "ค", .swipeDown: "ใ", .swipeDownLeft: "ฤ",
+                    .swipeDownRight: "ไ",
+                ],
+                GridSlot.center: [
+                    .swipeUp: "้", .swipeUpLeft: "่", .swipeUpRight: "ป",
+                    .swipeLeft: "ช", .swipeRight: "บ", .swipeDown: "ด",
+                    .swipeDownLeft: "ห", .swipeDownRight: "จ",
+                ],
+                GridSlot.midRight: [
+                    .swipeUpLeft: "ผ", .swipeUpRight: "ถ", .swipeLeft: "ท",
+                    .swipeDownLeft: "พ", .swipeDownRight: "ธ",
+                ],
+                GridSlot.bottomLeft: [
+                    .swipeUp: "ำ", .swipeUpLeft: "ญ", .swipeUpRight: "ย",
+                    .swipeLeft: "๊", .swipeDown: "๋",
+                ],
+                GridSlot.bottomCenter: [.swipeUp: "ว", .swipeLeft: "แ", .swipeRight: "ต"],
+                GridSlot.bottomRight: [
+                    .swipeUp: "ฉ", .swipeUpLeft: "ส", .swipeUpRight: "ซ",
+                    .swipeRight: "ศ", .swipeDownLeft: "ษ",
+                ],
+            ],
+            returnOverrides: [
+                GridSlot.topLeft: [
+                    .swipeUp: "ู", .swipeUpRight: "ี", .swipeLeft: "ฺ",
+                    .swipeDown: "ุ", .swipeDownLeft: "พ", .swipeDownRight: "ิ",
+                ],
+                GridSlot.topCenter: [
+                    .swipeUp: "โ", .swipeUpLeft: "ใ", .swipeUpRight: "ไ",
+                    .swipeDown: "ฦ", .swipeDownRight: "ญ",
+                ],
+                GridSlot.topRight: [
+                    .swipeUpLeft: "ฆ", .swipeRight: "ฃ", .swipeDown: "ข",
+                    .swipeDownLeft: "ฯ", .swipeDownRight: "ถ",
+                ],
+                GridSlot.midLeft: [
+                    .swipeUp: "ึ", .swipeUpLeft: "ื", .swipeUpRight: "จ",
+                    .swipeRight: "ข", .swipeDown: "ๅ", .swipeDownLeft: "ฦ",
+                    .swipeDownRight: "ฤ",
+                ],
+                GridSlot.center: [
+                    .swipeUp: "๋", .swipeUpLeft: "๊", .swipeUpRight: "ผ",
+                    .swipeLeft: "ฉ", .swipeRight: "ษ", .swipeDown: "ฎ",
+                    .swipeDownLeft: "ฮ", .swipeDownRight: "ช",
+                ],
+                GridSlot.midRight: [
+                    .swipeUpLeft: "ฝ", .swipeUpRight: "ภ", .swipeDownLeft: "ฟ",
+                    .swipeDownRight: "ณ",
+                ],
+                GridSlot.bottomLeft: [
+                    .swipeUp: "์", .swipeUpLeft: "แ", .swipeUpRight: "๎",
+                    .swipeLeft: "็",
+                ],
+                GridSlot.bottomCenter: [.swipeUp: "ๆ", .swipeRight: "ํ"],
+                GridSlot.bottomRight: [.swipeUp: "ฌ", .swipeRight: "ซ", .swipeDownLeft: "ำ"],
+            ],
+            numericBackToAlphaLabel: "กขค",
+            numericDigits: NumericLayouts.thaiDigits
         )
     }
 }

--- a/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
+++ b/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
@@ -26,6 +26,9 @@ enum NumericLayouts {
     /// Persian and Urdu layouts.
     static let persianDigits = ["۰", "۱", "۲", "۳", "۴", "۵", "۶", "۷", "۸", "۹"]
 
+    /// Thai digits (U+0E50–0E59), used by the Thai layout.
+    static let thaiDigits = ["๐", "๑", "๒", "๓", "๔", "๕", "๖", "๗", "๘", "๙"]
+
     /// Phone-style layout (1-2-3 in top row).
     ///
     /// - Parameter digits: Digit set indexed by value (0–9). Non-Latin layouts

--- a/wurstfingerTests/ModeDefinitionValidationTests.swift
+++ b/wurstfingerTests/ModeDefinitionValidationTests.swift
@@ -238,6 +238,7 @@ struct NativeDigitLayerTests {
         #expect(LanguageDefinitions.arabic.makeDefinition().numericDigits == NumericLayouts.arabicIndicDigits)
         #expect(LanguageDefinitions.persian.makeDefinition().numericDigits == NumericLayouts.persianDigits)
         #expect(LanguageDefinitions.urdu.makeDefinition().numericDigits == NumericLayouts.persianDigits)
+        #expect(LanguageDefinitions.thai.makeDefinition().numericDigits == NumericLayouts.thaiDigits)
         // The new non-Arabic-script languages keep Western digits.
         #expect(LanguageDefinitions.greek.makeDefinition().numericDigits == NumericLayouts.westernDigits)
     }

--- a/wurstfingerTests/TestHelpers.swift
+++ b/wurstfingerTests/TestHelpers.swift
@@ -139,7 +139,7 @@ final class InMemoryUserDefaults: UserDefaults {
 /// affordance (no shifted/capsLock modes, no shift binding) and
 /// auto-capitalization disabled in their definition settings.
 enum CaselessLanguages {
-    static let ids: Set<String> = ["he_IL", "ar", "fa_IR", "ur"]
+    static let ids: Set<String> = ["he_IL", "ar", "fa_IR", "ur", "th_TH"]
 }
 
 /// Creates a KeyboardViewModel wired to a MockTextTarget for testing.


### PR DESCRIPTION
## What

Adds the **Thai** (`th_TH`) keyboard layout. Centers า น ั / ก อ ร / ม เ ง.

## Stacking ⚠️

Stacked on **#241** (native digit layer), **#243** (Greek/PT/Ukrainian) and **#244** (Arabic/Persian/Urdu). Net-new change is the last commit (`Add Thai keyboard layout`). **Merge #241/#243/#244 first, then retarget this PR's base to `develop` before squash-merge.**

## How

- Consonants + combining vowel/tone marks on primary swipes.
- Alternate letter forms via the existing `returnOverrides` mechanism.
- **Native Thai digits ๐-๙** via the per-language digit layer (new `NumericLayouts.thaiDigits`), with a Thai back-to-alpha label (กขค).
- Static **LTR** grid — no composition engine needed. This is the last non-CJK language that fits the existing data-only path; Hindi/Japanese/Korean would each need a combine engine.
- No Latin accent ring (consistent with the curated layouts).

## Tests

Parameterized `LanguageDefinitionTests` / `LayoutValidationTests` cover Thai; `rtlLanguagesShipNativeDigits` extended to assert Thai ships ๐-๙. Build + tests green on iPhone 17 Pro sim.

## Verification still open

Functional simulator/on-device spot-check of taps + native numeric layer (analogous to the Arabic check already done).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for native digit sets in numeric layouts, including Western, Arabic-Indic, Persian, and Thai digits.
  * Expanded language support with additional layouts for Arabic, Greek, Persian, Portuguese, Thai, Ukrainian, and Urdu.
  * Numeric keys now match the selected language/script more closely, including the zero key and return-to-alpha label.
* **Bug Fixes**
  * Preserved the chosen digit set when switching or rebuilding keyboard modes.
  * Improved numeric layout consistency for right-to-left and script-specific languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->