### PR TITLE
Add Korean Hangul layout with syllable composition automaton

### DIFF
--- a/wurstfingerKeyboard/Definition/Language/KeyboardDefinition.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardDefinition.swift
@@ -107,6 +107,10 @@ enum InputMethodKind: String, Codable, Equatable {
     /// Vietnamese Telex: single-char and digraph lookback composition
     /// handled by `TelexMiddleware`.
     case telex
+
+    /// Korean Hangul: jamo → syllable composition handled by
+    /// `CombineMiddleware` driven by the `HangulComposer` automaton.
+    case hangul
 }
 
 /// Keyboard-specific settings for a KeyboardDefinition.

--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions+MessagEase.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions+MessagEase.swift
@@ -598,6 +598,43 @@ extension LanguageDefinitions {
             "ヲ": "ヺ",
         ],
     ])
+
+    // MARK: Korean
+
+    static let korean = LanguageDescriptor(
+        id: "ko_KR",
+        title: "한국어 (Korean)",
+        localeIdentifier: "ko_KR"
+    ) { meta in
+        GridKeyboardFactory.layout(
+            id: meta.id,
+            title: meta.title,
+            localeIdentifier: meta.localeIdentifier,
+            centerCharacters: [
+                ["ㄷ", "ㄹ", "ㅈ"],
+                ["ㄱ", "ㅇ", "ㄴ"],
+                ["ㅁ", "ㅅ", "ㅎ"],
+            ],
+            directionalOverrides: [
+                GridSlot.topLeft: [.swipeDownRight: "ㅌ"],
+                GridSlot.topCenter: [.swipeDown: "ㅛ"],
+                GridSlot.topRight: [.swipeDownLeft: "ㅊ"],
+                GridSlot.midLeft: [.swipeRight: "ㅕ"],
+                GridSlot.center: [
+                    .swipeUp: "ㅗ", .swipeUpLeft: "ㅔ", .swipeUpRight: "ㅡ",
+                    .swipeLeft: "ㅓ", .swipeRight: "ㅏ", .swipeDown: "ㅜ",
+                    .swipeDownLeft: "ㅐ", .swipeDownRight: "ㅣ",
+                ],
+                GridSlot.midRight: [.swipeLeft: "ㅑ"],
+                GridSlot.bottomLeft: [.swipeUpRight: "ㅂ"],
+                GridSlot.bottomCenter: [.swipeUp: "ㅠ", .swipeRight: "ㅋ"],
+                GridSlot.bottomRight: [.swipeUpLeft: "ㅍ"],
+            ],
+            supportsCapitalization: false,
+            numericBackToAlphaLabel: "가나다",
+            inputMethod: .hangul
+        )
+    }
 }
 
 // MARK: - Registry
