### PR TITLE
Add Emoji Mode With 12 Direct-Select Keys

### DIFF
--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -19178,6 +19178,143 @@
         }
       },
       "comment": "ACCESSIBILITY action name for the question-mark swipe; the Arabic script substitutes ؟ (VoiceOver)"
+    },
+    "Emoji": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الرموز التعبيرية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ایموجی"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Émoji"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אימוג'י"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इमोजी"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "絵文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이모티콘"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эмодзи"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อีโมจิ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Емодзі"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ایموجی"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
+++ b/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
@@ -14,15 +14,22 @@ enum CommonKeys {
 
     static let globe: KeyConfig = {
         var bindings: [GestureType: KeyBinding] = [:]
-        // Tap is intentionally inert: switching the input method lives on the
-        // swipe-left gesture below. The empty `.none` slot keeps the key's
-        // accessibility label without re-triggering the globe on a plain tap;
-        // `accessibilityActivationGesture` routes a VoiceOver activation to
-        // that swipe so the label stays true for gesture-free input.
+        // Tap opens the emoji layer — the key's centre is otherwise unused
+        // (switching the input method lives on the swipe-left gesture below).
+        // The 🙂 label renders as a monochrome SF Symbol via
+        // `KeyView.sfSymbolMap`, matching other keyboards' emoji keys.
+        //
+        // Because that tap now does something, a VoiceOver activation resolves
+        // on its own and `accessibilityActivationGesture` stays inert (see
+        // `KeyConfig.accessibilityActivationOverride`, which only substitutes a
+        // gesture for an inert tap). It is kept declared so the globe still
+        // stays operable without gestures if the emoji entry ever moves off the
+        // tap. The input-method switch remains reachable under VoiceOver as the
+        // named rotor action carried by the swipe-left binding's label.
         bindings[.tap] = KeyBinding(
-            label: "", action: .none,
-            category: .utility, returnAction: nil,
-            accessibilityLabel: String(localized: "Switch keyboard")
+            label: "🙂", action: .switchMode(ModeNames.emoji),
+            category: .modifier, returnAction: nil,
+            accessibilityLabel: String(localized: "Emoji")
         )
         bindings[.swipeLeft] = KeyBinding(
             label: "", action: .advanceToNextInputMode,

--- a/wurstfingerKeyboard/Definition/Language/EmojiLayouts.swift
+++ b/wurstfingerKeyboard/Definition/Language/EmojiLayouts.swift
@@ -40,7 +40,7 @@ enum EmojiLayouts {
             }
         }
 
-        keys[UtilitySlot.globe] = CommonKeys.globe
+        keys[UtilitySlot.globe] = toggleGlobe()
         keys[UtilitySlot.delete] = CommonKeys.delete
         keys[UtilitySlot.return] = CommonKeys.return
         keys[UtilitySlot.symbols] = backToMain(label: backToAlphaLabel)
@@ -70,6 +70,25 @@ enum EmojiLayouts {
             slideType: .none,
             style: .primary,
             tapCycleActions: nil
+        )
+    }
+
+    /// Globe key variant for the emoji layer: tapping the smiley again
+    /// returns to the main layer (toggle behavior). Swipes stay identical.
+    private static func toggleGlobe() -> KeyConfig {
+        let globe = CommonKeys.globe
+        var bindings = globe.bindings
+        if let tap = bindings[.tap] {
+            bindings[.tap] = KeyBinding(
+                label: tap.label, action: .switchMode(ModeNames.main),
+                category: tap.category, returnAction: nil,
+                accessibilityLabel: tap.accessibilityLabel
+            )
+        }
+        return KeyConfig(
+            id: globe.id, bindings: bindings, swipeMode: globe.swipeMode,
+            slideType: globe.slideType, style: globe.style,
+            tapCycleActions: globe.tapCycleActions
         )
     }
 

--- a/wurstfingerKeyboard/Definition/Language/EmojiLayouts.swift
+++ b/wurstfingerKeyboard/Definition/Language/EmojiLayouts.swift
@@ -1,0 +1,84 @@
+//
+//  EmojiLayouts.swift
+//  Wurstfinger
+//
+//  Emoji keyboard mode: direct-select keys for the most-used emojis.
+//
+
+import Foundation
+
+/// Emoji keyboard mode shared across all languages.
+///
+/// The 3x3 grid plus a three-way split space row gives 12 direct-select emoji
+/// keys — every emoji is a plain tap with a full-size label, no swipe
+/// gestures. The set is a static pick of the globally most-used emojis
+/// (Unicode CLDR frequency data); usage-based personalization and a full
+/// browse view are follow-ups.
+enum EmojiLayouts {
+    /// The 12 default emojis in display order: three 3x3 grid rows followed
+    /// by the split space row.
+    static let defaultEmojis: [[String]] = [
+        ["😂", "❤️", "🤣"],
+        ["👍", "😭", "🙏"],
+        ["😘", "🥰", "😍"],
+        ["😊", "🎉", "😁"],
+    ]
+
+    /// Slot ids matching `defaultEmojis` row by row.
+    static let slotRows: [[String]] = GridSlot.allSlots + [[
+        GridSlot.emojiExtraLeft, GridSlot.emojiExtraCenter, GridSlot.emojiExtraRight,
+    ]]
+
+    /// Builds the emoji mode. `backToAlphaLabel` labels the key that returns
+    /// to the main (alphabetic) layer, matching the numeric layer's label.
+    static func mode(backToAlphaLabel: String = NumericLayouts.defaultBackToAlphaLabel) -> KeyboardMode {
+        var keys: [String: KeyConfig] = [:]
+        for (rowIdx, row) in defaultEmojis.enumerated() {
+            for (colIdx, emoji) in row.enumerated() {
+                let slotId = slotRows[rowIdx][colIdx]
+                keys[slotId] = emojiKey(slotId, emoji: emoji)
+            }
+        }
+
+        keys[UtilitySlot.globe] = CommonKeys.globe
+        keys[UtilitySlot.delete] = CommonKeys.delete
+        keys[UtilitySlot.return] = CommonKeys.return
+        keys[UtilitySlot.symbols] = backToMain(label: backToAlphaLabel)
+
+        return KeyboardMode(
+            name: ModeNames.emoji,
+            keys: keys,
+            arrangements: StandardArrangements.emoji3x3,
+            autoTransitions: [:],
+            doubleTapMode: nil
+        )
+    }
+
+    /// Direct-select emoji key: tap commits the emoji, no swipe bindings.
+    /// The explicit `.emoji` category keeps the label exempt from the
+    /// practice-mode label-hiding toggles.
+    private static func emojiKey(_ id: String, emoji: String) -> KeyConfig {
+        KeyConfig(
+            id: id,
+            bindings: [
+                .tap: KeyBinding(
+                    label: emoji, action: .commitText(emoji),
+                    category: .emoji, returnAction: nil, accessibilityLabel: nil
+                ),
+            ],
+            swipeMode: .none,
+            slideType: .none,
+            style: .primary,
+            tapCycleActions: nil
+        )
+    }
+
+    /// Back-to-alphabet key on the symbols slot, mirroring the numeric layer.
+    private static func backToMain(label: String) -> KeyConfig {
+        KeyConfig.utility(
+            UtilitySlot.symbols, label: label, action: .switchMode(ModeNames.main),
+            swipeMode: .eightWay,
+            swipes: CommonKeys.clipboardSwipes
+        )
+    }
+}

--- a/wurstfingerKeyboard/Definition/Language/EmojiLayouts.swift
+++ b/wurstfingerKeyboard/Definition/Language/EmojiLayouts.swift
@@ -49,8 +49,7 @@ enum EmojiLayouts {
             name: ModeNames.emoji,
             keys: keys,
             arrangements: StandardArrangements.emoji3x3,
-            autoTransitions: [:],
-            doubleTapMode: nil
+            autoTransitions: [:]
         )
     }
 
