### PR TITLE
Add sequential CombineMiddleware and Hindi layout

### DIFF
--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -48,7 +48,8 @@ enum GridKeyboardFactory {
         supportsCapitalization: Bool = true,
         numericBackToAlphaLabel: String = NumericLayouts.defaultBackToAlphaLabel,
         numericDigits: [String] = NumericLayouts.westernDigits,
-        inputMethod: InputMethodKind = .direct
+        inputMethod: InputMethodKind = .direct,
+        combineRuleSet: ComposeRuleSet? = nil
     ) -> KeyboardDefinition {
         precondition(
             centerCharacters.count == 3 && centerCharacters.allSatisfy { $0.count == 3 },
@@ -177,7 +178,8 @@ enum GridKeyboardFactory {
             settings: KeyboardDefinitionSettings(
                 autoCapitalize: supportsCapitalization,
                 composeRuleOverrides: composeRuleOverrides,
-                inputMethod: inputMethod
+                inputMethod: inputMethod,
+                combineRuleSet: combineRuleSet
             ),
             numericBackToAlphaLabel: numericBackToAlphaLabel,
             numericDigits: numericDigits

--- a/wurstfingerKeyboard/Definition/Language/KeyboardDefinition.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardDefinition.swift
@@ -125,13 +125,23 @@ struct KeyboardDefinitionSettings: Codable, Equatable {
     /// `.direct`; set to `.telex` for Vietnamese Telex composition.
     let inputMethod: InputMethodKind
 
+    /// Sequential-combine rules (`trigger → base → result`) applied by
+    /// `CombineMiddleware`: when the just-typed character (`trigger`) follows a
+    /// matching `base` already in the document, both collapse to `result`.
+    /// Used by scripts that build characters from a base plus a following mark
+    /// — Devanagari vowel lengthening (इ + इ → ई), Japanese kana voicing.
+    /// nil = no sequential combine (the default for most languages).
+    let combineRuleSet: ComposeRuleSet?
+
     init(
         autoCapitalize: Bool,
         composeRuleOverrides: ComposeRuleSet?,
-        inputMethod: InputMethodKind = .direct
+        inputMethod: InputMethodKind = .direct,
+        combineRuleSet: ComposeRuleSet? = nil
     ) {
         self.autoCapitalize = autoCapitalize
         self.composeRuleOverrides = composeRuleOverrides
         self.inputMethod = inputMethod
+        self.combineRuleSet = combineRuleSet
     }
 }

--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
@@ -1014,6 +1014,7 @@ extension LanguageDefinitions {
                     .swipeLeft: "ध", .swipeRight: "घ", .swipeDownLeft: "ॉ",
                 ],
             ],
+            supportsCapitalization: false,
             numericBackToAlphaLabel: "कखग",
             numericDigits: NumericLayouts.devanagariDigits,
             combineRuleSet: hindiCombineRules

--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
@@ -554,6 +554,7 @@ enum LanguageDefinitions {
         german,
         greek,
         hebrew,
+        hindi,
         italian,
         persian,
         polish,
@@ -957,4 +958,75 @@ extension LanguageDefinitions {
             numericDigits: NumericLayouts.thaiDigits
         )
     }
+
+    // MARK: Hindi
+
+    static let hindi = LanguageDescriptor(
+        id: "hi_IN",
+        title: "हिन्दी (Hindi)",
+        localeIdentifier: "hi_IN"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["म", "न", "ल"],
+                ["ह", "क", "र"],
+                ["त", "प", "स"],
+            ],
+            directionalOverrides: [
+                GridSlot.topLeft: [
+                    .swipeUp: "ः", .swipeUpRight: "ँ", .swipeLeft: "ृ",
+                    .swipeRight: "अ", .swipeDown: "ओ", .swipeDownLeft: "ञ",
+                    .swipeDownRight: "द",
+                ],
+                GridSlot.topCenter: [
+                    .swipeUp: "आ", .swipeUpLeft: "ऊ", .swipeUpRight: "उ",
+                    .swipeLeft: "ौ", .swipeRight: "ो", .swipeDown: "व",
+                    .swipeDownLeft: "ई", .swipeDownRight: "इ",
+                ],
+                GridSlot.topRight: [.swipeRight: "़", .swipeDownLeft: "ज", .swipeDownRight: "ख"],
+                GridSlot.midLeft: [
+                    .swipeUp: "ऑ", .swipeUpLeft: "ॅ", .swipeUpRight: "थ",
+                    .swipeRight: "ब", .swipeDown: "झ", .swipeDownLeft: "ढ",
+                    .swipeDownRight: "श",
+                ],
+                GridSlot.center: [
+                    .swipeUp: "ा", .swipeUpLeft: "ू", .swipeUpRight: "ु",
+                    .swipeLeft: "ी", .swipeRight: "ि", .swipeDown: "्",
+                    .swipeDownLeft: "ै", .swipeDownRight: "े",
+                ],
+                GridSlot.midRight: [
+                    .swipeUp: "ट", .swipeUpLeft: "छ", .swipeUpRight: "ड",
+                    .swipeLeft: "फ", .swipeDown: "।", .swipeDownRight: "ठ",
+                ],
+                GridSlot.bottomLeft: [
+                    .swipeUp: "ऐ", .swipeUpLeft: "ऋ", .swipeUpRight: "ं",
+                    .swipeLeft: "ण",
+                ],
+                GridSlot.bottomCenter: [
+                    .swipeUp: "ए", .swipeUpRight: "औ", .swipeRight: "ग",
+                    .swipeDownRight: "ष",
+                ],
+                GridSlot.bottomRight: [
+                    .swipeUp: "च", .swipeUpLeft: "य", .swipeUpRight: "भ",
+                    .swipeLeft: "ध", .swipeRight: "घ", .swipeDownLeft: "ॉ",
+                ],
+            ],
+            numericBackToAlphaLabel: "कखग",
+            numericDigits: NumericLayouts.devanagariDigits,
+            combineRuleSet: hindiCombineRules
+        )
+    }
+
+    /// Devanagari vowel lengthening (short vowel typed twice → long).
+    /// From MessagEase `hindiCombine`; `trigger` is the second-typed vowel.
+    private static let hindiCombineRules = ComposeRuleSet(rules: [
+        "इ": ["इ": "ई"],
+        "उ": ["उ": "ऊ"],
+        "ऋ": ["ऋ": "ॠ"],
+        "ऌ": ["ऌ": "ॡ"],
+        "ऍ": ["ऍ": "ऎ"],
+    ])
 }