@@ -622,6 +659,7 @@ extension LanguageDefinitions {
         hiragana,
         italian,
         katakana,
+        korean,
         persian,
         polish,
         portuguese,

--- a/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
+++ b/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
@@ -41,7 +41,8 @@ enum NumericLayouts {
         digits: [String] = westernDigits,
         backToAlphaLabel: String = defaultBackToAlphaLabel
     ) -> KeyboardMode {
-        buildMode(
+        precondition(digits.count == 10, "digits must contain exactly 10 glyphs (values 0–9)")
+        return buildMode(
             centerDigits: [
                 [digits[1], digits[2], digits[3]],
                 [digits[4], digits[5], digits[6]],
@@ -60,7 +61,8 @@ enum NumericLayouts {
         digits: [String] = westernDigits,
         backToAlphaLabel: String = defaultBackToAlphaLabel
     ) -> KeyboardMode {
-        buildMode(
+        precondition(digits.count == 10, "digits must contain exactly 10 glyphs (values 0–9)")
+        return buildMode(
             centerDigits: [
                 [digits[7], digits[8], digits[9]],
                 [digits[4], digits[5], digits[6]],

--- a/wurstfingerKeyboard/Runtime/Compose/HangulComposer.swift
+++ b/wurstfingerKeyboard/Runtime/Compose/HangulComposer.swift
@@ -1,0 +1,167 @@
+//
+//  HangulComposer.swift
+//  Wurstfinger
+//
+//  Korean Hangul syllable composition automaton.
+//
+//  Korean is written in syllable blocks of a leading consonant (choseong),
+//  a vowel (jungseong) and an optional trailing consonant (jongseong),
+//  encoded as precomposed syllables in U+AC00…U+D7A3:
+//
+//      syllable = 0xAC00 + (L * 21 + V) * 28 + T
+//
+//  The keyboard emits individual compatibility jamo (U+3131…U+3163). This
+//  composer folds each newly typed jamo into the syllable currently under the
+//  cursor, driving a two-set (두벌식-style) automaton with single-character
+//  lookback: it decomposes the previous character, applies the jamo, and
+//  returns the recomposed replacement — which may be two syllables when a
+//  trailing consonant "moves" onto a following vowel (한 + ㅏ → 하나).
+//
+
+import Foundation
+
+/// Stateless Hangul syllable composition, driven by single-character lookback.
+///
+/// `combine(previous:jamo:)` returns the string that should replace
+/// `previous + jamo`, or `nil` when the jamo cannot fold into `previous` and
+/// should be committed on its own (starting a fresh syllable). It plugs into
+/// `CombineMiddleware` exactly like a table lookup — the middleware deletes the
+/// single `previous` character and commits the (possibly multi-character)
+/// result.
+enum HangulComposer {
+    // Compatibility-jamo tables in composition-index order.
+    private static let choseong = Array("ㄱㄲㄴㄷㄸㄹㅁㅂㅃㅅㅆㅇㅈㅉㅊㅋㅌㅍㅎ")
+    private static let jungseong = Array("ㅏㅐㅑㅒㅓㅔㅕㅖㅗㅘㅙㅚㅛㅜㅝㅞㅟㅠㅡㅢㅣ")
+    private static let jongseong = Array("\u{0}ㄱㄲㄳㄴㄵㄶㄷㄹㄺㄻㄼㄽㄾㄿㅀㅁㅂㅄㅅㅆㅇㅈㅊㅋㅌㅍㅎ")
+
+    private static let syllableBase = 0xAC00
+    private static let jungseongCount = 21
+    private static let jongseongCount = 28
+
+    // Vowel + vowel → compound vowel (e.g. ㅗ + ㅏ → ㅘ).
+    private static let compoundVowel: [String: Character] = [
+        "ㅗㅏ": "ㅘ", "ㅗㅐ": "ㅙ", "ㅗㅣ": "ㅚ",
+        "ㅜㅓ": "ㅝ", "ㅜㅔ": "ㅞ", "ㅜㅣ": "ㅟ",
+        "ㅡㅣ": "ㅢ",
+    ]
+
+    // Final + consonant → compound final (e.g. ㄱ + ㅅ → ㄳ), plus its inverse
+    // used when a compound final splits across a syllable boundary.
+    private static let compoundFinal: [String: Character] = [
+        "ㄱㅅ": "ㄳ", "ㄴㅈ": "ㄵ", "ㄴㅎ": "ㄶ", "ㄹㄱ": "ㄺ", "ㄹㅁ": "ㄻ",
+        "ㄹㅂ": "ㄼ", "ㄹㅅ": "ㄽ", "ㄹㅌ": "ㄾ", "ㄹㅍ": "ㄿ", "ㄹㅎ": "ㅀ",
+        "ㅂㅅ": "ㅄ",
+    ]
+    private static let splitFinal: [Character: (Character, Character)] = {
+        var out: [Character: (Character, Character)] = [:]
+        for (pair, combined) in compoundFinal {
+            let chars = Array(pair)
+            out[combined] = (chars[0], chars[1])
+        }
+        return out
+    }()
+
+    // MARK: - Classification
+
+    private static func choseongIndex(_ c: Character) -> Int? {
+        choseong.firstIndex(of: c)
+    }
+
+    private static func jungseongIndex(_ c: Character) -> Int? {
+        jungseong.firstIndex(of: c)
+    }
+
+    /// Trailing-consonant index (1…27); nil if the character is not a valid final.
+    private static func jongseongIndex(_ c: Character) -> Int? {
+        let i = jongseong.firstIndex(of: c)
+        return (i == 0) ? nil : i
+    }
+
+    private static func isConsonant(_ c: Character) -> Bool {
+        choseongIndex(c) != nil
+    }
+
+    private static func isVowel(_ c: Character) -> Bool {
+        jungseongIndex(c) != nil
+    }
+
+    // MARK: - Compose / decompose
+
+    /// Builds a precomposed syllable from a leading consonant, vowel and
+    /// optional trailing consonant. Returns nil if any part is out of set.
+    private static func compose(_ lead: Character, _ vowel: Character, _ tail: Character?) -> String? {
+        guard let li = choseongIndex(lead), let vi = jungseongIndex(vowel) else { return nil }
+        let ti = tail.flatMap(jongseongIndex) ?? 0
+        let scalar = syllableBase + (li * jungseongCount + vi) * jongseongCount + ti
+        return UnicodeScalar(scalar).map { String($0) }
+    }
+
+    private static func decompose(_ syllable: Character) -> (Character, Character, Character?)? {
+        guard let scalar = syllable.unicodeScalars.first?.value,
+              (0xAC00 ... 0xD7A3).contains(scalar) else { return nil }
+        let index = Int(scalar) - syllableBase
+        let ti = index % jongseongCount
+        let vi = (index / jongseongCount) % jungseongCount
+        let li = index / (jungseongCount * jongseongCount)
+        return (choseong[li], jungseong[vi], ti == 0 ? nil : jongseong[ti])
+    }
+
+    // MARK: - Combine
+
+    /// Folds `jamo` into `previous`. See the type doc for the contract.
+    static func combine(previous: String, jamo: String) -> String? {
+        guard previous.count == 1, jamo.count == 1,
+              let prev = previous.first, let j = jamo.first,
+              isConsonant(j) || isVowel(j)
+        else { return nil }
+
+        if let (lead, vowel, tail) = decompose(prev) {
+            return foldIntoSyllable(lead: lead, vowel: vowel, tail: tail, jamo: j)
+        }
+        return foldIntoLoneJamo(prev: prev, jamo: j)
+    }
+
+    private static func foldIntoSyllable(
+        lead: Character, vowel: Character, tail: Character?, jamo j: Character
+    ) -> String? {
+        if isVowel(j) {
+            guard let tail else {
+                // No final yet: extend the vowel into a compound if possible.
+                if let cv = compoundVowel[String(vowel) + String(j)] {
+                    return compose(lead, cv, nil)
+                }
+                return nil // A fresh vowel starts a new (standalone) syllable.
+            }
+            // A final followed by a vowel moves onto the new syllable.
+            if let (keep, move) = splitFinal[tail] {
+                guard let first = compose(lead, vowel, keep),
+                      let second = compose(move, j, nil) else { return nil }
+                return first + second
+            }
+            guard let first = compose(lead, vowel, nil),
+                  let second = compose(tail, j, nil) else { return nil }
+            return first + second
+        }
+
+        // Consonant.
+        guard let tail else {
+            // Attach as the trailing consonant when it is a valid final.
+            return jongseongIndex(j) != nil ? compose(lead, vowel, j) : nil
+        }
+        // Grow the final into a compound if this consonant allows it.
+        if let cf = compoundFinal[String(tail) + String(j)] {
+            return compose(lead, vowel, cf)
+        }
+        return nil // Otherwise the consonant begins a new syllable.
+    }
+
+    private static func foldIntoLoneJamo(prev: Character, jamo j: Character) -> String? {
+        if isConsonant(prev), isVowel(j) {
+            return compose(prev, j, nil) // Leading consonant + vowel → syllable.
+        }
+        if isVowel(prev), isVowel(j), let cv = compoundVowel[String(prev) + String(j)] {
+            return String(cv) // Two vowels → standalone compound vowel.
+        }
+        return nil
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -147,12 +147,14 @@ extension KeyboardViewModel {
             }
         ))
 
-        // 3b. Combine (sequential base+mark→combined, e.g. Devanagari vowel
-        //     lengthening, Japanese kana voicing). Inert unless the definition
-        //     carries a combine rule set.
+        // 3b. Combine (sequential base+mark→combined). Two flavours share the
+        //     same middleware: a static rule table (Devanagari vowel lengthening,
+        //     Japanese kana voicing) or the algorithmic Korean Hangul automaton.
+        //     Inert unless the definition opts into one.
         let combineRuleSet = definition.settings.combineRuleSet
+        let combinesHangul = inputMethod == .hangul
         middlewares.append(CombineMiddleware(
-            isActive: { combineRuleSet != nil },
+            isActive: { combineRuleSet != nil || combinesHangul },
             documentContextBefore: { [weak self] in
                 self?.textInputTarget?.documentContextBeforeInput
             },
@@ -160,7 +162,10 @@ extension KeyboardViewModel {
                 self?.textInputTarget?.deleteBackward()
             },
             combine: { previous, trigger in
-                combineRuleSet?.rules[trigger]?[previous]
+                if combinesHangul {
+                    return HangulComposer.combine(previous: previous, jamo: trigger)
+                }
+                return combineRuleSet?.rules[trigger]?[previous]
             }
         ))
 

--- a/wurstfingerTests/HangulComposerTests.swift
+++ b/wurstfingerTests/HangulComposerTests.swift
@@ -1,0 +1,101 @@
+//
+//  HangulComposerTests.swift
+//  wurstfingerTests
+//
+//  Unit tests for the Korean Hangul syllable composition automaton.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct HangulComposerTests {
+    // MARK: - Basic composition
+
+    @Test func leadPlusVowelFormsSyllable() {
+        #expect(HangulComposer.combine(previous: "ㅎ", jamo: "ㅏ") == "하")
+        #expect(HangulComposer.combine(previous: "ㄱ", jamo: "ㅏ") == "가")
+    }
+
+    @Test func vowelAddsFinalConsonant() {
+        // 하 (LV) + ㄴ → 한 (LVT)
+        #expect(HangulComposer.combine(previous: "하", jamo: "ㄴ") == "한")
+    }
+
+    // MARK: - Final consonant migration
+
+    @Test func finalMovesOntoFollowingVowel() {
+        // 한 (ㅎㅏㄴ) + ㅏ → 하 + 나
+        #expect(HangulComposer.combine(previous: "한", jamo: "ㅏ") == "하나")
+    }
+
+    @Test func compoundFinalSplitsWhenVowelFollows() {
+        // 갃 (ㄱㅏㄳ) + ㅏ → 각 + 사
+        #expect(HangulComposer.combine(previous: "갃", jamo: "ㅏ") == "각사")
+    }
+
+    // MARK: - Compound jamo
+
+    @Test func compoundVowelFromSyllable() {
+        // 고 (ㄱㅗ) + ㅏ → 과 (ㄱㅘ)
+        #expect(HangulComposer.combine(previous: "고", jamo: "ㅏ") == "과")
+    }
+
+    @Test func compoundVowelFromLoneVowel() {
+        #expect(HangulComposer.combine(previous: "ㅗ", jamo: "ㅏ") == "ㅘ")
+        #expect(HangulComposer.combine(previous: "ㅡ", jamo: "ㅣ") == "ㅢ")
+    }
+
+    @Test func compoundFinalGrowsFromSyllable() {
+        // 각 (ㄱㅏㄱ) + ㅅ → 갃 (ㄱㅏㄳ)
+        #expect(HangulComposer.combine(previous: "각", jamo: "ㅅ") == "갃")
+    }
+
+    // MARK: - Non-composition (returns nil → jamo commits on its own)
+
+    @Test func consonantAfterCompleteSyllableStartsFresh() {
+        // 한 already has a final; a new consonant does not merge.
+        #expect(HangulComposer.combine(previous: "한", jamo: "ㄱ") == nil)
+    }
+
+    @Test func twoLeadingConsonantsDoNotMerge() {
+        #expect(HangulComposer.combine(previous: "ㄱ", jamo: "ㄴ") == nil)
+    }
+
+    @Test func nonHangulPreviousIsIgnored() {
+        #expect(HangulComposer.combine(previous: "a", jamo: "ㄱ") == nil)
+        #expect(HangulComposer.combine(previous: " ", jamo: "ㅏ") == nil)
+    }
+
+    @Test func nonJamoTriggerIsIgnored() {
+        #expect(HangulComposer.combine(previous: "하", jamo: "1") == nil)
+    }
+
+    // MARK: - Word-level integration
+
+    /// Simulates CombineMiddleware over a jamo stream: each step either folds
+    /// into the last character (delete it, append the result) or, on nil,
+    /// appends the jamo verbatim — exactly what the middleware does.
+    private func type(_ jamos: [String]) -> String {
+        var doc = ""
+        for jamo in jamos {
+            if let last = doc.last,
+               let combined = HangulComposer.combine(previous: String(last), jamo: jamo) {
+                doc.removeLast()
+                doc += combined
+            } else {
+                doc += jamo
+            }
+        }
+        return doc
+    }
+
+    @Test func typesHangulWord() {
+        // 한글: ㅎ ㅏ ㄴ ㄱ ㅡ ㄹ
+        #expect(type(["ㅎ", "ㅏ", "ㄴ", "ㄱ", "ㅡ", "ㄹ"]) == "한글")
+        // 안녕: ㅇ ㅏ ㄴ ㄴ ㅕ ㅇ
+        #expect(type(["ㅇ", "ㅏ", "ㄴ", "ㄴ", "ㅕ", "ㅇ"]) == "안녕")
+        // 과자: ㄱ ㅗ ㅏ ㅈ ㅏ
+        #expect(type(["ㄱ", "ㅗ", "ㅏ", "ㅈ", "ㅏ"]) == "과자")
+    }
+}

--- a/wurstfingerTests/TestHelpers.swift
+++ b/wurstfingerTests/TestHelpers.swift
@@ -139,7 +139,7 @@ final class InMemoryUserDefaults: UserDefaults {
 /// affordance (no shifted/capsLock modes, no shift binding) and
 /// auto-capitalization disabled in their definition settings.
 enum CaselessLanguages {
-    static let ids: Set<String> = ["he_IL", "ar", "fa_IR", "ur", "th_TH", "hi_IN", "ja_JP", "ja_JP_katakana"]
+    static let ids: Set<String> = ["he_IL", "ar", "fa_IR", "ur", "th_TH", "hi_IN", "ja_JP", "ja_JP_katakana", "ko_KR"]
 }
 
 /// Creates a KeyboardViewModel wired to a MockTextTarget for testing.

--- a/wurstfingerUITests/TypingTests.swift
+++ b/wurstfingerUITests/TypingTests.swift
@@ -118,6 +118,17 @@ final class TypingTests: XCTestCase {
         assertTypedText(equals: "ई")
     }
 
+    /// Korean Hangul composition: the jamo ㅎ, ㅏ, ㄴ fold into one syllable 한
+    /// via the HangulComposer automaton behind CombineMiddleware.
+    @MainActor
+    func testKoreanJamoComposeSyllable() {
+        relaunch(language: "ko_KR")
+        tapKey("bottomRight") // ㅎ (leading consonant)
+        swipe(on: "center", dx: 40, dy: 0) // right → ㅏ, composes → 하
+        tapKey("midRight") // ㄴ (final consonant), composes → 한
+        assertTypedText(equals: "한")
+    }
+
     /// Japanese kana voicing: type か (center, up-left) then the dakuten mark ゛
     /// (bottom-center, up-left) → the two combine into が via CombineMiddleware.
     @MainActor


### PR DESCRIPTION
## What

Adds **Korean** (`ko_KR`) — the last MessagEase language. Unlike a rule-table language, Korean needs a real **Hangul syllable composition automaton**: jamo (ㅎ ㅏ ㄴ) fold into precomposed syllables (한, U+AC00…U+D7A3).

## Stacking ⚠️

Stacked on **#241/#243/#244/#247/#248/#249**. Net-new change is the last commit. **Merge those first, then retarget this PR's base to `develop` before squash-merge.**

## How

- **`HangulComposer`** (Runtime/Compose): stateless two-set (두벌식-style) automaton, single-character lookback. `combine(previous:jamo:)` decomposes the syllable under the cursor, folds in the new jamo, and returns the recomposed replacement — handling:
  - lead + vowel → syllable (ㅎ + ㅏ → 하), vowel + final (하 + ㄴ → 한);
  - **compound vowels** (ㅗ + ㅏ → ㅘ) and **compound finals** (ㄱ + ㅅ → ㄳ);
  - **final migration** onto a following vowel (한 + ㅏ → 하나, compound-final split 갃 + ㅏ → 각사).
- New `InputMethodKind.hangul`; the pipeline points **CombineMiddleware**'s combine closure at `HangulComposer` instead of a rule table — the automaton reuses the exact same delete-one-insert-result plumbing (the result can be two syllables).
- Korean layout, 1:1 from the reference: 14 consonants + 12 vowels (centers ㄷ ㄹ ㅈ / ㄱ ㅇ ㄴ / ㅁ ㅅ ㅎ). Western digits.
- The registry `all` array moved to a `LanguageDefinitions` extension (SwiftLint `type_body_length`).

## Known limitations (match MessagEase's base grid)

Double consonants (ㄲㄸㅃㅆㅉ) and ㅒ/ㅖ aren't reachable — not on the base grid. Compound vowels/finals ARE reachable via composition.

## Tests

- **13 `HangulComposerTests`**: composition, final migration, compound vowels/finals, non-composition guards, and word-level (한글, 안녕, 과자).
- **End-to-end UI test** `testKoreanJamoComposeSyllable`: taps ㅎ, swipes ㅏ, taps ㄴ on the real keyboard → asserts 한. **Passing** (21s); build + validation green.

## 🎉 With this, the full MessagEase language set is covered

Chinese exists only as prediction dictionaries in MessagEase (no key layout), so it isn't portable as a layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for more languages and scripts, including Korean, Hindi, Japanese, Arabic, Persian, Urdu, Thai, Greek, and Ukrainian.
  * Keyboard layouts can now use native digit sets for supported languages and numeric modes.
  * Enabled character combining for select languages, including Hangul composition and kana voicing.

* **Bug Fixes**
  * Improved numeric layouts so the displayed digits match the selected locale.
  * Fixed composition behavior when entering combined characters in supported languages.

* **Tests**
  * Added coverage for numeric digits, Hangul composition, and end-to-end typing behavior across multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->