@@ -75,21 +74,21 @@ enum EmojiLayouts {
 
     /// Globe key variant for the emoji layer: tapping the smiley again
     /// returns to the main layer (toggle behavior). Swipes stay identical.
+    ///
+    /// Copies the shared key and swaps only the tap binding, the same way
+    /// `KeyConfig.autoShifted` derives the shifted layer. Rebuilding the struct
+    /// field by field would silently drop whatever `KeyConfig` gains later —
+    /// today that is `accessibilityActivationGesture`.
     private static func toggleGlobe() -> KeyConfig {
-        let globe = CommonKeys.globe
-        var bindings = globe.bindings
-        if let tap = bindings[.tap] {
-            bindings[.tap] = KeyBinding(
+        var globe = CommonKeys.globe
+        if let tap = globe.bindings[.tap] {
+            globe.bindings[.tap] = KeyBinding(
                 label: tap.label, action: .switchMode(ModeNames.main),
                 category: tap.category, returnAction: nil,
                 accessibilityLabel: tap.accessibilityLabel
             )
         }
-        return KeyConfig(
-            id: globe.id, bindings: bindings, swipeMode: globe.swipeMode,
-            slideType: globe.slideType, style: globe.style,
-            tapCycleActions: globe.tapCycleActions
-        )
+        return globe
     }
 
     /// Back-to-alphabet key on the symbols slot, mirroring the numeric layer.
@@ -97,7 +96,7 @@ enum EmojiLayouts {
         KeyConfig.utility(
             UtilitySlot.symbols, label: label, action: .switchMode(ModeNames.main),
             swipeMode: .eightWay,
-            swipes: CommonKeys.clipboardSwipes
+            swipes: CommonKeys.clipboardBindings
         )
     }
 }

--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -177,6 +177,7 @@ enum GridKeyboardFactory {
             ModeNames.numeric: NumericLayouts.phone(
                 digits: numericDigits, backToAlphaLabel: numericBackToAlphaLabel
             ),
+            ModeNames.emoji: EmojiLayouts.mode(backToAlphaLabel: numericBackToAlphaLabel),
         ]
 
         if supportsCapitalization {

--- a/wurstfingerKeyboard/Definition/Layout/GridSlot.swift
+++ b/wurstfingerKeyboard/Definition/Layout/GridSlot.swift
@@ -21,6 +21,10 @@ enum GridSlot {
     static let bottomRight = "bottomRight"
     /// Extra slot for the "0" digit key (only used in numeric mode).
     static let zero = "zero"
+    /// Extra slots for the split space row (only used in emoji mode).
+    static let emojiExtraLeft = "emojiExtraLeft"
+    static let emojiExtraCenter = "emojiExtraCenter"
+    static let emojiExtraRight = "emojiExtraRight"
 
     /// Ordered list of all slots (for mapping from centerCharacters arrays)
     static let allSlots: [[String]] = [

--- a/wurstfingerKeyboard/Definition/Layout/StandardArrangements.swift
+++ b/wurstfingerKeyboard/Definition/Layout/StandardArrangements.swift
@@ -101,6 +101,30 @@ enum StandardArrangements {
         ]
     )
 
+    // MARK: - Emoji Portrait
+
+    /// Emoji mode portrait: same shape as `portrait`, but the space bar is
+    /// split into three direct-select emoji keys.
+    private static let emojiPortrait = GridArrangement(
+        columns: 4,
+        rows: [
+            [.init(keyId: GridSlot.topLeft), .init(keyId: GridSlot.topCenter), .init(keyId: GridSlot.topRight), .init(keyId: UtilitySlot.globe)],
+            [.init(keyId: GridSlot.midLeft), .init(keyId: GridSlot.center), .init(keyId: GridSlot.midRight), .init(keyId: UtilitySlot.symbols)],
+            [
+                .init(keyId: GridSlot.bottomLeft),
+                .init(keyId: GridSlot.bottomCenter),
+                .init(keyId: GridSlot.bottomRight),
+                .init(keyId: UtilitySlot.delete),
+            ],
+            [
+                .init(keyId: GridSlot.emojiExtraLeft),
+                .init(keyId: GridSlot.emojiExtraCenter),
+                .init(keyId: GridSlot.emojiExtraRight),
+                .init(keyId: UtilitySlot.return),
+            ],
+        ]
+    )
+
     // MARK: - Utility-Left Variants
 
     /// The utility keys that move to the leading edge when "Utility Keys on
@@ -131,5 +155,14 @@ enum StandardArrangements {
         .portraitUtilityLeft: utilityLeft(numericPortrait),
         .landscape: numericLandscape,
         .landscapeUtilityLeft: utilityLeft(numericLandscape),
+    ]
+
+    /// Emoji mode: the portrait arrangement is used in all contexts — the
+    /// 3-row landscape shape has no room for the three extra bottom-row keys.
+    static let emoji3x3: [ArrangementContext: GridArrangement] = [
+        .portrait: emojiPortrait,
+        .portraitUtilityLeft: utilityLeft(emojiPortrait),
+        .landscape: emojiPortrait,
+        .landscapeUtilityLeft: utilityLeft(emojiPortrait),
     ]
 }

--- a/wurstfingerKeyboard/Definition/Model/KeyCategory.swift
+++ b/wurstfingerKeyboard/Definition/Model/KeyCategory.swift
@@ -16,6 +16,7 @@ enum KeyCategory: String, Codable {
     case modifier // Shift, symbols toggle, caps lock
     case utility // Globe, delete, return
     case whitespace // Space, newline
+    case emoji // Direct emoji key — label always visible, no auto-shift
 }
 
 extension KeyAction {

--- a/wurstfingerKeyboard/Definition/Model/LabelCategory.swift
+++ b/wurstfingerKeyboard/Definition/Model/LabelCategory.swift
@@ -62,7 +62,7 @@ extension LabelCategory {
         switch binding.resolvedCategory {
         case .letter: .letter
         case .digit: .number
-        case .modifier, .utility, .whitespace: .functional
+        case .modifier, .utility, .whitespace, .emoji: .functional
         case .compose:
             // The accent-cycle key (🅒) is a control and stays visible; compose
             // *triggers* (´ ¨ ~ ° …) read as symbols and hide with the symbol

--- a/wurstfingerKeyboard/Localizable.xcstrings
+++ b/wurstfingerKeyboard/Localizable.xcstrings
@@ -2421,6 +2421,66 @@
             "state": "translated",
             "value": "Emoji"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الرموز التعبيرية"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ایموجی"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इमोजी"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "絵文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이모티콘"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อีโมจิ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Емодзі"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ایموجی"
+          }
         }
       }
     }

--- a/wurstfingerKeyboard/Localizable.xcstrings
+++ b/wurstfingerKeyboard/Localizable.xcstrings
@@ -2346,6 +2346,83 @@
         }
       },
       "comment": "ACCESSIBILITY action name for the question-mark swipe; the Arabic script substitutes ؟ (VoiceOver)"