--- a/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
+++ b/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
@@ -29,6 +29,9 @@ enum NumericLayouts {
     /// Thai digits (U+0E50–0E59), used by the Thai layout.
     static let thaiDigits = ["๐", "๑", "๒", "๓", "๔", "๕", "๖", "๗", "๘", "๙"]
 
+    /// Devanagari digits (U+0966–096F), used by the Hindi layout.
+    static let devanagariDigits = ["०", "१", "२", "३", "४", "५", "६", "७", "८", "९"]
+
     /// Phone-style layout (1-2-3 in top row).
     ///
     /// - Parameter digits: Digit set indexed by value (0–9). Non-Latin layouts

--- a/wurstfingerKeyboard/Runtime/Pipeline/CombineMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/CombineMiddleware.swift
@@ -1,0 +1,67 @@
+//
+//  CombineMiddleware.swift
+//  Wurstfinger
+//
+//  Rewrites a single-character `.commitText` action into a combined character
+//  when it follows a matching preceding character (sequential A+B→C combine).
+//
+
+import Foundation
+
+/// Applies sequential character composition: when the just-typed character
+/// (the trigger) follows a matching preceding character in the document, both
+/// are replaced by a single combined character.
+///
+/// This is the "type base, then modifier" pattern used by scripts that build
+/// characters from a base plus a following mark — e.g. Devanagari vowel
+/// lengthening (इ + इ → ई) or Japanese kana voicing (か + ゛ → が). It differs
+/// from `ComposeMiddleware`, which reacts to an explicit `.compose` dead-key
+/// action; here both characters are ordinary committed letters.
+///
+/// The lookup uses the same `trigger → base → result` shape as
+/// `ComposeRuleSet`, with the trigger being the *second* character typed and
+/// the base the character already in the document. The middleware is inert
+/// when `isActive` returns `false`, so non-combine layouts pay no runtime cost
+/// beyond a single closure call.
+///
+/// Injected closures keep this file independent of the definition/data layer,
+/// mirroring `TelexMiddleware` and `ComposeMiddleware`.
+struct CombineMiddleware: ActionMiddleware {
+    /// Whether combine composition should be applied. Typically bound to
+    /// whether the active definition carries a combine rule set.
+    let isActive: () -> Bool
+
+    /// Returns the document context immediately before the cursor. Only the
+    /// last character is inspected.
+    let documentContextBefore: () -> String?
+
+    /// Deletes one character from the document (the consumed base character).
+    let deleteBackward: () -> Void
+
+    /// Lookup: `(previous, trigger) -> result?`. Bound to a plain dictionary
+    /// lookup over the definition's combine rule set.
+    let combine: (_ previous: String, _ trigger: String) -> String?
+
+    func process(_ context: ActionContext, next: (ActionContext) -> Void) {
+        guard isActive(),
+              case let .commitText(text) = context.action,
+              text.count == 1,
+              let documentContext = documentContextBefore(),
+              let previous = documentContext.last
+        else {
+            next(context)
+            return
+        }
+
+        guard let combined = combine(String(previous), text) else {
+            next(context)
+            return
+        }
+
+        // Replace the consumed base character, then forward the combined result.
+        deleteBackward()
+        var transformed = context
+        transformed.action = .commitText(combined)
+        next(transformed)
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -147,6 +147,23 @@ extension KeyboardViewModel {
             }
         ))
 
+        // 3b. Combine (sequential base+mark→combined, e.g. Devanagari vowel
+        //     lengthening, Japanese kana voicing). Inert unless the definition
+        //     carries a combine rule set.
+        let combineRuleSet = definition.settings.combineRuleSet
+        middlewares.append(CombineMiddleware(
+            isActive: { combineRuleSet != nil },
+            documentContextBefore: { [weak self] in
+                self?.textInputTarget?.documentContextBeforeInput
+            },
+            deleteBackward: { [weak self] in
+                self?.textInputTarget?.deleteBackward()
+            },
+            combine: { previous, trigger in
+                combineRuleSet?.rules[trigger]?[previous]
+            }
+        ))
+
         // 4. Advanced text (delete-forward, capitalize, clipboard). The
         //    clipboard confirmation tick fires from the middleware's success
         //    paths (not upfront in the haptic middleware) so guarded no-ops

--- a/wurstfingerTests/ActionPipelineTests.swift
+++ b/wurstfingerTests/ActionPipelineTests.swift
@@ -393,6 +393,74 @@ struct ComposeMiddlewareTests {
     }
 }
 