+    },
+    "Emoji": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Émoji"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эмодзи"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אימוג'י"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emoji"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/wurstfingerKeyboard/Runtime/View/KeyAccessibilityActions.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyAccessibilityActions.swift
@@ -11,11 +11,12 @@ import SwiftUI
 ///
 /// VoiceOver activates an element by synthesizing a touch, which reaches the
 /// gesture recognizer as a plain tap — so every swipe-only binding is out of
-/// reach, including the globe's input-method switch, whose tap is inert by
-/// design. Each labelled binding becomes a named custom action, and a key
-/// with an inert tap additionally overrides the element's default activation
-/// with the gesture it declares. Both dispatch through the same `onGesture`
-/// callback as a real touch, so they share the resolver chain and pipeline.
+/// reach, including the globe's input-method switch, which lives on swipe-left
+/// while the tap opens the emoji layer. Each labelled binding becomes a named
+/// custom action, and a key whose tap is inert additionally overrides the
+/// element's default activation with the gesture it declares. Both dispatch
+/// through the same `onGesture` callback as a real touch, so they share the
+/// resolver chain and pipeline.
 struct KeyAccessibilityActions: ViewModifier {
     let key: KeyConfig
     let onGesture: (KeyConfig, GestureType, Bool) -> Void

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -107,6 +107,11 @@ struct KeyView: View {
         "🙂": 0.7,
     ]
 
+    /// Symbols rendered in the muted hint styling instead of the full label
+    /// color: the smiley shares its key with several globe functions and
+    /// must not outshine their hint glyphs.
+    private static let mutedSymbols: Set<String> = ["🙂"]
+
     var body: some View {
         keyContent
     }
@@ -299,9 +304,14 @@ struct KeyView: View {
         } else {
             if let sfName = Self.sfSymbolMap[primaryLabel] {
                 let scale = Self.sfSymbolScale[primaryLabel, default: 1]
+                let muted = Self.mutedSymbols.contains(primaryLabel)
                 Image(systemName: sfName)
-                    .font(Font.system(size: scaledFontSize * scale, weight: .semibold, design: .rounded))
-                    .foregroundColor(.primary)
+                    .font(Font.system(
+                        size: scaledFontSize * scale,
+                        weight: muted ? .medium : .semibold,
+                        design: .rounded
+                    ))
+                    .foregroundStyle(muted ? Color.primary.opacity(0.5) : Color.primary)
             } else {
                 Text(primaryLabel)
                     .font(Font.system(size: scaledFontSize, weight: .semibold, design: .rounded))

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -98,6 +98,7 @@ struct KeyView: View {
         "🌐": "globe",
         "⌫": "delete.backward",
         "↵": "return",
+        "🙂": "face.smiling",
     ]
 
     var body: some View {

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -101,6 +101,12 @@ struct KeyView: View {
         "🙂": "face.smiling",
     ]
 
+    /// Per-symbol size adjustment: the round smiley glyph renders optically
+    /// larger than the other utility icons at the same point size.
+    private static let sfSymbolScale: [String: CGFloat] = [
+        "🙂": 0.7,
+    ]
+
     var body: some View {
         keyContent
     }
@@ -291,14 +297,14 @@ struct KeyView: View {
             // The centre label is hidden by the label-visibility setting.
             EmptyView()
         } else {
-            let font = Font.system(size: scaledFontSize, weight: .semibold, design: .rounded)
             if let sfName = Self.sfSymbolMap[primaryLabel] {
+                let scale = Self.sfSymbolScale[primaryLabel, default: 1]
                 Image(systemName: sfName)
-                    .font(font)
+                    .font(Font.system(size: scaledFontSize * scale, weight: .semibold, design: .rounded))
                     .foregroundColor(.primary)
             } else {
                 Text(primaryLabel)
-                    .font(font)
+                    .font(Font.system(size: scaledFontSize, weight: .semibold, design: .rounded))
                     .foregroundColor(.primary)
                     // Multi-character labels ("123") outgrow the cell before
                     // the size cap does; shrink instead of wrapping.

--- a/wurstfingerTests/AccessibilityLabelTests.swift
+++ b/wurstfingerTests/AccessibilityLabelTests.swift
@@ -123,15 +123,30 @@ struct AccessibilityLabelTests {
         }
     }
 
-    @Test func globeActivationAdvancesTheInputMode() throws {
+    /// The globe's tap opens (and closes) the emoji layer, so an assistive
+    /// activation already does something and needs no substitute gesture —
+    /// `accessibilityActivationOverride` is nil by design here. The
+    /// input-method switch it used to stand in for stays reachable as the
+    /// named custom action carried by the swipe-left binding's label.
+    @Test func globeOffersTheInputModeSwitchAsACustomAction() throws {
         for def in try loadedDefinitions() {
             for (modeName, mode) in def.modes {
                 guard let globe = mode.keys[UtilitySlot.globe] else { continue }
+                // Annotated so `.none` reads as the key action, not `Optional.none`.
+                let tapAction: KeyAction = globe.bindings[.tap]?.action ?? .none
                 #expect(
-                    globe.accessibilityActivationOverride == .swipeLeft,
-                    "\(def.id)/\(modeName) globe does not route activation to the input-mode switch"
+                    tapAction != .none,
+                    "\(def.id)/\(modeName) globe tap is inert — activation would do nothing"
+                )
+                #expect(
+                    globe.accessibilityActivationOverride == nil,
+                    "\(def.id)/\(modeName) globe substitutes a gesture although its tap is live"
                 )
                 #expect(globe.bindings[.swipeLeft]?.action == .advanceToNextInputMode)
+                #expect(
+                    globe.accessibilityActions.contains { $0.gesture == .swipeLeft },
+                    "\(def.id)/\(modeName) globe does not offer the input-mode switch as an action"
+                )
             }
         }
     }
@@ -183,13 +198,14 @@ struct AccessibilityLabelTests {
     }
 
     /// End to end through the real resolver chain and pipeline: the gesture the
-    /// globe declares has to actually reach the input-mode switch.
-    @Test func globeActivationReachesTheInputModeSwitch() throws {
+    /// globe offers under the "switch keyboard" name has to actually reach the
+    /// input-mode switch.
+    @Test func globeInputModeActionReachesTheInputModeSwitch() throws {
         var advanced = 0
         let (viewModel, _) = makeViewModel(advanceToNextInputMode: { advanced += 1 })
         let globe = try #require(viewModel.activeModeFromDefinition?.key(for: UtilitySlot.globe))
-        let gesture = try #require(globe.accessibilityActivationOverride)
-        viewModel.handleGesture(gesture, keyId: UtilitySlot.globe, isReturn: false)
+        let action = try #require(globe.accessibilityActions.first { $0.gesture == .swipeLeft })
+        viewModel.handleGesture(action.gesture, keyId: UtilitySlot.globe, isReturn: false)
         #expect(advanced == 1)
     }
 }

--- a/wurstfingerTests/CommonKeysFactoryTests.swift
+++ b/wurstfingerTests/CommonKeysFactoryTests.swift
@@ -25,8 +25,8 @@ struct CommonKeysTests {
     @Test func globeKeyAction() {
         let globe = CommonKeys.globe
         #expect(globe.id == UtilitySlot.globe)
-        // Switching the input method lives on swipe-left; tap is intentionally inert.
-        #expect(globe.bindings[.tap]?.action == KeyAction.none)
+        // Switching the input method lives on swipe-left; tap opens the emoji layer.
+        #expect(globe.bindings[.tap]?.action == .switchMode(ModeNames.emoji))
         #expect(globe.bindings[.swipeLeft]?.action == .advanceToNextInputMode)
         // Cycling the in-keyboard language lives on swipe-right.
         #expect(globe.bindings[.swipeRight]?.action == .switchToNextLanguage)

--- a/wurstfingerTests/EmojiModeTests.swift
+++ b/wurstfingerTests/EmojiModeTests.swift
@@ -1,0 +1,117 @@
+//
+//  EmojiModeTests.swift
+//  WurstfingerTests
+//
+//  Tests for the emoji keyboard mode (direct-select emoji layer).
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct EmojiModeTests {
+    private let mode = EmojiLayouts.mode()
+
+    // MARK: - Mode Structure
+
+    @Test func everyLanguageDefinitionContainsEmojiMode() {
+        for descriptor in LanguageDefinitions.all {
+            let definition = descriptor.makeDefinition()
+            #expect(definition.mode(ModeNames.emoji) != nil, "\(definition.id) is missing the emoji mode")
+        }
+    }
+
+    @Test func emojiModeValidates() {
+        #expect(mode.validate().isEmpty)
+    }
+
+    @Test func hasTwelveDirectSelectEmojiKeys() {
+        let emojiSlots = Array(EmojiLayouts.slotRows.joined())
+        #expect(emojiSlots.count == 12)
+
+        var seen = Set<String>()
+        for slotId in emojiSlots {
+            guard let key = mode.key(for: slotId) else {
+                Issue.record("missing key for \(slotId)")
+                continue
+            }
+            // Direct select: exactly one tap binding, no swipes.
+            #expect(key.bindings.count == 1)
+            let tap = key.bindings[.tap]
+            #expect(tap != nil)
+            if let tap, case let .commitText(emoji) = tap.action {
+                #expect(tap.label == emoji)
+                seen.insert(emoji)
+            } else {
+                Issue.record("\(slotId) tap binding must commit text")
+            }
+        }
+        #expect(seen.count == 12, "all 12 emojis must be unique")
+    }
+
+    @Test func emojiLabelsAreNeverHidden() throws {
+        let key = try #require(mode.key(for: GridSlot.center))
+        let tap = try #require(key.bindings[.tap])
+        #expect(tap.resolvedCategory == .emoji)
+        #expect(LabelCategory.of(tap) == .functional)
+        #expect(LabelCategory.of(tap).isVisible(
+            hideLetters: true, hideStandardSymbols: true, hideExtraSymbols: true
+        ))
+    }
+
+    @Test func stayingInEmojiModeAfterCommit() {
+        // Empty autoTransitions — several emojis can be sent in a row.
+        #expect(mode.autoTransitions.isEmpty)
+        #expect(mode.nextMode(after: .emoji) == nil)
+    }
+
+    // MARK: - Arrangement
+
+    @Test func arrangementSplitsSpaceRowIntoEmojiKeys() throws {
+        let arrangement = try #require(mode.arrangement(for: .portrait))
+        let placedIds = arrangement.rows.flatMap { $0.map(\.keyId) }
+        #expect(!placedIds.contains(UtilitySlot.space))
+        for slotId in EmojiLayouts.slotRows.joined() {
+            #expect(placedIds.contains(slotId))
+        }
+        for utility in [UtilitySlot.globe, UtilitySlot.symbols, UtilitySlot.delete, UtilitySlot.return] {
+            #expect(placedIds.contains(utility))
+        }
+    }
+
+    @Test func landscapeFallsBackToPortraitShape() throws {
+        let landscape = try #require(mode.arrangement(for: .landscape))
+        let portrait = try #require(mode.arrangement(for: .portrait))
+        #expect(landscape == portrait)
+    }
+
+    // MARK: - Entry and Exit
+
+    @Test func globeTapOpensEmojiMode() throws {
+        let binding = try #require(CommonKeys.globe.bindings[.tap])
+        #expect(binding.action == .switchMode(ModeNames.emoji))
+        // The entry label stays visible under all label-hiding toggles.
+        #expect(LabelCategory.of(binding) == .functional)
+    }
+
+    @Test func emojiEntryKeepsGlobeSwipes() {
+        let bindings = CommonKeys.globe.bindings
+        #expect(bindings[.swipeLeft]?.action == .advanceToNextInputMode)
+        #expect(bindings[.swipeDown]?.action == .dismissKeyboard)
+        #expect(bindings[.swipeRight]?.action == .switchToNextLanguage)
+    }
+
+    @Test func backKeyReturnsToMainMode() throws {
+        let backKey = try #require(mode.key(for: UtilitySlot.symbols))
+        let tap = try #require(backKey.bindings[.tap])
+        #expect(tap.action == .switchMode(ModeNames.main))
+        #expect(tap.label == NumericLayouts.defaultBackToAlphaLabel)
+    }
+
+    @Test func backKeyUsesLanguageSpecificLabel() throws {
+        let hebrew = LanguageDefinitions.hebrew.makeDefinition()
+        let emojiMode = try #require(hebrew.mode(ModeNames.emoji))
+        let backKey = try #require(emojiMode.key(for: UtilitySlot.symbols))
+        #expect(backKey.bindings[.tap]?.label == hebrew.numericBackToAlphaLabel)
+    }
+}

--- a/wurstfingerTests/EmojiModeTests.swift
+++ b/wurstfingerTests/EmojiModeTests.swift
@@ -94,6 +94,14 @@ struct EmojiModeTests {
         #expect(LabelCategory.of(binding) == .functional)
     }
 
+    @Test func globeTapInEmojiModeTogglesBackToMain() throws {
+        let globe = try #require(mode.key(for: UtilitySlot.globe))
+        #expect(globe.bindings[.tap]?.action == .switchMode(ModeNames.main))
+        // The label stays the smiley; only the tap action toggles back.
+        #expect(globe.bindings[.tap]?.label == CommonKeys.globe.bindings[.tap]?.label)
+        #expect(globe.bindings[.swipeLeft]?.action == .advanceToNextInputMode)
+    }
+
     @Test func emojiEntryKeepsGlobeSwipes() {
         let bindings = CommonKeys.globe.bindings
         #expect(bindings[.swipeLeft]?.action == .advanceToNextInputMode)


### PR DESCRIPTION
## Summary

Adds an emoji layer as a new data-driven `KeyboardMode`, shared across all languages. The 3x3 grid plus a three-way split space row gives **12 direct-select emoji keys** — every emoji is a plain tap with a full-size label, no swipe gestures. The static set is the globally most-used emojis per Unicode CLDR frequency data (😂 ❤️ 🤣 / 👍 😭 🙏 / 😘 🥰 😍 / 😊 🎉 😁).

**Entry:** tap on the globe key's centre (previously intentionally inert), rendered as a monochrome SF Symbol smiley (`face.smiling`) like other keyboards' emoji keys. All existing globe swipes (input switch, dismiss, language cycle) are unchanged.
**Exit:** tap `abc` on the symbols slot (mirrors the numeric layer, including per-script labels like אבג). Backspace, return, and globe stay in place; the mode has no auto-transitions, so several emojis can be sent in a row.

## Design decisions

- **Direct taps only, no swipe hints:** emoji glyphs are illegible at hint size; 12 large tap targets cover the everyday case (personal emoji usage is extremely head-heavy).
- **Portrait arrangement in all contexts:** the 3-row landscape shape has no room for the split space row.
- **New `KeyCategory.emoji`:** keeps emoji labels exempt from the practice-mode label-hiding toggles (a plain `commitText` binding would classify as hideable `extraSymbol`).
- **Reference:** Thumb-Key solves this with Android's `androidx.emoji2` `EmojiPickerView`, which has no iOS counterpart to embed — hence the custom, gesture-native layer.

## Scope cuts (follow-ups)

- Usage-based personalization of the 12 keys (frequency store in shared defaults)
- Scrollable browse view for the full emoji set
- Skin-tone variants (could reuse return-swipe or the long-press hook from #240)

## Testing

- 11 new unit tests (`EmojiModeTests`): mode structure/validation across all languages, arrangement, entry/exit bindings, label visibility
- Full `WurstfingerTests` run green on iPhone 17 Pro simulator
- Installed and manually exercised on a physical iPhone 17 Pro (entry position + monochrome label already iterated once based on on-device feedback)

Screenshots follow before this leaves draft.