+// MARK: - CombineMiddleware
+
+struct CombineMiddlewareTests {
+    @Test func combinesWhenRuleMatches() {
+        var deleted = 0
+        let middleware = CombineMiddleware(
+            isActive: { true },
+            documentContextBefore: { "इ" },
+            deleteBackward: { deleted += 1 },
+            combine: { previous, trigger in
+                (previous == "इ" && trigger == "इ") ? "ई" : nil
+            }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .commitText("इ")))
+
+        #expect(sink.received.first?.action == .commitText("ई"))
+        #expect(deleted == 1, "The consumed base character must be deleted before the combined commit")
+    }
+
+    @Test func passesThroughWhenNoRuleMatches() {
+        let middleware = CombineMiddleware(
+            isActive: { true },
+            documentContextBefore: { "अ" },
+            deleteBackward: { Issue.record("Must not delete when no rule matches") },
+            combine: { _, _ in nil }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .commitText("इ")))
+
+        #expect(sink.received.first?.action == .commitText("इ"))
+    }
+
+    @Test func inertWhenInactive() {
+        let middleware = CombineMiddleware(
+            isActive: { false },
+            documentContextBefore: { Issue.record("Must not read context when inactive"); return "इ" },
+            deleteBackward: { Issue.record("Must not delete when inactive") },
+            combine: { _, _ in Issue.record("Must not combine when inactive"); return nil }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .commitText("इ")))
+
+        #expect(sink.received.first?.action == .commitText("इ"))
+    }
+
+    @Test func passesThroughWithoutPreviousCharacter() {
+        let middleware = CombineMiddleware(
+            isActive: { true },
+            documentContextBefore: { "" },
+            deleteBackward: { Issue.record("Must not delete without a previous char") },
+            combine: { _, _ in Issue.record("Must not combine without a previous char"); return nil }
+        )
+        let sink = RecordingMiddleware()
+        let pipeline = ActionPipeline(middlewares: [middleware, sink])
+
+        pipeline.process(PipelineFixtures.context(action: .commitText("इ")))
+
+        #expect(sink.received.first?.action == .commitText("इ"))
+    }
+}
+
 // MARK: - TextInputMiddleware
 
 // These tests use the shared `MockTextTarget` (TestHelpers.swift). A private

--- a/wurstfingerTests/ModeDefinitionValidationTests.swift
+++ b/wurstfingerTests/ModeDefinitionValidationTests.swift
@@ -249,6 +249,9 @@ struct NativeDigitLayerTests {
         // Sequential combine: short vowel typed twice → long vowel (इ + इ → ई).
         #expect(settings.combineRuleSet?.rules["इ"]?["इ"] == "ई")
         #expect(settings.combineRuleSet?.rules["उ"]?["उ"] == "ऊ")
+        #expect(settings.combineRuleSet?.rules["ऋ"]?["ऋ"] == "ॠ")
+        #expect(settings.combineRuleSet?.rules["ऌ"]?["ऌ"] == "ॡ")
+        #expect(settings.combineRuleSet?.rules["ऍ"]?["ऍ"] == "ऎ")
         // Languages without combine leave it nil.
         #expect(LanguageDefinitions.thai.makeDefinition().settings.combineRuleSet == nil)
     }

--- a/wurstfingerTests/ModeDefinitionValidationTests.swift
+++ b/wurstfingerTests/ModeDefinitionValidationTests.swift
@@ -239,8 +239,18 @@ struct NativeDigitLayerTests {
         #expect(LanguageDefinitions.persian.makeDefinition().numericDigits == NumericLayouts.persianDigits)
         #expect(LanguageDefinitions.urdu.makeDefinition().numericDigits == NumericLayouts.persianDigits)
         #expect(LanguageDefinitions.thai.makeDefinition().numericDigits == NumericLayouts.thaiDigits)
+        #expect(LanguageDefinitions.hindi.makeDefinition().numericDigits == NumericLayouts.devanagariDigits)
         // The new non-Arabic-script languages keep Western digits.
         #expect(LanguageDefinitions.greek.makeDefinition().numericDigits == NumericLayouts.westernDigits)
+    }
+
+    @Test func hindiCarriesVowelLengtheningCombineRules() {
+        let settings = LanguageDefinitions.hindi.makeDefinition().settings
+        // Sequential combine: short vowel typed twice → long vowel (इ + इ → ई).
+        #expect(settings.combineRuleSet?.rules["इ"]?["इ"] == "ई")
+        #expect(settings.combineRuleSet?.rules["उ"]?["उ"] == "ऊ")
+        // Languages without combine leave it nil.
+        #expect(LanguageDefinitions.thai.makeDefinition().settings.combineRuleSet == nil)
     }
 }
 

--- a/wurstfingerTests/TestHelpers.swift
+++ b/wurstfingerTests/TestHelpers.swift
@@ -139,7 +139,7 @@ final class InMemoryUserDefaults: UserDefaults {
 /// affordance (no shifted/capsLock modes, no shift binding) and
 /// auto-capitalization disabled in their definition settings.
 enum CaselessLanguages {
-    static let ids: Set<String> = ["he_IL", "ar", "fa_IR", "ur", "th_TH"]
+    static let ids: Set<String> = ["he_IL", "ar", "fa_IR", "ur", "th_TH", "hi_IN"]
 }
 
 /// Creates a KeyboardViewModel wired to a MockTextTarget for testing.

--- a/wurstfingerUITests/TypingTests.swift
+++ b/wurstfingerUITests/TypingTests.swift
@@ -108,6 +108,16 @@ final class TypingTests: XCTestCase {
 
     // MARK: - Tests
 
+    /// Hindi sequential combine: swiping the short vowel इ (top-center,
+    /// down-right) twice collapses to the long vowel ई via CombineMiddleware.
+    @MainActor
+    func testHindiVowelLengtheningCombines() {
+        relaunch(language: "hi_IN")
+        swipe(on: "topCenter", dx: 40, dy: 40) // down-right → इ
+        swipe(on: "topCenter", dx: 40, dy: 40) // down-right → इ, combines with previous → ई
+        assertTypedText(equals: "ई")
+    }
+
     /// Tapping letter keys appends each key's character in order.
     @MainActor
     func testTappingKeysSpellsTheirLabels() {


### PR DESCRIPTION
## What

Introduces a general **sequential character composition** engine and the first language that needs it — **Hindi** (`hi_IN`). This is the last missing piece for scripts MessagEase builds from base+mark sequences.

## Stacking ⚠️

Stacked on **#241/#243/#244/#247**. Net-new change is the last commit. **Merge those first, then retarget this PR's base to `develop` before squash-merge.**

## Engine

- **`CombineMiddleware`** (Runtime/Pipeline): modeled on `TelexMiddleware`; single-character lookback — when the just-typed char (trigger) follows a matching base already in the document, it deletes the base and commits the combined result. Inert unless the definition carries a combine rule set (no cost for other languages).
- Reuses **`ComposeRuleSet`** (`trigger→base→result`) as the data model — no new type. New optional `KeyboardDefinitionSettings.combineRuleSet`, threaded through `GridKeyboardFactory.layout`, wired into the pipeline right after Telex.

## Hindi (1:1 from the decompiled reference)

- Full Devanagari letter/matra grid — centers म न ल / ह क र / त प स; Latin ring and non-Devanagari stragglers filtered out.
- **Native Devanagari digits ०-९** (new `NumericLayouts.devanagariDigits`), कखग back-to-alpha label.
- **Vowel lengthening via combine**: इ+इ→ई, उ+उ→ऊ, ऋ+ऋ→ॠ, ऌ+ऌ→ॡ, ऍ+ऍ→ऎ (from MessagEase `hindiCombine`; the stray `k+a→क` artifact dropped).

## Tests

- `CombineMiddlewareTests`: match / no-match / inactive / no-previous-char.
- Hindi native-digit + combine-rule assertions.
- **End-to-end UI test** `testHindiVowelLengtheningCombines`: swipes इ twice on the real keyboard → asserts ई. **Passing** on iPhone 17 Pro sim, alongside the full validation suite.

## Not included (deliberate)

- **Japanese** (Hiragana/Katakana) reuses this exact engine (dakuten か+゛→が) — a natural follow-up, needs the kana layouts + a trigger-glyph decision.
- **Korean** needs a real Hangul syllable automaton (L+V+T→가), not just a rule table — MessagEase itself only does simplified jamo clustering. Out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for more languages, including Arabic, Greek, Hindi, Persian, Portuguese, Thai, Ukrainian, and Urdu.
  * Expanded numeric keyboard support to show native digit styles for multiple scripts.
  * Added smarter character combining behavior for supported languages, including Hindi vowel handling.

* **Bug Fixes**
  * Preserved the selected digit style when switching keyboard modes.
  * Improved behavior for right-to-left languages and script-specific layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->