### PR TITLE
Add a Data-Driven Theme Engine With Editable Themes

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -89,9 +89,10 @@ about the *thing bound to it* ("the `topLeft` key commits `q`").
 
 ### `…Style` is visual only
 
-`KeyStyle` (`.primary`, `.utility`, `.spacebar`, …) and `KeyboardStyle` (`.classic`,
-`.liquidGlass`) are appearance. `NumpadType` (digit order) and `CursorMovementType`
-(drag behavior) are **not** visual and therefore carry `…Type`.
+`KeyStyle` (`.primary`, `.utility`, `.spacebar`, …) is appearance, and so are
+`BoardSurfaceStyle` and `KeySurfaceStyle` (both `.color` / `.glass`), which say how a theme
+paints its two surfaces. `NumpadType` (digit order) and `CursorMovementType` (drag
+behavior) are **not** visual and therefore carry `…Type`.
 
 For new code: `…Style` = how it looks, `…Type` = a closed set of behavioral variants (as in
 `GestureType`, `SlideType`). Never `…Mode` for either — that word belongs to keyboard

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -14,11 +14,22 @@ deliberately left in English.
 
 Sources under `wurstfingerKeyboard/` compile into **both** products, so a
 string used there is looked up in whichever bundle is running and must exist in
-**both** catalogs. A string that only ever appears in settings therefore belongs
-in the host target — that is why `KeyboardStyle.displayName` lives in
-`StyleSettingsView.swift` and `HapticIntensityLevel.displayName` in
-`HapticSettingsView.swift`, next to the screens that show them, rather than
-next to the enums in `wurstfingerKeyboard/Settings/`.
+**both** catalogs. `catalogsRequiredBySourceDir` in
+`wurstfingerTests/LocalizationCompletenessTests.swift` encodes exactly that rule:
+a string found under `wurstfinger/` is required in the host catalog only, one
+found under `wurstfingerKeyboard/` is required in both.
+
+Where a display name is declared therefore decides how often it has to be
+translated. `HapticIntensityLevel.displayName` lives in
+`wurstfinger/HapticSettingsView.swift`, next to the screen that shows it rather
+than next to the enum in `wurstfingerKeyboard/Settings/`, so "Minimal", "Soft"
+and "Strong" exist in the host catalog only. The theme names go the other way:
+`displayName` and `displayDescription` are declared on `KeyboardThemeDefinition`
+in `wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift` because extension code
+reads them too — `ThemeStore.duplicate` names a copied theme after its source.
+"Classic", "Liquid Glass", "Dark Gold" and their three descriptions are
+consequently duplicated into **both** catalogs, and a new built-in theme has to
+be translated in both.
 
 ## English-only screens
 

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -10,7 +10,7 @@ deliberately left in English.
 | Catalog | Holds |
 | --- | --- |
 | `wurstfinger/Localizable.xcstrings` | Everything the host app displays: settings, onboarding, the test area — plus the keyboard's own strings, because the app renders real keyboards in its previews and showcase. |
-| `wurstfingerKeyboard/Localizable.xcstrings` | Only the strings the keyboard extension itself displays, today the VoiceOver labels of the utility keys. |
+| `wurstfingerKeyboard/Localizable.xcstrings` | The strings that live in extension sources: the VoiceOver labels of the utility keys, plus the built-in theme names and descriptions. |
 
 Sources under `wurstfingerKeyboard/` compile into **both** products, so a
 string used there is looked up in whichever bundle is running and must exist in

--- a/wurstfinger/AppStoreScreenshotView.swift
+++ b/wurstfinger/AppStoreScreenshotView.swift
@@ -15,6 +15,13 @@ struct AppStoreScreenshotView: View {
     @State private var displayText: String = "I love it!"
     @State private var receivedText: String = "How do you like the new keyboard?"
 
+    /// Explicit theme injection for screenshots: FORCE_THEME names a theme id
+    /// ("classic", "liquid-glass", "dark-gold"). Defaults to Classic so
+    /// leftover simulator state can never recolor screenshot output.
+    private let forcedTheme: KeyboardThemeDefinition = ProcessInfo.processInfo
+        .environment["FORCE_THEME"]
+        .flatMap { BuiltInThemes.theme(id: $0) } ?? BuiltInThemes.classic
+
     var body: some View {
         VStack(spacing: 0) {
             // iPhone status bar - at the very top
@@ -29,8 +36,9 @@ struct AppStoreScreenshotView: View {
             // Keyboard at the bottom. Its geometry is fully forced onto the
             // non-persisting view model in configureFromEnvironment (square
             // cells at the full reference key height), so the standard render
-            // path applies with no extra overrides here.
-            DataDrivenKeyboardRootView(viewModel: viewModel)
+            // path applies with no extra overrides here. The forced theme keeps
+            // screenshots deterministic (see forcedTheme).
+            DataDrivenKeyboardRootView(viewModel: viewModel, themeOverride: forcedTheme)
                 .frame(maxWidth: .infinity)
                 // `.contain` promotes the per-key accessibilityIdentifiers into
                 // a queryable container so UI tests can find keys by slot id.

--- a/wurstfinger/InteractiveKeyboardPreview.swift
+++ b/wurstfinger/InteractiveKeyboardPreview.swift
@@ -47,17 +47,25 @@ struct InteractiveKeyboardPreview: View {
     @Binding var width: Double
     @Binding var position: Double
 
+    /// Forces the keyboard preview into a specific appearance (so the theme
+    /// gallery can preview the light or dark slot regardless of the device
+    /// setting). `nil` follows the system.
+    var appearanceOverride: ColorScheme?
+
     @StateObject private var previewViewModel = KeyboardViewModel(shouldPersistSettings: false)
     @StateObject private var previewTarget = PreviewTextTarget()
+    @Environment(\.colorScheme) private var systemColorScheme
 
     init(
         aspectRatio: Binding<Double> = .constant(1.0),
         width: Binding<Double> = .constant(DeviceLayout.defaultKeyboardWidth),
-        position: Binding<Double> = .constant(0.5)
+        position: Binding<Double> = .constant(0.5),
+        appearanceOverride: ColorScheme? = nil
     ) {
         _aspectRatio = aspectRatio
         _width = width
         _position = position
+        self.appearanceOverride = appearanceOverride
     }
 
     private var previewHeight: CGFloat {
@@ -134,6 +142,9 @@ struct InteractiveKeyboardPreview: View {
             }
             .frame(height: previewHeight)
             .clipShape(RoundedRectangle(cornerRadius: 12))
+            // Preview the chosen slot's appearance (light/dark) independent of
+            // the device; the keyboard resolves its theme from this colorScheme.
+            .environment(\.colorScheme, appearanceOverride ?? systemColorScheme)
             .animation(.easeInOut(duration: 0.2), value: aspectRatio)
             .animation(.easeInOut(duration: 0.2), value: width)
             .animation(.easeInOut(duration: 0.2), value: position)

--- a/wurstfinger/InteractiveKeyboardPreview.swift
+++ b/wurstfinger/InteractiveKeyboardPreview.swift
@@ -52,6 +52,11 @@ struct InteractiveKeyboardPreview: View {
     /// setting). `nil` follows the system.
     var appearanceOverride: ColorScheme?
 
+    /// Renders with an explicit theme instead of the stored selection, so the
+    /// theme editor can preview unsaved edits through the real keyboard
+    /// instead of a second, drift-prone mock renderer.
+    var themeOverride: KeyboardThemeDefinition?
+
     @StateObject private var previewViewModel = KeyboardViewModel(shouldPersistSettings: false)
     @StateObject private var previewTarget = PreviewTextTarget()
     @Environment(\.colorScheme) private var systemColorScheme
@@ -60,12 +65,14 @@ struct InteractiveKeyboardPreview: View {
         aspectRatio: Binding<Double> = .constant(1.0),
         width: Binding<Double> = .constant(DeviceLayout.defaultKeyboardWidth),
         position: Binding<Double> = .constant(0.5),
-        appearanceOverride: ColorScheme? = nil
+        appearanceOverride: ColorScheme? = nil,
+        themeOverride: KeyboardThemeDefinition? = nil
     ) {
         _aspectRatio = aspectRatio
         _width = width
         _position = position
         self.appearanceOverride = appearanceOverride
+        self.themeOverride = themeOverride
     }
 
     private var previewHeight: CGFloat {
@@ -116,28 +123,32 @@ struct InteractiveKeyboardPreview: View {
                     // The proxy width makes the preview lay out against its
                     // real container instead of the full screen width, so the
                     // fit-clamp and horizontal position match the extension.
-                    DataDrivenKeyboardRootView(viewModel: previewViewModel, overrideWidth: proxy.size.width)
-                        .onChange(of: aspectRatio) { _, newValue in
-                            previewViewModel.keyAspectRatio = newValue
-                        }
-                        .onChange(of: width) { _, newValue in
-                            previewViewModel.keyboardWidth = newValue
-                        }
-                        .onChange(of: position) { _, newValue in
-                            previewViewModel.keyboardHorizontalPosition = newValue
-                        }
-                        .onAppear {
-                            previewViewModel.keyAspectRatio = aspectRatio
-                            previewViewModel.keyboardWidth = width
-                            previewViewModel.keyboardHorizontalPosition = position
+                    DataDrivenKeyboardRootView(
+                        viewModel: previewViewModel,
+                        overrideWidth: proxy.size.width,
+                        themeOverride: themeOverride
+                    )
+                    .onChange(of: aspectRatio) { _, newValue in
+                        previewViewModel.keyAspectRatio = newValue
+                    }
+                    .onChange(of: width) { _, newValue in
+                        previewViewModel.keyboardWidth = newValue
+                    }
+                    .onChange(of: position) { _, newValue in
+                        previewViewModel.keyboardHorizontalPosition = newValue
+                    }
+                    .onAppear {
+                        previewViewModel.keyAspectRatio = aspectRatio
+                        previewViewModel.keyboardWidth = width
+                        previewViewModel.keyboardHorizontalPosition = position
 
-                            // Wire up preview text target and load definition
-                            previewViewModel.bindTextInputTarget(previewTarget)
-                            let languageId = SharedDefaults.store.string(
-                                forKey: SettingsKey.selectedLanguageId.rawValue
-                            ) ?? LanguageSettings.detectSystemLanguage()
-                            previewViewModel.loadDefinition(for: languageId)
-                        }
+                        // Wire up preview text target and load definition
+                        previewViewModel.bindTextInputTarget(previewTarget)
+                        let languageId = SharedDefaults.store.string(
+                            forKey: SettingsKey.selectedLanguageId.rawValue
+                        ) ?? LanguageSettings.detectSystemLanguage()
+                        previewViewModel.loadDefinition(for: languageId)
+                    }
                 }
             }
             .frame(height: previewHeight)

--- a/wurstfinger/KeyboardShowcaseView.swift
+++ b/wurstfinger/KeyboardShowcaseView.swift
@@ -90,9 +90,16 @@ struct KeyboardShowcaseView: View {
         forceLanguage ?? LanguageSettings.resolvedLanguageId(storedId)
     }
 
+    /// Explicit theme injection for screenshots: FORCE_THEME names a theme id
+    /// ("classic", "liquid-glass", "dark-gold"). Defaults to Classic so
+    /// leftover simulator state can never recolor screenshot output.
+    private let forcedTheme: KeyboardThemeDefinition = ProcessInfo.processInfo
+        .environment["FORCE_THEME"]
+        .flatMap { BuiltInThemes.theme(id: $0) } ?? BuiltInThemes.classic
+
     var body: some View {
         VStack(spacing: 0) {
-            DataDrivenKeyboardRootView(viewModel: viewModel)
+            DataDrivenKeyboardRootView(viewModel: viewModel, themeOverride: forcedTheme)
                 .frame(maxWidth: .infinity)
                 .background(Color(.systemBackground))
                 // `.contain` promotes the per-key accessibilityIdentifiers into

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -4555,7 +4555,141 @@
     "Dark Gold": {
       "comment": "Keyboard theme name: dark-gold (proper name, do not translate)",
       "extractionState": "manual",
-      "shouldTranslate": false
+      "shouldTranslate": false,
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ذهبي داكن"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σκούρο χρυσό"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oro oscuro"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "طلایی تیره"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Or sombre"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "זהב כהה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डार्क गोल्ड"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamno zlatno"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oro scuro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダークゴールド"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다크 골드"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemne złoto"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouro escuro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмное золото"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทองเข้ม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темне золото"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈارک گولڈ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vàng sẫm"
+          }
+        }
+      }
     },
     "Dark keys with golden letters": {
       "comment": "Keyboard theme description: dark-gold",
@@ -4631,6 +4765,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Madilim na mga key na may gintong mga titik"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفاتيح داكنة بحروف ذهبية"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σκούρα πλήκτρα με χρυσά γράμματα"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدهای تیره با حروف طلایی"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सुनहरे अक्षरों वाली गहरी कीज़"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暗いキーに金色の文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "어두운 키에 금색 글자"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas escuras com letras douradas"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่มสีเข้มพร้อมตัวอักษรสีทอง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темні клавіші із золотими літерами"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سنہری حروف کے ساتھ گہری کیز"
           }
         }
       }

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -19182,7 +19182,141 @@
     "Dark Gold": {
       "comment": "Keyboard theme name: dark-gold (proper name, do not translate)",
       "extractionState": "manual",
-      "shouldTranslate": false
+      "shouldTranslate": false,
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ذهبي داكن"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σκούρο χρυσό"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oro oscuro"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "طلایی تیره"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Or sombre"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "זהב כהה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डार्क गोल्ड"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamno zlatno"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oro scuro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダークゴールド"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다크 골드"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemne złoto"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouro escuro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмное золото"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทองเข้ม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темне золото"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈارک گولڈ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vàng sẫm"
+          }
+        }
+      }
     },
     "Dark keys with golden letters": {
       "comment": "Keyboard theme description: dark-gold",
@@ -19258,6 +19392,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Madilim na mga key na may gintong mga titik"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفاتيح داكنة بحروف ذهبية"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σκούρα πλήκτρα με χρυσά γράμματα"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدهای تیره با حروف طلایی"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सुनहरे अक्षरों वाली गहरी कीज़"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暗いキーに金色の文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "어두운 키에 금색 글자"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas escuras com letras douradas"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่มสีเข้มพร้อมตัวอักษรสีทอง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темні клавіші із золотими літерами"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سنہری حروف کے ساتھ گہری کیز"
           }
         }
       }

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -19180,9 +19180,8 @@
       "comment": "ACCESSIBILITY action name for the question-mark swipe; the Arabic script substitutes ؟ (VoiceOver)"
     },
     "Dark Gold": {
-      "comment": "Keyboard theme name: dark-gold (proper name, do not translate)",
+      "comment": "Keyboard theme name: dark keys with golden letters",
       "extractionState": "manual",
-      "shouldTranslate": false,
       "localizations": {
         "ar": {
           "stringUnit": {
@@ -19452,144 +19451,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "سنہری حروف کے ساتھ گہری کیز"
-          }
-        }
-      }
-    },
-    "Color Themes": {
-      "comment": "Theme gallery: section header for fixed-color palettes",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Farb-Themes"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thèmes de couleur"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Temas de color"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Temi di colore"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Цветовые темы"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Motywy kolorów"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Färgteman"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Väriteemat"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Teme boja"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ערכות צבע"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chủ đề màu"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga Tema ng Kulay"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سمات الألوان"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Χρωματικά θέματα"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پوسته‌های رنگی"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "रंग थीम"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カラーテーマ"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "색상 테마"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Temas de cor"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ธีมสี"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Кольорові теми"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "رنگین تھیمز"
           }
         }
       }
@@ -20004,144 +19865,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "لائٹ موڈ"
-          }
-        }
-      }
-    },
-    "Styles": {
-      "comment": "Theme gallery: section header for adaptive/material styles",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stile"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Styles"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilos"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stili"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Стили"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Style"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stilar"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tyylit"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stilovi"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "סגנונות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kiểu"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga Estilo"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الأنماط"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Στιλ"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سبک‌ها"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "स्टाइल"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "スタイル"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "스타일"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilos"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สไตล์"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Стилі"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "انداز"
           }
         }
       }
@@ -23734,144 +23457,6 @@
         }
       }
     },
-    "Surfaces": {
-      "comment": "Theme editor: section header for surface fills",
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Flächen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Surfaces"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Superficies"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Superfici"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Поверхности"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Powierzchnie"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ytor"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pinnat"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Površine"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משטחים"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bề mặt"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga Ibabaw"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الأسطح"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Επιφάνειες"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سطوح"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सतहें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーと背景"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키와 배경"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Superfícies"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "พื้นผิว"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Поверхні"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سطحیں"
-          }
-        }
-      }
-    },
     "Theme name": {
       "comment": "Theme editor: placeholder for the theme name field",
       "extractionState": "manual",
@@ -24006,6 +23591,1938 @@
           "stringUnit": {
             "state": "translated",
             "value": "تھیم کا نام"
+          }
+        }
+      }
+    },
+    "Included themes can't be changed. Duplicate one to make a theme you can edit.": {
+      "comment": "Style screen: footer under the built-in themes, explaining why they have no Edit action",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يمكن تغيير السمات المضمَّنة. كرِّر إحداها للحصول على سمة يمكنك تحريرها."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mitgelieferte Themes lassen sich nicht ändern. Dupliziere eines, um ein Theme zu erhalten, das du bearbeiten kannst."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τα ενσωματωμένα θέματα δεν μπορούν να τροποποιηθούν. Δημιουργήστε διπλότυπο ενός θέματος για να αποκτήσετε ένα θέμα που μπορείτε να επεξεργαστείτε."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los temas incluidos no se pueden modificar. Duplica uno para crear un tema editable."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پوسته‌های همراه برنامه قابل تغییر نیستند. برای داشتن پوسته‌ای که بتوانید ویرایش کنید، یکی از آن‌ها را تکثیر کنید."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mukana tulevia teemoja ei voi muuttaa. Monista jokin niistä, niin saat teeman, jota voit muokata."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hindi mababago ang mga kasamang tema. I-duplicate ang isa para makagawa ng temang puwede mong i-edit."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les thèmes inclus ne peuvent pas être modifiés. Dupliquez-en un pour créer un thème modifiable."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "לא ניתן לשנות ערכות נושא מובנות. שכפל אחת מהן כדי ליצור ערכת נושא שניתן לערוך."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पहले से शामिल थीम बदली नहीं जा सकतीं। एडिट की जा सकने वाली थीम पाने के लिए किसी एक को डुप्लिकेट करें।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ugrađene teme ne mogu se mijenjati. Dupliciraj jednu da dobiješ temu koju možeš uređivati."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I temi inclusi non possono essere modificati. Duplicane uno per creare un tema modificabile."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "あらかじめ用意されているテーマは変更できません。編集できるテーマを作るには、いずれかを複製してください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 제공 테마는 변경할 수 없습니다. 편집할 수 있는 테마를 만들려면 하나를 복제하세요."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wbudowanych motywów nie można zmieniać. Zduplikuj jeden z nich, aby utworzyć motyw, który możesz edytować."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os temas incluídos não podem ser alterados. Duplique um para criar um tema editável."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Встроенные темы нельзя изменить. Дублируйте одну из них, чтобы создать тему, которую можно редактировать."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medföljande teman kan inte ändras. Duplicera ett för att skapa ett tema som du kan redigera."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ธีมที่มีมาให้ไม่สามารถเปลี่ยนแปลงได้ ทำสำเนาธีมใดธีมหนึ่งเพื่อสร้างธีมที่คุณแก้ไขได้"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вбудовані теми не можна змінювати. Дублюйте одну з них, щоб створити тему, яку можна редагувати."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پہلے سے شامل تھیمز تبدیل نہیں کی جا سکتیں۔ قابلِ ترمیم تھیم حاصل کرنے کے لیے کسی ایک کی کاپی بنائیں۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể thay đổi các chủ đề có sẵn. Hãy nhân bản một chủ đề để tạo bản mà bạn có thể chỉnh sửa."
+          }
+        }
+      }
+    },
+    "Duplicate %@": {
+      "comment": "Accessibility label: duplicate a theme; %@ is the theme name",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تكرار %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ duplizieren"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Δημιουργία διπλότυπου %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplicar %@"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تکثیر %@"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monista %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-duplicate ang %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dupliquer %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שכפל את %@"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ डुप्लिकेट करें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dupliciraj %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplica %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@を複製"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 복제"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplikuj %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplicar %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дублировать %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplicera %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทำสำเนา %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дублювати %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کی کاپی بنائیں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhân bản %@"
+          }
+        }
+      }
+    },
+    "Edit %@": {
+      "comment": "Accessibility label: edit a theme; %@ is the theme name",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحرير %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ bearbeiten"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επεξεργασία %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar %@"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ویرایش %@"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muokkaa teemaa %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-edit ang %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ערוך את %@"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ एडिट करें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uredi %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@を編集"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 편집"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edytuj %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменить %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redigera %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แก้ไข %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Редагувати %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ میں ترمیم کریں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chỉnh sửa %@"
+          }
+        }
+      }
+    },
+    "Delete %@": {
+      "comment": "Delete-confirmation button and accessibility label; %@ is the theme name",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ löschen"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διαγραφή %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar %@"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف %@"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tanggalin ang %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מחק את %@"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ हटाएँ"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izbriši %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimina %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@を削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 삭제"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radera %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลบ %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ حذف کریں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa %@"
+          }
+        }
+      }
+    },
+    "New Theme": {
+      "comment": "Theme editor: navigation title when editing a freshly duplicated theme",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سمة جديدة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neues Theme"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Νέο θέμα"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuevo tema"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پوستهٔ جدید"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uusi teema"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bagong tema"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouveau thème"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ערכת נושא חדשה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नई थीम"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nova tema"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuovo tema"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規テーマ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새로운 테마"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowy motyw"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novo tema"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новая тема"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nytt tema"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ธีมใหม่"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нова тема"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نئی تھیم"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chủ đề mới"
+          }
+        }
+      }
+    },
+    "Keys": {
+      "comment": "Theme editor: section header for the key settings. Plural; distinct from the 'Key' color label in the same section",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المفاتيح"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasten"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πλήκτρα"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدها"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäimet"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Key"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touches"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקשים"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कुंजियाँ"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipke"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasti"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーの外観"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키 외관"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klawisze"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавиши"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangenter"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รูปลักษณ์ปุ่ม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавіші"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کیز"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Các phím"
+          }
+        }
+      }
+    },
+    "Liquid Glass keys": {
+      "comment": "Accessibility label of the glass switch in the Keys section; the visible label is only 'Liquid Glass'",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفاتيح Liquid Glass"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass für die Tasten"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πλήκτρα Liquid Glass"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas Liquid Glass"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدهای Liquid Glass"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass -näppäimet"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass para sa mga key"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touches Liquid Glass"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקשי Liquid Glass"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass कुंजियाँ"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipke Liquid Glass"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasti Liquid Glass"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass（キー）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass 키"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klawisze Liquid Glass"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas Liquid Glass"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавиши Liquid Glass"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass för tangenterna"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass สำหรับปุ่ม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавіші Liquid Glass"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass کیز"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím Liquid Glass"
+          }
+        }
+      }
+    },
+    "Glass keys take their color from what is behind the keyboard, so the key colors do not apply. Corner radius still shapes them. Liquid Glass draws no border, so the border settings only take effect if this theme is used on a device before iOS 26.": {
+      "comment": "Theme editor: Keys section footer on iOS 26 and later, while glass keys are on",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تستمد المفاتيح الزجاجية لونها مما خلف لوحة المفاتيح، لذا لا تُطبَّق ألوان المفاتيح. وما زال نصف قطر الزوايا يحدّد شكلها. ولا يرسم Liquid Glass أي حد، لذا لا تسري إعدادات الحد إلا إذا استُخدمت هذه السمة على جهاز بإصدار أقدم من iOS 26."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Glastasten übernehmen die Farbe des Inhalts hinter der Tastatur, daher haben die Tastenfarben keine Wirkung. Der Eckenradius formt sie weiterhin. Liquid Glass zeichnet keinen Rahmen; die Rahmeneinstellungen wirken sich deshalb nur aus, wenn dieses Theme auf einem Gerät mit einer iOS-Version vor 26 verwendet wird."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τα γυάλινα πλήκτρα παίρνουν το χρώμα τους από ό,τι βρίσκεται πίσω από το πληκτρολόγιο, επομένως τα χρώματα των πλήκτρων δεν ισχύουν. Το στρογγύλεμα γωνιών εξακολουθεί να καθορίζει το σχήμα τους. Το Liquid Glass δεν σχεδιάζει περίγραμμα, επομένως οι ρυθμίσεις περιγράμματος ισχύουν μόνο αν αυτό το θέμα χρησιμοποιηθεί σε συσκευή με έκδοση παλαιότερη από το iOS 26."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las teclas de cristal toman su color de lo que hay detrás del teclado, por lo que los colores de las teclas no se aplican. El radio de esquina sigue definiendo su forma. Liquid Glass no dibuja ningún borde, así que los ajustes del borde solo tienen efecto si este tema se usa en un dispositivo con una versión anterior a iOS 26."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدهای شیشه‌ای رنگ خود را از آنچه پشت صفحه‌کلید است می‌گیرند، بنابراین رنگ‌های کلید اعمال نمی‌شوند. شعاع گوشه همچنان شکل آن‌ها را تعیین می‌کند. Liquid Glass هیچ حاشیه‌ای رسم نمی‌کند، بنابراین تنظیمات حاشیه فقط در صورتی اثر می‌کنند که این پوسته روی دستگاهی با نسخه‌ای پیش از iOS 26 استفاده شود."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lasinäppäimet ottavat värinsä näppäimistön takana olevasta sisällöstä, joten näppäinten värejä ei käytetä. Kulman pyöristys muotoilee niitä edelleen. Liquid Glass ei piirrä reunusta, joten reunusasetukset vaikuttavat vain, jos tätä teemaa käytetään laitteessa, jossa on iOS 26:ta vanhempi versio."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kinukuha ng mga glass key ang kulay mula sa kung ano ang nasa likod ng keyboard, kaya hindi nalalapat ang mga kulay ng key. Hinuhubog pa rin ng radius ng sulok ang mga ito. Walang iginuguhit na border ang Liquid Glass, kaya nagkakabisa lang ang mga setting ng border kung gagamitin ang temang ito sa device na may bersyong mas luma kaysa iOS 26."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les touches en verre tirent leur couleur de ce qui se trouve derrière le clavier ; les couleurs des touches ne s'appliquent donc pas. Le rayon des coins continue de déterminer leur forme. Liquid Glass ne trace aucune bordure : les réglages de bordure ne prennent effet que si ce thème est utilisé sur un appareil doté d'une version antérieure à iOS 26."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקשי זכוכית מקבלים את צבעם ממה שנמצא מאחורי המקלדת, ולכן צבעי המקשים אינם חלים. רדיוס הפינה עדיין קובע את צורתם. Liquid Glass אינו מצייר מסגרת, ולכן הגדרות המסגרת ייכנסו לתוקף רק אם ערכת נושא זו תשמש במכשיר עם גרסה מוקדמת מ‑iOS 26."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ग्लास कुंजियाँ अपना रंग कीबोर्ड के पीछे मौजूद चीज़ से लेती हैं, इसलिए कुंजियों के रंग लागू नहीं होते। कॉर्नर रेडियस फिर भी उनका आकार तय करता है। Liquid Glass कोई बॉर्डर नहीं बनाता, इसलिए बॉर्डर सेटिंग्स तभी असर करती हैं जब यह थीम iOS 26 से पहले के किसी डिवाइस पर इस्तेमाल हो।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Staklene tipke preuzimaju boju onoga što se nalazi iza tipkovnice, pa se boje tipki ne primjenjuju. Radijus kuta ih i dalje oblikuje. Liquid Glass ne crta rub, pa postavke ruba djeluju samo ako se ova tema koristi na uređaju s verzijom starijom od iOS-a 26."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I tasti in vetro assumono il colore di ciò che si trova dietro la tastiera, quindi i colori dei tasti non vengono applicati. Il raggio degli angoli continua a definirne la forma. Liquid Glass non disegna alcun bordo, perciò le impostazioni del bordo hanno effetto solo se questo tema viene usato su un dispositivo con una versione precedente a iOS 26."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ガラスのキーはキーボードの背後にあるものから色を取り込むため、キーの色は適用されません。角の丸みはガラスのキーにも引き続き適用されます。Liquid Glassは枠線を描画しないため、枠線の設定が反映されるのは、このテーマをiOS 26より前のバージョンのデバイスで使用した場合のみです。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "유리 키는 키보드 뒤에 있는 내용에서 색상을 가져오므로 키 색상이 적용되지 않습니다. 모서리 둥글기는 유리 키의 모양에도 계속 적용됩니다. Liquid Glass는 테두리를 그리지 않으므로, 테두리 설정은 이 테마를 iOS 26 이전 버전의 기기에서 사용할 때만 적용됩니다."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Szklane klawisze przejmują kolor tego, co znajduje się za klawiaturą, więc kolory klawiszy nie działają. Promień narożnika nadal je kształtuje. Liquid Glass nie rysuje obramowania, więc ustawienia obramowania zadziałają tylko wtedy, gdy ten motyw zostanie użyty na urządzeniu z systemem starszym niż iOS 26."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As teclas de vidro assumem a cor do que está por trás do teclado, pelo que as cores das teclas não são aplicadas. O raio dos cantos continua a definir a sua forma. O Liquid Glass não desenha qualquer contorno, por isso as definições do contorno só têm efeito se este tema for usado num dispositivo com uma versão anterior ao iOS 26."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стеклянные клавиши принимают цвет того, что находится за клавиатурой, поэтому цвета клавиш не применяются. Радиус скругления по-прежнему задаёт их форму. Liquid Glass не рисует границу, поэтому настройки границы действуют, только если эта тема используется на устройстве с версией до iOS 26."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Glastangenter tar sin färg från det som finns bakom tangentbordet, så tangentfärgerna används inte. Hörnradien formar dem fortfarande. Liquid Glass ritar ingen kant, så kantinställningarna får bara effekt om det här temat används på en enhet med en iOS-version före 26."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่มแบบกระจกจะดึงสีจากสิ่งที่อยู่ด้านหลังแป้นพิมพ์ สีปุ่มจึงไม่มีผล ความโค้งมุมยังคงกำหนดรูปทรงของปุ่มแบบกระจก Liquid Glass ไม่วาดเส้นขอบ การตั้งค่าเส้นขอบจึงมีผลเฉพาะเมื่อใช้ธีมนี้บนอุปกรณ์ที่ใช้เวอร์ชันก่อน iOS 26"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скляні клавіші беруть колір того, що розташовано за клавіатурою, тому кольори клавіш не застосовуються. Радіус заокруглення все одно визначає їхню форму. Liquid Glass не малює рамки, тому параметри рамки діють, лише якщо цю тему використано на пристрої з версією до iOS 26."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گلاس کیز اپنا رنگ کی بورڈ کے پیچھے موجود چیز سے لیتی ہیں، اس لیے کیز کے رنگ لاگو نہیں ہوتے۔ کونے کی گولائی پھر بھی ان کی شکل بناتی ہے۔ Liquid Glass کوئی بارڈر نہیں بناتا، اس لیے بارڈر کی ترتیبات صرف اسی صورت میں اثر کرتی ہیں جب یہ تھیم iOS 26 سے پہلے والے کسی ڈیوائس پر استعمال ہو۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím kính lấy màu từ nội dung phía sau bàn phím, nên màu phím không có tác dụng. Bán kính góc vẫn định hình phím kính. Liquid Glass không vẽ viền, nên các cài đặt viền chỉ có tác dụng nếu chủ đề này được dùng trên thiết bị chạy phiên bản cũ hơn iOS 26."
+          }
+        }
+      }
+    },
+    "Glass keys take their color from what is behind the keyboard, so the key colors do not apply. Corner radius and border still apply: this system renders a simplified translucent style instead of Liquid Glass.": {
+      "comment": "Theme editor: Keys section footer before iOS 26, while glass keys are on",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تستمد المفاتيح الزجاجية لونها مما خلف لوحة المفاتيح، لذا لا تُطبَّق ألوان المفاتيح. أما نصف قطر الزوايا والحد فما زالا يُطبَّقان: يعرض هذا النظام نمطًا مبسّطًا شبه شفاف بدلًا من Liquid Glass."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Glastasten übernehmen die Farbe des Inhalts hinter der Tastatur, daher haben die Tastenfarben keine Wirkung. Eckenradius und Rahmen wirken sich weiterhin aus: Diese Systemversion stellt statt Liquid Glass einen vereinfachten durchscheinenden Stil dar."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τα γυάλινα πλήκτρα παίρνουν το χρώμα τους από ό,τι βρίσκεται πίσω από το πληκτρολόγιο, επομένως τα χρώματα των πλήκτρων δεν ισχύουν. Το στρογγύλεμα γωνιών και το περίγραμμα εξακολουθούν να ισχύουν: αυτό το σύστημα εμφανίζει ένα απλοποιημένο ημιδιαφανές στιλ αντί για το Liquid Glass."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las teclas de cristal toman su color de lo que hay detrás del teclado, por lo que los colores de las teclas no se aplican. El radio de esquina y el borde sí se aplican: este sistema muestra un estilo translúcido simplificado en lugar de Liquid Glass."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدهای شیشه‌ای رنگ خود را از آنچه پشت صفحه‌کلید است می‌گیرند، بنابراین رنگ‌های کلید اعمال نمی‌شوند. شعاع گوشه و حاشیه همچنان اعمال می‌شوند: این سیستم به‌جای Liquid Glass یک سبک نیمه‌شفاف ساده‌شده نمایش می‌دهد."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lasinäppäimet ottavat värinsä näppäimistön takana olevasta sisällöstä, joten näppäinten värejä ei käytetä. Kulman pyöristys ja reunus vaikuttavat edelleen: tämä järjestelmäversio näyttää Liquid Glassin sijaan yksinkertaistetun läpikuultavan tyylin."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kinukuha ng mga glass key ang kulay mula sa kung ano ang nasa likod ng keyboard, kaya hindi nalalapat ang mga kulay ng key. Nalalapat pa rin ang radius ng sulok at ang border: nagre-render ang sistemang ito ng pinasimpleng translucent na estilo sa halip na Liquid Glass."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les touches en verre tirent leur couleur de ce qui se trouve derrière le clavier ; les couleurs des touches ne s'appliquent donc pas. Le rayon des coins et la bordure s'appliquent toujours : ce système affiche un style translucide simplifié à la place de Liquid Glass."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקשי זכוכית מקבלים את צבעם ממה שנמצא מאחורי המקלדת, ולכן צבעי המקשים אינם חלים. רדיוס הפינה והמסגרת עדיין חלים: מערכת זו מציגה סגנון שקוף למחצה ופשוט יותר במקום Liquid Glass."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ग्लास कुंजियाँ अपना रंग कीबोर्ड के पीछे मौजूद चीज़ से लेती हैं, इसलिए कुंजियों के रंग लागू नहीं होते। कॉर्नर रेडियस और बॉर्डर फिर भी लागू होते हैं: यह सिस्टम Liquid Glass के बजाय सरलीकृत पारभासी स्टाइल दिखाता है।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Staklene tipke preuzimaju boju onoga što se nalazi iza tipkovnice, pa se boje tipki ne primjenjuju. Radijus kuta i rub i dalje se primjenjuju: ovaj sustav prikazuje pojednostavljeni poluprozirni stil umjesto stila Liquid Glass."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I tasti in vetro assumono il colore di ciò che si trova dietro la tastiera, quindi i colori dei tasti non vengono applicati. Il raggio degli angoli e il bordo vengono comunque applicati: questo sistema mostra uno stile traslucido semplificato invece di Liquid Glass."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ガラスのキーはキーボードの背後にあるものから色を取り込むため、キーの色は適用されません。角の丸みと枠線は引き続き適用されます。このシステムでは、Liquid Glassの代わりに簡素化された半透明のスタイルで表示されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "유리 키는 키보드 뒤에 있는 내용에서 색상을 가져오므로 키 색상이 적용되지 않습니다. 모서리 둥글기와 테두리는 그대로 적용됩니다. 이 시스템에서는 Liquid Glass 대신 단순화된 반투명 스타일이 사용됩니다."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Szklane klawisze przejmują kolor tego, co znajduje się za klawiaturą, więc kolory klawiszy nie działają. Promień narożnika i obramowanie nadal działają: ten system wyświetla uproszczony półprzezroczysty styl zamiast Liquid Glass."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As teclas de vidro assumem a cor do que está por trás do teclado, pelo que as cores das teclas não são aplicadas. O raio dos cantos e o contorno continuam a ser aplicados: este sistema apresenta um estilo translúcido simplificado em vez do Liquid Glass."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стеклянные клавиши принимают цвет того, что находится за клавиатурой, поэтому цвета клавиш не применяются. Радиус скругления и граница по-прежнему применяются: эта система отображает упрощённый полупрозрачный стиль вместо Liquid Glass."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Glastangenter tar sin färg från det som finns bakom tangentbordet, så tangentfärgerna används inte. Hörnradie och kant gäller fortfarande: Den här systemversionen visar en förenklad halvgenomskinlig stil i stället för Liquid Glass."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่มแบบกระจกจะดึงสีจากสิ่งที่อยู่ด้านหลังแป้นพิมพ์ สีปุ่มจึงไม่มีผล ความโค้งมุมและเส้นขอบยังคงมีผล เนื่องจากระบบนี้แสดงผลเป็นสไตล์โปร่งแสงแบบเรียบง่ายแทน Liquid Glass"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скляні клавіші беруть колір того, що розташовано за клавіатурою, тому кольори клавіш не застосовуються. Радіус заокруглення та рамка все одно застосовуються: ця система показує спрощений напівпрозорий стиль замість Liquid Glass."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گلاس کیز اپنا رنگ کی بورڈ کے پیچھے موجود چیز سے لیتی ہیں، اس لیے کیز کے رنگ لاگو نہیں ہوتے۔ کونے کی گولائی اور بارڈر پھر بھی لاگو ہوتے ہیں: یہ سسٹم Liquid Glass کے بجائے ایک سادہ نیم شفاف انداز دکھاتا ہے۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím kính lấy màu từ nội dung phía sau bàn phím, nên màu phím không có tác dụng. Bán kính góc và viền vẫn có tác dụng: hệ thống này hiển thị một kiểu trong mờ đơn giản hóa thay cho Liquid Glass."
+          }
+        }
+      }
+    },
+    "Background": {
+      "comment": "Theme editor: section header for the keyboard background. Distinct from the 'Keyboard background' color label inside it",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الخلفية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hintergrund"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Φόντο"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fondo"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پس‌زمینه"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tausta"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Background"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrière-plan"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "רקע"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बैकग्राउंड"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pozadina"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sfondo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "背景"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "배경"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tło"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fundo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Фон"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bakgrund"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พื้นหลัง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тло"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پس منظر"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nền"
+          }
+        }
+      }
+    },
+    "Liquid Glass background": {
+      "comment": "Accessibility label of the glass switch in the Background section; the visible label is only 'Liquid Glass'",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خلفية Liquid Glass"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass für den Hintergrund"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Φόντο Liquid Glass"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fondo Liquid Glass"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پس‌زمینهٔ Liquid Glass"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass -tausta"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass para sa background"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrière-plan Liquid Glass"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "רקע Liquid Glass"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass बैकग्राउंड"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pozadina Liquid Glass"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sfondo Liquid Glass"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass（背景）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass 배경"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tło Liquid Glass"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fundo Liquid Glass"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Фон Liquid Glass"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass för bakgrunden"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass สำหรับพื้นหลัง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тло Liquid Glass"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass پس منظر"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nền Liquid Glass"
+          }
+        }
+      }
+    },
+    "A glass background lets the app behind the keyboard show through, so the background color does not apply.": {
+      "comment": "Theme editor: Background section footer, while the glass background is on",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تُظهر الخلفية الزجاجية التطبيق الموجود خلف لوحة المفاتيح، لذا لا يُطبَّق لون الخلفية."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Glas-Hintergrund lässt die App hinter der Tastatur durchscheinen, daher hat die Hintergrundfarbe keine Wirkung."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Το γυάλινο φόντο αφήνει να φαίνεται η εφαρμογή πίσω από το πληκτρολόγιο, επομένως το χρώμα φόντου δεν ισχύει."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un fondo de cristal deja ver la app que hay detrás del teclado, por lo que el color de fondo no se aplica."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پس‌زمینهٔ شیشه‌ای اجازه می‌دهد برنامهٔ پشت صفحه‌کلید دیده شود، بنابراین رنگ پس‌زمینه اعمال نمی‌شود."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lasitaustan läpi näkyy näppäimistön takana oleva sovellus, joten taustaväriä ei käytetä."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sa glass na background, natatanaw ang app sa likod ng keyboard, kaya hindi nalalapat ang kulay ng background."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un arrière-plan en verre laisse transparaître l'app située derrière le clavier ; la couleur d'arrière-plan ne s'applique donc pas."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "רקע זכוכית חושף את האפליקציה שמאחורי המקלדת, ולכן צבע הרקע אינו חל."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ग्लास बैकग्राउंड कीबोर्ड के पीछे मौजूद ऐप को झलकने देता है, इसलिए बैकग्राउंड का रंग लागू नहीं होता।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kroz staklenu pozadinu vidi se aplikacija iza tipkovnice, pa se boja pozadine ne primjenjuje."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uno sfondo in vetro lascia intravedere l'app dietro la tastiera, quindi il colore di sfondo non viene applicato."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ガラスの背景では、キーボードの背後にあるAppが透けて見えるため、背景色は適用されません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "유리 배경에서는 키보드 뒤의 앱이 비쳐 보이므로 배경 색상이 적용되지 않습니다."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przez szklane tło prześwituje aplikacja znajdująca się za klawiaturą, więc kolor tła nie działa."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um fundo de vidro deixa transparecer a app que está por trás do teclado, pelo que a cor de fundo não é aplicada."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сквозь стеклянный фон просвечивает приложение за клавиатурой, поэтому цвет фона не применяется."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En glasbakgrund låter appen bakom tangentbordet synas igenom, så bakgrundsfärgen används inte."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พื้นหลังแบบกระจกจะทำให้มองทะลุเห็นแอปที่อยู่ด้านหลังแป้นพิมพ์ สีพื้นหลังจึงไม่มีผล"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Крізь скляне тло просвічує програма за клавіатурою, тому колір тла не застосовується."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گلاس پس منظر کی بورڈ کے پیچھے موجود ایپ کو جھلکنے دیتا ہے، اس لیے پس منظر کا رنگ لاگو نہیں ہوتا۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nền kính cho phép nhìn xuyên thấy ứng dụng phía sau bàn phím, nên màu nền không có tác dụng."
+          }
+        }
+      }
+    },
+    "Trail color": {
+      "comment": "Theme editor: color of the gesture trail drawn under the finger while swiping",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لون الأثر"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spurfarbe"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Χρώμα ίχνους"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color de la estela"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رنگ رد اشاره"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jäljen väri"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kulay ng bakas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couleur du tracé"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "צבע השובל"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "निशान का रंग"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Boja traga"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colore della scia"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "軌跡の色"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "궤적 색상"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kolor śladu"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cor do rasto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цвет следа"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spårfärg"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สีเส้นทาง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Колір сліду"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نشان کا رنگ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Màu vệt"
+          }
+        }
+      }
+    },
+    "Turn on Gesture Trail in Settings to draw this color while you swipe.": {
+      "comment": "Theme editor: footer under the trail color, shown while the gesture trail feature is off",
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فعِّل أثر الإيماءة في الإعدادات لرسم هذا اللون أثناء التمرير."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiviere die Wischspur in den Einstellungen, damit diese Farbe beim Wischen gezeichnet wird."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ενεργοποιήστε το «Ίχνος κίνησης» στις Ρυθμίσεις για να σχεδιάζεται αυτό το χρώμα καθώς σαρώνετε."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa Estela del gesto en Ajustes para que la estela se dibuje con este color al deslizar."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رد اشاره را در تنظیمات فعال کنید تا این رنگ هنگام کشیدن انگشت ترسیم شود."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ota Eleen jälki käyttöön Asetuksissa, niin tämä väri piirtyy, kun pyyhkäiset."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-on ang Bakas ng galaw sa Mga Setting para maiguhit ang kulay na ito habang nagsa-swipe ka."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activez Tracé du geste dans Réglages pour que le tracé s'affiche dans cette couleur lorsque vous balayez."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הפעל את שובל התנועה בהגדרות כדי לצייר את הצבע הזה בזמן ההחלקה."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्वाइप करते समय यह रंग दिखाने के लिए सेटिंग्स में जेस्चर का निशान चालू करें।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uključi „Trag geste” u Postavkama kako bi se ova boja crtala dok prelaziš prstom."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva Scia del gesto in Impostazioni per disegnare la scia con questo colore mentre scorri."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スワイプ中にこの色を描画するには、「設定」で「ジェスチャの軌跡」をオンにしてください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스와이프할 때 이 색상이 그려지도록 하려면 설정에서 제스처 궤적을 켜세요."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Włącz „Ślad gestu” w Ustawieniach, aby ten kolor był rysowany podczas przesuwania palcem."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ative Rasto do gesto em Definições para que o rasto seja desenhado com esta cor ao deslizar."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включите «След жеста» в разделе «Настройки», чтобы этот цвет рисовался при смахивании."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivera Gestspår i Inställningar så att den här färgen ritas när du sveper."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดใช้ \"เส้นทางการปัด\" ใน \"การตั้งค่า\" เพื่อวาดสีนี้ขณะที่คุณปัด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увімкніть «Слід жесту» у розділі «Налаштування», щоб цей колір малювався, поки ви проводите пальцем."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سوائپ کرتے وقت یہ رنگ دکھانے کے لیے ترتیبات میں اشارے کا نشان فعال کریں۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bật Vệt vuốt trong Cài đặt để vẽ màu này khi bạn vuốt."
           }
         }
       }

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -20359,6 +20359,66 @@
             "state": "translated",
             "value": "%@ Kopya"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخة من %@"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ αντίγραφο"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کپی"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ कॉपी"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@のコピー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 복사본"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ cópia"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ สำเนา"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (копія)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کی کاپی"
+          }
         }
       }
     },
@@ -20436,6 +20496,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ Kopya %lld"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخة %2$lld من %1$@"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ αντίγραφο %lld"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کپی %lld"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ कॉपी %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@のコピー %lld"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 복사본 %lld"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ cópia %lld"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ สำเนา %lld"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (копія %lld)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کی کاپی %lld"
           }
         }
       }
@@ -20515,6 +20635,66 @@
             "state": "translated",
             "value": "Kulay ng border"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لون الحد"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Χρώμα περιγράμματος"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رنگ حاشیه"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बॉर्डर का रंग"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "枠線の色"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테두리 색상"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cor do contorno"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สีเส้นขอบ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Колір рамки"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بارڈر کا رنگ"
+          }
         }
       }
     },
@@ -20592,6 +20772,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lapad ng border"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عرض الحد"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πάχος περιγράμματος"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ضخامت حاشیه"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बॉर्डर की चौड़ाई"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "枠線の太さ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테두리 두께"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Espessura do contorno"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ความหนาเส้นขอบ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Товщина рамки"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بارڈر کی چوڑائی"
           }
         }
       }
@@ -20671,6 +20911,66 @@
             "state": "translated",
             "value": "Kanselahin"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Άκυρο"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لغو"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रद्द करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยกเลิก"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скасувати"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منسوخ کریں"
+          }
         }
       }
     },
@@ -20748,6 +21048,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Radius ng sulok"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نصف قطر الزوايا"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Στρογγύλεμα γωνιών"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شعاع گوشه"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कॉर्नर रेडियस"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "角の丸み"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모서리 둥글기"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raio dos cantos"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ความโค้งมุม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Радіус заокруглення"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کونے کی گولائی"
           }
         }
       }
@@ -20827,6 +21187,66 @@
             "state": "translated",
             "value": "Tanggalin ang tema"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف السمة"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διαγραφή θέματος"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف پوسته"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "थीम हटाएँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テーマを削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테마 삭제"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar tema"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลบธีม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити тему"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تھیم حذف کریں"
+          }
         }
       }
     },
@@ -20904,6 +21324,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tanggalin ang temang ito?"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هل تريد حذف هذه السمة؟"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διαγραφή αυτού του θέματος;"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "این پوسته حذف شود؟"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "यह थीम हटाएँ?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このテーマを削除しますか？"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 테마를 삭제하시겠습니까?"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar este tema?"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลบธีมนี้หรือไม่"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити цю тему?"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کیا یہ تھیم حذف کریں؟"
           }
         }
       }
@@ -20983,6 +21463,66 @@
             "state": "translated",
             "value": "I-duplicate"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تكرار"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διπλότυπο"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تکثیر"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डुप्लिकेट करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복제"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplicar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทำสำเนา"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дублювати"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کاپی بنائیں"
+          }
         }
       }
     },
@@ -21060,6 +21600,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "I-edit"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحرير"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επεξεργασία"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ویرایش"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एडिट करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編集"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แก้ไข"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Редагувати"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترمیم"
           }
         }
       }
@@ -21139,6 +21739,66 @@
             "state": "translated",
             "value": "I-edit ang tema"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحرير السمة"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επεξεργασία θέματος"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ویرایش پوسته"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "थीम एडिट करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テーマを編集"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테마 편집"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar tema"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แก้ไขธีม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Редагувати тему"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تھیم میں ترمیم"
+          }
         }
       }
     },
@@ -21216,6 +21876,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Label ng function"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التسمية الوظيفية"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ετικέτα λειτουργίας"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برچسب کلید کاربردی"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "फ़ंक्शन लेबल"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "機能キーの文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기능 키 글자"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiqueta de função"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ป้ายกำกับฟังก์ชัน"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Службовий підпис"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فنکشن لیبل"
           }
         }
       }
@@ -21295,6 +22015,66 @@
             "state": "translated",
             "value": "Titik ng hint"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرف التلميح"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Γράμμα υπόδειξης"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرف راهنما"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हिंट अक्षर"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヒントの文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "힌트 글자"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letra de indicação"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวอักษรคำใบ้"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Літера-підказка"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہنٹ حرف"
+          }
         }
       }
     },
@@ -21372,6 +22152,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Simbolo ng hint"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رمز التلميح"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σύμβολο υπόδειξης"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نماد راهنما"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हिंट सिंबल"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヒントの記号"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "힌트 기호"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Símbolo de indicação"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สัญลักษณ์คำใบ้"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Символ-підказка"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہنٹ علامت"
           }
         }
       }
@@ -21451,6 +22291,66 @@
             "state": "translated",
             "value": "Key"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المفتاح"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πλήκτρο"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلید"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कुंजी"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tecla"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่ม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавіша"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی"
+          }
         }
       }
     },
@@ -21528,6 +22428,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Key (pinindot)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المفتاح (مضغوط)"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πλήκτρο (πατημένο)"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلید (فشرده)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कुंजी (दबी हुई)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キー（押下時）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키(누른 상태)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tecla (premida)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่ม (ขณะกด)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавіша (натиснута)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی (دبی ہوئی)"
           }
         }
       }
@@ -21607,6 +22567,66 @@
             "state": "translated",
             "value": "Border ng key"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حد المفتاح"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Περίγραμμα πλήκτρου"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حاشیهٔ کلید"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कुंजी का बॉर्डर"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーの枠線"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키 테두리"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contorno da tecla"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เส้นขอบปุ่ม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Рамка клавіші"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی کا بارڈر"
+          }
         }
       }
     },
@@ -21684,6 +22704,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Background ng keyboard"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خلفية لوحة المفاتيح"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Φόντο πληκτρολογίου"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پس‌زمینهٔ صفحه‌کلید"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड बैकग्राउंड"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードの背景"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 배경"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fundo do teclado"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พื้นหลังคีย์บอร์ด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тло клавіатури"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی بورڈ کا پس منظر"
           }
         }
       }
@@ -21763,6 +22843,66 @@
             "state": "translated",
             "value": "Mga Label"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التسميات"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ετικέτες"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برچسب‌ها"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लेबल"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ラベル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "레이블"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiquetas"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ป้ายกำกับ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підписи"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لیبل"
+          }
         }
       }
     },
@@ -21840,6 +22980,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pangunahing titik"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الحرف الرئيسي"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κύριο γράμμα"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرف اصلی"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मुख्य अक्षर"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メインの文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 글자"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letra principal"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวอักษรหลัก"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Основна літера"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مرکزی حرف"
           }
         }
       }
@@ -21919,6 +23119,66 @@
             "state": "translated",
             "value": "Aking mga tema"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سماتي"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τα θέματά μου"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پوسته‌های من"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मेरी थीम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マイテーマ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "나의 테마"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os meus temas"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ธีมของฉัน"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мої теми"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "میری تھیمز"
+          }
         }
       }
     },
@@ -21996,6 +23256,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pangalan"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاسم"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Όνομα"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نام"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नाम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名前"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이름"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ชื่อ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назва"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نام"
           }
         }
       }
@@ -22075,6 +23395,66 @@
             "state": "translated",
             "value": "Prominenteng icon"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أيقونة بارزة"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Έντονο εικονίδιο"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آیکون برجسته"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "प्रमुख आइकन"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目立つアイコン"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "강조 아이콘"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ícone destacado"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไอคอนเด่น"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помітний значок"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمایاں آئیکن"
+          }
         }
       }
     },
@@ -22152,6 +23532,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "I-save"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حفظ"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αποθήκευση"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ذخیره"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेव करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บันทึก"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зберегти"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "محفوظ کریں"
           }
         }
       }
@@ -22231,6 +23671,66 @@
             "state": "translated",
             "value": "Banayad na icon"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أيقونة خافتة"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διακριτικό εικονίδιο"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آیکون کم‌رنگ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हल्का आइकन"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控えめなアイコン"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연한 아이콘"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ícone discreto"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไอคอนจาง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приглушений значок"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہلکا آئیکن"
+          }
         }
       }
     },
@@ -22309,6 +23809,66 @@
             "state": "translated",
             "value": "Mga Ibabaw"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الأسطح"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επιφάνειες"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سطوح"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सतहें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーと背景"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키와 배경"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superfícies"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พื้นผิว"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхні"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سطحیں"
+          }
         }
       }
     },
@@ -22386,6 +23946,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pangalan ng tema"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسم السمة"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Όνομα θέματος"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نام پوسته"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "थीम का नाम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テーマ名"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테마 이름"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome do tema"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ชื่อธีม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назва теми"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تھیم کا نام"
           }
         }
       }

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -19455,6 +19455,594 @@
           }
         }
       }
+    },
+    "Color Themes": {
+      "comment": "Theme gallery: section header for fixed-color palettes",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farb-Themes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thèmes de couleur"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temas de color"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temi di colore"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цветовые темы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Motywy kolorów"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Färgteman"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Väriteemat"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teme boja"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ערכות צבע"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chủ đề màu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Tema ng Kulay"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سمات الألوان"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Χρωματικά θέματα"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پوسته‌های رنگی"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रंग थीम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カラーテーマ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "색상 테마"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temas de cor"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ธีมสี"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кольорові теми"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رنگین تھیمز"
+          }
+        }
+      }
+    },
+    "Dark Mode": {
+      "comment": "Theme gallery: segment selecting the dark-appearance theme slot",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dunkel"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sombre"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oscuro"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scuro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмный"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemny"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mörkt"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tumma"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "כהה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tối"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Madilim"
+          }
+        }
+      }
+    },
+    "Editing appearance": {
+      "comment": "Theme gallery: accessibility label for the light/dark slot picker",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erscheinungsbild bearbeiten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier l’apparence"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar apariencia"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica aspetto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Редактирование оформления"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edytuj wygląd"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redigera utseende"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muokkaa ulkoasua"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uredi izgled"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "עריכת מראה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chỉnh sửa giao diện"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-edit ang hitsura"
+          }
+        }
+      }
+    },
+    "Light Mode": {
+      "comment": "Theme gallery: segment selecting the light-appearance theme slot",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hell"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clair"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claro"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiaro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Светлый"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jasny"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ljust"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaalea"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Svijetlo"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "בהיר"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sáng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maliwanag"
+          }
+        }
+      }
+    },
+    "Styles": {
+      "comment": "Theme gallery: section header for adaptive/material styles",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stile"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Styles"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilos"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stili"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стили"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Style"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stilar"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tyylit"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stilovi"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סגנונות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiểu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Estilo"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الأنماط"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Στιλ"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سبک‌ها"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्टाइल"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スタイル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스타일"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilos"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สไตล์"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стилі"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انداز"
+          }
+        }
+      }
+    },
+    "Use a different theme in Dark Mode": {
+      "comment": "Theme gallery: toggle to assign a separate theme for Dark Mode",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Dunkelmodus anderes Theme verwenden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utiliser un thème différent en mode sombre"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar un tema diferente en modo oscuro"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa un tema diverso in modalità scura"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Другая тема в тёмном режиме"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Użyj innego motywu w trybie ciemnym"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Använd ett annat tema i mörkt läge"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Käytä eri teemaa tummassa tilassa"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koristi drugu temu u tamnom načinu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "השתמש בערכת נושא שונה במצב כהה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dùng chủ đề khác ở chế độ tối"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gumamit ng ibang tema sa Dark Mode"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -19178,6 +19178,89 @@
         }
       },
       "comment": "ACCESSIBILITY action name for the question-mark swipe; the Arabic script substitutes ؟ (VoiceOver)"
+    },
+    "Dark Gold": {
+      "comment": "Keyboard theme name: dark-gold (proper name, do not translate)",
+      "extractionState": "manual",
+      "shouldTranslate": false
+    },
+    "Dark keys with golden letters": {
+      "comment": "Keyboard theme description: dark-gold",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dunkle Tasten mit goldenen Buchstaben"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touches sombres aux lettres dorées"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas oscuras con letras doradas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasti scuri con lettere dorate"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмные клавиши с золотыми буквами"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemne klawisze ze złotymi literami"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mörka tangenter med gyllene bokstäver"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tummat näppäimet ja kultaiset kirjaimet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamne tipke sa zlatnim slovima"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקשים כהים עם אותיות זהובות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím tối với chữ vàng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Madilim na mga key na may gintong mga titik"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -1,12563 +1,143 @@
 {
   "sourceLanguage": "en",
   "strings": {
-    "Home": {
+    "%@ (default: %@)": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start"
+            "value": "%@ (Standard: %@)"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Accueil"
+            "value": "%@ (par défaut : %@)"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Inicio"
+            "value": "%@ (predeterminado: %@)"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Home"
+            "value": "%@ (predefinita: %@)"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Главная"
+            "value": "%@ (по умолчанию: %@)"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start"
+            "value": "%@ (domyślny: %@)"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hem"
+            "value": "%@ (standard: %@)"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Etusivu"
+            "value": "%@ (oletus: %@)"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Početna"
+            "value": "%@ (zadano: %@)"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "בית"
+            "value": "%@ (ברירת מחדל: %@)"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Trang chủ"
+            "value": "%@ (mặc định: %@)"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Home"
+            "value": "%@ (default: %@)"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Αρχική"
+            "value": "%@ (προεπιλογή: %@)"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Início"
+            "value": "%@ (predefinição: %@)"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Головна"
+            "value": "%@ (за замовчуванням: %@)"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "الرئيسية"
+            "value": "%@ (افتراضي: %@)"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "خانه"
+            "value": "%@ (پیش‌فرض: %@)"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "ہوم"
+            "value": "%@ (طے شدہ: %@)"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "หน้าแรก"
+            "value": "%@ (ค่าเริ่มต้น: %@)"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "होम"
+            "value": "%@ (डिफ़ॉल्ट: %@)"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ホーム"
+            "value": "%@（デフォルト：%@）"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "홈"
+            "value": "%@ (기본값: %@)"
           }
         }
       },
-      "comment": "Tab bar label for the home/landing screen"
-    },
-    "Setup": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einrichtung"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configuration"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configuración"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configurazione"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Настройка"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Konfiguracja"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Konfigurering"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Käyttöönotto"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Postavljanje"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הגדרה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thiết lập"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Setup"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ρύθμιση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configuração"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Налаштування"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإعداد"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "راه‌اندازی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سیٹ اپ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตั้งค่า"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सेटअप"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セットアップ"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "설정 방법"
-          }
-        }
-      },
-      "comment": "Tab label and title for the first-run setup wizard"
-    },
-    "Test": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Test"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Test"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prueba"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prova"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Проба"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Test"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testa"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testaa"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Isprobaj"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "בדיקה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thử"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Test"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Δοκιμή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тест"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اختبار"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "آزمایش"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ٹیسٹ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ทดสอบ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "टेस्ट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "テスト"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "테스트"
-          }
-        }
-      },
-      "comment": "Tab label for the try-it-out / test screen"
-    },
-    "Settings": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einstellungen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réglages"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajustes"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impostazioni"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Настройки"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ustawienia"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inställningar"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Asetukset"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Postavke"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הגדרות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cài đặt"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga Setting"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ρυθμίσεις"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Definições"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Налаштування"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإعدادات"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تنظیمات"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ترتیبات"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตั้งค่า"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सेटिंग्स"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "設定"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "설정"
-          }
-        }
-      },
-      "comment": "Tab label and navigation title for settings"
-    },
-    "The Keyboard for Fat Fingers": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Tastatur für Wurstfinger"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Le clavier pour les gros doigts"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El teclado para dedos torpes"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La tastiera per dita grosse"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Клавиатура для толстых пальцев"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klawiatura dla grubych palców"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tangentbordet för tjocka fingrar"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Näppäimistö paksuille sormille"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tipkovnica za debele prste"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "המקלדת לאצבעות עבות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bàn phím cho ngón tay to"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ang Keyboard para sa Malalaking Daliri"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Το πληκτρολόγιο για χοντρά δάχτυλα"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O teclado para dedos gordos"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Клавіатура для товстих пальців"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لوحة المفاتيح لأصحاب الأصابع الكبيرة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "صفحه‌کلید برای انگشتان درشت"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "موٹی انگلیوں کے لیے کی بورڈ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คีย์บอร์ดสำหรับนิ้วอวบ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "मोटी उंगलियों के लिए कीबोर्ड"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "太い指のためのキーボード"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "손가락이 두꺼운 분을 위한 키보드"
-          }
-        }
-      },
-      "comment": "Playful app tagline/slogan"
-    },
-    "Setup Instructions": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anleitung zur Einrichtung"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instructions de configuration"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instrucciones de configuración"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Istruzioni di configurazione"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Инструкция по настройке"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instrukcje konfiguracji"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Konfigureringsanvisningar"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Käyttöönotto-ohjeet"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upute za postavljanje"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הוראות הגדרה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hướng dẫn thiết lập"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga Tagubilin sa Setup"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Οδηγίες ρύθμισης"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instruções de configuração"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Інструкції з налаштування"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تعليمات الإعداد"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "دستورالعمل راه‌اندازی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سیٹ اپ ہدایات"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "วิธีตั้งค่า"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सेटअप निर्देश"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セットアップ手順"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "설정 안내"
-          }
-        }
-      },
-      "comment": "Button leading to setup steps"
-    },
-    "Issues": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Issues"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Signaler un problème"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incidencias"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Problemi"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сообщить об ошибке"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zgłoszenia"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ärenden"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ongelmat"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Problemi"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "בעיות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Báo lỗi"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga Issue"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Προβλήματα"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Problemas"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Проблеми"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "المشكلات"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مشکل‌ها"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مسائل"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปัญหา"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "समस्याएँ"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "問題"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "문제 해결"
-          }
-        }
-      },
-      "comment": "Link to the GitHub issue tracker (report bugs)"
-    },
-    "Enable keyboard": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastatur aktivieren"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activer le clavier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activar el teclado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attiva la tastiera"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Включите клавиатуру"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Włącz klawiaturę"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktivera tangentbordet"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ota näppäimistö käyttöön"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Omogući tipkovnicu"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הפעלת המקלדת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bật bàn phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-enable ang keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ενεργοποίηση πληκτρολογίου"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ativar teclado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Увімкнути клавіатуру"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تفعيل لوحة المفاتيح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فعال‌سازی صفحه‌کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ فعال کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เปิดใช้คีย์บอร์ด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड चालू करें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードを有効にする"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 켜기"
-          }
-        }
-      },
-      "comment": "Onboarding step 1 title"
-    },
-    "Open iOS Settings → General → Keyboard → Keyboards and add Wurstfinger.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Öffne iOS Einstellungen → Allgemein → Tastatur → Tastaturen und füge Wurstfinger hinzu."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ouvrez Réglages iOS → Général → Clavier → Claviers et ajoutez Wurstfinger."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abre Ajustes de iOS → General → Teclado → Teclados y añade Wurstfinger."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apri Impostazioni iOS → Generali → Tastiera → Tastiere e aggiungi Wurstfinger."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Откройте «Настройки» iOS → «Основные» → «Клавиатура» → «Клавиатуры» и добавьте Wurstfinger."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otwórz Ustawienia iOS → Ogólne → Klawiatura → Klawiatury i dodaj Wurstfinger."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Öppna Inställningar → Allmänt → Tangentbord → Tangentbord och lägg till Wurstfinger."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avaa iOS-Asetukset → Yleiset → Näppäimistö → Näppäimistöt ja lisää Wurstfinger."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otvori Postavke → Općenito → Tipkovnica → Tipkovnice i dodaj Wurstfinger."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פתח את הגדרות iOS → כללי → מקלדת → מקלדות והוסף את Wurstfinger."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mở Cài đặt iOS → Cài đặt chung → Bàn phím → Bàn phím và thêm Wurstfinger."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buksan ang Mga Setting ng iOS → Pangkalahatan → Keyboard → Mga Keyboard at idagdag ang Wurstfinger."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ανοίξτε Ρυθμίσεις iOS → Γενικά → Πληκτρολόγιο → Πληκτρολόγια και προσθέστε το Wurstfinger."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abra Definições do iOS → Geral → Teclado → Teclados e adicione o Wurstfinger."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відкрийте Параметри iOS → Основні → Клавіатура → Клавіатури та додайте Wurstfinger."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "افتح الإعدادات ← عام ← لوحة المفاتيح ← لوحات المفاتيح وأضِف Wurstfinger."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تنظیمات iOS → عمومی → صفحه‌کلید → صفحه‌کلیدها را باز کنید و Wurstfinger را اضافه کنید."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iOS کی ترتیبات → عمومی → کی بورڈ → کی بورڈز کھولیں اور Wurstfinger شامل کریں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เปิดการตั้งค่า iOS → ทั่วไป → แป้นพิมพ์ → แป้นพิมพ์ แล้วเพิ่ม Wurstfinger"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iOS सेटिंग्स → सामान्य → कीबोर्ड → कीबोर्ड खोलें और Wurstfinger जोड़ें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iOSの「設定」→「一般」→「キーボード」→「キーボード」を開いて、Wurstfingerを追加します。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iOS 설정 → 일반 → 키보드 → 키보드로 이동하여 Wurstfinger를 추가하세요."
-          }
-        }
-      },
-      "comment": "Onboarding step 1 description; the arrow-separated words are iOS Settings menu names — use official localized iOS terms"
-    },
-    "Open Settings": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einstellungen öffnen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ouvrir Réglages"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abrir Ajustes"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apri Impostazioni"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Открыть Настройки"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otwórz Ustawienia"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Öppna Inställningar"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avaa Asetukset"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otvori Postavke"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פתח הגדרות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mở Cài đặt"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buksan ang Mga Setting"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Άνοιγμα Ρυθμίσεων"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abrir Definições"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відкрити Параметри"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فتح الإعدادات"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "باز کردن تنظیمات"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ترتیبات کھولیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เปิดการตั้งค่า"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सेटिंग्स खोलें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "設定を開く"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "설정 열기"
-          }
-        }
-      },
-      "comment": "Button that opens the iOS Settings app"
-    },
-    "Allow full access": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vollzugriff erlauben"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autoriser l'accès complet"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permitir acceso completo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Consenti accesso completo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Разрешите полный доступ"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przyznaj pełny dostęp"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tillåt fullständig åtkomst"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Salli täysi käyttöoikeus"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dopusti puni pristup"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אפשר גישה מלאה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cho phép truy cập đầy đủ"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payagan ang Full Access"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Να επιτρέπεται η πλήρης πρόσβαση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permitir acesso total"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Дозволити повний доступ"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "السماح بالوصول الكامل"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اجازهٔ دسترسی کامل"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مکمل رسائی کی اجازت دیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อนุญาตการเข้าถึงเต็มรูปแบบ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पूर्ण एक्सेस दें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フルアクセスを許可"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 접근 허용"
-          }
-        }
-      },
-      "comment": "Onboarding step 2 title; refers to the iOS keyboard 'Allow Full Access' toggle"
-    },
-    "Activate \"Allow Full Access\" so cursor control and deletion gestures work.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktiviere \"Vollzugriff erlauben\", damit Cursorsteuerung und Löschgesten funktionieren."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activez « Autoriser l'accès complet » pour que le contrôle du curseur et les gestes de suppression fonctionnent."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activa \"Permitir acceso completo\" para que funcionen el control del cursor y los gestos de borrado."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attiva \"Consenti accesso completo\" affinché il controllo del cursore e i gesti di eliminazione funzionino."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Включите «Разрешить полный доступ», чтобы работали управление курсором и жесты удаления."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Włącz „Przyznaj pełny dostęp”, aby działało sterowanie kursorem i gesty usuwania."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktivera \"Tillåt fullständig åtkomst\" så att markörstyrning och raderingsgester fungerar."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ota käyttöön \"Salli täysi käyttöoikeus\", jotta kohdistimen ohjaus ja poistoeleet toimivat."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uključi „Dopusti puni pristup” kako bi radile geste za upravljanje pokazivačem i brisanje."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הפעל את \"אפשר גישה מלאה\" כדי שמחוות שליטת הסמן והמחיקה יפעלו."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bật \"Cho phép truy cập đầy đủ\" để các cử chỉ điều khiển con trỏ và xóa hoạt động."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-activate ang \"Payagan ang Full Access\" para gumana ang kontrol ng cursor at mga gesture sa pagbura."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ενεργοποιήστε την επιλογή «Να επιτρέπεται η πλήρης πρόσβαση» ώστε να λειτουργούν ο έλεγχος του δρομέα και οι χειρονομίες διαγραφής."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ative \"Permitir acesso total\" para que os gestos de controlo do cursor e de eliminação funcionem."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Увімкніть «Дозволити повний доступ», щоб працювали керування курсором і жести видалення."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فعِّل \"السماح بالوصول الكامل\" حتى تعمل إيماءات التحكم في المؤشر والحذف."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "«اجازهٔ دسترسی کامل» را فعال کنید تا کنترل نشانگر و حرکت‌های حذف کار کنند."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"مکمل رسائی کی اجازت دیں\" فعال کریں تاکہ کرسر کنٹرول اور حذف کرنے کے اشارے کام کریں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เปิดใช้ \"อนุญาตการเข้าถึงเต็มรูปแบบ\" เพื่อให้การควบคุมเคอร์เซอร์และเจสเจอร์ลบข้อความทำงานได้"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"पूर्ण एक्सेस दें\" चालू करें ताकि कर्सर नियंत्रण और डिलीट जेस्चर काम करें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カーソル操作と削除ジェスチャを使えるように「フルアクセスを許可」をオンにしてください。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "커서 제어 및 삭제 제스처가 작동하도록 \"전체 접근 허용\"을 켜세요."
-          }
-        }
-      },
-      "comment": "Onboarding step 2 description; 'Allow Full Access' is the iOS toggle name (localized)"
-    },
-    "Try the keyboard": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastatur ausprobieren"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Essayer le clavier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prueba el teclado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prova la tastiera"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Попробуйте клавиатуру"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wypróbuj klawiaturę"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prova tangentbordet"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kokeile näppäimistöä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Isprobaj tipkovnicu"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "נסה את המקלדת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thử bàn phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Subukan ang keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Δοκιμάστε το πληκτρολόγιο"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Experimentar o teclado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Спробувати клавіатуру"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جرّب لوحة المفاتيح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "امتحان صفحه‌کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ آزمائیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ลองใช้คีย์บอร์ด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड आज़माएँ"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードを試す"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 사용해 보기"
-          }
-        }
-      },
-      "comment": "Onboarding step 3 title"
-    },
-    "Switch to the Test tab and experiment with gestures.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wechsle zum Tab „Test“ und probiere die Gesten aus."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passez à l'onglet Test et expérimentez les gestes."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ve a la pestaña Prueba y experimenta con los gestos."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passa alla scheda Prova e sperimenta con i gesti."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перейдите на вкладку «Проба» и поэкспериментируйте с жестами."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przejdź do karty Test i poeksperymentuj z gestami."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Byt till fliken Testa och experimentera med gester."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Siirry Testaa-välilehdelle ja kokeile eleitä."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prijeđi na karticu Isprobaj i isprobaj geste."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "עבור ללשונית בדיקה והתנסה במחוות."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chuyển sang thẻ Thử và thử nghiệm các cử chỉ."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lumipat sa Test tab at mag-eksperimento sa mga gesture."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Μεταβείτε στην καρτέλα Δοκιμή και πειραματιστείτε με τις χειρονομίες."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mude para o separador Testar e experimente os gestos."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перейдіть на вкладку «Тест» та поекспериментуйте з жестами."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "انتقل إلى علامة تبويب الاختبار وجرّب الإيماءات."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "به زبانهٔ آزمایش بروید و حرکت‌ها را امتحان کنید."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ٹیسٹ ٹیب پر جائیں اور اشاروں کے ساتھ تجربہ کریں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สลับไปที่แท็บทดสอบและลองใช้เจสเจอร์ต่างๆ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "टेस्ट टैब पर जाएँ और जेस्चर के साथ प्रयोग करें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "「テスト」タブに切り替えて、ジェスチャを試してみましょう。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "테스트 탭으로 이동하여 제스처를 사용해 보세요."
-          }
-        }
-      },
-      "comment": "Onboarding step 3 description; 'Test tab' refers to the in-app tab labeled 'Test'"
-    },
-    "General": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allgemein"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Général"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "General"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Generali"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Основные"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ogólne"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allmänt"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Yleiset"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Općenito"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "כללי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cài đặt chung"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pangkalahatan"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Γενικά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geral"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Основні"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "عام"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "عمومی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "عمومی"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ทั่วไป"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सामान्य"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一般"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "일반"
-          }
-        }
-      },
-      "comment": "Settings section header"
-    },
-    "Utility Keys on Left": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Funktionstasten links"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Touches utilitaires à gauche"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Teclas de función a la izquierda"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tasti funzione a sinistra"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Служебные клавиши слева"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klawisze funkcyjne po lewej"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Funktionstangenter till vänster"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apunäppäimet vasemmalla"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pomoćne tipke lijevo"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מקשי שירות מימין"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phím tiện ích bên trái"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga Utility Key sa Kaliwa"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Πλήκτρα βοηθητικών λειτουργιών στα αριστερά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Teclas utilitárias à esquerda"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Службові клавіші ліворуч"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مفاتيح الأدوات على اليسار"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کلیدهای کاربردی در سمت چپ"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "یوٹیلیٹی کیز بائیں طرف"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปุ่มยูทิลิตีอยู่ด้านซ้าย"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "यूटिलिटी कीज़ बाईं ओर"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ユーティリティキーを左に配置"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기능 키를 왼쪽에 배치"
-          }
-        }
-      },
-      "comment": "Toggle title: place utility column on the left side"
-    },
-    "Places globe, symbols, delete and return on the left": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Platziert Globus, Symbole, Löschen und Zeilenschalter links"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Place le globe, les symboles, la suppression et le retour à gauche"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coloca el globo, los símbolos, borrar e intro a la izquierda"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Posiziona globo, simboli, elimina e a capo a sinistra"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Размещает глобус, символы, удаление и ввод слева"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Umieszcza globus, symbole, usuwanie i enter po lewej stronie"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Placerar jordglob, symboler, radera och retur till vänster"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sijoittaa maapallon, symbolit, poiston ja rivinvaihdon vasemmalle"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Postavlja globus, simbole, brisanje i povratak na lijevu stranu"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ממקם את הגלובוס, הסמלים, המחיקה והשורה החדשה בצד שמאל"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Đặt phím địa cầu, ký hiệu, xóa và xuống dòng ở bên trái"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inilalagay ang globe, symbols, delete at return sa kaliwa"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Τοποθετεί την υδρόγειο, τα σύμβολα, τη διαγραφή και το return στα αριστερά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coloca o globo, os símbolos, a eliminação e a tecla de retorno à esquerda"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Розміщує глобус, символи, видалення й Enter ліворуч"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يضع مفاتيح الكرة الأرضية والرموز والحذف والإدخال على اليسار"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کلیدهای کره، نمادها، حذف و بازگشت را در سمت چپ قرار می‌دهد"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "گلوب، علامتیں، حذف اور ریٹرن کو بائیں طرف رکھتا ہے"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "วางปุ่มลูกโลก สัญลักษณ์ ลบ และขึ้นบรรทัดใหม่ไว้ทางซ้าย"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ग्लोब, सिंबल, डिलीट और रिटर्न को बाईं ओर रखता है"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "地球儀、記号、削除、改行のキーを左側に配置します"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "지구본, 기호, 삭제, 줄바꿈 키를 왼쪽에 배치합니다"
-          }
-        }
-      },
-      "comment": "Toggle subtitle explaining the utility-keys-on-left option"
-    },
-    "Auto-Capitalize": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-Großschreibung"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Majuscule automatique"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mayúsculas automáticas"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maiuscole automatiche"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Автопрописные"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autom. wielkie litery"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automatisk versal"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automaattiset isot kirjaimet"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automatska velika slova"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אותיות רישיות אוטומטיות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tự động viết hoa"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-Capitalize"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αυτόματα κεφαλαία"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maiúsculas automáticas"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Автоматичні великі літери"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الأحرف الكبيرة تلقائيًا"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بزرگ‌نویسی خودکار"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خودکار کیپیٹلائز"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "พิมพ์ตัวใหญ่อัตโนมัติ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ऑटो-कैपिटलाइज़"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自動大文字化"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "자동 대문자화"
-          }
-        }
-      },
-      "comment": "Toggle title"
-    },
-    "Capitalize after sentence-ending punctuation": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Großschreibung nach satzschließenden Satzzeichen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Met une majuscule après la ponctuation de fin de phrase"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poner en mayúscula tras un signo de puntuación final"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maiuscola dopo la punteggiatura di fine frase"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Заглавная буква после знаков конца предложения"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wielka litera po znaku kończącym zdanie"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stor bokstav efter meningsavslutande skiljetecken"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iso alkukirjain lauseen päättävän välimerkin jälkeen"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Veliko slovo nakon interpunkcije na kraju rečenice"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אות רישית לאחר סימן פיסוק שמסיים משפט"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Viết hoa sau dấu kết thúc câu"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-capitalize pagkatapos ng panapos na bantas"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Κεφαλαίο μετά από σημείο στίξης τέλους πρότασης"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coloca maiúscula após a pontuação de fim de frase"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Велика літера після розділового знака в кінці речення"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "استخدام حرف كبير بعد علامات نهاية الجملة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بزرگ‌نویسی پس از نشانه‌های پایان جمله"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جملہ ختم کرنے والی رموز اوقاف کے بعد بڑا حرف بنائیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "พิมพ์ตัวใหญ่หลังเครื่องหมายจบประโยค"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "वाक्य समाप्त करने वाले विराम चिह्न के बाद बड़ा अक्षर बनाएँ"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "文末の句読点の後に大文字にします"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "문장 끝 문장 부호 뒤에 대문자로 시작합니다"
-          }
-        }
-      },
-      "comment": "Toggle subtitle"
-    },
-    "Double-Space Period": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نقطة بمسافتين"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Punkt durch Doppel-Leerzeichen"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Τελεία με διπλό κενό"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Punto con doble espacio"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نقطه با دو فاصله"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piste kaksoisvälilyönnillä"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tuldok sa dobleng espasyo"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Point par double espace"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "נקודה ברווח כפול"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "डबल-स्पेस से पूर्ण विराम"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Točka dvostrukim razmakom"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Punto con doppio spazio"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ダブルスペースでピリオド"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "더블 스페이스로 마침표"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kropka podwójną spacją"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ponto com espaço duplo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Точка двойным пробелом"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Punkt med dubbla mellanslag"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ใส่จุดด้วยการเว้นวรรคสองครั้ง"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Крапка подвійним пробілом"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ڈبل اسپیس سے وقفہ"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dấu chấm bằng cách nhấn cách hai lần"
-          }
-        }
-      },
-      "comment": "Toggle title: a double space inserts a period"
-    },
-    "Type two spaces to insert a period": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اكتب مسافتين لإدراج نقطة"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zwei Leerzeichen fügen einen Punkt ein"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Δύο κενά εισάγουν μια τελεία"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribe dos espacios para insertar un punto"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برای درج نقطه دو بار فاصله بزنید"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kaksi välilyöntiä lisää pisteen"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mag-type ng dalawang espasyo para maglagay ng tuldok"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deux espaces insèrent un point"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "שני רווחים מוסיפים נקודה"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पूर्ण विराम लगाने के लिए दो बार स्पेस दबाएँ"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dva razmaka umeću točku"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Due spazi inseriscono un punto"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "スペースを2回押すとピリオドを入力"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "스페이스를 두 번 누르면 마침표 입력"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dwie spacje wstawiają kropkę"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dois espaços inserem um ponto"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Два пробела вставляют точку"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Två mellanslag infogar en punkt"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เว้นวรรคสองครั้งเพื่อใส่จุด"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Два пробіли вставляють крапку"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "وقفہ ڈالنے کے لیے دو بار اسپیس دبائیں"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nhấn phím cách hai lần để chèn dấu chấm"
-          }
-        }
-      },
-      "comment": "Toggle subtitle: explains double-space to period"
-    },
-    "Type Numbers by Holding": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "كتابة الأرقام بالضغط المطوّل"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ziffern durch Halten"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αριθμοί με παρατεταμένο πάτημα"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Números manteniendo pulsado"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تایپ اعداد با نگه‌داشتن"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numerot pitkällä painalluksella"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga numero sa pagpindot nang matagal"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chiffres par appui long"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ספרות בלחיצה ארוכה"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "दबाकर रखने से अंक"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Brojke dugim pritiskom"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numeri tenendo premuto"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "長押しで数字を入力"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "길게 눌러 숫자 입력"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cyfry przez przytrzymanie"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Números mantendo premido"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ввод цифр удержанием"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Siffror med långt tryck"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "พิมพ์ตัวเลขด้วยการกดค้าง"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Введення цифр утриманням"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "دبا کر رکھنے سے ہندسے"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nhập số bằng cách giữ phím"
-          }
-        }
-      },
-      "comment": "Toggle title: type digits by long-pressing letter keys"
-    },
-    "Hold a letter key to type its digit": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اضغط مطوّلاً على حرف لكتابة رقمه"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Halte eine Buchstabentaste, um ihre Ziffer einzugeben"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Κρατήστε ένα γράμμα για να πληκτρολογήσετε το ψηφίο του"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mantén pulsada una letra para escribir su número"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کلید حرف را نگه دارید تا عدد آن تایپ شود"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pidä kirjainta pohjassa saadaksesi sen numeron"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pindutin nang matagal ang letra para sa numero nito"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maintenez une lettre pour saisir son chiffre"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "החזיקו מקש אות כדי להקליד את הספרה שלו"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अक्षर दबाए रखें और उसका अंक टाइप करें"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dugo pritisni slovo za njegovu brojku"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tieni premuta una lettera per la sua cifra"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "文字キーを長押しすると数字を入力できます"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "문자 키를 길게 누르면 숫자가 입력됩니다"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przytrzymaj literę, aby wpisać jej cyfrę"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mantenha premida uma letra para o seu algarismo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Удержание буквы вводит её цифру"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Håll in en bokstav för att skriva dess siffra"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กดตัวอักษรค้างไว้เพื่อพิมพ์ตัวเลข"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Утримання літери вводить її цифру"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حرف دبائے رکھیں تاکہ اس کا ہندسہ ٹائپ ہو"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giữ phím chữ để nhập số của phím"
-          }
-        }
-      },
-      "comment": "Toggle subtitle explaining the type-numbers-by-holding option"
-    },
-    "Cursor Movement": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cursorbewegung"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Déplacement du curseur"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Movimiento del cursor"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Movimento del cursore"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перемещение курсора"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ruch kursora"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Markörförflyttning"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kohdistimen liike"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pomicanje pokazivača"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "תנועת הסמן"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Di chuyển con trỏ"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Paggalaw ng Cursor"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Κίνηση δρομέα"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Movimento do cursor"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Переміщення курсора"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حركة المؤشر"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حرکت نشانگر"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کرسر کی حرکت"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การเลื่อนเคอร์เซอร์"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कर्सर मूवमेंट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カーソル移動"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "커서 이동"
-          }
-        }
-      },
-      "comment": "Settings row title"
-    },
-    "Continuous": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fortlaufend"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continu"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continuo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continuo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Непрерывное"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ciągły"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kontinuerlig"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jatkuva"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kontinuirano"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "רציפה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liên tục"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tuluy-tuloy"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Συνεχής"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contínuo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Безперервно"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مستمرة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پیوسته"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مسلسل"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ต่อเนื่อง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "निरंतर"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "連続"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "연속"
-          }
-        }
-      },
-      "comment": "Picker option for cursor movement style (drag continuously)"
-    },
-    "Step-by-step": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schrittweise"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pas à pas"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Paso a paso"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passo passo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Пошаговое"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Krok po kroku"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Steg för steg"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Askel kerrallaan"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Korak po korak"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "צעד אחר צעד"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Từng bước"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hakbang-hakbang"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Βήμα προς βήμα"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passo a passo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Покроково"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خطوة بخطوة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "گام‌به‌گام"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قدم بہ قدم"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ทีละขั้น"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "चरण-दर-चरण"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1文字ずつ"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "단계별"
-          }
-        }
-      },
-      "comment": "Picker option for cursor movement style (one character per swipe)"
-    },
-    "Appearance": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Darstellung"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apparence"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aspecto"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aspetto"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Внешний вид"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wygląd"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utseende"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ulkoasu"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Izgled"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מראה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giao diện"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hitsura"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Εμφάνιση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aspeto"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вигляд"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "المظهر"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ظاهر"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ظاہری شکل"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รูปลักษณ์"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "दिखावट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "外観"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "외관"
-          }
-        }
-      },
-      "comment": "Settings section header"
-    },
-    "Customize the look and feel of your keyboard.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passe das Erscheinungsbild deiner Tastatur an."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personnalisez l'apparence de votre clavier."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personaliza el aspecto de tu teclado."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personalizza l'aspetto della tua tastiera."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Настройте внешний вид клавиатуры."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dostosuj wygląd swojej klawiatury."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anpassa tangentbordets utseende och känsla."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mukauta näppäimistösi ulkoasua ja tuntumaa."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prilagodi izgled i dojam svoje tipkovnice."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "התאם אישית את המראה והתחושה של המקלדת."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tùy chỉnh giao diện và cảm nhận của bàn phím."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-customize ang hitsura at pakiramdam ng iyong keyboard."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Προσαρμόστε την εμφάνιση και την αίσθηση του πληκτρολογίου σας."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personalize o aspeto e o comportamento do seu teclado."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Налаштуйте вигляд і поведінку вашої клавіатури."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خصِّص شكل ومظهر لوحة المفاتيح."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ظاهر و حس صفحه‌کلید خود را سفارشی کنید."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اپنے کی بورڈ کی شکل و صورت کو اپنی مرضی کے مطابق بنائیں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปรับแต่งหน้าตาและสัมผัสของคีย์บอร์ดของคุณ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अपने कीबोर्ड के लुक और फील को कस्टमाइज़ करें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードの見た目や操作感をカスタマイズします。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드의 모양과 느낌을 원하는 대로 설정하세요."
-          }
-        }
-      },
-      "comment": "Settings section footer"
-    },
-    "Style": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stil"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Style"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stile"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Стиль"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Styl"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stil"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tyyli"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stil"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "סגנון"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kiểu"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Στιλ"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Стиль"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "النمط"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سبک"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "انداز"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สไตล์"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "स्टाइल"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "スタイル"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "스타일"
-          }
-        }
-      },
-      "comment": "Settings row / title: visual style"
-    },
-    "Key Aspect Ratio": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seitenverhältnis der Tasten"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proportions des touches"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporción de las teclas"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporzioni dei tasti"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Соотношение сторон клавиш"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporcje klawiszy"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tangenternas proportioner"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Näppäinten kuvasuhde"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Omjer stranica tipki"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "יחס גובה-רוחב של המקשים"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tỷ lệ phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aspect Ratio ng Key"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αναλογία διαστάσεων πλήκτρων"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporção das teclas"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Співвідношення сторін клавіш"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسبة أبعاد المفتاح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسبت ابعاد کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی کا پہلو تناسب"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อัตราส่วนปุ่ม"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "की आस्पेक्ट रेशियो"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーの縦横比"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키 가로세로 비율"
-          }
-        }
-      },
-      "comment": "Settings row / title: width-to-height ratio of keys"
-    },
-    "Size & Position": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Größe & Position"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taille et position"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamaño y posición"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dimensioni e posizione"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Размер и положение"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rozmiar i położenie"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Storlek och position"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Koko ja sijainti"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Veličina i položaj"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גודל ומיקום"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kích cỡ & Vị trí"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sukat at Posisyon"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Μέγεθος και θέση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamanho e posição"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Розмір і положення"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الحجم والموضع"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اندازه و موقعیت"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سائز اور پوزیشن"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขนาดและตำแหน่ง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आकार और स्थिति"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サイズと位置"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "크기 및 위치"
-          }
-        }
-      },
-      "comment": "Settings row / title: keyboard size and position"
-    },
-    "Numpad Style": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ziffernblock-Stil"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Style du pavé numérique"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo del teclado numérico"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stile tastierino numerico"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Стиль цифровой панели"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Styl klawiatury numerycznej"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stil på sifferknappsats"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numeronäppäimistön tyyli"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stil numeričke tipkovnice"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "סגנון לוח המספרים"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kiểu bàn phím số"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo ng Numpad"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Στιλ αριθμητικού πληκτρολογίου"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo do teclado numérico"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Стиль цифрового блоку"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نمط لوحة الأرقام"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سبک صفحهٔ اعداد"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نمپیڈ انداز"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สไตล์แป้นตัวเลข"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "नंबरपैड स्टाइल"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "テンキーのスタイル"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "숫자 패드 스타일"
-          }
-        }
-      },
-      "comment": "Settings row title: number pad layout style"
-    },
-    "Classic (7-8-9)": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klassisch (7-8-9)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Classique (7-8-9)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clásico (7-8-9)"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Classico (7-8-9)"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Классический (7-8-9)"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klasyczny (7-8-9)"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klassisk (7-8-9)"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klassinen (7-8-9)"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klasično (7-8-9)"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "קלאסי (7-8-9)"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cổ điển (7-8-9)"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klasiko (7-8-9)"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Κλασικό (7-8-9)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clássico (7-8-9)"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Класичний (7-8-9)"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "كلاسيكي (7-8-9)"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کلاسیک (۷-۸-۹)"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کلاسک (7-8-9)"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คลาสสิก (7-8-9)"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "क्लासिक (7-8-9)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クラシック（7-8-9）"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "클래식 (7-8-9)"
-          }
-        }
-      },
-      "comment": "Picker option: calculator-style numpad with 7-8-9 on top"
-    },
-    "Phone (1-2-3)": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telefon (1-2-3)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Téléphone (1-2-3)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Teléfono (1-2-3)"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telefono (1-2-3)"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Телефонный (1-2-3)"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telefoniczny (1-2-3)"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telefon (1-2-3)"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Puhelin (1-2-3)"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telefon (1-2-3)"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "טלפון (1-2-3)"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Điện thoại (1-2-3)"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telepono (1-2-3)"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Τηλέφωνο (1-2-3)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telefone (1-2-3)"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Телефонний (1-2-3)"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الهاتف (1-2-3)"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تلفن (۱-۲-۳)"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فون (1-2-3)"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "โทรศัพท์ (1-2-3)"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "फ़ोन (1-2-3)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "電話（1-2-3）"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전화기 (1-2-3)"
-          }
-        }
-      },
-      "comment": "Picker option: phone-style numpad with 1-2-3 on top"
-    },
-    "Feedback": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retour"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Respuesta"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Отклик"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reakcje"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Återkoppling"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Palaute"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Povratne informacije"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משוב"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phản hồi"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ανάδραση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retorno"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відгук"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الاستجابة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بازخورد"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فیڈ بیک"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตอบสนอง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "फ़ीडबैक"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フィードバック"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "피드백"
-          }
-        }
-      },
-      "comment": "Settings section header (covers haptic feedback)"
-    },
-    "Haptic Feedback": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptisches Feedback"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retour haptique"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Respuesta háptica"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback aptico"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тактильный отклик"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reakcje haptyczne"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taktil återkoppling"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tuntopalaute"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptičke povratne informacije"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משוב מישושי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phản hồi xúc giác"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptic Feedback"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Απτική ανάδραση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retorno tátil"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тактильний відгук"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الاستجابة اللمسية"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بازخورد لمسی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ہیپٹک فیڈ بیک"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตอบสนองแบบสัมผัส"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "हैप्टिक फ़ीडबैक"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "触覚フィードバック"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "햅틱 피드백"
-          }
-        }
-      },
-      "comment": "Row title / toggle: vibration feedback"
-    },
-    "Advanced": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erweitert"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avancé"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avanzado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avanzate"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Дополнительно"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zaawansowane"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avancerat"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lisäasetukset"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Napredno"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מתקדם"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nâng cao"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Advanced"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Για προχωρημένους"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avançado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Додатково"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "متقدم"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پیشرفته"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ایڈوانسڈ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขั้นสูง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "उन्नत"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "詳細"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "고급"
-          }
-        }
-      },
-      "comment": "Settings section header"
-    },
-    "Expert": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Experte"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expert"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Experto"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esperto"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Для экспертов"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ekspert"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expert"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Asiantuntija"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stručno"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מומחה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chuyên gia"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expert"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ειδικός"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Especialista"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Експертний"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الخبير"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حرفه‌ای"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ماہر"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ผู้เชี่ยวชาญ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "एक्सपर्ट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エキスパート"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전문가"
-          }
-        }
-      },
-      "comment": "Settings row title leading to expert/advanced gesture tuning"
-    },
-    "About": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Über"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "À propos"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Información"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informazioni"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "О приложении"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informacje"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Om"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tietoja"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O aplikaciji"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אודות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giới thiệu"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tungkol Dito"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Σχετικά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Acerca de"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Про програму"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حول"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "درباره"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بارے میں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เกี่ยวกับ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "परिचय"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "情報"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "정보"
-          }
-        }
-      },
-      "comment": "Settings section header"
-    },
-    "Version": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versión"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versione"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Версия"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wersja"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versio"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verzija"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גרסה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phiên bản"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bersyon"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Έκδοση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versão"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Версія"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإصدار"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسخه"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ورژن"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เวอร์ชัน"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "वर्शन"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "バージョン"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "버전"
-          }
-        }
-      },
-      "comment": "About row label (app version)"
-    },
-    "License": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lizenz"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licence"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licencia"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licenza"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Лицензия"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licencja"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licens"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lisenssi"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licenca"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "רישיון"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giấy phép"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lisensya"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Άδεια χρήσης"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licença"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ліцензія"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الترخيص"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مجوز"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لائسنس"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สัญญาอนุญาต"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "लाइसेंस"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ライセンス"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "라이선스"
-          }
-        }
-      },
-      "comment": "About row label (software license)"
-    },
-    "Imprint": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impressum"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mentions légales"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aviso legal"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Note legali"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Выходные данные"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nota prawna"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utgivningsinformation"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Julkaisutiedot"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impresum"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פרטים משפטיים"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thông tin pháp lý"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Imprint"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Στοιχεία έκδοσης"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ficha técnica"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вихідні дані"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بيانات الناشر"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اطلاعات ناشر"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "امپرنٹ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ข้อมูลผู้จัดทำ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "इम्प्रिंट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "運営者情報"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제작 정보"
-          }
-        }
-      },
-      "comment": "About row / title: legal imprint / impressum"
-    },
-    "Switching Keyboards": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastatur wechseln"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Changer de clavier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambiar de teclado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambia tastiera"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Переключение клавиатуры"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przełącz klawiaturę"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Byt tangentbord"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vaihda näppäimistöä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Promjena tipkovnice"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "החלף מקלדת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chuyển bàn phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Magpalit ng Keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Εναλλαγή πληκτρολογίου"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mudar de teclado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перемкнути клавіатуру"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تبديل لوحة المفاتيح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تعویض صفحه‌کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ تبدیل کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สลับคีย์บอร์ด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड बदलें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードを切り替える"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 전환"
-          }
-        }
-      },
-      "comment": "Header above instructions on how to switch keyboards"
-    },
-    "Tap the globe icon on your keyboard to switch between installed keyboards": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tippe auf das Globussymbol deiner Tastatur, um zwischen installierten Tastaturen zu wechseln"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Touchez l'icône du globe sur votre clavier pour passer d'un clavier installé à un autre"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toca el icono del globo en tu teclado para cambiar entre los teclados instalados"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tocca l'icona del globo sulla tastiera per passare da una tastiera installata all'altra"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Нажмите значок глобуса на клавиатуре, чтобы переключаться между установленными клавиатурами"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stuknij ikonę globusa na klawiaturze, aby przełączać zainstalowane klawiatury"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tryck på jordglobsikonen på tangentbordet för att växla mellan installerade tangentbord"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vaihda asennettujen näppäimistöjen välillä napauttamalla maapallokuvaketta näppäimistössä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dodirni ikonu globusa na tipkovnici za prebacivanje između instaliranih tipkovnica"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הקש על סמל הגלובוס במקלדת כדי לעבור בין המקלדות המותקנות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chạm biểu tượng địa cầu trên bàn phím để chuyển giữa các bàn phím đã cài"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-tap ang globe icon sa iyong keyboard para magpalit sa pagitan ng mga naka-install na keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Πατήστε το εικονίδιο της υδρογείου στο πληκτρολόγιό σας για εναλλαγή μεταξύ των εγκατεστημένων πληκτρολογίων"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toque no ícone do globo no teclado para alternar entre os teclados instalados"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Торкніться значка глобуса на клавіатурі, щоб перемикатися між встановленими клавіатурами"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اضغط على أيقونة الكرة الأرضية في لوحة المفاتيح للتبديل بين لوحات المفاتيح المثبَّتة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "روی نماد کره در صفحه‌کلید ضربه بزنید تا بین صفحه‌کلیدهای نصب‌شده جابه‌جا شوید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "انسٹال شدہ کی بورڈز کے درمیان تبدیل کرنے کے لیے اپنے کی بورڈ پر گلوب آئیکن پر ٹیپ کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แตะไอคอนลูกโลกบนคีย์บอร์ดเพื่อสลับระหว่างคีย์บอร์ดที่ติดตั้งไว้"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "इंस्टॉल किए गए कीबोर्ड के बीच स्विच करने के लिए अपने कीबोर्ड पर ग्लोब आइकन पर टैप करें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードの地球儀アイコンをタップすると、インストール済みのキーボードを切り替えられます"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드의 지구본 아이콘을 탭하면 설치된 키보드 간에 전환할 수 있습니다"
-          }
-        }
-      },
-      "comment": "Instruction text"
-    },
-    "Test Field": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testfeld"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Champ de test"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Campo de prueba"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Campo di prova"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Поле для пробы"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pole testowe"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testfält"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testikenttä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Polje za isprobavanje"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "שדה בדיקה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ô thử"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Test Field"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Πεδίο δοκιμής"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Campo de teste"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тестове поле"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حقل الاختبار"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فیلد آزمایش"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ٹیسٹ فیلڈ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ช่องทดสอบ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "टेस्ट फ़ील्ड"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "テスト入力欄"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "테스트 입력란"
-          }
-        }
-      },
-      "comment": "Label above a text field for trying the keyboard"
-    },
-    "Tap here to open keyboard...": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hier tippen, um die Tastatur zu öffnen …"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Touchez ici pour ouvrir le clavier…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toca aquí para abrir el teclado..."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tocca qui per aprire la tastiera..."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Нажмите здесь, чтобы открыть клавиатуру…"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stuknij tutaj, aby otworzyć klawiaturę..."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tryck här för att öppna tangentbordet …"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avaa näppäimistö napauttamalla tähän..."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dodirni ovdje za otvaranje tipkovnice..."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הקש כאן כדי לפתוח את המקלדת..."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chạm vào đây để mở bàn phím..."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-tap dito para buksan ang keyboard..."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Πατήστε εδώ για άνοιγμα πληκτρολογίου..."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toque aqui para abrir o teclado..."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Торкніться тут, щоб відкрити клавіатуру…"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اضغط هنا لفتح لوحة المفاتيح..."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برای باز کردن صفحه‌کلید اینجا ضربه بزنید..."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ کھولنے کے لیے یہاں ٹیپ کریں..."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แตะที่นี่เพื่อเปิดคีย์บอร์ด..."
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड खोलने के लिए यहाँ टैप करें..."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ここをタップしてキーボードを開く…"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "여기를 탭하여 키보드 열기..."
-          }
-        }
-      },
-      "comment": "Placeholder text in the test field"
-    },
-    "Clear": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Löschen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Effacer"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Borrar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancella"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Очистить"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wyczyść"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rensa"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tyhjennä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Očisti"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "נקה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xóa hết"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-clear"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Εκκαθάριση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limpar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Очистити"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مسح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پاک کردن"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "صاف کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ล้าง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "साफ़ करें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "消去"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "지우기"
-          }
-        }
-      },
-      "comment": "Button: clear the text field"
-    },
-    "Done": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fertig"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aceptar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fine"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Готово"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gotowe"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klar"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valmis"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gotovo"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "סיום"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xong"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tapos na"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Τέλος"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Concluído"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Готово"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تم"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تمام"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ہو گیا"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เสร็จสิ้น"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "हो गया"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完了"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "완료"
-          }
-        }
-      },
-      "comment": "Keyboard toolbar button to dismiss the keyboard / finish editing"
-    },
-    "MessagEase Layout": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase-Layout"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disposition MessagEase"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disposición MessagEase"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Layout MessagEase"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Раскладка MessagEase"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Układ MessagEase"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase-layout"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase-asettelu"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase raspored"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פריסת MessagEase"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bố cục MessagEase"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase Layout"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Διάταξη MessagEase"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esquema MessagEase"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Розкладка MessagEase"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تخطيط MessagEase"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "چیدمان MessagEase"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase لے آؤٹ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เลย์เอาต์ MessagEase"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase लेआउट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEaseレイアウト"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase 레이아웃"
-          }
-        }
-      },
-      "comment": "Caption under each language option; 'MessagEase' is a product name (keep)"
-    },
-    "Visual Style": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Visueller Stil"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Style visuel"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo visual"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stile visivo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Визуальный стиль"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Styl wizualny"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Visuell stil"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Visuaalinen tyyli"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vizualni stil"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "סגנון חזותי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kiểu hiển thị"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Visual na Estilo"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Οπτικό στιλ"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo visual"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Візуальний стиль"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "النمط المرئي"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سبک ظاهری"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بصری انداز"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สไตล์การแสดงผล"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "विज़ुअल स्टाइल"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "表示スタイル"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "비주얼 스타일"
-          }
-        }
-      },
-      "comment": "Header for keyboard visual style options"
-    },
-    "Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass ist für iOS 26 und neuer ausgelegt. Auf älteren Versionen wird ein vereinfachter durchscheinender Stil verwendet."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass est conçu pour iOS 26 et versions ultérieures. Sur les versions antérieures, un style translucide simplifié est utilisé."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass está diseñado para iOS 26 y posteriores. En versiones anteriores se usa un estilo translúcido simplificado."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass è progettato per iOS 26 e versioni successive. Nelle versioni precedenti viene usato uno stile traslucido semplificato."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass разработан для iOS 26 и новее. В более ранних версиях используется упрощённый полупрозрачный стиль."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass jest zaprojektowany dla iOS 26 i nowszych. W starszych wersjach używany jest uproszczony półprzezroczysty styl."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass är utformat för iOS 26 och senare. På äldre versioner används en förenklad halvgenomskinlig stil."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass on suunniteltu iOS 26:lle ja uudemmille. Vanhemmissa versioissa käytetään yksinkertaistettua läpikuultavaa tyyliä."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass je osmišljen za iOS 26 i novije. Na starijim verzijama koristi se pojednostavljeni poluprozirni stil."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass מיועד ל‑iOS 26 ואילך. בגרסאות קודמות נעשה שימוש בסגנון שקוף למחצה ופשוט יותר."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass được thiết kế cho iOS 26 trở lên. Trên các phiên bản cũ hơn, một kiểu trong mờ đơn giản hóa sẽ được dùng."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ang Liquid Glass ay idinisenyo para sa iOS 26 pataas. Sa mas lumang bersyon, gagamitin ang pinasimpleng translucent na estilo."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Το Liquid Glass απαιτεί iOS 26 ή νεότερη έκδοση. Σε αυτή τη συσκευή θα χρησιμοποιηθεί το κλασικό στιλ."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O Liquid Glass requer o iOS 26 ou posterior. Neste dispositivo será usado o estilo clássico."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass потребує iOS 26 або новішої версії. На цьому пристрої використовуватиметься класичний стиль."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يتطلب Liquid Glass نظام iOS 26 أو أحدث. سيُستخدم النمط الكلاسيكي على هذا الجهاز."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass به iOS 26 یا جدیدتر نیاز دارد. در این دستگاه از سبک کلاسیک استفاده می‌شود."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass کے لیے iOS 26 یا بعد کا ورژن درکار ہے۔ اس ڈیوائس پر کلاسک انداز استعمال ہوگا۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass ต้องใช้ iOS 26 ขึ้นไป อุปกรณ์นี้จะใช้สไตล์คลาสสิกแทน"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass के लिए iOS 26 या बाद का वर्शन ज़रूरी है। इस डिवाइस पर क्लासिक स्टाइल इस्तेमाल होगी।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid GlassにはiOS 26以降が必要です。このデバイスではクラシックスタイルが使用されます。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass는 iOS 26 이상이 필요합니다. 이 기기에서는 클래식 스타일이 사용됩니다."
-          }
-        }
-      },
-      "comment": "Note shown on pre-iOS-26 devices; 'Liquid Glass' is a style name (keep)"
-    },
-    "Open the keyboard once to sync Full Access status.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Öffne die Tastatur einmal, um den Status von Vollzugriff zu synchronisieren."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ouvrez le clavier une fois pour synchroniser l'état de l'accès complet."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abre el teclado una vez para sincronizar el estado del acceso completo."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apri la tastiera una volta per sincronizzare lo stato dell'accesso completo."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Откройте клавиатуру один раз, чтобы синхронизировать статус полного доступа."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otwórz raz klawiaturę, aby zsynchronizować stan pełnego dostępu."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Öppna tangentbordet en gång för att synkronisera status för fullständig åtkomst."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avaa näppäimistö kerran, jotta täyden käyttöoikeuden tila synkronoituu."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jednom otvori tipkovnicu za sinkronizaciju statusa punog pristupa."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פתח את המקלדת פעם אחת כדי לסנכרן את מצב הגישה המלאה."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mở bàn phím một lần để đồng bộ trạng thái Truy cập đầy đủ."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buksan ang keyboard nang isang beses para i-sync ang status ng Full Access."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ανοίξτε το πληκτρολόγιο μία φορά για συγχρονισμό της κατάστασης πλήρους πρόσβασης."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abra o teclado uma vez para sincronizar o estado do acesso total."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відкрийте клавіатуру один раз, щоб синхронізувати стан повного доступу."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "افتح لوحة المفاتيح مرة واحدة لمزامنة حالة الوصول الكامل."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "یک‌بار صفحه‌کلید را باز کنید تا وضعیت دسترسی کامل همگام شود."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مکمل رسائی کی حالت سنک کرنے کے لیے کی بورڈ ایک بار کھولیں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เปิดคีย์บอร์ดหนึ่งครั้งเพื่อซิงค์สถานะการเข้าถึงเต็มรูปแบบ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पूर्ण एक्सेस स्थिति सिंक करने के लिए कीबोर्ड एक बार खोलें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フルアクセスの状態を同期するために、キーボードを一度開いてください。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 접근 상태를 동기화하려면 키보드를 한 번 열어 주세요."
-          }
-        }
-      },
-      "comment": "Caption; 'Full Access' is the iOS term"
-    },
-    "Tap Feedback": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tipp-Feedback"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retour au toucher"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Respuesta al tocar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback al tocco"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Отклик при нажатии"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reakcja na stuknięcie"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Återkoppling vid tryck"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Napautuspalaute"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Povratne informacije dodira"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משוב בהקשה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phản hồi khi chạm"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap Feedback"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ανάδραση πατήματος"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retorno ao tocar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відгук на дотик"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "استجابة اللمس"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بازخورد ضربه"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ٹیپ فیڈ بیک"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตอบสนองเมื่อแตะ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "टैप फ़ीडबैक"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タップ時のフィードバック"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "탭 피드백"
-          }
-        }
-      },
-      "comment": "Slider control title: haptic strength when tapping keys"
-    },
-    "Applies when you touch any key.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gilt, wenn du eine beliebige Taste berührst."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "S'applique lorsque vous touchez une touche."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se aplica al tocar cualquier tecla."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si applica quando tocchi un tasto qualsiasi."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Применяется при касании любой клавиши."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Działa przy dotknięciu dowolnego klawisza."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gäller när du rör vid en tangent."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vaikuttaa, kun kosketat mitä tahansa näppäintä."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Primjenjuje se kad dodirneš bilo koju tipku."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "חל בעת נגיעה בכל מקש."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Áp dụng khi bạn chạm vào phím bất kỳ."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nalalapat kapag humawak ka sa anumang key."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ισχύει όταν αγγίζετε οποιοδήποτε πλήκτρο."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplica-se quando toca em qualquer tecla."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Застосовується, коли ви торкаєтеся будь-якої клавіші."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تُطبَّق عند لمس أي مفتاح."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "هنگام لمس هر کلید اعمال می‌شود."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جب آپ کوئی کی چھوتے ہیں تو لاگو ہوتا ہے۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ใช้เมื่อคุณแตะปุ่มใดก็ตาม"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "किसी भी की को छूने पर लागू होता है।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "いずれかのキーに触れたときに適用されます。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "아무 키나 누를 때 적용됩니다."
-          }
-        }
-      },
-      "comment": "Caption under the Tap Feedback slider"
-    },
-    "Drag Feedback": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zieh-Feedback"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retour au glissement"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Respuesta al arrastrar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback al trascinamento"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Отклик при перетягивании"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reakcja na przeciąganie"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Återkoppling vid dragning"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vetopalaute"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Povratne informacije povlačenja"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משוב בגרירה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phản hồi khi kéo"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Drag Feedback"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ανάδραση συρσίματος"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retorno ao arrastar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відгук на перетягування"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "استجابة السحب"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بازخورد کشیدن"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ڈریگ فیڈ بیک"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตอบสนองเมื่อลาก"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ड्रैग फ़ीडबैक"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ドラッグ時のフィードバック"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "드래그 피드백"
-          }
-        }
-      },
-      "comment": "Slider control title: haptic strength when dragging"
-    },
-    "Applies when you drag the Space or Delete key to move the cursor or delete text.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gilt, wenn du die Leertaste oder Löschtaste ziehst, um den Cursor zu bewegen oder Text zu löschen."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "S'applique lorsque vous faites glisser la touche Espace ou Suppr. pour déplacer le curseur ou supprimer du texte."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se aplica al arrastrar la tecla Espacio o Borrar para mover el cursor o borrar texto."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si applica quando trascini il tasto Spazio o Elimina per spostare il cursore o eliminare il testo."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Применяется при перетягивании клавиши пробела или удаления для перемещения курсора или удаления текста."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Działa przy przeciąganiu klawisza spacji lub usuwania w celu przesunięcia kursora lub usunięcia tekstu."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gäller när du drar mellanslags- eller raderingstangenten för att flytta markören eller radera text."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vaikuttaa, kun vedät väli- tai poistonäppäintä siirtääksesi kohdistinta tai poistaaksesi tekstiä."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Primjenjuje se kad povučeš tipku Razmaknica ili Brisanje za pomicanje pokazivača ili brisanje teksta."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "חל בעת גרירת מקש הרווח או המחיקה כדי להזיז את הסמן או למחוק טקסט."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Áp dụng khi bạn kéo phím Cách hoặc Xóa để di chuyển con trỏ hoặc xóa văn bản."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nalalapat kapag ni-drag mo ang Space o Delete key para igalaw ang cursor o magbura ng teksto."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ισχύει όταν σέρνετε το πλήκτρο διαστήματος ή διαγραφής για να μετακινήσετε τον δρομέα ή να διαγράψετε κείμενο."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplica-se quando arrasta a tecla Espaço ou Eliminar para mover o cursor ou apagar texto."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Застосовується, коли ви перетягуєте клавішу пробілу або видалення, щоб перемістити курсор чи видалити текст."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تُطبَّق عند سحب مفتاح المسافة أو الحذف لتحريك المؤشر أو حذف النص."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "هنگامی که کلید فاصله یا حذف را برای جابه‌جایی نشانگر یا حذف متن می‌کشید اعمال می‌شود."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جب آپ کرسر کو منتقل کرنے یا متن حذف کرنے کے لیے اسپیس یا ڈیلیٹ کی کو ڈریگ کرتے ہیں تو لاگو ہوتا ہے۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ใช้เมื่อคุณลากปุ่มเว้นวรรคหรือปุ่มลบเพื่อเลื่อนเคอร์เซอร์หรือลบข้อความ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कर्सर हिलाने या टेक्स्ट डिलीट करने के लिए स्पेस या डिलीट की को ड्रैग करने पर लागू होता है।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "スペースキーや削除キーをドラッグしてカーソルを移動したり、テキストを削除したりするときに適用されます。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "스페이스 또는 삭제 키를 드래그하여 커서를 이동하거나 텍스트를 삭제할 때 적용됩니다."
-          }
-        }
-      },
-      "comment": "Caption; 'Space' and 'Delete' are key names"
-    },
-    "Off": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aus"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Désactivé"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apagado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Выкл."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wył."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Av"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pois"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Isklj."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "כבוי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tắt"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Off"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ανενεργό"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desligado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вимк."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إيقاف"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خاموش"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بند"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปิด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "बंद"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "オフ"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "끔"
-          }
-        }
-      },
-      "comment": "Slider minimum label (intensity off)"
-    },
-    "Minimal": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimal"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimal"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mínimo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Минимальный"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimalny"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimal"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimaalinen"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimalno"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מינימלי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tối thiểu"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimal"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ελάχιστη"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mínimo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Мінімальний"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الحد الأدنى"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کمینه"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کم سے کم"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "น้อยที่สุด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "न्यूनतम"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最小"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "최소"
-          }
-        }
-      },
-      "comment": "Haptic intensity level name"
-    },
-    "Soft": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sanft"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Doux"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Suave"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Morbido"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Мягкий"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Miękki"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mjuk"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pehmeä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mekano"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "רך"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Êm"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Malambot"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Απαλή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Suave"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "М’який"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خفيف"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ملایم"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نرم"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เบา"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "मृदु"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ソフト"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "약하게"
-          }
-        }
-      },
-      "comment": "Haptic intensity level name"
-    },
-    "Light": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leicht"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Léger"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ligero"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leggero"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Лёгкий"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lekki"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lätt"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kevyt"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lagano"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "קל"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nhẹ"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Magaan"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ελαφριά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ligeiro"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Легкий"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خفيف جدًا"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سبک"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ہلکا"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อ่อน"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "हल्का"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "弱"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "가볍게"
-          }
-        }
-      },
-      "comment": "Haptic intensity level name"
-    },
-    "Medium": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mittel"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Moyen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medio"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medio"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Средний"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Średni"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medel"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keskitaso"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Srednje"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "בינוני"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vừa"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Katamtaman"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Μεσαία"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Médio"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Середній"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "متوسط"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "متوسط"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "درمیانہ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปานกลาง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "मध्यम"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "보통"
-          }
-        }
-      },
-      "comment": "Haptic intensity level name"
-    },
-    "Strong": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stark"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fort"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fuerte"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Forte"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сильный"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Silny"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stark"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voimakas"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jako"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "חזק"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mạnh"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Malakas"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Δυνατή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Forte"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сильний"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قوي"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قوی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مضبوط"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แรง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "तीव्र"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "強"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "강하게"
-          }
-        }
-      },
-      "comment": "Haptic intensity level name"
-    },
-    "Max": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Max"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Max"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Máx."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Max"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Макс."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maks."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Max"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maks."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maks."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מרבי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tối đa"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Max"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Μέγιστη"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Máximo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Максимальний"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الحد الأقصى"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بیشینه"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "زیادہ سے زیادہ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สูงสุด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अधिकतम"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最大"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "최대"
-          }
-        }
-      },
-      "comment": "Slider maximum label (maximum intensity)"
-    },
-    "Haptics": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptik"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retour haptique"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Háptica"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aptica"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тактильный отклик"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptyka"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taktil återkoppling"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tuntopalaute"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptika"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משוב מישושי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xúc giác"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptics"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Απτική ανάδραση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tátil"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тактильний відгук"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الاستجابة اللمسية"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لرزش لمسی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ہیپٹکس"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การสั่นตอบสนอง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "हैप्टिक्स"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "触覚フィードバック"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "햅틱"
-          }
-        }
-      },
-      "comment": "Navigation title for haptic settings"
-    },
-    "Reset": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zurücksetzen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réinitialiser"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ripristina"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сбросить"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resetuj"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Återställ"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Palauta"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vrati izvorno"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אפס"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Đặt lại"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-reset"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Επαναφορά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Repor"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Скинути"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إعادة تعيين"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بازنشانی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ری سیٹ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รีเซ็ต"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "रीसेट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リセット"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "재설정"
-          }
-        }
-      },
-      "comment": "Button to reset values to defaults"
-    },
-    "Value": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wert"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valeur"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valor"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valore"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Значение"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wartość"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Värde"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arvo"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vrijednost"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ערך"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giá trị"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Halaga"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Τιμή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valor"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Значення"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "القيمة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مقدار"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قدر"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ค่า"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "मान"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "値"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "값"
-          }
-        }
-      },
-      "comment": "Label/placeholder for a numeric input field"
-    },
-    "Haptic feedback requires Full Access. Enable it in **Settings › Wurstfinger › Keyboards › Wurstfinger › Allow Full Access**.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptisches Feedback erfordert Vollzugriff. Aktiviere ihn unter **Einstellungen › Wurstfinger › Tastaturen › Wurstfinger › Vollzugriff erlauben**."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Le retour haptique nécessite l'accès complet. Activez-le dans **Réglages › Wurstfinger › Claviers › Wurstfinger › Autoriser l'accès complet**."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La respuesta háptica requiere acceso completo. Actívalo en **Ajustes › Wurstfinger › Teclados › Wurstfinger › Permitir acceso completo**."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Il feedback aptico richiede l'accesso completo. Attivalo in **Impostazioni › Wurstfinger › Tastiere › Wurstfinger › Consenti accesso completo**."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тактильный отклик требует полного доступа. Включите его в **Настройки › Wurstfinger › Клавиатуры › Wurstfinger › Разрешить полный доступ**."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reakcje haptyczne wymagają pełnego dostępu. Włącz go w **Ustawienia › Wurstfinger › Klawiatury › Wurstfinger › Przyznaj pełny dostęp**."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taktil återkoppling kräver fullständig åtkomst. Aktivera den i **Inställningar › Wurstfinger › Tangentbord › Wurstfinger › Tillåt fullständig åtkomst**."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tuntopalaute vaatii täyden käyttöoikeuden. Ota se käyttöön kohdassa **Asetukset › Wurstfinger › Näppäimistöt › Wurstfinger › Salli täysi käyttöoikeus**."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptičke povratne informacije zahtijevaju puni pristup. Uključi ga u **Postavke › Wurstfinger › Tipkovnice › Wurstfinger › Dopusti puni pristup**."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משוב מישושי דורש גישה מלאה. הפעל אותה ב-**הגדרות › Wurstfinger › מקלדות › Wurstfinger › אפשר גישה מלאה**."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phản hồi xúc giác yêu cầu Truy cập đầy đủ. Bật trong **Cài đặt › Wurstfinger › Bàn phím › Wurstfinger › Cho phép truy cập đầy đủ**."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kailangan ng haptic feedback ang Full Access. I-enable ito sa **Mga Setting › Wurstfinger › Mga Keyboard › Wurstfinger › Payagan ang Full Access**."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Η απτική ανάδραση απαιτεί πλήρη πρόσβαση. Ενεργοποιήστε την στο **Ρυθμίσεις › Wurstfinger › Πληκτρολόγια › Wurstfinger › Να επιτρέπεται η πλήρης πρόσβαση**."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O retorno tátil requer acesso total. Ative-o em **Definições › Wurstfinger › Teclados › Wurstfinger › Permitir acesso total**."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тактильний відгук потребує повного доступу. Увімкніть його в **Параметри › Wurstfinger › Клавіатури › Wurstfinger › Дозволити повний доступ**."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تتطلب الاستجابة اللمسية الوصول الكامل. فعِّلها في **الإعدادات › Wurstfinger › لوحات المفاتيح › Wurstfinger › السماح بالوصول الكامل**."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بازخورد لمسی به دسترسی کامل نیاز دارد. آن را در **تنظیمات › Wurstfinger › صفحه‌کلیدها › Wurstfinger › اجازهٔ دسترسی کامل** فعال کنید."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ہیپٹک فیڈ بیک کے لیے مکمل رسائی درکار ہے۔ اسے **ترتیبات › Wurstfinger › کی بورڈز › Wurstfinger › مکمل رسائی کی اجازت دیں** میں فعال کریں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตอบสนองแบบสัมผัสต้องใช้การเข้าถึงเต็มรูปแบบ เปิดใช้งานได้ที่ **การตั้งค่า › Wurstfinger › แป้นพิมพ์ › Wurstfinger › อนุญาตการเข้าถึงเต็มรูปแบบ**"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "हैप्टिक फ़ीडबैक के लिए पूर्ण एक्सेस ज़रूरी है। इसे **सेटिंग्स › Wurstfinger › कीबोर्ड › Wurstfinger › पूर्ण एक्सेस दें** में चालू करें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "触覚フィードバックにはフルアクセスが必要です。**「設定」› Wurstfinger ›「キーボード」› Wurstfinger ›「フルアクセスを許可」**で有効にしてください。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "햅틱 피드백에는 전체 접근이 필요합니다. **설정 › Wurstfinger › 키보드 › Wurstfinger › 전체 접근 허용**에서 켜세요."
-          }
-        }
-      },
-      "comment": "Warning with markdown bold and › separators; the path words inside ** ** are iOS Settings names — localize Settings/Keyboards/Allow Full Access, keep 'Wurstfinger', keep markdown ** and ›"
-    },
-    "Keyboard Size": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastaturgröße"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taille du clavier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamaño del teclado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dimensione della tastiera"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Размер клавиатуры"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rozmiar klawiatury"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tangentbordets storlek"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Näppäimistön koko"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Veličina tipkovnice"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גודל המקלדת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kích thước bàn phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Laki ng Keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Μέγεθος πληκτρολογίου"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamanho do teclado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Розмір клавіатури"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حجم لوحة المفاتيح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اندازه صفحه‌کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ کا سائز"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขนาดคีย์บอร์ด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड का आकार"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードのサイズ"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 크기"
-          }
-        }
-      },
-      "comment": "Slider title: overall keyboard size"
-    },
-    "Size relative to the standard keyboard. It stays the same in every orientation; if it does not fit, it shrinks to the screen.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Größe im Verhältnis zur Standardtastatur. Sie bleibt in jeder Bildschirmausrichtung gleich; passt sie nicht auf den Bildschirm, wird sie auf die Bildschirmbreite verkleinert."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taille par rapport au clavier standard. Elle reste identique dans toutes les orientations ; si le clavier ne tient pas, il est réduit à la largeur de l'écran."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamaño relativo al teclado estándar. Se mantiene igual en todas las orientaciones; si no cabe, se reduce al ancho de la pantalla."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dimensione relativa alla tastiera standard. Resta invariata in ogni orientamento; se non c'è spazio sufficiente, viene ridotta alla larghezza dello schermo."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Размер относительно стандартной клавиатуры. Он одинаков в любой ориентации; если клавиатура не помещается, она уменьшается до ширины экрана."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rozmiar względem klawiatury standardowej. Pozostaje taki sam w każdej orientacji; jeśli klawiatura się nie mieści, jest zmniejszana do szerokości ekranu."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Storlek i förhållande till standardtangentbordet. Den är densamma i alla riktningar; om tangentbordet inte får plats krymps det till skärmens bredd."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Koko suhteessa vakionäppäimistöön. Se pysyy samana kaikissa asennoissa; jos näppäimistö ei mahdu, se kutistetaan näytön leveyteen."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Veličina u odnosu na standardnu tipkovnicu. Ostaje ista u svakoj orijentaciji; ako tipkovnica ne stane, smanjuje se na širinu zaslona."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הגודל ביחס למקלדת הרגילה. הוא נשאר זהה בכל כיוון; אם המקלדת לא נכנסת, היא מוקטנת לרוחב המסך."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kích thước so với bàn phím tiêu chuẩn. Kích thước này giữ nguyên ở mọi hướng màn hình; nếu không vừa, bàn phím sẽ thu nhỏ theo chiều rộng màn hình."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Laki kumpara sa karaniwang keyboard. Nananatili itong pareho sa lahat ng oryentasyon; kung hindi kasya, liliitan ito ayon sa lapad ng screen."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Μέγεθος σε σχέση με το τυπικό πληκτρολόγιο. Παραμένει το ίδιο σε κάθε προσανατολισμό· αν δεν χωράει, σμικρύνεται στο πλάτος της οθόνης."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamanho relativo ao teclado padrão. Mantém-se igual em qualquer orientação; se não couber, é reduzido à largura do ecrã."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Розмір відносно стандартної клавіатури. Він однаковий у будь-якій орієнтації; якщо клавіатура не вміщується, вона зменшується до ширини екрана."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الحجم بالنسبة إلى لوحة المفاتيح القياسية. يبقى كما هو في كل الاتجاهات، وإذا لم تتسع لوحة المفاتيح فسيتم تصغيرها لتناسب عرض الشاشة."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اندازه نسبت به صفحه‌کلید استاندارد. در همه جهت‌ها یکسان می‌ماند؛ اگر جا نشود، به عرض صفحه کوچک می‌شود."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "معیاری کی بورڈ کے مقابلے میں سائز۔ یہ ہر سمت میں یکساں رہتا ہے؛ اگر کی بورڈ نہ سما سکے تو اسے اسکرین کی چوڑائی کے مطابق چھوٹا کر دیا جاتا ہے۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขนาดเทียบกับคีย์บอร์ดมาตรฐาน ขนาดจะเท่าเดิมในทุกการวางแนว หากไม่พอดีจะย่อลงให้เท่าความกว้างของหน้าจอ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "मानक कीबोर्ड की तुलना में आकार। यह हर ओरिएंटेशन में एक जैसा रहता है; अगर यह नहीं समाता, तो इसे स्क्रीन की चौड़ाई तक छोटा कर दिया जाता है।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "標準キーボードを基準としたサイズです。どの画面の向きでも同じ大きさを保ち、収まらない場合は画面幅に合わせて縮小されます。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "표준 키보드를 기준으로 한 크기입니다. 화면 방향이 바뀌어도 그대로 유지되며, 들어가지 않으면 화면 너비에 맞춰 줄어듭니다."
-          }
-        }
-      },
-      "comment": "Caption under the size slider"
-    },
-    "Horizontal Position": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Horizontale Position"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Position horizontale"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Posición horizontal"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Posizione orizzontale"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Положение по горизонтали"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Położenie poziome"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Horisontell position"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vaakasijainti"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vodoravni položaj"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מיקום אופקי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vị trí ngang"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Horizontal na Posisyon"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Οριζόντια θέση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Posição horizontal"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Горизонтальне положення"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الموضع الأفقي"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "موقعیت افقی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "افقی پوزیشن"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตำแหน่งแนวนอน"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "क्षैतिज स्थिति"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水平方向の位置"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "가로 위치"
-          }
-        }
-      },
-      "comment": "Slider title"
-    },
-    "Left": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Links"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gauche"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Izquierda"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sinistra"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Слева"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lewo"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vänster"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vasen"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lijevo"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "שמאל"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trái"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kaliwa"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αριστερά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esquerda"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ліворуч"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اليسار"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "چپ"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بائیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ซ้าย"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "बायाँ"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "左"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "왼쪽"
-          }
-        }
-      },
-      "comment": "Slider label: left position"
-    },
-    "Center": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mitte"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Centre"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Centro"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Centro"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "По центру"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Środek"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Centrerad"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keskellä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sredina"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מרכז"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giữa"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gitna"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Κέντρο"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Centro"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "По центру"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الوسط"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "وسط"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "درمیان"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กึ่งกลาง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "केंद्र"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中央"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "가운데"
-          }
-        }
-      },
-      "comment": "Slider label: center position"
-    },
-    "Right": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rechts"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Droite"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Derecha"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Destra"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Справа"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prawo"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Höger"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oikea"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desno"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ימין"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phải"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kanan"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Δεξιά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Direita"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Праворуч"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اليمين"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "راست"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "دائیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขวา"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "दायाँ"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "右"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "오른쪽"
-          }
-        }
-      },
-      "comment": "Slider label: right position"
-    },
-    "Adjust the horizontal position of the keyboard when it is narrower than the screen.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passe die horizontale Position der Tastatur an, wenn sie schmaler als der Bildschirm ist."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajustez la position horizontale du clavier lorsqu'il est plus étroit que l'écran."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajusta la posición horizontal del teclado cuando es más estrecho que la pantalla."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Regola la posizione orizzontale della tastiera quando è più stretta dello schermo."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Настройте положение клавиатуры по горизонтали, когда она уже экрана."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dostosuj poziome położenie klawiatury, gdy jest węższa niż ekran."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Justera tangentbordets horisontella position när det är smalare än skärmen."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Säädä näppäimistön vaakasijaintia, kun se on näyttöä kapeampi."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prilagodi vodoravni položaj tipkovnice kad je uža od zaslona."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "התאם את המיקום האופקי של המקלדת כאשר היא צרה מהמסך."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Điều chỉnh vị trí ngang của bàn phím khi bàn phím hẹp hơn màn hình."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iayos ang horizontal na posisyon ng keyboard kapag mas makitid ito kaysa sa screen."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Προσαρμόστε την οριζόντια θέση του πληκτρολογίου όταν είναι στενότερο από την οθόνη."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajuste a posição horizontal do teclado quando este for mais estreito do que o ecrã."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Регулюйте горизонтальне положення клавіатури, коли вона вужча за екран."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اضبط الموضع الأفقي للوحة المفاتيح عندما تكون أضيق من الشاشة."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "وقتی صفحه‌کلید از صفحه نمایش باریک‌تر است، موقعیت افقی آن را تنظیم کنید."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جب کی بورڈ اسکرین سے تنگ ہو تو اس کی افقی پوزیشن ایڈجسٹ کریں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปรับตำแหน่งแนวนอนของคีย์บอร์ดเมื่อคีย์บอร์ดแคบกว่าหน้าจอ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "जब कीबोर्ड स्क्रीन से सँकरा हो, तो उसकी क्षैतिज स्थिति समायोजित करें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードが画面より狭いときに、水平方向の位置を調整します。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드가 화면보다 좁을 때 가로 위치를 조정합니다."
-          }
-        }
-      },
-      "comment": "Caption under the position slider"
-    },
-    "Aspect Ratio": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seitenverhältnis"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proportions"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporción"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporzioni"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Соотношение сторон"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporcje"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proportioner"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kuvasuhde"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Omjer stranica"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "יחס גובה-רוחב"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tỷ lệ khung"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aspect Ratio"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αναλογία διαστάσεων"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporção"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Співвідношення сторін"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسبة الأبعاد"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسبت ابعاد"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پہلو تناسب"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อัตราส่วน"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आस्पेक्ट रेशियो"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "縦横比"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "가로세로 비율"
-          }
-        }
-      },
-      "comment": "Slider title: key width-to-height ratio"
-    },
-    "Square · Default": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quadratisch · Standard"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Carré · Par défaut"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cuadrado · Por defecto"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quadrato · Predefinito"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Квадрат · По умолчанию"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kwadratowe · Domyślne"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kvadratisk · Standard"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Neliö · Oletus"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kvadratno · Zadano"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מרובע · ברירת מחדל"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vuông · Mặc định"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parisukat · Default"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Τετράγωνο · Προεπιλογή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quadrado · Predefinição"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Квадратне · За замовчуванням"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مربّع · افتراضي"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مربع · پیش‌فرض"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مربع · طے شدہ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สี่เหลี่ยมจัตุรัส · ค่าเริ่มต้น"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "वर्ग · डिफ़ॉल्ट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正方形・デフォルト"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "정사각형 · 기본값"
-          }
-        }
-      },
-      "comment": "Slider tick label at ratio 1.0; keep the · middle dot"
-    },
-    "Wide": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Breit"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Large"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ancho"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Largo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Широкие"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Szerokie"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bred"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leveä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Široko"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "רחב"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rộng"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Malapad"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Πλατύ"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Largo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Широке"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "عريض"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پهن"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "چوڑا"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กว้าง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "चौड़ा"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワイド"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "넓게"
-          }
-        }
-      },
-      "comment": "Slider tick label (wider keys)"
-    },
-    "Golden": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Golden"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Doré"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Áureo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aureo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Золотое сечение"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Złote"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gyllene"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kultainen"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zlatni rez"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "זהב"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tỷ lệ vàng"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Golden"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Χρυσή τομή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dourado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Золотий перетин"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ذهبي"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "طلایی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "گولڈن"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อัตราส่วนทอง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "गोल्डन"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "黄金比"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "황금비"
-          }
-        }
-      },
-      "comment": "Slider tick label at the golden ratio 1.62"
-    },
-    "Adjust the width-to-height ratio of the keys. 1.0 creates square keys (the default), and 1.62 is the golden ratio (widest).": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passe das Verhältnis von Breite zu Höhe der Tasten an. 1,0 erzeugt quadratische Tasten (Standard), 1,62 ist der Goldene Schnitt (am breitesten)."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajustez le rapport largeur/hauteur des touches. 1,0 crée des touches carrées (par défaut) et 1,62 correspond au nombre d'or (le plus large)."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajusta la proporción entre el ancho y el alto de las teclas. 1.0 crea teclas cuadradas (por defecto) y 1.62 es la proporción áurea (las más anchas)."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Regola il rapporto larghezza-altezza dei tasti. 1.0 crea tasti quadrati (l'impostazione predefinita), mentre 1.62 è la sezione aurea (la più larga)."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Настройте соотношение ширины и высоты клавиш. 1.0 создаёт квадратные клавиши (по умолчанию), а 1.62 — золотое сечение (самые широкие)."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dostosuj stosunek szerokości do wysokości klawiszy. 1.0 daje klawisze kwadratowe (domyślnie), a 1.62 to złoty podział (najszersze)."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Justera tangenternas förhållande mellan bredd och höjd. 1,0 ger kvadratiska tangenter (standard) och 1,62 är det gyllene snittet (bredast)."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Säädä näppäinten leveyden ja korkeuden suhdetta. 1,0 tuottaa neliönmuotoiset näppäimet (oletus) ja 1,62 on kultainen leikkaus (levein)."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prilagodi omjer širine i visine tipki. 1.0 stvara kvadratne tipke (zadano), a 1.62 je zlatni rez (najšire)."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "התאם את יחס הרוחב-גובה של המקשים. 1.0 יוצר מקשים מרובעים (ברירת המחדל), ו-1.62 הוא יחס הזהב (הרחב ביותר)."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Điều chỉnh tỷ lệ rộng trên cao của phím. 1.0 tạo phím vuông (mặc định), và 1.62 là tỷ lệ vàng (rộng nhất)."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iayos ang ratio ng lapad-sa-taas ng mga key. Ang 1.0 ay gumagawa ng parisukat na key (ang default), at ang 1.62 ay ang golden ratio (pinakamalapad)."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Προσαρμόστε την αναλογία πλάτους προς ύψος των πλήκτρων. Το 1.0 δημιουργεί τετράγωνα πλήκτρα (η προεπιλογή) και το 1.62 είναι η χρυσή τομή (το πλατύτερο)."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajuste a proporção entre a largura e a altura das teclas. 1.0 cria teclas quadradas (a predefinição) e 1.62 é a proporção áurea (a mais larga)."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Регулюйте співвідношення ширини до висоти клавіш. 1.0 створює квадратні клавіші (за замовчуванням), а 1.62 — це золотий перетин (найширше)."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اضبط نسبة العرض إلى الارتفاع للمفاتيح. تُنشئ القيمة 1.0 مفاتيح مربّعة (الافتراضي)، والقيمة 1.62 هي النسبة الذهبية (الأعرض)."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسبت عرض به ارتفاع کلیدها را تنظیم کنید. ۱٫۰ کلیدهای مربعی می‌سازد (پیش‌فرض) و ۱٫۶۲ نسبت طلایی است (پهن‌ترین)."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کیز کی چوڑائی اور اونچائی کا تناسب ایڈجسٹ کریں۔ 1.0 مربع کیز بناتا ہے (طے شدہ)، اور 1.62 گولڈن تناسب ہے (سب سے چوڑا)۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปรับอัตราส่วนความกว้างต่อความสูงของปุ่ม 1.0 จะได้ปุ่มสี่เหลี่ยมจัตุรัส (ค่าเริ่มต้น) และ 1.62 คืออัตราส่วนทอง (กว้างที่สุด)"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीज़ के चौड़ाई-से-ऊँचाई अनुपात को समायोजित करें। 1.0 वर्गाकार कीज़ बनाता है (डिफ़ॉल्ट), और 1.62 गोल्डन रेशियो है (सबसे चौड़ा)।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーの幅と高さの比率を調整します。1.0で正方形のキー（デフォルト）になり、1.62で黄金比（最も幅広）になります。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키의 너비 대 높이 비율을 조정합니다. 1.0은 정사각형 키(기본값)를, 1.62는 황금비(가장 넓음)를 만듭니다."
-          }
-        }
-      },
-      "comment": "Caption under the aspect ratio slider"
-    },
-    "Preview": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vorschau"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aperçu"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vista previa"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anteprima"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Предпросмотр"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Podgląd"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Förhandsvisning"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esikatselu"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pregled"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "תצוגה מקדימה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xem trước"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preview"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Προεπισκόπηση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pré-visualização"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перегляд"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "معاينة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پیش‌نمایش"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پیش منظر"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตัวอย่าง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "प्रीव्यू"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プレビュー"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "미리보기"
-          }
-        }
-      },
-      "comment": "Header above the interactive keyboard preview"
-    },
-    "Type on the keyboard below": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tippe auf der Tastatur unten"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tapez sur le clavier ci-dessous"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribe con el teclado de abajo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scrivi sulla tastiera qui sotto"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Печатайте на клавиатуре ниже"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pisz na klawiaturze poniżej"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skriv på tangentbordet nedan"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kirjoita alla olevalla näppäimistöllä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tipkaj na tipkovnici ispod"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הקלד במקלדת שלמטה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gõ trên bàn phím bên dưới"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mag-type sa keyboard sa ibaba"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Πληκτρολογήστε στο παρακάτω πληκτρολόγιο"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escreva no teclado abaixo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Друкуйте на клавіатурі нижче"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اكتب على لوحة المفاتيح أدناه"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "روی صفحه‌کلید زیر تایپ کنید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نیچے کی بورڈ پر ٹائپ کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "พิมพ์บนคีย์บอร์ดด้านล่าง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "नीचे दिए कीबोर्ड पर टाइप करें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "下のキーボードで入力してください"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "아래 키보드로 입력해 보세요"
-          }
-        }
-      },
-      "comment": "Placeholder text in the preview when empty"
-    },
-    "Switch keyboard": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastatur wechseln"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Changer de clavier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambiar de teclado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambia tastiera"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Переключить клавиатуру"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przełącz klawiaturę"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Byt tangentbord"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vaihda näppäimistöä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Promijeni tipkovnicu"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "החלף מקלדת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chuyển bàn phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Magpalit ng keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Εναλλαγή πληκτρολογίου"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mudar de teclado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перемкнути клавіатуру"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تبديل لوحة المفاتيح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تعویض صفحه‌کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ تبدیل کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สลับคีย์บอร์ด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड बदलें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードを切り替える"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 전환"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the globe key (VoiceOver)"
-    },
-    "Hide keyboard": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastatur ausblenden"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Masquer le clavier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ocultar teclado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nascondi tastiera"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Скрыть клавиатуру"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ukryj klawiaturę"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dölj tangentbordet"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piilota näppäimistö"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sakrij tipkovnicu"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הסתר מקלדת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ẩn bàn phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Itago ang keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Απόκρυψη πληκτρολογίου"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ocultar teclado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сховати клавіатуру"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إخفاء لوحة المفاتيح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پنهان کردن صفحه‌کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ چھپائیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ซ่อนคีย์บอร์ด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड छिपाएँ"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードを隠す"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 숨기기"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for dismiss-keyboard gesture (VoiceOver)"
-    },
-    "Delete": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Löschen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Supprimer"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Borrar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elimina"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Удалить"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usuń"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Radera"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poista"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Brisanje"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מחק"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xóa"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Διαγραφή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eliminar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Видалити"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حذف"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حذف"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حذف کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ลบ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "डिलीट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "削除"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "삭제"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the delete/backspace key (VoiceOver)"
-    },
-    "Next language": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nächste Sprache"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Langue suivante"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Idioma siguiente"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lingua successiva"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Следующий язык"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Następny język"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nästa språk"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seuraava kieli"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sljedeći jezik"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "השפה הבאה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ngôn ngữ tiếp theo"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Susunod na wika"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Επόμενη γλώσσα"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Próximo idioma"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Наступна мова"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اللغة التالية"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "زبان بعدی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اگلی زبان"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ภาษาถัดไป"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अगली भाषा"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "次の言語"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "다음 언어"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY action name for the switch-to-next-language gesture (VoiceOver)"
-    },
-    "New line": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Neue Zeile"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nouvelle ligne"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nueva línea"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A capo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Новая строка"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nowy wiersz"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ny rad"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uusi rivi"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Novi redak"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "שורה חדשה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dòng mới"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bagong linya"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Νέα γραμμή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nova linha"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Новий рядок"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سطر جديد"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خط جدید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نئی لائن"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขึ้นบรรทัดใหม่"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "नई लाइन"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "改行"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "줄바꿈"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the return/newline key (VoiceOver)"
-    },
-    "Copy": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopieren"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copiar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copia"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Копировать"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopiuj"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopiera"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopioi"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopiraj"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "העתק"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sao chép"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopyahin"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αντιγραφή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copiar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Копіювати"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسخ"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کپی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کاپی کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คัดลอก"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कॉपी"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コピー"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "복사"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the copy gesture (VoiceOver)"
-    },
-    "Cut": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ausschneiden"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couper"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taglia"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вырезать"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wytnij"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klipp ut"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leikkaa"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Izreži"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גזור"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cắt"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gupitin"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αποκοπή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вирізати"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قص"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برش"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کٹ کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตัด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カット"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "오려두기"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the cut gesture (VoiceOver)"
-    },
-    "Cut all": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alles ausschneiden"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tout couper"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar todo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taglia tutto"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вырезать всё"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wytnij wszystko"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klipp ut allt"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leikkaa kaikki"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Izreži sve"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גזור הכול"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cắt tất cả"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gupitin lahat"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αποκοπή όλων"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar tudo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вирізати все"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قص الكل"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برش همه"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سب کاٹیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตัดทั้งหมด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सभी काटें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "すべて切り取り"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "모두 잘라내기"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the cut-all gesture (VoiceOver)"
-    },
-    "Paste": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einsetzen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coller"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pegar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incolla"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вставить"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wklej"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klistra in"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liitä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zalijepi"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הדבק"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dán"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-paste"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Επικόλληση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Colar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вставити"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لصق"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "چسباندن"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پیسٹ کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "วาง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पेस्ट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ペースト"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "붙여넣기"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the paste gesture (VoiceOver)"
-    },
-    "Space": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leertaste"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Espace"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Espacio"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Spazio"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Пробел"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Spacja"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mellanslag"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Välilyönti"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Razmaknica"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "רווח"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phím cách"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Space"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Διάστημα"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Espaço"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Пробіл"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مسافة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فاصله"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اسپیس"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เว้นวรรค"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "स्पेस"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "スペース"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "스페이스"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the space bar (VoiceOver)"
+      "comment": "Languages summary: list of languages + pinned default language"
     },
     "%@ + %lld more": {
       "extractionState": "manual",
@@ -12697,695 +277,695 @@
       },
       "comment": "Languages summary: first language + count of remaining"
     },
-    "%@ (default: %@)": {
+    "About": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (Standard: %@)"
+            "value": "Über"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (par défaut : %@)"
+            "value": "À propos"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (predeterminado: %@)"
+            "value": "Información"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (predefinita: %@)"
+            "value": "Informazioni"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (по умолчанию: %@)"
+            "value": "О приложении"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (domyślny: %@)"
+            "value": "Informacje"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (standard: %@)"
+            "value": "Om"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (oletus: %@)"
+            "value": "Tietoja"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (zadano: %@)"
+            "value": "O aplikaciji"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (ברירת מחדל: %@)"
+            "value": "אודות"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (mặc định: %@)"
+            "value": "Giới thiệu"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (default: %@)"
+            "value": "Tungkol Dito"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (προεπιλογή: %@)"
+            "value": "Σχετικά"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (predefinição: %@)"
+            "value": "Acerca de"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (за замовчуванням: %@)"
+            "value": "Про програму"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (افتراضي: %@)"
+            "value": "حول"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (پیش‌فرض: %@)"
+            "value": "درباره"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (طے شدہ: %@)"
+            "value": "بارے میں"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (ค่าเริ่มต้น: %@)"
+            "value": "เกี่ยวกับ"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (डिफ़ॉल्ट: %@)"
+            "value": "परिचय"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@（デフォルト：%@）"
+            "value": "情報"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (기본값: %@)"
+            "value": "정보"
           }
         }
       },
-      "comment": "Languages summary: list of languages + pinned default language"
+      "comment": "Settings section header"
     },
-    "Current: %@:1": {
+    "Activate \"Allow Full Access\" so cursor control and deletion gestures work.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aktuell: %@:1"
+            "value": "Aktiviere \"Vollzugriff erlauben\", damit Cursorsteuerung und Löschgesten funktionieren."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Actuel : %@:1"
+            "value": "Activez « Autoriser l'accès complet » pour que le contrôle du curseur et les gestes de suppression fonctionnent."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Actual: %@:1"
+            "value": "Activa \"Permitir acceso completo\" para que funcionen el control del cursor y los gestos de borrado."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Attuale: %@:1"
+            "value": "Attiva \"Consenti accesso completo\" affinché il controllo del cursore e i gesti di eliminazione funzionino."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Текущее: %@:1"
+            "value": "Включите «Разрешить полный доступ», чтобы работали управление курсором и жесты удаления."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Obecnie: %@:1"
+            "value": "Włącz „Przyznaj pełny dostęp”, aby działało sterowanie kursorem i gesty usuwania."
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aktuellt: %@:1"
+            "value": "Aktivera \"Tillåt fullständig åtkomst\" så att markörstyrning och raderingsgester fungerar."
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nykyinen: %@:1"
+            "value": "Ota käyttöön \"Salli täysi käyttöoikeus\", jotta kohdistimen ohjaus ja poistoeleet toimivat."
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Trenutno: %@:1"
+            "value": "Uključi „Dopusti puni pristup” kako bi radile geste za upravljanje pokazivačem i brisanje."
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "נוכחי: %@:1"
+            "value": "הפעל את \"אפשר גישה מלאה\" כדי שמחוות שליטת הסמן והמחיקה יפעלו."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hiện tại: %@:1"
+            "value": "Bật \"Cho phép truy cập đầy đủ\" để các cử chỉ điều khiển con trỏ và xóa hoạt động."
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kasalukuyan: %@:1"
+            "value": "I-activate ang \"Payagan ang Full Access\" para gumana ang kontrol ng cursor at mga gesture sa pagbura."
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Τρέχον: %@:1"
+            "value": "Ενεργοποιήστε την επιλογή «Να επιτρέπεται η πλήρης πρόσβαση» ώστε να λειτουργούν ο έλεγχος του δρομέα και οι χειρονομίες διαγραφής."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atual: %@:1"
+            "value": "Ative \"Permitir acesso total\" para que os gestos de controlo do cursor e de eliminação funcionem."
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Поточне: %@:1"
+            "value": "Увімкніть «Дозволити повний доступ», щоб працювали керування курсором і жести видалення."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "الحالي: %@:1"
+            "value": "فعِّل \"السماح بالوصول الكامل\" حتى تعمل إيماءات التحكم في المؤشر والحذف."
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "فعلی: %@:۱"
+            "value": "«اجازهٔ دسترسی کامل» را فعال کنید تا کنترل نشانگر و حرکت‌های حذف کار کنند."
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "موجودہ: %@:1"
+            "value": "\"مکمل رسائی کی اجازت دیں\" فعال کریں تاکہ کرسر کنٹرول اور حذف کرنے کے اشارے کام کریں۔"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ปัจจุบัน: %@:1"
+            "value": "เปิดใช้ \"อนุญาตการเข้าถึงเต็มรูปแบบ\" เพื่อให้การควบคุมเคอร์เซอร์และเจสเจอร์ลบข้อความทำงานได้"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "वर्तमान: %@:1"
+            "value": "\"पूर्ण एक्सेस दें\" चालू करें ताकि कर्सर नियंत्रण और डिलीट जेस्चर काम करें।"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "現在：%@:1"
+            "value": "カーソル操作と削除ジェスチャを使えるように「フルアクセスを許可」をオンにしてください。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "현재: %@:1"
+            "value": "커서 제어 및 삭제 제스처가 작동하도록 \"전체 접근 허용\"을 켜세요."
           }
         }
       },
-      "comment": "Key aspect ratio subtitle, e.g. 'Current: 1.00:1'"
+      "comment": "Onboarding step 2 description; 'Allow Full Access' is the iOS toggle name (localized)"
     },
-    "Scale: %@, Position: %@": {
+    "Adjust the horizontal position of the keyboard when it is narrower than the screen.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Größe: %@, Position: %@"
+            "value": "Passe die horizontale Position der Tastatur an, wenn sie schmaler als der Bildschirm ist."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Échelle : %@, position : %@"
+            "value": "Ajustez la position horizontale du clavier lorsqu'il est plus étroit que l'écran."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Escala: %@, posición: %@"
+            "value": "Ajusta la posición horizontal del teclado cuando es más estrecho que la pantalla."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scala: %@, posizione: %@"
+            "value": "Regola la posizione orizzontale della tastiera quando è più stretta dello schermo."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Масштаб: %@, положение: %@"
+            "value": "Настройте положение клавиатуры по горизонтали, когда она уже экрана."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Skala: %@, położenie: %@"
+            "value": "Dostosuj poziome położenie klawiatury, gdy jest węższa niż ekran."
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Skala: %@, position: %@"
+            "value": "Justera tangentbordets horisontella position när det är smalare än skärmen."
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Koko: %@, sijainti: %@"
+            "value": "Säädä näppäimistön vaakasijaintia, kun se on näyttöä kapeampi."
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Veličina: %@, položaj: %@"
+            "value": "Prilagodi vodoravni položaj tipkovnice kad je uža od zaslona."
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "קנה מידה: %@, מיקום: %@"
+            "value": "התאם את המיקום האופקי של המקלדת כאשר היא צרה מהמסך."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tỷ lệ: %@, vị trí: %@"
+            "value": "Điều chỉnh vị trí ngang của bàn phím khi bàn phím hẹp hơn màn hình."
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scale: %@, posisyon: %@"
+            "value": "Iayos ang horizontal na posisyon ng keyboard kapag mas makitid ito kaysa sa screen."
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Κλίμακα: %@, Θέση: %@"
+            "value": "Προσαρμόστε την οριζόντια θέση του πληκτρολογίου όταν είναι στενότερο από την οθόνη."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Escala: %@, Posição: %@"
+            "value": "Ajuste a posição horizontal do teclado quando este for mais estreito do que o ecrã."
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Масштаб: %@, положення: %@"
+            "value": "Регулюйте горизонтальне положення клавіатури, коли вона вужча за екран."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "الحجم: %@، الموضع: %@"
+            "value": "اضبط الموضع الأفقي للوحة المفاتيح عندما تكون أضيق من الشاشة."
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "مقیاس: %@، موقعیت: %@"
+            "value": "وقتی صفحه‌کلید از صفحه نمایش باریک‌تر است، موقعیت افقی آن را تنظیم کنید."
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "اسکیل: %@، پوزیشن: %@"
+            "value": "جب کی بورڈ اسکرین سے تنگ ہو تو اس کی افقی پوزیشن ایڈجسٹ کریں۔"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ขนาด: %@, ตำแหน่ง: %@"
+            "value": "ปรับตำแหน่งแนวนอนของคีย์บอร์ดเมื่อคีย์บอร์ดแคบกว่าหน้าจอ"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "स्केल: %@, स्थिति: %@"
+            "value": "जब कीबोर्ड स्क्रीन से सँकरा हो, तो उसकी क्षैतिज स्थिति समायोजित करें।"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "サイズ：%@、位置：%@"
+            "value": "キーボードが画面より狭いときに、水平方向の位置を調整します。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "크기: %@, 위치: %@"
+            "value": "키보드가 화면보다 좁을 때 가로 위치를 조정합니다."
           }
         }
       },
-      "comment": "Size & Position subtitle, e.g. 'Scale: 100%, Position: Center'"
+      "comment": "Caption under the position slider"
     },
-    "Tap: %@ • Drag: %@": {
+    "Adjust the width-to-height ratio of the keys. 1.0 creates square keys (the default), and 1.62 is the golden ratio (widest).": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tippen: %@ • Ziehen: %@"
+            "value": "Passe das Verhältnis von Breite zu Höhe der Tasten an. 1,0 erzeugt quadratische Tasten (Standard), 1,62 ist der Goldene Schnitt (am breitesten)."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Toucher : %@ • Glisser : %@"
+            "value": "Ajustez le rapport largeur/hauteur des touches. 1,0 crée des touches carrées (par défaut) et 1,62 correspond au nombre d'or (le plus large)."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tocar: %@ • Arrastrar: %@"
+            "value": "Ajusta la proporción entre el ancho y el alto de las teclas. 1.0 crea teclas cuadradas (por defecto) y 1.62 es la proporción áurea (las más anchas)."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tocco: %@ • Trascinamento: %@"
+            "value": "Regola il rapporto larghezza-altezza dei tasti. 1.0 crea tasti quadrati (l'impostazione predefinita), mentre 1.62 è la sezione aurea (la più larga)."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Нажатие: %@ • Перетягивание: %@"
+            "value": "Настройте соотношение ширины и высоты клавиш. 1.0 создаёт квадратные клавиши (по умолчанию), а 1.62 — золотое сечение (самые широкие)."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Stuknięcie: %@ • Przeciąganie: %@"
+            "value": "Dostosuj stosunek szerokości do wysokości klawiszy. 1.0 daje klawisze kwadratowe (domyślnie), a 1.62 to złoty podział (najszersze)."
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tryck: %@ • Dragning: %@"
+            "value": "Justera tangenternas förhållande mellan bredd och höjd. 1,0 ger kvadratiska tangenter (standard) och 1,62 är det gyllene snittet (bredast)."
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Napautus: %@ • Veto: %@"
+            "value": "Säädä näppäinten leveyden ja korkeuden suhdetta. 1,0 tuottaa neliönmuotoiset näppäimet (oletus) ja 1,62 on kultainen leikkaus (levein)."
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dodir: %@ • Povlačenje: %@"
+            "value": "Prilagodi omjer širine i visine tipki. 1.0 stvara kvadratne tipke (zadano), a 1.62 je zlatni rez (najšire)."
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "הקשה: %@ • גרירה: %@"
+            "value": "התאם את יחס הרוחב-גובה של המקשים. 1.0 יוצר מקשים מרובעים (ברירת המחדל), ו-1.62 הוא יחס הזהב (הרחב ביותר)."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chạm: %@ • Kéo: %@"
+            "value": "Điều chỉnh tỷ lệ rộng trên cao của phím. 1.0 tạo phím vuông (mặc định), và 1.62 là tỷ lệ vàng (rộng nhất)."
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tap: %@ • Drag: %@"
+            "value": "Iayos ang ratio ng lapad-sa-taas ng mga key. Ang 1.0 ay gumagawa ng parisukat na key (ang default), at ang 1.62 ay ang golden ratio (pinakamalapad)."
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Πάτημα: %@ • Σύρσιμο: %@"
+            "value": "Προσαρμόστε την αναλογία πλάτους προς ύψος των πλήκτρων. Το 1.0 δημιουργεί τετράγωνα πλήκτρα (η προεπιλογή) και το 1.62 είναι η χρυσή τομή (το πλατύτερο)."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Toque: %@ • Arrastar: %@"
+            "value": "Ajuste a proporção entre a largura e a altura das teclas. 1.0 cria teclas quadradas (a predefinição) e 1.62 é a proporção áurea (a mais larga)."
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Дотик: %@ • Перетягування: %@"
+            "value": "Регулюйте співвідношення ширини до висоти клавіш. 1.0 створює квадратні клавіші (за замовчуванням), а 1.62 — це золотий перетин (найширше)."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "اللمس: %@ • السحب: %@"
+            "value": "اضبط نسبة العرض إلى الارتفاع للمفاتيح. تُنشئ القيمة 1.0 مفاتيح مربّعة (الافتراضي)، والقيمة 1.62 هي النسبة الذهبية (الأعرض)."
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "ضربه: %@ • کشیدن: %@"
+            "value": "نسبت عرض به ارتفاع کلیدها را تنظیم کنید. ۱٫۰ کلیدهای مربعی می‌سازد (پیش‌فرض) و ۱٫۶۲ نسبت طلایی است (پهن‌ترین)."
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "ٹیپ: %@ • ڈریگ: %@"
+            "value": "کیز کی چوڑائی اور اونچائی کا تناسب ایڈجسٹ کریں۔ 1.0 مربع کیز بناتا ہے (طے شدہ)، اور 1.62 گولڈن تناسب ہے (سب سے چوڑا)۔"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "แตะ: %@ • ลาก: %@"
+            "value": "ปรับอัตราส่วนความกว้างต่อความสูงของปุ่ม 1.0 จะได้ปุ่มสี่เหลี่ยมจัตุรัส (ค่าเริ่มต้น) และ 1.62 คืออัตราส่วนทอง (กว้างที่สุด)"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "टैप: %@ • ड्रैग: %@"
+            "value": "कीज़ के चौड़ाई-से-ऊँचाई अनुपात को समायोजित करें। 1.0 वर्गाकार कीज़ बनाता है (डिफ़ॉल्ट), और 1.62 गोल्डन रेशियो है (सबसे चौड़ा)।"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "タップ：%@ • ドラッグ：%@"
+            "value": "キーの幅と高さの比率を調整します。1.0で正方形のキー（デフォルト）になり、1.62で黄金比（最も幅広）になります。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "탭: %@ • 드래그: %@"
+            "value": "키의 너비 대 높이 비율을 조정합니다. 1.0은 정사각형 키(기본값)를, 1.62는 황금비(가장 넓음)를 만듭니다."
           }
         }
       },
-      "comment": "Haptic feedback subtitle, e.g. 'Tap: 50% • Drag: Off'"
+      "comment": "Caption under the aspect ratio slider"
     },
-    "Gesture tuning enabled": {
+    "Advanced": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestenanpassung aktiviert"
+            "value": "Erweitert"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Réglage des gestes activé"
+            "value": "Avancé"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ajuste de gestos activado"
+            "value": "Avanzado"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Regolazione dei gesti attivata"
+            "value": "Avanzate"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Настройка жестов включена"
+            "value": "Дополнительно"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dostrajanie gestów włączone"
+            "value": "Zaawansowane"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestjustering aktiverad"
+            "value": "Avancerat"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Eleiden hienosäätö käytössä"
+            "value": "Lisäasetukset"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Podešavanje gesti uključeno"
+            "value": "Napredno"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "כוונון מחוות מופעל"
+            "value": "מתקדם"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Đã bật tinh chỉnh cử chỉ"
+            "value": "Nâng cao"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Naka-enable ang pag-tune ng gesture"
+            "value": "Advanced"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Η ρύθμιση χειρονομιών είναι ενεργή"
+            "value": "Για προχωρημένους"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ajuste de gestos ativado"
+            "value": "Avançado"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Налаштування жестів увімкнено"
+            "value": "Додатково"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "ضبط الإيماءات مُفعَّل"
+            "value": "متقدم"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "تنظیم حرکت‌ها فعال شد"
+            "value": "پیشرفته"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "اشارہ ٹیوننگ فعال ہے"
+            "value": "ایڈوانسڈ"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "เปิดใช้การปรับแต่งเจสเจอร์"
+            "value": "ขั้นสูง"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "जेस्चर ट्यूनिंग चालू है"
+            "value": "उन्नत"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ジェスチャ調整が有効"
+            "value": "詳細"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "제스처 조정 사용"
+            "value": "고급"
           }
         }
       },
-      "comment": "Expert row subtitle when expert mode is on"
+      "comment": "Settings section header"
     },
     "Advanced gesture settings": {
       "extractionState": "manual",
@@ -13525,419 +1105,1936 @@
       },
       "comment": "Expert row subtitle when expert mode is off"
     },
-    "Drag to move cursor": {
+    "All labels visible": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ziehen bewegt den Cursor"
+            "value": "Alle Beschriftungen sichtbar"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Glisser pour déplacer le curseur"
+            "value": "Toutes les étiquettes visibles"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arrastra para mover el cursor"
+            "value": "Todas las etiquetas visibles"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Trascina per spostare il cursore"
+            "value": "Tutte le etichette visibili"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Перетягивание перемещает курсор"
+            "value": "Все подписи видны"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Przeciągnij, aby przesunąć kursor"
+            "value": "Wszystkie etykiety widoczne"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dra för att flytta markören"
+            "value": "Alla etiketter synliga"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Siirrä kohdistinta vetämällä"
+            "value": "Kaikki merkinnät näkyvissä"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Povuci za pomicanje pokazivača"
+            "value": "Sve oznake vidljive"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "גרירה מזיזה את הסמן"
+            "value": "כל התוויות גלויות"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kéo để di chuyển con trỏ"
+            "value": "Hiển thị tất cả nhãn"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "I-drag para igalaw ang cursor"
+            "value": "Nakikita ang lahat ng label"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Σύρετε για μετακίνηση του δρομέα"
+            "value": "Όλες οι ετικέτες ορατές"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arrastar para mover o cursor"
+            "value": "Todas as etiquetas visíveis"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Перетягніть, щоб перемістити курсор"
+            "value": "Усі підписи видимі"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "اسحب لتحريك المؤشر"
+            "value": "جميع التسميات ظاهرة"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "برای جابه‌جایی نشانگر بکشید"
+            "value": "همهٔ برچسب‌ها نمایان"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "کرسر منتقل کرنے کے لیے ڈریگ کریں"
+            "value": "تمام لیبل نظر آ رہے ہیں"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ลากเพื่อเลื่อนเคอร์เซอร์"
+            "value": "แสดงป้ายกำกับทั้งหมด"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "कर्सर हिलाने के लिए ड्रैग करें"
+            "value": "सभी लेबल दिखाई दे रहे हैं"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ドラッグしてカーソルを移動"
+            "value": "すべてのラベルを表示"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "드래그하여 커서 이동"
+            "value": "모든 레이블 표시"
           }
         }
       },
-      "comment": "Cursor movement subtitle: continuous style"
+      "comment": "Label visibility subtitle when nothing is hidden"
     },
-    "Swipe per character, return-swipe per word": {
+    "Allow full access": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wischen pro Zeichen, Hin-und-zurück-Wischen pro Wort"
+            "value": "Vollzugriff erlauben"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Balayage par caractère, aller-retour par mot"
+            "value": "Autoriser l'accès complet"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desliza por carácter, desliza y vuelve por palabra"
+            "value": "Permitir acceso completo"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scorri per carattere, scorri e torna per parola"
+            "value": "Consenti accesso completo"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Свайп — символ, свайп с возвратом — слово"
+            "value": "Разрешите полный доступ"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Przesunięcie – znak, przesunięcie z powrotem – słowo"
+            "value": "Przyznaj pełny dostęp"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Svep per tecken, retursvep per ord"
+            "value": "Tillåt fullständig åtkomst"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pyyhkäisy siirtää merkin, paluupyyhkäisy sanan"
+            "value": "Salli täysi käyttöoikeus"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prijelaz po znaku, povratni prijelaz po riječi"
+            "value": "Dopusti puni pristup"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "החלקה לכל תו, החלקה וחזרה לכל מילה"
+            "value": "אפשר גישה מלאה"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vuốt theo ký tự, vuốt và quay lại theo từ"
+            "value": "Cho phép truy cập đầy đủ"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Swipe kada character, return-swipe kada salita"
+            "value": "Payagan ang Full Access"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Σάρωση ανά χαρακτήρα, σάρωση επιστροφής ανά λέξη"
+            "value": "Να επιτρέπεται η πλήρης πρόσβαση"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Deslize por carácter, deslize de retorno por palavra"
+            "value": "Permitir acesso total"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Свайп для символу, зворотний свайп для слова"
+            "value": "Дозволити повний доступ"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "تمرير لكل حرف، وتمرير عائد لكل كلمة"
+            "value": "السماح بالوصول الكامل"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "کشیدن برای هر نویسه، کشیدن‌و‌بازگشت برای هر واژه"
+            "value": "اجازهٔ دسترسی کامل"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "ہر حرف کے لیے سوائپ، ہر لفظ کے لیے ریٹرن سوائپ"
+            "value": "مکمل رسائی کی اجازت دیں"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ปัดทีละตัวอักษร ปัดกลับทีละคำ"
+            "value": "อนุญาตการเข้าถึงเต็มรูปแบบ"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "प्रति अक्षर स्वाइप, प्रति शब्द रिटर्न-स्वाइप"
+            "value": "पूर्ण एक्सेस दें"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "スワイプで1文字ずつ、リターンスワイプで1単語ずつ"
+            "value": "フルアクセスを許可"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "글자 단위 스와이프, 단어 단위 리턴 스와이프"
+            "value": "전체 접근 허용"
           }
         }
       },
-      "comment": "Cursor movement subtitle: discrete style"
+      "comment": "Onboarding step 2 title; refers to the iOS keyboard 'Allow Full Access' toggle"
     },
-    "Phone layout (1-2-3)": {
+    "Appearance": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Telefon-Layout (1-2-3)"
+            "value": "Darstellung"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Disposition téléphone (1-2-3)"
+            "value": "Apparence"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Disposición de teléfono (1-2-3)"
+            "value": "Aspecto"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Layout telefono (1-2-3)"
+            "value": "Aspetto"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Телефонная раскладка (1-2-3)"
+            "value": "Внешний вид"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Układ telefoniczny (1-2-3)"
+            "value": "Wygląd"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Telefonlayout (1-2-3)"
+            "value": "Utseende"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Puhelinasettelu (1-2-3)"
+            "value": "Ulkoasu"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Telefonski raspored (1-2-3)"
+            "value": "Izgled"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "פריסת טלפון (1-2-3)"
+            "value": "מראה"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bố cục điện thoại (1-2-3)"
+            "value": "Giao diện"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Layout ng telepono (1-2-3)"
+            "value": "Hitsura"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Διάταξη τηλεφώνου (1-2-3)"
+            "value": "Εμφάνιση"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Esquema de telefone (1-2-3)"
+            "value": "Aspeto"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Телефонна розкладка (1-2-3)"
+            "value": "Вигляд"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "تخطيط الهاتف (1-2-3)"
+            "value": "المظهر"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "چیدمان تلفن (۱-۲-۳)"
+            "value": "ظاهر"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "فون لے آؤٹ (1-2-3)"
+            "value": "ظاہری شکل"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "เลย์เอาต์โทรศัพท์ (1-2-3)"
+            "value": "รูปลักษณ์"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "फ़ोन लेआउट (1-2-3)"
+            "value": "दिखावट"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "電話レイアウト（1-2-3）"
+            "value": "外観"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "전화기 레이아웃 (1-2-3)"
+            "value": "외관"
           }
         }
       },
-      "comment": "Numpad style subtitle: phone layout"
+      "comment": "Settings section header"
+    },
+    "Applies when you drag the Space or Delete key to move the cursor or delete text.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gilt, wenn du die Leertaste oder Löschtaste ziehst, um den Cursor zu bewegen oder Text zu löschen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "S'applique lorsque vous faites glisser la touche Espace ou Suppr. pour déplacer le curseur ou supprimer du texte."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se aplica al arrastrar la tecla Espacio o Borrar para mover el cursor o borrar texto."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si applica quando trascini il tasto Spazio o Elimina per spostare il cursore o eliminare il testo."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Применяется при перетягивании клавиши пробела или удаления для перемещения курсора или удаления текста."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Działa przy przeciąganiu klawisza spacji lub usuwania w celu przesunięcia kursora lub usunięcia tekstu."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gäller när du drar mellanslags- eller raderingstangenten för att flytta markören eller radera text."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaikuttaa, kun vedät väli- tai poistonäppäintä siirtääksesi kohdistinta tai poistaaksesi tekstiä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primjenjuje se kad povučeš tipku Razmaknica ili Brisanje za pomicanje pokazivača ili brisanje teksta."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "חל בעת גרירת מקש הרווח או המחיקה כדי להזיז את הסמן או למחוק טקסט."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Áp dụng khi bạn kéo phím Cách hoặc Xóa để di chuyển con trỏ hoặc xóa văn bản."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nalalapat kapag ni-drag mo ang Space o Delete key para igalaw ang cursor o magbura ng teksto."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ισχύει όταν σέρνετε το πλήκτρο διαστήματος ή διαγραφής για να μετακινήσετε τον δρομέα ή να διαγράψετε κείμενο."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplica-se quando arrasta a tecla Espaço ou Eliminar para mover o cursor ou apagar texto."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Застосовується, коли ви перетягуєте клавішу пробілу або видалення, щоб перемістити курсор чи видалити текст."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تُطبَّق عند سحب مفتاح المسافة أو الحذف لتحريك المؤشر أو حذف النص."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هنگامی که کلید فاصله یا حذف را برای جابه‌جایی نشانگر یا حذف متن می‌کشید اعمال می‌شود."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جب آپ کرسر کو منتقل کرنے یا متن حذف کرنے کے لیے اسپیس یا ڈیلیٹ کی کو ڈریگ کرتے ہیں تو لاگو ہوتا ہے۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ใช้เมื่อคุณลากปุ่มเว้นวรรคหรือปุ่มลบเพื่อเลื่อนเคอร์เซอร์หรือลบข้อความ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कर्सर हिलाने या टेक्स्ट डिलीट करने के लिए स्पेस या डिलीट की को ड्रैग करने पर लागू होता है।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スペースキーや削除キーをドラッグしてカーソルを移動したり、テキストを削除したりするときに適用されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스페이스 또는 삭제 키를 드래그하여 커서를 이동하거나 텍스트를 삭제할 때 적용됩니다."
+          }
+        }
+      },
+      "comment": "Caption; 'Space' and 'Delete' are key names"
+    },
+    "Applies when you touch any key.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gilt, wenn du eine beliebige Taste berührst."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "S'applique lorsque vous touchez une touche."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se aplica al tocar cualquier tecla."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si applica quando tocchi un tasto qualsiasi."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Применяется при касании любой клавиши."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Działa przy dotknięciu dowolnego klawisza."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gäller när du rör vid en tangent."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaikuttaa, kun kosketat mitä tahansa näppäintä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primjenjuje se kad dodirneš bilo koju tipku."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "חל בעת נגיעה בכל מקש."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Áp dụng khi bạn chạm vào phím bất kỳ."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nalalapat kapag humawak ka sa anumang key."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ισχύει όταν αγγίζετε οποιοδήποτε πλήκτρο."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplica-se quando toca em qualquer tecla."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Застосовується, коли ви торкаєтеся будь-якої клавіші."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تُطبَّق عند لمس أي مفتاح."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هنگام لمس هر کلید اعمال می‌شود."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جب آپ کوئی کی چھوتے ہیں تو لاگو ہوتا ہے۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ใช้เมื่อคุณแตะปุ่มใดก็ตาม"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "किसी भी की को छूने पर लागू होता है।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "いずれかのキーに触れたときに適用されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아무 키나 누를 때 적용됩니다."
+          }
+        }
+      },
+      "comment": "Caption under the Tap Feedback slider"
+    },
+    "Aspect Ratio": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenverhältnis"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proportions"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporción"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporzioni"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Соотношение сторон"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporcje"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proportioner"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kuvasuhde"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omjer stranica"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "יחס גובה-רוחב"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tỷ lệ khung"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aspect Ratio"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αναλογία διαστάσεων"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporção"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Співвідношення сторін"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسبة الأبعاد"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسبت ابعاد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پہلو تناسب"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อัตราส่วน"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आस्पेक्ट रेशियो"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "縦横比"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가로세로 비율"
+          }
+        }
+      },
+      "comment": "Slider title: key width-to-height ratio"
+    },
+    "At least one language must be enabled.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mindestens eine Sprache muss aktiviert sein."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Au moins une langue doit être activée."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Al menos un idioma debe estar activado."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Almeno una lingua deve essere attiva."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хотя бы один язык должен быть включён."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Co najmniej jeden język musi być włączony."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minst ett språk måste vara aktiverat."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vähintään yhden kielen on oltava käytössä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Najmanje jedan jezik mora biti omogućen."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "לפחות שפה אחת חייבת להיות מופעלת."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phải bật ít nhất một ngôn ngữ."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kailangang naka-enable ang kahit isang wika."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πρέπει να είναι ενεργοποιημένη τουλάχιστον μία γλώσσα."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "É necessário ativar pelo menos um idioma."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Має бути увімкнена принаймні одна мова."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يجب تفعيل لغة واحدة على الأقل."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دست‌کم یک زبان باید فعال باشد."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کم از کم ایک زبان فعال ہونی چاہیے۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ต้องเปิดใช้อย่างน้อยหนึ่งภาษา"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कम से कम एक भाषा चालू होनी चाहिए।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "少なくとも1つの言語を有効にする必要があります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "언어를 하나 이상 사용해야 합니다."
+          }
+        }
+      },
+      "comment": "Alert message when disabling the last language"
+    },
+    "Auto-Capitalize": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Großschreibung"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Majuscule automatique"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mayúsculas automáticas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maiuscole automatiche"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автопрописные"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autom. wielkie litery"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisk versal"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automaattiset isot kirjaimet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatska velika slova"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אותיות רישיות אוטומטיות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tự động viết hoa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Capitalize"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αυτόματα κεφαλαία"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maiúsculas automáticas"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматичні великі літери"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الأحرف الكبيرة تلقائيًا"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بزرگ‌نویسی خودکار"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خودکار کیپیٹلائز"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พิมพ์ตัวใหญ่อัตโนมัติ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ऑटो-कैपिटलाइज़"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動大文字化"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 대문자화"
+          }
+        }
+      },
+      "comment": "Toggle title"
+    },
+    "Cannot Disable": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deaktivieren nicht möglich"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactivation impossible"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede desactivar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile disattivare"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нельзя отключить"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie można wyłączyć"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kan inte avaktiveras"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ei voi poistaa käytöstä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nije moguće onemogućiti"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "לא ניתן להשבית"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể tắt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hindi Maaaring I-disable"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αδυναμία απενεργοποίησης"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não é possível desativar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неможливо вимкнути"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يمكن التعطيل"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمی‌توان غیرفعال کرد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غیر فعال نہیں کیا جا سکتا"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิดใช้ไม่ได้"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बंद नहीं कर सकते"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効にできません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 중지할 수 없음"
+          }
+        }
+      },
+      "comment": "Alert title when disabling the last language"
+    },
+    "Capitalize after sentence-ending punctuation": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Großschreibung nach satzschließenden Satzzeichen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Met une majuscule après la ponctuation de fin de phrase"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poner en mayúscula tras un signo de puntuación final"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maiuscola dopo la punteggiatura di fine frase"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заглавная буква после знаков конца предложения"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wielka litera po znaku kończącym zdanie"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stor bokstav efter meningsavslutande skiljetecken"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iso alkukirjain lauseen päättävän välimerkin jälkeen"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veliko slovo nakon interpunkcije na kraju rečenice"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אות רישית לאחר סימן פיסוק שמסיים משפט"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Viết hoa sau dấu kết thúc câu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-capitalize pagkatapos ng panapos na bantas"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κεφαλαίο μετά από σημείο στίξης τέλους πρότασης"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coloca maiúscula após a pontuação de fim de frase"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Велика літера після розділового знака в кінці речення"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استخدام حرف كبير بعد علامات نهاية الجملة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بزرگ‌نویسی پس از نشانه‌های پایان جمله"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جملہ ختم کرنے والی رموز اوقاف کے بعد بڑا حرف بنائیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พิมพ์ตัวใหญ่หลังเครื่องหมายจบประโยค"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वाक्य समाप्त करने वाले विराम चिह्न के बाद बड़ा अक्षर बनाएँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文末の句読点の後に大文字にします"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문장 끝 문장 부호 뒤에 대문자로 시작합니다"
+          }
+        }
+      },
+      "comment": "Toggle subtitle"
+    },
+    "Center": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mitte"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centre"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centro"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По центру"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Środek"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centrerad"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keskellä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sredina"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מרכז"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giữa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gitna"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κέντρο"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centro"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По центру"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوسط"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وسط"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "درمیان"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กึ่งกลาง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "केंद्र"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가운데"
+          }
+        }
+      },
+      "comment": "Slider label: center position"
+    },
+    "Circle the 123 key to cut the text around the cursor. Swipe down on the same key to paste it back. Both gestures stay on the key after it switches the keyboard to numbers.": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ارسم دائرة على مفتاح 123 لقص النص حول المؤشر. اسحب لأسفل على المفتاح نفسه للصقه مرة أخرى. تبقى الإيماءتان على المفتاح بعد أن يبدّل لوحة المفاتيح إلى الأرقام."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kreise die 123-Taste ein, um den Text um den Cursor auszuschneiden. Streiche auf derselben Taste nach unten, um ihn wieder einzufügen. Beide Gesten bleiben auf der Taste, auch nachdem sie die Tastatur auf Zahlen umgestellt hat."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κάντε κυκλική κίνηση στο πλήκτρο 123 για αποκοπή του κειμένου γύρω από τον δρομέα. Σύρετε προς τα κάτω στο ίδιο πλήκτρο για να το επικολλήσετε ξανά. Και οι δύο κινήσεις παραμένουν στο πλήκτρο αφού αυτό αλλάξει το πληκτρολόγιο σε αριθμούς."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traza un círculo en la tecla 123 para cortar el texto alrededor del cursor. Desliza hacia abajo en la misma tecla para volver a pegarlo. Ambos gestos siguen en la tecla después de que cambie el teclado a números."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روی کلید 123 دایره بکشید تا متن اطراف مکان‌نما بریده شود. برای چسباندن دوباره، روی همان کلید به پایین بکشید. هر دو حرکت پس از آنکه کلید صفحه‌کلید را به اعداد تغییر دهد، روی همان کلید باقی می‌مانند."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piirrä ympyrä 123-näppäimeen, niin kohdistimen ympärillä oleva teksti leikataan. Liu’uta samaa näppäintä alaspäin liittääksesi sen takaisin. Molemmat eleet säilyvät näppäimellä sen jälkeen, kun se on vaihtanut näppäimistön numeroihin."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umikot sa 123 key para gupitin ang teksto sa paligid ng cursor. Mag-swipe pababa sa parehong key para i-paste ito ulit. Nananatili ang dalawang galaw sa key kahit matapos nitong palitan ang keyboard sa mga numero."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tracez un cercle sur la touche 123 pour couper le texte autour du curseur. Balayez vers le bas sur la même touche pour le recoller. Les deux gestes restent sur la touche après qu’elle a basculé le clavier sur les chiffres."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שרטטו מעגל על מקש 123 כדי לגזור את הטקסט סביב הסמן. החליקו מטה על אותו מקש כדי להדביק אותו בחזרה. שתי המחוות נשארות על המקש גם אחרי שהוא מחליף את המקלדת למספרים."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कर्सर के आसपास का टेक्स्ट काटने के लिए 123 कुंजी पर गोला बनाएँ। उसे वापस चिपकाने के लिए उसी कुंजी पर नीचे स्वाइप करें। कुंजी द्वारा कीबोर्ड को अंकों पर बदलने के बाद भी दोनों हावभाव उसी कुंजी पर बने रहते हैं।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Napravi kružni pokret po tipki 123 za izrezivanje teksta oko pokazivača. Povuci prema dolje po istoj tipki da ga zalijepiš natrag. Obje geste ostaju na tipki i nakon što ona prebaci tipkovnicu na brojke."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traccia un cerchio sul tasto 123 per tagliare il testo attorno al cursore. Scorri verso il basso sullo stesso tasto per incollarlo di nuovo. Entrambi i gesti restano sul tasto anche dopo che ha portato la tastiera ai numeri."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "123キーで円を描くと、カーソル周辺のテキストを切り取ります。同じキーを下にスワイプすると貼り付け直せます。 このキーがキーボードを数字に切り替えたあとも、両方のジェスチャーはそのまま使えます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "123 키에서 원을 그리면 커서 주변 텍스트를 잘라냅니다. 같은 키를 아래로 쓸어내리면 다시 붙여넣습니다. 이 키가 키보드를 숫자로 전환한 뒤에도 두 제스처는 그대로 유지됩니다."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zakreśl kółko na klawiszu 123, aby wyciąć tekst wokół kursora. Przesuń w dół na tym samym klawiszu, aby wkleić go z powrotem. Oba gesty pozostają na klawiszu także po przełączeniu klawiatury na cyfry."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trace um círculo na tecla 123 para cortar o texto à volta do cursor. Deslize para baixo na mesma tecla para o colar de novo. Ambos os gestos permanecem na tecla depois de esta mudar o teclado para números."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обведите клавишу 123, чтобы вырезать текст вокруг курсора. Свайп вниз по той же клавише вернёт его. Оба жеста остаются на клавише и после переключения на цифры."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rita en cirkel på 123-tangenten för att klippa ut texten runt markören. Svep nedåt på samma tangent för att klistra in den igen. Båda gesterna finns kvar på tangenten även efter att den växlat tangentbordet till siffror."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วนนิ้วบนปุ่ม 123 เพื่อตัดข้อความรอบเคอร์เซอร์ ปัดลงบนปุ่มเดียวกันเพื่อวางกลับ ทั้งสองท่าทางยังคงอยู่บนปุ่มนี้แม้หลังจากที่ปุ่มสลับแป้นพิมพ์เป็นตัวเลขแล้ว"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обведіть клавішу 123, щоб вирізати текст навколо курсора. Проведіть вниз по тій самій клавіші, щоб вставити його назад. Обидва жести залишаються на клавіші й після перемикання на цифри."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کرسر کے ارد گرد متن کاٹنے کے لیے 123 کلید پر دائرہ بنائیں۔ اسے واپس چسپاں کرنے کے لیے اسی کلید پر نیچے سوائپ کریں۔ کلید کے کی بورڈ کو ہندسوں پر بدلنے کے بعد بھی دونوں اشارے اسی کلید پر برقرار رہتے ہیں۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vẽ vòng tròn trên phím 123 để cắt văn bản quanh con trỏ. Vuốt xuống trên cùng phím đó để dán lại. Cả hai cử chỉ vẫn nằm trên phím sau khi phím chuyển bàn phím sang số."
+          }
+        }
+      }
+    },
+    "Classic": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisch"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classique"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clásico"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classico"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Классический"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasyczny"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisk"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassinen"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasično"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "קלאסי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cổ điển"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasiko"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κλασικό"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clássico"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Класичний"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كلاسيكي"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلاسیک"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلاسک"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คลาสสิก"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्लासिक"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラシック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클래식"
+          }
+        }
+      },
+      "comment": "Keyboard style name"
+    },
+    "Classic (7-8-9)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisch (7-8-9)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classique (7-8-9)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clásico (7-8-9)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classico (7-8-9)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Классический (7-8-9)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasyczny (7-8-9)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisk (7-8-9)"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassinen (7-8-9)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasično (7-8-9)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "קלאסי (7-8-9)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cổ điển (7-8-9)"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasiko (7-8-9)"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κλασικό (7-8-9)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clássico (7-8-9)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Класичний (7-8-9)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كلاسيكي (7-8-9)"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلاسیک (۷-۸-۹)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلاسک (7-8-9)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คลาสสิก (7-8-9)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्लासिक (7-8-9)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラシック（7-8-9）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클래식 (7-8-9)"
+          }
+        }
+      },
+      "comment": "Picker option: calculator-style numpad with 7-8-9 on top"
     },
     "Classic layout (7-8-9)": {
       "extractionState": "manual",
@@ -14077,143 +3174,4777 @@
       },
       "comment": "Numpad style subtitle: classic layout"
     },
-    "All labels visible": {
+    "Clear": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alle Beschriftungen sichtbar"
+            "value": "Löschen"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Toutes les étiquettes visibles"
+            "value": "Effacer"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas las etiquetas visibles"
+            "value": "Borrar"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tutte le etichette visibili"
+            "value": "Cancella"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Все подписи видны"
+            "value": "Очистить"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wszystkie etykiety widoczne"
+            "value": "Wyczyść"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alla etiketter synliga"
+            "value": "Rensa"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kaikki merkinnät näkyvissä"
+            "value": "Tyhjennä"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sve oznake vidljive"
+            "value": "Očisti"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "כל התוויות גלויות"
+            "value": "נקה"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hiển thị tất cả nhãn"
+            "value": "Xóa hết"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nakikita ang lahat ng label"
+            "value": "I-clear"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Όλες οι ετικέτες ορατές"
+            "value": "Εκκαθάριση"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as etiquetas visíveis"
+            "value": "Limpar"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Усі підписи видимі"
+            "value": "Очистити"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "جميع التسميات ظاهرة"
+            "value": "مسح"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "همهٔ برچسب‌ها نمایان"
+            "value": "پاک کردن"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "تمام لیبل نظر آ رہے ہیں"
+            "value": "صاف کریں"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "แสดงป้ายกำกับทั้งหมด"
+            "value": "ล้าง"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "सभी लेबल दिखाई दे रहे हैं"
+            "value": "साफ़ करें"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "すべてのラベルを表示"
+            "value": "消去"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "모든 레이블 표시"
+            "value": "지우기"
           }
         }
       },
-      "comment": "Label visibility subtitle when nothing is hidden"
+      "comment": "Button: clear the text field"
+    },
+    "Continuous": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fortlaufend"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continu"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Непрерывное"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciągły"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontinuerlig"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jatkuva"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontinuirano"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "רציפה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liên tục"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tuluy-tuloy"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Συνεχής"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contínuo"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Безперервно"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مستمرة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیوسته"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسلسل"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ต่อเนื่อง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "निरंतर"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連続"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연속"
+          }
+        }
+      },
+      "comment": "Picker option for cursor movement style (drag continuously)"
+    },
+    "Copy": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копировать"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiuj"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiera"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopioi"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiraj"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "העתק"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sao chép"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopyahin"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αντιγραφή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копіювати"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کپی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کاپی کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คัดลอก"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कॉपी"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복사"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the copy gesture (VoiceOver)"
+    },
+    "Current: %@:1": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktuell: %@:1"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actuel : %@:1"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actual: %@:1"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attuale: %@:1"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Текущее: %@:1"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obecnie: %@:1"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktuellt: %@:1"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nykyinen: %@:1"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trenutno: %@:1"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "נוכחי: %@:1"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiện tại: %@:1"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kasalukuyan: %@:1"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τρέχον: %@:1"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atual: %@:1"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поточне: %@:1"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الحالي: %@:1"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فعلی: %@:۱"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "موجودہ: %@:1"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปัจจุบัน: %@:1"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वर्तमान: %@:1"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在：%@:1"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재: %@:1"
+          }
+        }
+      },
+      "comment": "Key aspect ratio subtitle, e.g. 'Current: 1.00:1'"
+    },
+    "Cursor Movement": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cursorbewegung"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déplacement du curseur"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Movimiento del cursor"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Movimento del cursore"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемещение курсора"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruch kursora"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markörförflyttning"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kohdistimen liike"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pomicanje pokazivača"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תנועת הסמן"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Di chuyển con trỏ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paggalaw ng Cursor"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κίνηση δρομέα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Movimento do cursor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переміщення курсора"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حركة المؤشر"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرکت نشانگر"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کرسر کی حرکت"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การเลื่อนเคอร์เซอร์"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कर्सर मूवमेंट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カーソル移動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "커서 이동"
+          }
+        }
+      },
+      "comment": "Settings row title"
+    },
+    "Customize the look and feel of your keyboard.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passe das Erscheinungsbild deiner Tastatur an."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personnalisez l'apparence de votre clavier."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personaliza el aspecto de tu teclado."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizza l'aspetto della tua tastiera."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройте внешний вид клавиатуры."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dostosuj wygląd swojej klawiatury."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anpassa tangentbordets utseende och känsla."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mukauta näppäimistösi ulkoasua ja tuntumaa."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prilagodi izgled i dojam svoje tipkovnice."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "התאם אישית את המראה והתחושה של המקלדת."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tùy chỉnh giao diện và cảm nhận của bàn phím."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-customize ang hitsura at pakiramdam ng iyong keyboard."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Προσαρμόστε την εμφάνιση και την αίσθηση του πληκτρολογίου σας."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalize o aspeto e o comportamento do seu teclado."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштуйте вигляд і поведінку вашої клавіатури."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خصِّص شكل ومظهر لوحة المفاتيح."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ظاهر و حس صفحه‌کلید خود را سفارشی کنید."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اپنے کی بورڈ کی شکل و صورت کو اپنی مرضی کے مطابق بنائیں۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปรับแต่งหน้าตาและสัมผัสของคีย์บอร์ดของคุณ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अपने कीबोर्ड के लुक और फील को कस्टमाइज़ करें।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードの見た目や操作感をカスタマイズします。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드의 모양과 느낌을 원하는 대로 설정하세요."
+          }
+        }
+      },
+      "comment": "Settings section footer"
+    },
+    "Cut": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausschneiden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couper"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taglia"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вырезать"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wytnij"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klipp ut"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leikkaa"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izreži"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גזור"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cắt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gupitin"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αποκοπή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вирізати"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قص"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برش"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کٹ کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오려두기"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the cut gesture (VoiceOver)"
+    },
+    "Cut All by Circling": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قص الكل بحركة دائرية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles ausschneiden per Kreis"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αποκοπή όλων με κυκλική κίνηση"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar todo con un círculo"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برش همه با حرکت دایره‌ای"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leikkaa kaikki ympyröimällä"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gupitin lahat sa pamamagitan ng pag-ikot"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout couper en traçant un cercle"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גזירת הכול בתנועה מעגלית"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "गोला बनाकर सब कुछ काटें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izreži sve kružnim pokretom"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taglia tutto con un cerchio"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "円を描いてすべて切り取り"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "원을 그려 전체 잘라내기"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wytnij wszystko kółkiem"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar tudo com um círculo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вырезать всё круговым жестом"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klipp ut allt med en cirkel"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัดทั้งหมดด้วยการวนนิ้ว"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вирізати все круговим жестом"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دائرہ بنا کر سب کاٹیں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cắt tất cả bằng vòng tròn"
+          }
+        }
+      }
+    },
+    "Cut all": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles ausschneiden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout couper"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar todo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taglia tutto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вырезать всё"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wytnij wszystko"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klipp ut allt"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leikkaa kaikki"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izreži sve"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גזור הכול"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cắt tất cả"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gupitin lahat"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αποκοπή όλων"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar tudo"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вирізати все"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قص الكل"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برش همه"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سب کاٹیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัดทั้งหมด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सभी काटें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて切り取り"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모두 잘라내기"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the cut-all gesture (VoiceOver)"
+    },
+    "Cutting to the clipboard requires Full Access": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتطلب القص إلى الحافظة الوصول الكامل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausschneiden in die Zwischenablage erfordert Vollzugriff"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Η αποκοπή στο πρόχειρο απαιτεί πλήρη πρόσβαση"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar al portapapeles requiere acceso completo"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برش به کلیپ‌بورد به دسترسی کامل نیاز دارد"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leikkaaminen leikepöydälle vaatii täyden käyttöoikeuden"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kailangan ng Full Access para gupitin papunta sa clipboard"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couper vers le presse-papiers nécessite l'accès complet"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גזירה ללוח דורשת גישה מלאה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्लिपबोर्ड में काटने के लिए पूर्ण एक्सेस ज़रूरी है"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izrezivanje u međuspremnik zahtijeva puni pristup"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il taglio negli appunti richiede l'accesso completo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリップボードへの切り取りにはフルアクセスが必要です"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클립보드로 잘라내려면 전체 접근이 필요합니다"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wycinanie do schowka wymaga pełnego dostępu"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar para a área de transferência requer acesso total"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вырезание в буфер обмена требует полного доступа"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Att klippa ut till urklipp kräver fullständig åtkomst"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตัดไปยังคลิปบอร์ดต้องใช้การเข้าถึงเต็มรูปแบบ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вирізання в буфер обміну потребує повного доступу"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلپ بورڈ میں کاٹنے کے لیے مکمل رسائی درکار ہے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cắt vào bảng nhớ tạm yêu cầu Truy cập đầy đủ"
+          }
+        }
+      }
+    },
+    "Dark Gold": {
+      "comment": "Keyboard theme name: dark-gold (proper name, do not translate)",
+      "extractionState": "manual",
+      "shouldTranslate": false
+    },
+    "Dark keys with golden letters": {
+      "comment": "Keyboard theme description: dark-gold",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dunkle Tasten mit goldenen Buchstaben"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touches sombres aux lettres dorées"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas oscuras con letras doradas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasti scuri con lettere dorate"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмные клавиши с золотыми буквами"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemne klawisze ze złotymi literami"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mörka tangenter med gyllene bokstäver"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tummat näppäimet ja kultaiset kirjaimet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamne tipke sa zlatnim slovima"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקשים כהים עם אותיות זהובות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím tối với chữ vàng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Madilim na mga key na may gintong mga titik"
+          }
+        }
+      }
+    },
+    "Default": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Par défaut"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predeterminado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predefinita"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domyślny"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oletus"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zadano"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ברירת מחדל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mặc định"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Προεπιλογή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predefinição"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "За замовчуванням"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افتراضي"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیش‌فرض"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "طے شدہ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ค่าเริ่มต้น"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डिफ़ॉल्ट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값"
+          }
+        }
+      },
+      "comment": "Badge on the default startup language"
+    },
+    "Delete": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimina"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radera"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brisanje"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מחק"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διαγραφή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลบ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डिलीट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "삭제"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the delete/backspace key (VoiceOver)"
+    },
+    "Disable %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ deaktivieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactiver %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivar %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disattiva %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отключить %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyłącz %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaktivera %@"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista %@ käytöstä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onemogući %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "השבתת %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tắt %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-disable ang %@"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Απενεργοποίηση %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desativar %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вимкнути %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعطيل %@"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غیرفعال کردن %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ غیر فعال کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิดใช้ %@"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ बंद करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@を無効にする"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 사용 안 함"
+          }
+        }
+      },
+      "comment": "Accessibility label: disable a language; %@ is the language name"
+    },
+    "Disabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deaktiviert"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactivé"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disattivato"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отключено"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyłączone"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaktiverad"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ei käytössä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onemogućeno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מושבת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã tắt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naka-disable"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Απενεργοποιημένο"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desativado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вимкнено"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مُعطَّل"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غیرفعال"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غیر فعال"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิดใช้แล้ว"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बंद"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 안 함"
+          }
+        }
+      },
+      "comment": "Accessibility value: language is disabled"
+    },
+    "Done": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fertig"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aceptar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fine"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Готово"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gotowe"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klar"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valmis"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gotovo"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סיום"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xong"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tapos na"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τέλος"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Concluído"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Готово"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تمام"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہو گیا"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เสร็จสิ้น"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हो गया"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "완료"
+          }
+        }
+      },
+      "comment": "Keyboard toolbar button to dismiss the keyboard / finish editing"
+    },
+    "Double-Space Period": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقطة بمسافتين"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punkt durch Doppel-Leerzeichen"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τελεία με διπλό κενό"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punto con doble espacio"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقطه با دو فاصله"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piste kaksoisvälilyönnillä"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tuldok sa dobleng espasyo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Point par double espace"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "נקודה ברווח כפול"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डबल-स्पेस से पूर्ण विराम"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Točka dvostrukim razmakom"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punto con doppio spazio"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダブルスペースでピリオド"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "더블 스페이스로 마침표"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kropka podwójną spacją"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ponto com espaço duplo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Точка двойным пробелом"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punkt med dubbla mellanslag"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ใส่จุดด้วยการเว้นวรรคสองครั้ง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Крапка подвійним пробілом"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈبل اسپیس سے وقفہ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dấu chấm bằng cách nhấn cách hai lần"
+          }
+        }
+      },
+      "comment": "Toggle title: a double space inserts a period"
+    },
+    "Drag Feedback": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zieh-Feedback"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour au glissement"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Respuesta al arrastrar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback al trascinamento"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отклик при перетягивании"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reakcja na przeciąganie"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Återkoppling vid dragning"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vetopalaute"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povratne informacije povlačenja"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משוב בגרירה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phản hồi khi kéo"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drag Feedback"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ανάδραση συρσίματος"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retorno ao arrastar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відгук на перетягування"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استجابة السحب"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازخورد کشیدن"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈریگ فیڈ بیک"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตอบสนองเมื่อลาก"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ड्रैग फ़ीडबैक"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドラッグ時のフィードバック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "드래그 피드백"
+          }
+        }
+      },
+      "comment": "Slider control title: haptic strength when dragging"
+    },
+    "Drag to move cursor": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ziehen bewegt den Cursor"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Glisser pour déplacer le curseur"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrastra para mover el cursor"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trascina per spostare il cursore"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перетягивание перемещает курсор"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przeciągnij, aby przesunąć kursor"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dra för att flytta markören"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siirrä kohdistinta vetämällä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povuci za pomicanje pokazivača"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גרירה מזיזה את הסמן"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kéo để di chuyển con trỏ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-drag para igalaw ang cursor"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σύρετε για μετακίνηση του δρομέα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrastar para mover o cursor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перетягніть, щоб перемістити курсор"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسحب لتحريك المؤشر"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برای جابه‌جایی نشانگر بکشید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کرسر منتقل کرنے کے لیے ڈریگ کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลากเพื่อเลื่อนเคอร์เซอร์"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कर्सर हिलाने के लिए ड्रैग करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドラッグしてカーソルを移動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "드래그하여 커서 이동"
+          }
+        }
+      },
+      "comment": "Cursor movement subtitle: continuous style"
+    },
+    "Draw the path your finger takes": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يرسم المسار الذي يسلكه إصبعك"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeichnet den Weg deines Fingers nach"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σχεδιάζει τη διαδρομή που ακολουθεί το δάχτυλο"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dibuja el recorrido de tu dedo"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسیری را که انگشت شما طی می‌کند رسم می‌کند"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piirtää sormesi kulkeman reitin"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iguguhit ang dinaanan ng iyong daliri"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trace le chemin parcouru par votre doigt"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מצייר את המסלול שהאצבע עוברת"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आपकी उंगली के रास्ते को दिखाता है"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crta putanju kojom prolazi prst"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disegna il percorso del tuo dito"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "指がなぞった軌跡を描きます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "손가락이 지나간 경로를 그립니다"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rysuje ścieżkę, którą pokonuje palec"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desenha o caminho percorrido pelo dedo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Рисует путь, по которому движется палец"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ritar vägen som fingret tar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วาดเส้นทางที่นิ้วของคุณลากผ่าน"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Малює шлях, яким рухається палець"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آپ کی انگلی جس راستے سے گزرے، اسے کھینچتا ہے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vẽ đường đi của ngón tay bạn"
+          }
+        }
+      },
+      "comment": "Toggle subtitle explaining the gesture trail"
+    },
+    "Enable %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ aktivieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включить %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Włącz %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivera %@"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ota %@ käyttöön"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omogući %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הפעלת %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bật %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-enable ang %@"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ενεργοποίηση %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativar %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увімкнути %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تفعيل %@"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فعال کردن %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ فعال کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดใช้ %@"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ चालू करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@を有効にする"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 사용"
+          }
+        }
+      },
+      "comment": "Accessibility label: enable a language; %@ is the language name"
+    },
+    "Enable keyboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastatur aktivieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer le clavier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar el teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva la tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включите клавиатуру"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Włącz klawiaturę"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivera tangentbordet"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ota näppäimistö käyttöön"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omogući tipkovnicu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הפעלת המקלדת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bật bàn phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-enable ang keyboard"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ενεργοποίηση πληκτρολογίου"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativar teclado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увімкнути клавіатуру"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تفعيل لوحة المفاتيح"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فعال‌سازی صفحه‌کلید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی بورڈ فعال کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดใช้คีย์บอร์ด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड चालू करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードを有効にする"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 켜기"
+          }
+        }
+      },
+      "comment": "Onboarding step 1 title"
+    },
+    "Enabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiviert"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activé"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attivato"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включено"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Włączone"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiverad"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Käytössä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omogućeno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מופעל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã bật"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naka-enable"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ενεργοποιημένο"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увімкнено"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مُفعَّل"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فعال"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فعال"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดใช้แล้ว"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "चालू"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용"
+          }
+        }
+      },
+      "comment": "Accessibility value: language is enabled"
+    },
+    "Expert": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experte"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experto"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esperto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для экспертов"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ekspert"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expert"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asiantuntija"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stručno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מומחה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyên gia"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expert"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ειδικός"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Especialista"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Експертний"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الخبير"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرفه‌ای"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ماہر"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ผู้เชี่ยวชาญ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एक्सपर्ट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エキスパート"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전문가"
+          }
+        }
+      },
+      "comment": "Settings row title leading to expert/advanced gesture tuning"
+    },
+    "Feedback": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Respuesta"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отклик"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reakcje"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Återkoppling"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Palaute"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povratne informacije"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משוב"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phản hồi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ανάδραση"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retorno"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відгук"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاستجابة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازخورد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فیڈ بیک"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตอบสนอง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "फ़ीडबैक"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィードバック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "피드백"
+          }
+        }
+      },
+      "comment": "Settings section header (covers haptic feedback)"
+    },
+    "General": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allgemein"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Général"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generali"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Основные"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ogólne"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allmänt"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yleiset"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Općenito"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "כללי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt chung"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pangkalahatan"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Γενικά"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geral"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Основні"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عام"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عمومی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عمومی"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทั่วไป"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सामान्य"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일반"
+          }
+        }
+      },
+      "comment": "Settings section header"
+    },
+    "Gesture Trail": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أثر الإيماءة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wischspur"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ίχνος κίνησης"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estela del gesto"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رد اشاره"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eleen jälki"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bakas ng galaw"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tracé du geste"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שובל התנועה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इशारे का निशान"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trag geste"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scia del gesto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ジェスチャの軌跡"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제스처 궤적"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ślad gestu"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rasto do gesto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "След жеста"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestspår"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เส้นทางการปัด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Слід жесту"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اشارے کا نشان"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vệt vuốt"
+          }
+        }
+      },
+      "comment": "Toggle title: draws a fading trail under the finger while it swipes"
+    },
+    "Gesture tuning enabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestenanpassung aktiviert"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglage des gestes activé"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajuste de gestos activado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regolazione dei gesti attivata"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройка жестов включена"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dostrajanie gestów włączone"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestjustering aktiverad"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eleiden hienosäätö käytössä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podešavanje gesti uključeno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "כוונון מחוות מופעל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã bật tinh chỉnh cử chỉ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naka-enable ang pag-tune ng gesture"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Η ρύθμιση χειρονομιών είναι ενεργή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajuste de gestos ativado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування жестів увімкнено"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ضبط الإيماءات مُفعَّل"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنظیم حرکت‌ها فعال شد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اشارہ ٹیوننگ فعال ہے"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดใช้การปรับแต่งเจสเจอร์"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जेस्चर ट्यूनिंग चालू है"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ジェスチャ調整が有効"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제스처 조정 사용"
+          }
+        }
+      },
+      "comment": "Expert row subtitle when expert mode is on"
+    },
+    "Gestures": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإيماءات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesten"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Χειρονομίες"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestos"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اشاره‌ها"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eleet"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Galaw"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestes"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מחוות"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जेस्चर"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geste"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesti"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ジェスチャ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제스처"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesty"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Жесты"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gester"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ท่าทาง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Жести"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اشارے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cử chỉ"
+          }
+        }
+      }
+    },
+    "Golden": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Golden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doré"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Áureo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aureo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Золотое сечение"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Złote"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gyllene"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kultainen"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zlatni rez"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "זהב"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tỷ lệ vàng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Golden"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Χρυσή τομή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dourado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Золотий перетин"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ذهبي"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "طلایی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گولڈن"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อัตราส่วนทอง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "गोल्डन"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "黄金比"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "황금비"
+          }
+        }
+      },
+      "comment": "Slider tick label at the golden ratio 1.62"
+    },
+    "Haptic Feedback": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptisches Feedback"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour haptique"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Respuesta háptica"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback aptico"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тактильный отклик"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reakcje haptyczne"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taktil återkoppling"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tuntopalaute"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptičke povratne informacije"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משוב מישושי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phản hồi xúc giác"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptic Feedback"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Απτική ανάδραση"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retorno tátil"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тактильний відгук"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاستجابة اللمسية"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازخورد لمسی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہیپٹک فیڈ بیک"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตอบสนองแบบสัมผัส"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हैप्टिक फ़ीडबैक"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "触覚フィードバック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "햅틱 피드백"
+          }
+        }
+      },
+      "comment": "Row title / toggle: vibration feedback"
+    },
+    "Haptic feedback requires Full Access. Enable it in **Settings › Wurstfinger › Keyboards › Wurstfinger › Allow Full Access**.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptisches Feedback erfordert Vollzugriff. Aktiviere ihn unter **Einstellungen › Wurstfinger › Tastaturen › Wurstfinger › Vollzugriff erlauben**."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le retour haptique nécessite l'accès complet. Activez-le dans **Réglages › Wurstfinger › Claviers › Wurstfinger › Autoriser l'accès complet**."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La respuesta háptica requiere acceso completo. Actívalo en **Ajustes › Wurstfinger › Teclados › Wurstfinger › Permitir acceso completo**."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il feedback aptico richiede l'accesso completo. Attivalo in **Impostazioni › Wurstfinger › Tastiere › Wurstfinger › Consenti accesso completo**."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тактильный отклик требует полного доступа. Включите его в **Настройки › Wurstfinger › Клавиатуры › Wurstfinger › Разрешить полный доступ**."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reakcje haptyczne wymagają pełnego dostępu. Włącz go w **Ustawienia › Wurstfinger › Klawiatury › Wurstfinger › Przyznaj pełny dostęp**."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taktil återkoppling kräver fullständig åtkomst. Aktivera den i **Inställningar › Wurstfinger › Tangentbord › Wurstfinger › Tillåt fullständig åtkomst**."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tuntopalaute vaatii täyden käyttöoikeuden. Ota se käyttöön kohdassa **Asetukset › Wurstfinger › Näppäimistöt › Wurstfinger › Salli täysi käyttöoikeus**."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptičke povratne informacije zahtijevaju puni pristup. Uključi ga u **Postavke › Wurstfinger › Tipkovnice › Wurstfinger › Dopusti puni pristup**."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משוב מישושי דורש גישה מלאה. הפעל אותה ב-**הגדרות › Wurstfinger › מקלדות › Wurstfinger › אפשר גישה מלאה**."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phản hồi xúc giác yêu cầu Truy cập đầy đủ. Bật trong **Cài đặt › Wurstfinger › Bàn phím › Wurstfinger › Cho phép truy cập đầy đủ**."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kailangan ng haptic feedback ang Full Access. I-enable ito sa **Mga Setting › Wurstfinger › Mga Keyboard › Wurstfinger › Payagan ang Full Access**."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Η απτική ανάδραση απαιτεί πλήρη πρόσβαση. Ενεργοποιήστε την στο **Ρυθμίσεις › Wurstfinger › Πληκτρολόγια › Wurstfinger › Να επιτρέπεται η πλήρης πρόσβαση**."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O retorno tátil requer acesso total. Ative-o em **Definições › Wurstfinger › Teclados › Wurstfinger › Permitir acesso total**."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тактильний відгук потребує повного доступу. Увімкніть його в **Параметри › Wurstfinger › Клавіатури › Wurstfinger › Дозволити повний доступ**."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تتطلب الاستجابة اللمسية الوصول الكامل. فعِّلها في **الإعدادات › Wurstfinger › لوحات المفاتيح › Wurstfinger › السماح بالوصول الكامل**."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازخورد لمسی به دسترسی کامل نیاز دارد. آن را در **تنظیمات › Wurstfinger › صفحه‌کلیدها › Wurstfinger › اجازهٔ دسترسی کامل** فعال کنید."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہیپٹک فیڈ بیک کے لیے مکمل رسائی درکار ہے۔ اسے **ترتیبات › Wurstfinger › کی بورڈز › Wurstfinger › مکمل رسائی کی اجازت دیں** میں فعال کریں۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตอบสนองแบบสัมผัสต้องใช้การเข้าถึงเต็มรูปแบบ เปิดใช้งานได้ที่ **การตั้งค่า › Wurstfinger › แป้นพิมพ์ › Wurstfinger › อนุญาตการเข้าถึงเต็มรูปแบบ**"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हैप्टिक फ़ीडबैक के लिए पूर्ण एक्सेस ज़रूरी है। इसे **सेटिंग्स › Wurstfinger › कीबोर्ड › Wurstfinger › पूर्ण एक्सेस दें** में चालू करें।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "触覚フィードバックにはフルアクセスが必要です。**「設定」› Wurstfinger ›「キーボード」› Wurstfinger ›「フルアクセスを許可」**で有効にしてください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "햅틱 피드백에는 전체 접근이 필요합니다. **설정 › Wurstfinger › 키보드 › Wurstfinger › 전체 접근 허용**에서 켜세요."
+          }
+        }
+      },
+      "comment": "Warning with markdown bold and › separators; the path words inside ** ** are iOS Settings names — localize Settings/Keyboards/Allow Full Access, keep 'Wurstfinger', keep markdown ** and ›"
+    },
+    "Haptics": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptik"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour haptique"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Háptica"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aptica"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тактильный отклик"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptyka"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taktil återkoppling"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tuntopalaute"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptika"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משוב מישושי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xúc giác"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptics"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Απτική ανάδραση"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tátil"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тактильний відгук"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاستجابة اللمسية"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لرزش لمسی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہیپٹکس"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การสั่นตอบสนอง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हैप्टिक्स"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "触覚フィードバック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "햅틱"
+          }
+        }
+      },
+      "comment": "Navigation title for haptic settings"
+    },
+    "Hide keyboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastatur ausblenden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masquer le clavier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nascondi tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скрыть клавиатуру"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ukryj klawiaturę"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dölj tangentbordet"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piilota näppäimistö"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sakrij tipkovnicu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הסתר מקלדת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ẩn bàn phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Itago ang keyboard"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Απόκρυψη πληκτρολογίου"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar teclado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сховати клавіатуру"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إخفاء لوحة المفاتيح"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پنهان کردن صفحه‌کلید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی بورڈ چھپائیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ซ่อนคีย์บอร์ด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड छिपाएँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードを隠す"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 숨기기"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for dismiss-keyboard gesture (VoiceOver)"
+    },
+    "Hide labels to practice the layout from memory. Numbers and control keys are always visible.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blende Beschriftungen aus, um das Layout aus dem Gedächtnis zu üben. Zahlen und Steuertasten sind immer sichtbar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masquez les étiquettes pour vous exercer à la disposition de mémoire. Les chiffres et les touches de contrôle restent toujours visibles."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oculta las etiquetas para practicar la disposición de memoria. Los números y las teclas de control siempre están visibles."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nascondi le etichette per esercitarti con il layout a memoria. I numeri e i tasti di controllo restano sempre visibili."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скройте подписи, чтобы тренировать раскладку по памяти. Цифры и служебные клавиши всегда видны."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ukryj etykiety, aby ćwiczyć układ z pamięci. Cyfry i klawisze sterujące są zawsze widoczne."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dölj etiketter för att öva på layouten ur minnet. Siffror och kontrolltangenter är alltid synliga."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piilota merkinnät harjoitellaksesi asettelua muistista. Numerot ja ohjausnäppäimet ovat aina näkyvissä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sakrij oznake da vježbaš raspored napamet. Brojevi i upravljačke tipke uvijek su vidljivi."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הסתר תוויות כדי לתרגל את הפריסה מהזיכרון. הספרות ומקשי הבקרה תמיד גלויים."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ẩn nhãn để luyện tập bố cục theo trí nhớ. Số và các phím điều khiển luôn hiển thị."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Itago ang mga label para masanay sa layout mula sa memorya. Laging nakikita ang mga numero at control key."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Απόκρυψη ετικετών για εξάσκηση της διάταξης από μνήμης. Οι αριθμοί και τα πλήκτρα ελέγχου είναι πάντα ορατά."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oculte os rótulos para praticar o layout de memória. Números e teclas de controle estão sempre visíveis."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приховайте підписи, щоб вивчати розкладку напам'ять. Цифри та клавіші керування завжди видимі."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أخفِ التسميات للتدرب على التخطيط من الذاكرة. الأرقام ومفاتيح التحكم مرئية دائمًا."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برچسب‌ها را پنهان کنید تا چیدمان را از حفظ تمرین کنید. اعداد و کلیدهای کنترل همیشه نمایان هستند."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترتیب کو یادداشت سے مشق کرنے کے لیے لیبل چھپائیں۔ نمبر اور کنٹرول کیز ہمیشہ نظر آتی ہیں۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ซ่อนป้ายกำกับเพื่อฝึกเค้าโครงจากความจำ ตัวเลขและปุ่มควบคุมจะแสดงอยู่เสมอ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लेआउट को याद से अभ्यास करने के लिए लेबल छिपाएँ। संख्याएँ और नियंत्रण कुंजियाँ हमेशा दिखती हैं।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レイアウトを記憶で練習するにはラベルを非表示にします。数字と制御キーは常に表示されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "레이아웃을 외워서 연습하려면 라벨을 숨기세요. 숫자와 컨트롤 키는 항상 표시됩니다."
+          }
+        }
+      },
+      "comment": "Label visibility footer"
     },
     "Hiding %@": {
       "extractionState": "manual",
@@ -14353,419 +8084,5249 @@
       },
       "comment": "Label visibility subtitle; %@ is a list like 'letters, extra symbols'"
     },
-    "letters": {
+    "Hold a letter key to type its digit": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط مطوّلاً على حرف لكتابة رقمه"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Buchstaben"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "lettres"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "letras"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "lettere"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "буквы"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "litery"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "bokstäver"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "kirjaimet"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "slova"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אותיות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "chữ cái"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "mga letra"
+            "value": "Halte eine Buchstabentaste, um ihre Ziffer einzugeben"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "γράμματα"
+            "value": "Κρατήστε ένα γράμμα για να πληκτρολογήσετε το ψηφίο του"
           }
         },
-        "pt": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "letras"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "літери"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الحروف"
+            "value": "Mantén pulsada una letra para escribir su número"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "حروف"
+            "value": "کلید حرف را نگه دارید تا عدد آن تایپ شود"
           }
         },
-        "ur": {
+        "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "حروف"
+            "value": "Pidä kirjainta pohjassa saadaksesi sen numeron"
           }
         },
-        "th": {
+        "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "ตัวอักษร"
+            "value": "Pindutin nang matagal ang letra para sa numero nito"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maintenez une lettre pour saisir son chiffre"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "החזיקו מקש אות כדי להקליד את הספרה שלו"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "अक्षर"
+            "value": "अक्षर दबाए रखें और उसका अंक टाइप करें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dugo pritisni slovo za njegovu brojku"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tieni premuta una lettera per la sua cifra"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "文字"
+            "value": "文字キーを長押しすると数字を入力できます"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "문자"
+            "value": "문자 키를 길게 누르면 숫자가 입력됩니다"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przytrzymaj literę, aby wpisać jej cyfrę"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantenha premida uma letra para o seu algarismo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удержание буквы вводит её цифру"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Håll in en bokstav för att skriva dess siffra"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กดตัวอักษรค้างไว้เพื่อพิมพ์ตัวเลข"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Утримання літери вводить її цифру"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرف دبائے رکھیں تاکہ اس کا ہندسہ ٹائپ ہو"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giữ phím chữ để nhập số của phím"
           }
         }
       },
-      "comment": "Label visibility list item"
+      "comment": "Toggle subtitle explaining the type-numbers-by-holding option"
     },
-    "standard symbols": {
+    "Home": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Standardsymbole"
+            "value": "Start"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "symboles standard"
+            "value": "Accueil"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "símbolos estándar"
+            "value": "Inicio"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "simboli standard"
+            "value": "Home"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "стандартные символы"
+            "value": "Главная"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "symbole standardowe"
+            "value": "Start"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "standardsymboler"
+            "value": "Hem"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "vakiosymbolit"
+            "value": "Etusivu"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "standardni simboli"
+            "value": "Početna"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "סמלים רגילים"
+            "value": "בית"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "ký hiệu chuẩn"
+            "value": "Trang chủ"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "mga karaniwang simbolo"
+            "value": "Home"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "τυπικά σύμβολα"
+            "value": "Αρχική"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "símbolos padrão"
+            "value": "Início"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "стандартні символи"
+            "value": "Головна"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "الرموز القياسية"
+            "value": "الرئيسية"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "نمادهای استاندارد"
+            "value": "خانه"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "معیاری علامتیں"
+            "value": "ہوم"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "สัญลักษณ์มาตรฐาน"
+            "value": "หน้าแรก"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "मानक सिंबल"
+            "value": "होम"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "標準記号"
+            "value": "ホーム"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "기본 기호"
+            "value": "홈"
           }
         }
       },
-      "comment": "Label visibility list item"
+      "comment": "Tab bar label for the home/landing screen"
     },
-    "extra symbols": {
+    "Horizontal Position": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Zusatzsymbole"
+            "value": "Horizontale Position"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "symboles supplémentaires"
+            "value": "Position horizontale"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "símbolos adicionales"
+            "value": "Posición horizontal"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "simboli extra"
+            "value": "Posizione orizzontale"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "дополнительные символы"
+            "value": "Положение по горизонтали"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "symbole dodatkowe"
+            "value": "Położenie poziome"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "extra symboler"
+            "value": "Horisontell position"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "lisäsymbolit"
+            "value": "Vaakasijainti"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "dodatni simboli"
+            "value": "Vodoravni položaj"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "סמלים נוספים"
+            "value": "מיקום אופקי"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "ký hiệu bổ sung"
+            "value": "Vị trí ngang"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "mga dagdag na simbolo"
+            "value": "Horizontal na Posisyon"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "επιπλέον σύμβολα"
+            "value": "Οριζόντια θέση"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "símbolos extra"
+            "value": "Posição horizontal"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "додаткові символи"
+            "value": "Горизонтальне положення"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "الرموز الإضافية"
+            "value": "الموضع الأفقي"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "نمادهای اضافی"
+            "value": "موقعیت افقی"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "اضافی علامتیں"
+            "value": "افقی پوزیشن"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "สัญลักษณ์เพิ่มเติม"
+            "value": "ตำแหน่งแนวนอน"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "अतिरिक्त सिंबल"
+            "value": "क्षैतिज स्थिति"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "追加記号"
+            "value": "水平方向の位置"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "추가 기호"
+            "value": "가로 위치"
           }
         }
       },
-      "comment": "Label visibility list item"
+      "comment": "Slider title"
+    },
+    "Imprint": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impressum"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mentions légales"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aviso legal"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note legali"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выходные данные"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nota prawna"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utgivningsinformation"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Julkaisutiedot"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impresum"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פרטים משפטיים"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thông tin pháp lý"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imprint"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Στοιχεία έκδοσης"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ficha técnica"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вихідні дані"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بيانات الناشر"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اطلاعات ناشر"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "امپرنٹ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ข้อมูลผู้จัดทำ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इम्प्रिंट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "運営者情報"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제작 정보"
+          }
+        }
+      },
+      "comment": "About row / title: legal imprint / impressum"
+    },
+    "Issues": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Issues"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signaler un problème"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incidencias"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problemi"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сообщить об ошибке"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zgłoszenia"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ärenden"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ongelmat"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problemi"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "בעיות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Báo lỗi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Issue"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Προβλήματα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problemas"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проблеми"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المشكلات"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مشکل‌ها"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسائل"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปัญหา"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "समस्याएँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "問題"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문제 해결"
+          }
+        }
+      },
+      "comment": "Link to the GitHub issue tracker (report bugs)"
+    },
+    "Key Aspect Ratio": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenverhältnis der Tasten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proportions des touches"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporción de las teclas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporzioni dei tasti"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Соотношение сторон клавиш"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporcje klawiszy"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangenternas proportioner"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäinten kuvasuhde"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omjer stranica tipki"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "יחס גובה-רוחב של המקשים"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tỷ lệ phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aspect Ratio ng Key"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αναλογία διαστάσεων πλήκτρων"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporção das teclas"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Співвідношення сторін клавіш"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسبة أبعاد المفتاح"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسبت ابعاد کلید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی کا پہلو تناسب"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อัตราส่วนปุ่ม"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "की आस्पेक्ट रेशियो"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーの縦横比"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키 가로세로 비율"
+          }
+        }
+      },
+      "comment": "Settings row / title: width-to-height ratio of keys"
+    },
+    "Keyboard Size": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastaturgröße"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taille du clavier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamaño del teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dimensione della tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Размер клавиатуры"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozmiar klawiatury"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangentbordets storlek"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäimistön koko"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veličina tipkovnice"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גודל המקלדת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kích thước bàn phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laki ng Keyboard"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Μέγεθος πληκτρολογίου"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamanho do teclado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Розмір клавіатури"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حجم لوحة المفاتيح"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اندازه صفحه‌کلید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی بورڈ کا سائز"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ขนาดคีย์บอร์ด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड का आकार"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードのサイズ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 크기"
+          }
+        }
+      },
+      "comment": "Slider title: overall keyboard size"
+    },
+    "Label Visibility": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sichtbarkeit der Beschriftungen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visibilité des étiquettes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visibilidad de etiquetas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visibilità delle etichette"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видимость подписей"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Widoczność etykiet"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiketternas synlighet"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Merkintöjen näkyvyys"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vidljivost oznaka"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "נראות תוויות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiển thị nhãn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visibility ng Label"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ορατότητα ετικετών"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visibilidade das etiquetas"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видимість підписів"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ظهور التسميات"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمایان‌بودن برچسب‌ها"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لیبل کی نمائش"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การแสดงป้ายกำกับ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लेबल दृश्यता"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ラベルの表示"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "레이블 표시"
+          }
+        }
+      },
+      "comment": "Settings row title"
+    },
+    "Languages": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langues"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idiomas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lingue"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Языки"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Języki"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Språk"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kielet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jezici"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שפות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ngôn ngữ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Wika"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Γλώσσες"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idiomas"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мови"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اللغات"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زبان‌ها"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زبانیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ภาษา"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "भाषाएँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "언어"
+          }
+        }
+      },
+      "comment": "Settings row title / language selection screen title"
+    },
+    "Left": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Links"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gauche"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izquierda"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sinistra"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Слева"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lewo"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vänster"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vasen"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lijevo"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שמאל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trái"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaliwa"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αριστερά"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esquerda"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ліворуч"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اليسار"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چپ"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بائیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ซ้าย"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बायाँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "왼쪽"
+          }
+        }
+      },
+      "comment": "Slider label: left position"
+    },
+    "License": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licence"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licencia"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licenza"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лицензия"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licencja"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licens"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lisenssi"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licenca"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "רישיון"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giấy phép"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lisensya"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Άδεια χρήσης"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licença"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ліцензія"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الترخيص"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مجوز"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لائسنس"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สัญญาอนุญาต"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लाइसेंस"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライセンス"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "라이선스"
+          }
+        }
+      },
+      "comment": "About row label (software license)"
+    },
+    "Light": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leicht"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Léger"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ligero"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leggero"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лёгкий"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lekki"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lätt"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kevyt"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lagano"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "קל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhẹ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Magaan"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ελαφριά"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ligeiro"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Легкий"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خفيف جدًا"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سبک"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہلکا"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อ่อน"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हल्का"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "弱"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가볍게"
+          }
+        }
+      },
+      "comment": "Haptic intensity level name"
+    },
+    "Liquid Glass": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        }
+      },
+      "comment": "Keyboard style name (Apple design language, not translated)"
+    },
+    "Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass ist für iOS 26 und neuer ausgelegt. Auf älteren Versionen wird ein vereinfachter durchscheinender Stil verwendet."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass est conçu pour iOS 26 et versions ultérieures. Sur les versions antérieures, un style translucide simplifié est utilisé."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass está diseñado para iOS 26 y posteriores. En versiones anteriores se usa un estilo translúcido simplificado."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass è progettato per iOS 26 e versioni successive. Nelle versioni precedenti viene usato uno stile traslucido semplificato."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass разработан для iOS 26 и новее. В более ранних версиях используется упрощённый полупрозрачный стиль."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass jest zaprojektowany dla iOS 26 i nowszych. W starszych wersjach używany jest uproszczony półprzezroczysty styl."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass är utformat för iOS 26 och senare. På äldre versioner används en förenklad halvgenomskinlig stil."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass on suunniteltu iOS 26:lle ja uudemmille. Vanhemmissa versioissa käytetään yksinkertaistettua läpikuultavaa tyyliä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass je osmišljen za iOS 26 i novije. Na starijim verzijama koristi se pojednostavljeni poluprozirni stil."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass מיועד ל‑iOS 26 ואילך. בגרסאות קודמות נעשה שימוש בסגנון שקוף למחצה ופשוט יותר."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass được thiết kế cho iOS 26 trở lên. Trên các phiên bản cũ hơn, một kiểu trong mờ đơn giản hóa sẽ được dùng."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ang Liquid Glass ay idinisenyo para sa iOS 26 pataas. Sa mas lumang bersyon, gagamitin ang pinasimpleng translucent na estilo."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Το Liquid Glass απαιτεί iOS 26 ή νεότερη έκδοση. Σε αυτή τη συσκευή θα χρησιμοποιηθεί το κλασικό στιλ."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Liquid Glass requer o iOS 26 ou posterior. Neste dispositivo será usado o estilo clássico."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass потребує iOS 26 або новішої версії. На цьому пристрої використовуватиметься класичний стиль."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتطلب Liquid Glass نظام iOS 26 أو أحدث. سيُستخدم النمط الكلاسيكي على هذا الجهاز."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass به iOS 26 یا جدیدتر نیاز دارد. در این دستگاه از سبک کلاسیک استفاده می‌شود."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass کے لیے iOS 26 یا بعد کا ورژن درکار ہے۔ اس ڈیوائس پر کلاسک انداز استعمال ہوگا۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass ต้องใช้ iOS 26 ขึ้นไป อุปกรณ์นี้จะใช้สไตล์คลาสสิกแทน"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass के लिए iOS 26 या बाद का वर्शन ज़रूरी है। इस डिवाइस पर क्लासिक स्टाइल इस्तेमाल होगी।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid GlassにはiOS 26以降が必要です。このデバイスではクラシックスタイルが使用されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass는 iOS 26 이상이 필요합니다. 이 기기에서는 클래식 스타일이 사용됩니다."
+          }
+        }
+      },
+      "comment": "Note shown on pre-iOS-26 devices; 'Liquid Glass' is a style name (keep)"
+    },
+    "Max": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Máx."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Макс."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maks."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maks."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maks."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מרבי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tối đa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Μέγιστη"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Máximo"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Максимальний"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الحد الأقصى"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بیشینه"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زیادہ سے زیادہ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สูงสุด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अधिकतम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最大"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최대"
+          }
+        }
+      },
+      "comment": "Slider maximum label (maximum intensity)"
+    },
+    "Medium": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mittel"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moyen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medio"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medio"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Средний"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Średni"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medel"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keskitaso"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Srednje"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "בינוני"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vừa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Katamtaman"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Μεσαία"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Médio"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Середній"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متوسط"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متوسط"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "درمیانہ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปานกลาง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मध्यम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보통"
+          }
+        }
+      },
+      "comment": "Haptic intensity level name"
+    },
+    "MessagEase Layout": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase-Layout"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disposition MessagEase"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disposición MessagEase"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Layout MessagEase"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Раскладка MessagEase"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Układ MessagEase"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase-layout"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase-asettelu"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase raspored"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פריסת MessagEase"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bố cục MessagEase"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase Layout"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διάταξη MessagEase"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esquema MessagEase"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Розкладка MessagEase"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تخطيط MessagEase"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چیدمان MessagEase"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase لے آؤٹ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เลย์เอาต์ MessagEase"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase लेआउट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEaseレイアウト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase 레이아웃"
+          }
+        }
+      },
+      "comment": "Caption under each language option; 'MessagEase' is a product name (keep)"
+    },
+    "Minimal": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimal"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mínimo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Минимальный"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimalny"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimal"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimaalinen"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimalno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מינימלי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tối thiểu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimal"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ελάχιστη"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mínimo"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мінімальний"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الحد الأدنى"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کمینه"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کم سے کم"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "น้อยที่สุด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "न्यूनतम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最小"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최소"
+          }
+        }
+      },
+      "comment": "Haptic intensity level name"
+    },
+    "New line": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neue Zeile"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouvelle ligne"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nueva línea"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A capo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новая строка"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowy wiersz"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ny rad"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uusi rivi"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novi redak"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שורה חדשה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dòng mới"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bagong linya"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Νέα γραμμή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nova linha"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новий рядок"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سطر جديد"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خط جدید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نئی لائن"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ขึ้นบรรทัดใหม่"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नई लाइन"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "改行"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "줄바꿈"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the return/newline key (VoiceOver)"
+    },
+    "Next language": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nächste Sprache"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langue suivante"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma siguiente"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lingua successiva"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Следующий язык"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Następny język"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nästa språk"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seuraava kieli"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sljedeći jezik"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "השפה הבאה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ngôn ngữ tiếp theo"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Susunod na wika"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επόμενη γλώσσα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Próximo idioma"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Наступна мова"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اللغة التالية"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زبان بعدی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اگلی زبان"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ภาษาถัดไป"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अगली भाषा"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次の言語"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음 언어"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY action name for the switch-to-next-language gesture (VoiceOver)"
+    },
+    "Numpad Style": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ziffernblock-Stil"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Style du pavé numérique"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilo del teclado numérico"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stile tastierino numerico"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стиль цифровой панели"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Styl klawiatury numerycznej"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stil på sifferknappsats"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Numeronäppäimistön tyyli"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stil numeričke tipkovnice"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סגנון לוח המספרים"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiểu bàn phím số"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilo ng Numpad"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Στιλ αριθμητικού πληκτρολογίου"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilo do teclado numérico"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стиль цифрового блоку"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمط لوحة الأرقام"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سبک صفحهٔ اعداد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمپیڈ انداز"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สไตล์แป้นตัวเลข"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नंबरपैड स्टाइल"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テンキーのスタイル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "숫자 패드 스타일"
+          }
+        }
+      },
+      "comment": "Settings row title: number pad layout style"
+    },
+    "OK": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ОК"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "U redu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אישור"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "موافق"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تأیید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹھیک ہے"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตกลง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ठीक है"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인"
+          }
+        }
+      },
+      "comment": "Alert confirmation button"
+    },
+    "Off": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactivé"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apagado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выкл."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wył."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Av"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pois"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isklj."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "כבוי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tắt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ανενεργό"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desligado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вимк."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيقاف"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خاموش"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بند"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बंद"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "끔"
+          }
+        }
+      },
+      "comment": "Slider minimum label (intensity off)"
+    },
+    "Open Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen öffnen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir Réglages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Ajustes"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri Impostazioni"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть Настройки"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz Ustawienia"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öppna Inställningar"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaa Asetukset"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvori Postavke"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פתח הגדרות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở Cài đặt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buksan ang Mga Setting"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Άνοιγμα Ρυθμίσεων"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Definições"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрити Параметри"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح الإعدادات"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "باز کردن تنظیمات"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترتیبات کھولیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดการตั้งค่า"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटिंग्स खोलें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定を開く"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 열기"
+          }
+        }
+      },
+      "comment": "Button that opens the iOS Settings app"
+    },
+    "Open iOS Settings → General → Keyboard → Keyboards and add Wurstfinger.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffne iOS Einstellungen → Allgemein → Tastatur → Tastaturen und füge Wurstfinger hinzu."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrez Réglages iOS → Général → Clavier → Claviers et ajoutez Wurstfinger."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre Ajustes de iOS → General → Teclado → Teclados y añade Wurstfinger."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri Impostazioni iOS → Generali → Tastiera → Tastiere e aggiungi Wurstfinger."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Откройте «Настройки» iOS → «Основные» → «Клавиатура» → «Клавиатуры» и добавьте Wurstfinger."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz Ustawienia iOS → Ogólne → Klawiatura → Klawiatury i dodaj Wurstfinger."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öppna Inställningar → Allmänt → Tangentbord → Tangentbord och lägg till Wurstfinger."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaa iOS-Asetukset → Yleiset → Näppäimistö → Näppäimistöt ja lisää Wurstfinger."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvori Postavke → Općenito → Tipkovnica → Tipkovnice i dodaj Wurstfinger."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פתח את הגדרות iOS → כללי → מקלדת → מקלדות והוסף את Wurstfinger."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở Cài đặt iOS → Cài đặt chung → Bàn phím → Bàn phím và thêm Wurstfinger."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buksan ang Mga Setting ng iOS → Pangkalahatan → Keyboard → Mga Keyboard at idagdag ang Wurstfinger."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ανοίξτε Ρυθμίσεις iOS → Γενικά → Πληκτρολόγιο → Πληκτρολόγια και προσθέστε το Wurstfinger."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra Definições do iOS → Geral → Teclado → Teclados e adicione o Wurstfinger."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрийте Параметри iOS → Основні → Клавіатура → Клавіатури та додайте Wurstfinger."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افتح الإعدادات ← عام ← لوحة المفاتيح ← لوحات المفاتيح وأضِف Wurstfinger."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنظیمات iOS → عمومی → صفحه‌کلید → صفحه‌کلیدها را باز کنید و Wurstfinger را اضافه کنید."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS کی ترتیبات → عمومی → کی بورڈ → کی بورڈز کھولیں اور Wurstfinger شامل کریں۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดการตั้งค่า iOS → ทั่วไป → แป้นพิมพ์ → แป้นพิมพ์ แล้วเพิ่ม Wurstfinger"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS सेटिंग्स → सामान्य → कीबोर्ड → कीबोर्ड खोलें और Wurstfinger जोड़ें।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOSの「設定」→「一般」→「キーボード」→「キーボード」を開いて、Wurstfingerを追加します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS 설정 → 일반 → 키보드 → 키보드로 이동하여 Wurstfinger를 추가하세요."
+          }
+        }
+      },
+      "comment": "Onboarding step 1 description; the arrow-separated words are iOS Settings menu names — use official localized iOS terms"
+    },
+    "Open the keyboard once to sync Full Access status.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffne die Tastatur einmal, um den Status von Vollzugriff zu synchronisieren."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrez le clavier une fois pour synchroniser l'état de l'accès complet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre el teclado una vez para sincronizar el estado del acceso completo."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri la tastiera una volta per sincronizzare lo stato dell'accesso completo."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Откройте клавиатуру один раз, чтобы синхронизировать статус полного доступа."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz raz klawiaturę, aby zsynchronizować stan pełnego dostępu."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öppna tangentbordet en gång för att synkronisera status för fullständig åtkomst."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaa näppäimistö kerran, jotta täyden käyttöoikeuden tila synkronoituu."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jednom otvori tipkovnicu za sinkronizaciju statusa punog pristupa."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פתח את המקלדת פעם אחת כדי לסנכרן את מצב הגישה המלאה."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở bàn phím một lần để đồng bộ trạng thái Truy cập đầy đủ."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buksan ang keyboard nang isang beses para i-sync ang status ng Full Access."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ανοίξτε το πληκτρολόγιο μία φορά για συγχρονισμό της κατάστασης πλήρους πρόσβασης."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra o teclado uma vez para sincronizar o estado do acesso total."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрийте клавіатуру один раз, щоб синхронізувати стан повного доступу."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افتح لوحة المفاتيح مرة واحدة لمزامنة حالة الوصول الكامل."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "یک‌بار صفحه‌کلید را باز کنید تا وضعیت دسترسی کامل همگام شود."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مکمل رسائی کی حالت سنک کرنے کے لیے کی بورڈ ایک بار کھولیں۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดคีย์บอร์ดหนึ่งครั้งเพื่อซิงค์สถานะการเข้าถึงเต็มรูปแบบ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पूर्ण एक्सेस स्थिति सिंक करने के लिए कीबोर्ड एक बार खोलें।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フルアクセスの状態を同期するために、キーボードを一度開いてください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 접근 상태를 동기화하려면 키보드를 한 번 열어 주세요."
+          }
+        }
+      },
+      "comment": "Caption; 'Full Access' is the iOS term"
+    },
+    "Paste": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einsetzen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coller"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pegar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incolla"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вставить"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wklej"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klistra in"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liitä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zalijepi"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הדבק"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dán"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-paste"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επικόλληση"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вставити"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لصق"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چسباندن"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیسٹ کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วาง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पेस्ट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペースト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "붙여넣기"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the paste gesture (VoiceOver)"
+    },
+    "Phone (1-2-3)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefon (1-2-3)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléphone (1-2-3)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teléfono (1-2-3)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefono (1-2-3)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Телефонный (1-2-3)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefoniczny (1-2-3)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefon (1-2-3)"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puhelin (1-2-3)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefon (1-2-3)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "טלפון (1-2-3)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Điện thoại (1-2-3)"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telepono (1-2-3)"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τηλέφωνο (1-2-3)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefone (1-2-3)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Телефонний (1-2-3)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الهاتف (1-2-3)"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تلفن (۱-۲-۳)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فون (1-2-3)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โทรศัพท์ (1-2-3)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "फ़ोन (1-2-3)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電話（1-2-3）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전화기 (1-2-3)"
+          }
+        }
+      },
+      "comment": "Picker option: phone-style numpad with 1-2-3 on top"
+    },
+    "Phone layout (1-2-3)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefon-Layout (1-2-3)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disposition téléphone (1-2-3)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disposición de teléfono (1-2-3)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Layout telefono (1-2-3)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Телефонная раскладка (1-2-3)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Układ telefoniczny (1-2-3)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefonlayout (1-2-3)"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puhelinasettelu (1-2-3)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefonski raspored (1-2-3)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פריסת טלפון (1-2-3)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bố cục điện thoại (1-2-3)"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Layout ng telepono (1-2-3)"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διάταξη τηλεφώνου (1-2-3)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esquema de telefone (1-2-3)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Телефонна розкладка (1-2-3)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تخطيط الهاتف (1-2-3)"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چیدمان تلفن (۱-۲-۳)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فون لے آؤٹ (1-2-3)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เลย์เอาต์โทรศัพท์ (1-2-3)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "फ़ोन लेआउट (1-2-3)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電話レイアウト（1-2-3）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전화기 레이아웃 (1-2-3)"
+          }
+        }
+      },
+      "comment": "Numpad style subtitle: phone layout"
+    },
+    "Places globe, symbols, delete and return on the left": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Platziert Globus, Symbole, Löschen und Zeilenschalter links"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Place le globe, les symboles, la suppression et le retour à gauche"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coloca el globo, los símbolos, borrar e intro a la izquierda"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Posiziona globo, simboli, elimina e a capo a sinistra"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Размещает глобус, символы, удаление и ввод слева"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umieszcza globus, symbole, usuwanie i enter po lewej stronie"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Placerar jordglob, symboler, radera och retur till vänster"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sijoittaa maapallon, symbolit, poiston ja rivinvaihdon vasemmalle"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postavlja globus, simbole, brisanje i povratak na lijevu stranu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ממקם את הגלובוס, הסמלים, המחיקה והשורה החדשה בצד שמאל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đặt phím địa cầu, ký hiệu, xóa và xuống dòng ở bên trái"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inilalagay ang globe, symbols, delete at return sa kaliwa"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τοποθετεί την υδρόγειο, τα σύμβολα, τη διαγραφή και το return στα αριστερά"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coloca o globo, os símbolos, a eliminação e a tecla de retorno à esquerda"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Розміщує глобус, символи, видалення й Enter ліворуч"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يضع مفاتيح الكرة الأرضية والرموز والحذف والإدخال على اليسار"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدهای کره، نمادها، حذف و بازگشت را در سمت چپ قرار می‌دهد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گلوب، علامتیں، حذف اور ریٹرن کو بائیں طرف رکھتا ہے"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วางปุ่มลูกโลก สัญลักษณ์ ลบ และขึ้นบรรทัดใหม่ไว้ทางซ้าย"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ग्लोब, सिंबल, डिलीट और रिटर्न को बाईं ओर रखता है"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地球儀、記号、削除、改行のキーを左側に配置します"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지구본, 기호, 삭제, 줄바꿈 키를 왼쪽에 배치합니다"
+          }
+        }
+      },
+      "comment": "Toggle subtitle explaining the utility-keys-on-left option"
+    },
+    "Preview": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorschau"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aperçu"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vista previa"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anteprima"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предпросмотр"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podgląd"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Förhandsvisning"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esikatselu"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pregled"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תצוגה מקדימה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xem trước"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preview"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Προεπισκόπηση"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pré-visualização"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перегляд"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معاينة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیش‌نمایش"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیش منظر"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวอย่าง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "प्रीव्यू"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プレビュー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "미리보기"
+          }
+        }
+      },
+      "comment": "Header above the interactive keyboard preview"
+    },
+    "Reset": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurücksetzen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinitialiser"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ripristina"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetuj"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Återställ"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Palauta"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vrati izvorno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אפס"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đặt lại"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-reset"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επαναφορά"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скинути"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تعيين"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازنشانی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ری سیٹ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รีเซ็ต"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रीसेट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リセット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "재설정"
+          }
+        }
+      },
+      "comment": "Button to reset values to defaults"
+    },
+    "Right": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechts"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Droite"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Derecha"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destra"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Справа"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prawo"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Höger"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oikea"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ימין"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phải"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kanan"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Δεξιά"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Direita"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Праворуч"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اليمين"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "راست"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دائیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ขวา"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "दायाँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오른쪽"
+          }
+        }
+      },
+      "comment": "Slider label: right position"
+    },
+    "Scale: %@, Position: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Größe: %@, Position: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échelle : %@, position : %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escala: %@, posición: %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scala: %@, posizione: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштаб: %@, положение: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skala: %@, położenie: %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skala: %@, position: %@"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koko: %@, sijainti: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veličina: %@, položaj: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "קנה מידה: %@, מיקום: %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tỷ lệ: %@, vị trí: %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scale: %@, posisyon: %@"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κλίμακα: %@, Θέση: %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escala: %@, Posição: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштаб: %@, положення: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الحجم: %@، الموضع: %@"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مقیاس: %@، موقعیت: %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسکیل: %@، پوزیشن: %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ขนาด: %@, ตำแหน่ง: %@"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्केल: %@, स्थिति: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイズ：%@、位置：%@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "크기: %@, 위치: %@"
+          }
+        }
+      },
+      "comment": "Size & Position subtitle, e.g. 'Scale: 100%, Position: Center'"
+    },
+    "Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustawienia"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inställningar"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asetukset"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postavke"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הגדרות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Setting"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ρυθμίσεις"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definições"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإعدادات"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنظیمات"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترتیبات"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตั้งค่า"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटिंग्स"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정"
+          }
+        }
+      },
+      "comment": "Tab label and navigation title for settings"
+    },
+    "Setup": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einrichtung"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurazione"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройка"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguracja"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigurering"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Käyttöönotto"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postavljanje"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הגדרה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thiết lập"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Setup"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ρύθμιση"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuração"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإعداد"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "راه‌اندازی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سیٹ اپ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตั้งค่า"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटअप"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セットアップ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 방법"
+          }
+        }
+      },
+      "comment": "Tab label and title for the first-run setup wizard"
+    },
+    "Setup Instructions": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anleitung zur Einrichtung"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instructions de configuration"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instrucciones de configuración"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Istruzioni di configurazione"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Инструкция по настройке"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instrukcje konfiguracji"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigureringsanvisningar"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Käyttöönotto-ohjeet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upute za postavljanje"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הוראות הגדרה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hướng dẫn thiết lập"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Tagubilin sa Setup"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Οδηγίες ρύθμισης"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instruções de configuração"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Інструкції з налаштування"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعليمات الإعداد"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دستورالعمل راه‌اندازی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سیٹ اپ ہدایات"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วิธีตั้งค่า"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटअप निर्देश"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セットアップ手順"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 안내"
+          }
+        }
+      },
+      "comment": "Button leading to setup steps"
+    },
+    "Show Extra Symbols": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zusatzsymbole anzeigen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher les symboles supplémentaires"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar símbolos adicionales"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra simboli extra"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать дополнительные символы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokazuj symbole dodatkowe"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visa extra symboler"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näytä lisäsymbolit"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prikaži dodatne simbole"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הצגת סמלים נוספים"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiện ký hiệu bổ sung"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ipakita ang mga dagdag na simbolo"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Εμφάνιση πρόσθετων συμβόλων"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar símbolos extras"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показувати додаткові символи"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إظهار الرموز الإضافية"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمایش نمادهای اضافی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضافی علامات دکھائیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แสดงสัญลักษณ์เพิ่มเติม"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अतिरिक्त चिह्न दिखाएँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加記号を表示"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추가 기호 표시"
+          }
+        }
+      },
+      "comment": "Label visibility toggle"
     },
     "Show Letters": {
       "extractionState": "manual",
@@ -15043,557 +13604,2765 @@
       },
       "comment": "Label visibility toggle"
     },
-    "Show Extra Symbols": {
+    "Size & Position": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Zusatzsymbole anzeigen"
+            "value": "Größe & Position"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Afficher les symboles supplémentaires"
+            "value": "Taille et position"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar símbolos adicionales"
+            "value": "Tamaño y posición"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostra simboli extra"
+            "value": "Dimensioni e posizione"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Показывать дополнительные символы"
+            "value": "Размер и положение"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pokazuj symbole dodatkowe"
+            "value": "Rozmiar i położenie"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visa extra symboler"
+            "value": "Storlek och position"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Näytä lisäsymbolit"
+            "value": "Koko ja sijainti"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prikaži dodatne simbole"
+            "value": "Veličina i položaj"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "הצגת סמלים נוספים"
+            "value": "גודל ומיקום"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hiện ký hiệu bổ sung"
+            "value": "Kích cỡ & Vị trí"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ipakita ang mga dagdag na simbolo"
+            "value": "Sukat at Posisyon"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Εμφάνιση πρόσθετων συμβόλων"
+            "value": "Μέγεθος και θέση"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar símbolos extras"
+            "value": "Tamanho e posição"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Показувати додаткові символи"
+            "value": "Розмір і положення"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "إظهار الرموز الإضافية"
+            "value": "الحجم والموضع"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "نمایش نمادهای اضافی"
+            "value": "اندازه و موقعیت"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "اضافی علامات دکھائیں"
+            "value": "سائز اور پوزیشن"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "แสดงสัญลักษณ์เพิ่มเติม"
+            "value": "ขนาดและตำแหน่ง"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "अतिरिक्त चिह्न दिखाएँ"
+            "value": "आकार और स्थिति"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "追加記号を表示"
+            "value": "サイズと位置"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "추가 기호 표시"
+            "value": "크기 및 위치"
           }
         }
       },
-      "comment": "Label visibility toggle"
+      "comment": "Settings row / title: keyboard size and position"
     },
-    "Hide labels to practice the layout from memory. Numbers and control keys are always visible.": {
+    "Size relative to the standard keyboard. It stays the same in every orientation; if it does not fit, it shrinks to the screen.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Blende Beschriftungen aus, um das Layout aus dem Gedächtnis zu üben. Zahlen und Steuertasten sind immer sichtbar."
+            "value": "Größe im Verhältnis zur Standardtastatur. Sie bleibt in jeder Bildschirmausrichtung gleich; passt sie nicht auf den Bildschirm, wird sie auf die Bildschirmbreite verkleinert."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Masquez les étiquettes pour vous exercer à la disposition de mémoire. Les chiffres et les touches de contrôle restent toujours visibles."
+            "value": "Taille par rapport au clavier standard. Elle reste identique dans toutes les orientations ; si le clavier ne tient pas, il est réduit à la largeur de l'écran."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Oculta las etiquetas para practicar la disposición de memoria. Los números y las teclas de control siempre están visibles."
+            "value": "Tamaño relativo al teclado estándar. Se mantiene igual en todas las orientaciones; si no cabe, se reduce al ancho de la pantalla."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nascondi le etichette per esercitarti con il layout a memoria. I numeri e i tasti di controllo restano sempre visibili."
+            "value": "Dimensione relativa alla tastiera standard. Resta invariata in ogni orientamento; se non c'è spazio sufficiente, viene ridotta alla larghezza dello schermo."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Скройте подписи, чтобы тренировать раскладку по памяти. Цифры и служебные клавиши всегда видны."
+            "value": "Размер относительно стандартной клавиатуры. Он одинаков в любой ориентации; если клавиатура не помещается, она уменьшается до ширины экрана."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ukryj etykiety, aby ćwiczyć układ z pamięci. Cyfry i klawisze sterujące są zawsze widoczne."
+            "value": "Rozmiar względem klawiatury standardowej. Pozostaje taki sam w każdej orientacji; jeśli klawiatura się nie mieści, jest zmniejszana do szerokości ekranu."
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dölj etiketter för att öva på layouten ur minnet. Siffror och kontrolltangenter är alltid synliga."
+            "value": "Storlek i förhållande till standardtangentbordet. Den är densamma i alla riktningar; om tangentbordet inte får plats krymps det till skärmens bredd."
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Piilota merkinnät harjoitellaksesi asettelua muistista. Numerot ja ohjausnäppäimet ovat aina näkyvissä."
+            "value": "Koko suhteessa vakionäppäimistöön. Se pysyy samana kaikissa asennoissa; jos näppäimistö ei mahdu, se kutistetaan näytön leveyteen."
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sakrij oznake da vježbaš raspored napamet. Brojevi i upravljačke tipke uvijek su vidljivi."
+            "value": "Veličina u odnosu na standardnu tipkovnicu. Ostaje ista u svakoj orijentaciji; ako tipkovnica ne stane, smanjuje se na širinu zaslona."
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "הסתר תוויות כדי לתרגל את הפריסה מהזיכרון. הספרות ומקשי הבקרה תמיד גלויים."
+            "value": "הגודל ביחס למקלדת הרגילה. הוא נשאר זהה בכל כיוון; אם המקלדת לא נכנסת, היא מוקטנת לרוחב המסך."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ẩn nhãn để luyện tập bố cục theo trí nhớ. Số và các phím điều khiển luôn hiển thị."
+            "value": "Kích thước so với bàn phím tiêu chuẩn. Kích thước này giữ nguyên ở mọi hướng màn hình; nếu không vừa, bàn phím sẽ thu nhỏ theo chiều rộng màn hình."
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Itago ang mga label para masanay sa layout mula sa memorya. Laging nakikita ang mga numero at control key."
+            "value": "Laki kumpara sa karaniwang keyboard. Nananatili itong pareho sa lahat ng oryentasyon; kung hindi kasya, liliitan ito ayon sa lapad ng screen."
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Απόκρυψη ετικετών για εξάσκηση της διάταξης από μνήμης. Οι αριθμοί και τα πλήκτρα ελέγχου είναι πάντα ορατά."
+            "value": "Μέγεθος σε σχέση με το τυπικό πληκτρολόγιο. Παραμένει το ίδιο σε κάθε προσανατολισμό· αν δεν χωράει, σμικρύνεται στο πλάτος της οθόνης."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Oculte os rótulos para praticar o layout de memória. Números e teclas de controle estão sempre visíveis."
+            "value": "Tamanho relativo ao teclado padrão. Mantém-se igual em qualquer orientação; se não couber, é reduzido à largura do ecrã."
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Приховайте підписи, щоб вивчати розкладку напам'ять. Цифри та клавіші керування завжди видимі."
+            "value": "Розмір відносно стандартної клавіатури. Він однаковий у будь-якій орієнтації; якщо клавіатура не вміщується, вона зменшується до ширини екрана."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "أخفِ التسميات للتدرب على التخطيط من الذاكرة. الأرقام ومفاتيح التحكم مرئية دائمًا."
+            "value": "الحجم بالنسبة إلى لوحة المفاتيح القياسية. يبقى كما هو في كل الاتجاهات، وإذا لم تتسع لوحة المفاتيح فسيتم تصغيرها لتناسب عرض الشاشة."
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "برچسب‌ها را پنهان کنید تا چیدمان را از حفظ تمرین کنید. اعداد و کلیدهای کنترل همیشه نمایان هستند."
+            "value": "اندازه نسبت به صفحه‌کلید استاندارد. در همه جهت‌ها یکسان می‌ماند؛ اگر جا نشود، به عرض صفحه کوچک می‌شود."
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "ترتیب کو یادداشت سے مشق کرنے کے لیے لیبل چھپائیں۔ نمبر اور کنٹرول کیز ہمیشہ نظر آتی ہیں۔"
+            "value": "معیاری کی بورڈ کے مقابلے میں سائز۔ یہ ہر سمت میں یکساں رہتا ہے؛ اگر کی بورڈ نہ سما سکے تو اسے اسکرین کی چوڑائی کے مطابق چھوٹا کر دیا جاتا ہے۔"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ซ่อนป้ายกำกับเพื่อฝึกเค้าโครงจากความจำ ตัวเลขและปุ่มควบคุมจะแสดงอยู่เสมอ"
+            "value": "ขนาดเทียบกับคีย์บอร์ดมาตรฐาน ขนาดจะเท่าเดิมในทุกการวางแนว หากไม่พอดีจะย่อลงให้เท่าความกว้างของหน้าจอ"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "लेआउट को याद से अभ्यास करने के लिए लेबल छिपाएँ। संख्याएँ और नियंत्रण कुंजियाँ हमेशा दिखती हैं।"
+            "value": "मानक कीबोर्ड की तुलना में आकार। यह हर ओरिएंटेशन में एक जैसा रहता है; अगर यह नहीं समाता, तो इसे स्क्रीन की चौड़ाई तक छोटा कर दिया जाता है।"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "レイアウトを記憶で練習するにはラベルを非表示にします。数字と制御キーは常に表示されます。"
+            "value": "標準キーボードを基準としたサイズです。どの画面の向きでも同じ大きさを保ち、収まらない場合は画面幅に合わせて縮小されます。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "레이아웃을 외워서 연습하려면 라벨을 숨기세요. 숫자와 컨트롤 키는 항상 표시됩니다."
+            "value": "표준 키보드를 기준으로 한 크기입니다. 화면 방향이 바뀌어도 그대로 유지되며, 들어가지 않으면 화면 너비에 맞춰 줄어듭니다."
           }
         }
       },
-      "comment": "Label visibility footer"
+      "comment": "Caption under the size slider"
     },
-    "Classic": {
+    "Soft": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Klassisch"
+            "value": "Sanft"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Classique"
+            "value": "Doux"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Clásico"
+            "value": "Suave"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Classico"
+            "value": "Morbido"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Классический"
+            "value": "Мягкий"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Klasyczny"
+            "value": "Miękki"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Klassisk"
+            "value": "Mjuk"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Klassinen"
+            "value": "Pehmeä"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Klasično"
+            "value": "Mekano"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "קלאסי"
+            "value": "רך"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cổ điển"
+            "value": "Êm"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Klasiko"
+            "value": "Malambot"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Κλασικό"
+            "value": "Απαλή"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Clássico"
+            "value": "Suave"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Класичний"
+            "value": "М’який"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "كلاسيكي"
+            "value": "خفيف"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "کلاسیک"
+            "value": "ملایم"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "کلاسک"
+            "value": "نرم"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "คลาสสิก"
+            "value": "เบา"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "क्लासिक"
+            "value": "मृदु"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "クラシック"
+            "value": "ソフト"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "클래식"
+            "value": "약하게"
           }
         }
       },
-      "comment": "Keyboard style name"
+      "comment": "Haptic intensity level name"
     },
-    "Liquid Glass": {
+    "Space": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Leertaste"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Espace"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Espacio"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Spazio"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Пробел"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Spacja"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Mellanslag"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Välilyönti"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Razmaknica"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "רווח"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Phím cách"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Space"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Διάστημα"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Espaço"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Пробіл"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "مسافة"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "فاصله"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "اسپیس"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "เว้นวรรค"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "स्पेस"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "スペース"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "스페이스"
           }
         }
       },
-      "comment": "Keyboard style name (Apple design language, not translated)"
+      "comment": "ACCESSIBILITY label for the space bar (VoiceOver)"
+    },
+    "Square · Default": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quadratisch · Standard"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carré · Par défaut"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuadrado · Por defecto"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quadrato · Predefinito"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Квадрат · По умолчанию"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kwadratowe · Domyślne"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kvadratisk · Standard"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neliö · Oletus"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kvadratno · Zadano"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מרובע · ברירת מחדל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuông · Mặc định"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parisukat · Default"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τετράγωνο · Προεπιλογή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quadrado · Predefinição"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Квадратне · За замовчуванням"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مربّع · افتراضي"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مربع · پیش‌فرض"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مربع · طے شدہ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สี่เหลี่ยมจัตุรัส · ค่าเริ่มต้น"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वर्ग · डिफ़ॉल्ट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正方形・デフォルト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정사각형 · 기본값"
+          }
+        }
+      },
+      "comment": "Slider tick label at ratio 1.0; keep the · middle dot"
+    },
+    "Step-by-step": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schrittweise"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas à pas"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paso a paso"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passo passo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пошаговое"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Krok po kroku"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Steg för steg"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Askel kerrallaan"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korak po korak"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "צעד אחר צעד"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Từng bước"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hakbang-hakbang"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Βήμα προς βήμα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passo a passo"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Покроково"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خطوة بخطوة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گام‌به‌گام"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قدم بہ قدم"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทีละขั้น"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "चरण-दर-चरण"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1文字ずつ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "단계별"
+          }
+        }
+      },
+      "comment": "Picker option for cursor movement style (one character per swipe)"
+    },
+    "Strong": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stark"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fort"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuerte"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forte"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сильный"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Silny"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stark"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voimakas"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jako"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "חזק"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mạnh"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Malakas"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Δυνατή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forte"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сильний"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قوي"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قوی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مضبوط"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แรง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "तीव्र"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "強"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "강하게"
+          }
+        }
+      },
+      "comment": "Haptic intensity level name"
+    },
+    "Style": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stil"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Style"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stile"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стиль"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Styl"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stil"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tyyli"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stil"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סגנון"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiểu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilo"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Στιλ"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilo"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стиль"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "النمط"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سبک"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انداز"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สไตล์"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्टाइल"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スタイル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스타일"
+          }
+        }
+      },
+      "comment": "Settings row / title: visual style"
+    },
+    "Swipe per character, return-swipe per word": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wischen pro Zeichen, Hin-und-zurück-Wischen pro Wort"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Balayage par caractère, aller-retour par mot"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desliza por carácter, desliza y vuelve por palabra"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scorri per carattere, scorri e torna per parola"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Свайп — символ, свайп с возвратом — слово"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przesunięcie – znak, przesunięcie z powrotem – słowo"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Svep per tecken, retursvep per ord"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pyyhkäisy siirtää merkin, paluupyyhkäisy sanan"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prijelaz po znaku, povratni prijelaz po riječi"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "החלקה לכל תו, החלקה וחזרה לכל מילה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuốt theo ký tự, vuốt và quay lại theo từ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swipe kada character, return-swipe kada salita"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σάρωση ανά χαρακτήρα, σάρωση επιστροφής ανά λέξη"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deslize por carácter, deslize de retorno por palavra"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Свайп для символу, зворотний свайп для слова"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تمرير لكل حرف، وتمرير عائد لكل كلمة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کشیدن برای هر نویسه، کشیدن‌و‌بازگشت برای هر واژه"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہر حرف کے لیے سوائپ، ہر لفظ کے لیے ریٹرن سوائپ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปัดทีละตัวอักษร ปัดกลับทีละคำ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "प्रति अक्षर स्वाइप, प्रति शब्द रिटर्न-स्वाइप"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スワイプで1文字ずつ、リターンスワイプで1単語ずつ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글자 단위 스와이프, 단어 단위 리턴 스와이프"
+          }
+        }
+      },
+      "comment": "Cursor movement subtitle: discrete style"
+    },
+    "Swipe right on the globe key to switch languages. Tap a language to set it as the default startup language.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wische auf der Globus-Taste nach rechts, um die Sprache zu wechseln. Tippe auf eine Sprache, um sie als Standard-Startsprache festzulegen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Balayez vers la droite sur la touche globe pour changer de langue. Touchez une langue pour la définir comme langue par défaut au démarrage."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desliza hacia la derecha sobre la tecla del globo para cambiar de idioma. Toca un idioma para establecerlo como idioma predeterminado de inicio."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scorri verso destra sul tasto globo per cambiare lingua. Tocca una lingua per impostarla come lingua predefinita all'avvio."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Смахните вправо по клавише глобуса, чтобы переключить язык. Нажмите на язык, чтобы сделать его языком по умолчанию при запуске."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przesuń w prawo po klawiszu globusa, aby przełączyć język. Stuknij język, aby ustawić go jako domyślny język startowy."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Svep åt höger på jordglobstangenten för att byta språk. Tryck på ett språk för att ange det som standardspråk vid start."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaihda kieltä pyyhkäisemällä maapallonäppäintä oikealle. Aseta kieli oletuskieleksi napauttamalla sitä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prijeđi udesno po tipki globusa za promjenu jezika. Dodirni jezik da ga postaviš kao zadani početni jezik."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "החלק ימינה על מקש הגלובוס כדי להחליף שפה. הקש על שפה כדי להגדיר אותה כשפת ברירת המחדל בהפעלה."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuốt sang phải trên phím địa cầu để chuyển ngôn ngữ. Chạm vào một ngôn ngữ để đặt làm ngôn ngữ mặc định khi khởi động."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mag-swipe pakanan sa globe key para magpalit ng wika. I-tap ang isang wika para gawin itong default na panimulang wika."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σαρώστε δεξιά στο πλήκτρο της υδρογείου για εναλλαγή γλωσσών. Πατήστε μια γλώσσα για να την ορίσετε ως προεπιλεγμένη γλώσσα εκκίνησης."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deslize para a direita na tecla do globo para mudar de idioma. Toque num idioma para o definir como idioma de arranque predefinido."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проведіть праворуч по клавіші глобуса, щоб перемкнути мови. Торкніться мови, щоб зробити її мовою запуску за замовчуванням."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مرِّر يمينًا على مفتاح الكرة الأرضية لتبديل اللغات. اضغط على لغة لتعيينها كلغة البدء الافتراضية."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روی کلید کره به راست بکشید تا زبان‌ها را عوض کنید. روی یک زبان ضربه بزنید تا آن را به‌عنوان زبان پیش‌فرض هنگام شروع تنظیم کنید."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زبانیں تبدیل کرنے کے لیے گلوب کی پر دائیں سوائپ کریں۔ کسی زبان کو طے شدہ آغازی زبان مقرر کرنے کے لیے اس پر ٹیپ کریں۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปัดขวาที่ปุ่มลูกโลกเพื่อสลับภาษา แตะภาษาเพื่อตั้งเป็นภาษาเริ่มต้นเมื่อเปิดใช้งาน"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "भाषाएँ बदलने के लिए ग्लोब की पर दाईं ओर स्वाइप करें। किसी भाषा को डिफ़ॉल्ट स्टार्टअप भाषा बनाने के लिए उस पर टैप करें।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地球儀キーを右にスワイプすると言語を切り替えられます。言語をタップすると、起動時のデフォルト言語に設定されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지구본 키를 오른쪽으로 스와이프하여 언어를 전환하세요. 언어를 탭하면 기본 시작 언어로 설정됩니다."
+          }
+        }
+      },
+      "comment": "Footer on the language selection screen"
+    },
+    "Switch keyboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastatur wechseln"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changer de clavier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar de teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переключить клавиатуру"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przełącz klawiaturę"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Byt tangentbord"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaihda näppäimistöä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Promijeni tipkovnicu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "החלף מקלדת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyển bàn phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Magpalit ng keyboard"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Εναλλαγή πληκτρολογίου"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mudar de teclado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемкнути клавіатуру"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تبديل لوحة المفاتيح"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعویض صفحه‌کلید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی بورڈ تبدیل کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สลับคีย์บอร์ด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड बदलें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードを切り替える"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 전환"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the globe key (VoiceOver)"
+    },
+    "Switch to the Test tab and experiment with gestures.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wechsle zum Tab „Test“ und probiere die Gesten aus."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passez à l'onglet Test et expérimentez les gestes."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ve a la pestaña Prueba y experimenta con los gestos."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passa alla scheda Prova e sperimenta con i gesti."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейдите на вкладку «Проба» и поэкспериментируйте с жестами."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przejdź do karty Test i poeksperymentuj z gestami."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Byt till fliken Testa och experimentera med gester."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siirry Testaa-välilehdelle ja kokeile eleitä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prijeđi na karticu Isprobaj i isprobaj geste."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "עבור ללשונית בדיקה והתנסה במחוות."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyển sang thẻ Thử và thử nghiệm các cử chỉ."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lumipat sa Test tab at mag-eksperimento sa mga gesture."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Μεταβείτε στην καρτέλα Δοκιμή και πειραματιστείτε με τις χειρονομίες."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mude para o separador Testar e experimente os gestos."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейдіть на вкладку «Тест» та поекспериментуйте з жестами."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انتقل إلى علامة تبويب الاختبار وجرّب الإيماءات."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "به زبانهٔ آزمایش بروید و حرکت‌ها را امتحان کنید."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹیسٹ ٹیب پر جائیں اور اشاروں کے ساتھ تجربہ کریں۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สลับไปที่แท็บทดสอบและลองใช้เจสเจอร์ต่างๆ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "टेस्ट टैब पर जाएँ और जेस्चर के साथ प्रयोग करें।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「テスト」タブに切り替えて、ジェスチャを試してみましょう。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테스트 탭으로 이동하여 제스처를 사용해 보세요."
+          }
+        }
+      },
+      "comment": "Onboarding step 3 description; 'Test tab' refers to the in-app tab labeled 'Test'"
+    },
+    "Switching Keyboards": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastatur wechseln"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changer de clavier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar de teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переключение клавиатуры"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przełącz klawiaturę"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Byt tangentbord"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaihda näppäimistöä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Promjena tipkovnice"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "החלף מקלדת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyển bàn phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Magpalit ng Keyboard"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Εναλλαγή πληκτρολογίου"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mudar de teclado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемкнути клавіатуру"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تبديل لوحة المفاتيح"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعویض صفحه‌کلید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی بورڈ تبدیل کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สลับคีย์บอร์ด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड बदलें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードを切り替える"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 전환"
+          }
+        }
+      },
+      "comment": "Header above instructions on how to switch keyboards"
+    },
+    "Tap Feedback": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipp-Feedback"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour au toucher"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Respuesta al tocar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback al tocco"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отклик при нажатии"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reakcja na stuknięcie"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Återkoppling vid tryck"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Napautuspalaute"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povratne informacije dodira"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משוב בהקשה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phản hồi khi chạm"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap Feedback"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ανάδραση πατήματος"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retorno ao tocar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відгук на дотик"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استجابة اللمس"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازخورد ضربه"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹیپ فیڈ بیک"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตอบสนองเมื่อแตะ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "टैप फ़ीडबैक"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タップ時のフィードバック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭 피드백"
+          }
+        }
+      },
+      "comment": "Slider control title: haptic strength when tapping keys"
+    },
+    "Tap here to open keyboard...": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hier tippen, um die Tastatur zu öffnen …"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touchez ici pour ouvrir le clavier…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca aquí para abrir el teclado..."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tocca qui per aprire la tastiera..."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нажмите здесь, чтобы открыть клавиатуру…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stuknij tutaj, aby otworzyć klawiaturę..."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tryck här för att öppna tangentbordet …"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaa näppäimistö napauttamalla tähän..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodirni ovdje za otvaranje tipkovnice..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הקש כאן כדי לפתוח את המקלדת..."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chạm vào đây để mở bàn phím..."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-tap dito para buksan ang keyboard..."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πατήστε εδώ για άνοιγμα πληκτρολογίου..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque aqui para abrir o teclado..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Торкніться тут, щоб відкрити клавіатуру…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط هنا لفتح لوحة المفاتيح..."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برای باز کردن صفحه‌کلید اینجا ضربه بزنید..."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی بورڈ کھولنے کے لیے یہاں ٹیپ کریں..."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แตะที่นี่เพื่อเปิดคีย์บอร์ด..."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड खोलने के लिए यहाँ टैप करें..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ここをタップしてキーボードを開く…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "여기를 탭하여 키보드 열기..."
+          }
+        }
+      },
+      "comment": "Placeholder text in the test field"
+    },
+    "Tap the globe icon on your keyboard to switch between installed keyboards": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tippe auf das Globussymbol deiner Tastatur, um zwischen installierten Tastaturen zu wechseln"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touchez l'icône du globe sur votre clavier pour passer d'un clavier installé à un autre"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca el icono del globo en tu teclado para cambiar entre los teclados instalados"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tocca l'icona del globo sulla tastiera per passare da una tastiera installata all'altra"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нажмите значок глобуса на клавиатуре, чтобы переключаться между установленными клавиатурами"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stuknij ikonę globusa na klawiaturze, aby przełączać zainstalowane klawiatury"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tryck på jordglobsikonen på tangentbordet för att växla mellan installerade tangentbord"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaihda asennettujen näppäimistöjen välillä napauttamalla maapallokuvaketta näppäimistössä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodirni ikonu globusa na tipkovnici za prebacivanje između instaliranih tipkovnica"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הקש על סמל הגלובוס במקלדת כדי לעבור בין המקלדות המותקנות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chạm biểu tượng địa cầu trên bàn phím để chuyển giữa các bàn phím đã cài"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-tap ang globe icon sa iyong keyboard para magpalit sa pagitan ng mga naka-install na keyboard"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πατήστε το εικονίδιο της υδρογείου στο πληκτρολόγιό σας για εναλλαγή μεταξύ των εγκατεστημένων πληκτρολογίων"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque no ícone do globo no teclado para alternar entre os teclados instalados"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Торкніться значка глобуса на клавіатурі, щоб перемикатися між встановленими клавіатурами"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط على أيقونة الكرة الأرضية في لوحة المفاتيح للتبديل بين لوحات المفاتيح المثبَّتة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روی نماد کره در صفحه‌کلید ضربه بزنید تا بین صفحه‌کلیدهای نصب‌شده جابه‌جا شوید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انسٹال شدہ کی بورڈز کے درمیان تبدیل کرنے کے لیے اپنے کی بورڈ پر گلوب آئیکن پر ٹیپ کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แตะไอคอนลูกโลกบนคีย์บอร์ดเพื่อสลับระหว่างคีย์บอร์ดที่ติดตั้งไว้"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इंस्टॉल किए गए कीबोर्ड के बीच स्विच करने के लिए अपने कीबोर्ड पर ग्लोब आइकन पर टैप करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードの地球儀アイコンをタップすると、インストール済みのキーボードを切り替えられます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드의 지구본 아이콘을 탭하면 설치된 키보드 간에 전환할 수 있습니다"
+          }
+        }
+      },
+      "comment": "Instruction text"
+    },
+    "Tap: %@ • Drag: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tippen: %@ • Ziehen: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toucher : %@ • Glisser : %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tocar: %@ • Arrastrar: %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tocco: %@ • Trascinamento: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нажатие: %@ • Перетягивание: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stuknięcie: %@ • Przeciąganie: %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tryck: %@ • Dragning: %@"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Napautus: %@ • Veto: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodir: %@ • Povlačenje: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הקשה: %@ • גרירה: %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chạm: %@ • Kéo: %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap: %@ • Drag: %@"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πάτημα: %@ • Σύρσιμο: %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque: %@ • Arrastar: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дотик: %@ • Перетягування: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اللمس: %@ • السحب: %@"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ضربه: %@ • کشیدن: %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹیپ: %@ • ڈریگ: %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แตะ: %@ • ลาก: %@"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "टैप: %@ • ड्रैग: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タップ：%@ • ドラッグ：%@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭: %@ • 드래그: %@"
+          }
+        }
+      },
+      "comment": "Haptic feedback subtitle, e.g. 'Tap: 50% • Drag: Off'"
+    },
+    "Test": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prueba"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prova"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проба"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testa"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testaa"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isprobaj"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "בדיקה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thử"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Δοκιμή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тест"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختبار"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آزمایش"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹیسٹ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทดสอบ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "टेस्ट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テスト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테스트"
+          }
+        }
+      },
+      "comment": "Tab label for the try-it-out / test screen"
+    },
+    "Test Field": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testfeld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Champ de test"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Campo de prueba"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Campo di prova"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поле для пробы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pole testowe"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testfält"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testikenttä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polje za isprobavanje"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שדה בדיקה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ô thử"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test Field"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πεδίο δοκιμής"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Campo de teste"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тестове поле"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حقل الاختبار"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فیلد آزمایش"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹیسٹ فیلڈ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ช่องทดสอบ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "टेस्ट फ़ील्ड"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テスト入力欄"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테스트 입력란"
+          }
+        }
+      },
+      "comment": "Label above a text field for trying the keyboard"
+    },
+    "The Keyboard for Fat Fingers": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Tastatur für Wurstfinger"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le clavier pour les gros doigts"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El teclado para dedos torpes"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La tastiera per dita grosse"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавиатура для толстых пальцев"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klawiatura dla grubych palców"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangentbordet för tjocka fingrar"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäimistö paksuille sormille"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipkovnica za debele prste"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "המקלדת לאצבעות עבות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bàn phím cho ngón tay to"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ang Keyboard para sa Malalaking Daliri"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Το πληκτρολόγιο για χοντρά δάχτυλα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O teclado para dedos gordos"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавіатура для товстих пальців"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لوحة المفاتيح لأصحاب الأصابع الكبيرة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صفحه‌کلید برای انگشتان درشت"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "موٹی انگلیوں کے لیے کی بورڈ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คีย์บอร์ดสำหรับนิ้วอวบ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मोटी उंगलियों के लिए कीबोर्ड"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "太い指のためのキーボード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "손가락이 두꺼운 분을 위한 키보드"
+          }
+        }
+      },
+      "comment": "Playful app tagline/slogan"
     },
     "Traditional opaque keys": {
       "extractionState": "manual",
@@ -15871,2347 +16640,1661 @@
       },
       "comment": "Keyboard style description: Liquid Glass"
     },
-    "Disable %@": {
+    "Try the keyboard": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ deaktivieren"
+            "value": "Tastatur ausprobieren"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Désactiver %@"
+            "value": "Essayer le clavier"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desactivar %@"
+            "value": "Prueba el teclado"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Disattiva %@"
+            "value": "Prova la tastiera"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Отключить %@"
+            "value": "Попробуйте клавиатуру"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wyłącz %@"
+            "value": "Wypróbuj klawiaturę"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Avaktivera %@"
+            "value": "Prova tangentbordet"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Poista %@ käytöstä"
+            "value": "Kokeile näppäimistöä"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Onemogući %@"
+            "value": "Isprobaj tipkovnicu"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "השבתת %@"
+            "value": "נסה את המקלדת"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tắt %@"
+            "value": "Thử bàn phím"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "I-disable ang %@"
+            "value": "Subukan ang keyboard"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Απενεργοποίηση %@"
+            "value": "Δοκιμάστε το πληκτρολόγιο"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar %@"
+            "value": "Experimentar o teclado"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Вимкнути %@"
+            "value": "Спробувати клавіатуру"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "تعطيل %@"
+            "value": "جرّب لوحة المفاتيح"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "غیرفعال کردن %@"
+            "value": "امتحان صفحه‌کلید"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ غیر فعال کریں"
+            "value": "کی بورڈ آزمائیں"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ปิดใช้ %@"
+            "value": "ลองใช้คีย์บอร์ด"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ बंद करें"
+            "value": "कीबोर्ड आज़माएँ"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@を無効にする"
+            "value": "キーボードを試す"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ 사용 안 함"
+            "value": "키보드 사용해 보기"
           }
         }
       },
-      "comment": "Accessibility label: disable a language; %@ is the language name"
+      "comment": "Onboarding step 3 title"
     },
-    "Enable %@": {
+    "Type Numbers by Holding": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كتابة الأرقام بالضغط المطوّل"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ aktivieren"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activer %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activar %@"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attiva %@"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Включить %@"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Włącz %@"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktivera %@"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ota %@ käyttöön"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Omogući %@"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הפעלת %@"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bật %@"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-enable ang %@"
+            "value": "Ziffern durch Halten"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ενεργοποίηση %@"
+            "value": "Αριθμοί με παρατεταμένο πάτημα"
           }
         },
-        "pt": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar %@"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Увімкнути %@"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تفعيل %@"
+            "value": "Números manteniendo pulsado"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "فعال کردن %@"
+            "value": "تایپ اعداد با نگه‌داشتن"
           }
         },
-        "ur": {
+        "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ فعال کریں"
+            "value": "Numerot pitkällä painalluksella"
           }
         },
-        "th": {
+        "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "เปิดใช้ %@"
+            "value": "Mga numero sa pagpindot nang matagal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiffres par appui long"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ספרות בלחיצה ארוכה"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ चालू करें"
+            "value": "दबाकर रखने से अंक"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brojke dugim pritiskom"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Numeri tenendo premuto"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@を有効にする"
+            "value": "長押しで数字を入力"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ 사용"
+            "value": "길게 눌러 숫자 입력"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cyfry przez przytrzymanie"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Números mantendo premido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ввод цифр удержанием"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siffror med långt tryck"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พิมพ์ตัวเลขด้วยการกดค้าง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введення цифр утриманням"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دبا کر رکھنے سے ہندسے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhập số bằng cách giữ phím"
           }
         }
       },
-      "comment": "Accessibility label: enable a language; %@ is the language name"
+      "comment": "Toggle title: type digits by long-pressing letter keys"
     },
-    "Enabled": {
+    "Type on the keyboard below": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aktiviert"
+            "value": "Tippe auf der Tastatur unten"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Activé"
+            "value": "Tapez sur le clavier ci-dessous"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Activado"
+            "value": "Escribe con el teclado de abajo"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Attivato"
+            "value": "Scrivi sulla tastiera qui sotto"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Включено"
+            "value": "Печатайте на клавиатуре ниже"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Włączone"
+            "value": "Pisz na klawiaturze poniżej"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aktiverad"
+            "value": "Skriv på tangentbordet nedan"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Käytössä"
+            "value": "Kirjoita alla olevalla näppäimistöllä"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Omogućeno"
+            "value": "Tipkaj na tipkovnici ispod"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "מופעל"
+            "value": "הקלד במקלדת שלמטה"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Đã bật"
+            "value": "Gõ trên bàn phím bên dưới"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Naka-enable"
+            "value": "Mag-type sa keyboard sa ibaba"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ενεργοποιημένο"
+            "value": "Πληκτρολογήστε στο παρακάτω πληκτρολόγιο"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativado"
+            "value": "Escreva no teclado abaixo"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Увімкнено"
+            "value": "Друкуйте на клавіатурі нижче"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "مُفعَّل"
+            "value": "اكتب على لوحة المفاتيح أدناه"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "فعال"
+            "value": "روی صفحه‌کلید زیر تایپ کنید"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "فعال"
+            "value": "نیچے کی بورڈ پر ٹائپ کریں"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "เปิดใช้แล้ว"
+            "value": "พิมพ์บนคีย์บอร์ดด้านล่าง"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "चालू"
+            "value": "नीचे दिए कीबोर्ड पर टाइप करें"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "有効"
+            "value": "下のキーボードで入力してください"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사용"
+            "value": "아래 키보드로 입력해 보세요"
           }
         }
       },
-      "comment": "Accessibility value: language is enabled"
+      "comment": "Placeholder text in the preview when empty"
     },
-    "Disabled": {
+    "Type two spaces to insert a period": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اكتب مسافتين لإدراج نقطة"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Deaktiviert"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Désactivé"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desactivado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disattivato"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Отключено"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wyłączone"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avaktiverad"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ei käytössä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Onemogućeno"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מושבת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Đã tắt"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Naka-disable"
+            "value": "Zwei Leerzeichen fügen einen Punkt ein"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Απενεργοποιημένο"
+            "value": "Δύο κενά εισάγουν μια τελεία"
           }
         },
-        "pt": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вимкнено"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مُعطَّل"
+            "value": "Escribe dos espacios para insertar un punto"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "غیرفعال"
+            "value": "برای درج نقطه دو بار فاصله بزنید"
           }
         },
-        "ur": {
+        "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "غیر فعال"
+            "value": "Kaksi välilyöntiä lisää pisteen"
           }
         },
-        "th": {
+        "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "ปิดใช้แล้ว"
+            "value": "Mag-type ng dalawang espasyo para maglagay ng tuldok"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deux espaces insèrent un point"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שני רווחים מוסיפים נקודה"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "बंद"
+            "value": "पूर्ण विराम लगाने के लिए दो बार स्पेस दबाएँ"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dva razmaka umeću točku"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Due spazi inseriscono un punto"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "無効"
+            "value": "スペースを2回押すとピリオドを入力"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사용 안 함"
+            "value": "스페이스를 두 번 누르면 마침표 입력"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dwie spacje wstawiają kropkę"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dois espaços inserem um ponto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Два пробела вставляют точку"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Två mellanslag infogar en punkt"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เว้นวรรคสองครั้งเพื่อใส่จุด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Два пробіли вставляють крапку"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وقفہ ڈالنے کے لیے دو بار اسپیس دبائیں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhấn phím cách hai lần để chèn dấu chấm"
           }
         }
       },
-      "comment": "Accessibility value: language is disabled"
+      "comment": "Toggle subtitle: explains double-space to period"
     },
-    "Languages": {
+    "Utility Keys on Left": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sprachen"
+            "value": "Funktionstasten links"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Langues"
+            "value": "Touches utilitaires à gauche"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Idiomas"
+            "value": "Teclas de función a la izquierda"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Lingue"
+            "value": "Tasti funzione a sinistra"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Языки"
+            "value": "Служебные клавиши слева"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Języki"
+            "value": "Klawisze funkcyjne po lewej"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Språk"
+            "value": "Funktionstangenter till vänster"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kielet"
+            "value": "Apunäppäimet vasemmalla"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Jezici"
+            "value": "Pomoćne tipke lijevo"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "שפות"
+            "value": "מקשי שירות מימין"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ngôn ngữ"
+            "value": "Phím tiện ích bên trái"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mga Wika"
+            "value": "Mga Utility Key sa Kaliwa"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Γλώσσες"
+            "value": "Πλήκτρα βοηθητικών λειτουργιών στα αριστερά"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Idiomas"
+            "value": "Teclas utilitárias à esquerda"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Мови"
+            "value": "Службові клавіші ліворуч"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "اللغات"
+            "value": "مفاتيح الأدوات على اليسار"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "زبان‌ها"
+            "value": "کلیدهای کاربردی در سمت چپ"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "زبانیں"
+            "value": "یوٹیلیٹی کیز بائیں طرف"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ภาษา"
+            "value": "ปุ่มยูทิลิตีอยู่ด้านซ้าย"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "भाषाएँ"
+            "value": "यूटिलिटी कीज़ बाईं ओर"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "言語"
+            "value": "ユーティリティキーを左に配置"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "언어"
+            "value": "기능 키를 왼쪽에 배치"
           }
         }
       },
-      "comment": "Settings row title / language selection screen title"
+      "comment": "Toggle title: place utility column on the left side"
     },
-    "Label Visibility": {
+    "Value": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sichtbarkeit der Beschriftungen"
+            "value": "Wert"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visibilité des étiquettes"
+            "value": "Valeur"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visibilidad de etiquetas"
+            "value": "Valor"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visibilità delle etichette"
+            "value": "Valore"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Видимость подписей"
+            "value": "Значение"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Widoczność etykiet"
+            "value": "Wartość"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Etiketternas synlighet"
+            "value": "Värde"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Merkintöjen näkyvyys"
+            "value": "Arvo"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vidljivost oznaka"
+            "value": "Vrijednost"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "נראות תוויות"
+            "value": "ערך"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hiển thị nhãn"
+            "value": "Giá trị"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visibility ng Label"
+            "value": "Halaga"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ορατότητα ετικετών"
+            "value": "Τιμή"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visibilidade das etiquetas"
+            "value": "Valor"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Видимість підписів"
+            "value": "Значення"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "ظهور التسميات"
+            "value": "القيمة"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "نمایان‌بودن برچسب‌ها"
+            "value": "مقدار"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "لیبل کی نمائش"
+            "value": "قدر"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "การแสดงป้ายกำกับ"
+            "value": "ค่า"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "लेबल दृश्यता"
+            "value": "मान"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ラベルの表示"
+            "value": "値"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "레이블 표시"
+            "value": "값"
           }
         }
       },
-      "comment": "Settings row title"
+      "comment": "Label/placeholder for a numeric input field"
     },
-    "Default": {
+    "Version": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Standard"
+            "value": "Version"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Par défaut"
+            "value": "Version"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predeterminado"
+            "value": "Versión"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinita"
+            "value": "Versione"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "По умолчанию"
+            "value": "Версия"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Domyślny"
+            "value": "Wersja"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Standard"
+            "value": "Version"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Oletus"
+            "value": "Versio"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Zadano"
+            "value": "Verzija"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "ברירת מחדל"
+            "value": "גרסה"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mặc định"
+            "value": "Phiên bản"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Default"
+            "value": "Bersyon"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Προεπιλογή"
+            "value": "Έκδοση"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição"
+            "value": "Versão"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "За замовчуванням"
+            "value": "Версія"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "افتراضي"
+            "value": "الإصدار"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "پیش‌فرض"
+            "value": "نسخه"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "طے شدہ"
+            "value": "ورژن"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ค่าเริ่มต้น"
+            "value": "เวอร์ชัน"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "डिफ़ॉल्ट"
+            "value": "वर्शन"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "デフォルト"
+            "value": "バージョン"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "기본값"
+            "value": "버전"
           }
         }
       },
-      "comment": "Badge on the default startup language"
+      "comment": "About row label (app version)"
     },
-    "Cannot Disable": {
+    "Visual Style": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Deaktivieren nicht möglich"
+            "value": "Visueller Stil"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Désactivation impossible"
+            "value": "Style visuel"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se puede desactivar"
+            "value": "Estilo visual"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Impossibile disattivare"
+            "value": "Stile visivo"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Нельзя отключить"
+            "value": "Визуальный стиль"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nie można wyłączyć"
+            "value": "Styl wizualny"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kan inte avaktiveras"
+            "value": "Visuell stil"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ei voi poistaa käytöstä"
+            "value": "Visuaalinen tyyli"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nije moguće onemogućiti"
+            "value": "Vizualni stil"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "לא ניתן להשבית"
+            "value": "סגנון חזותי"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Không thể tắt"
+            "value": "Kiểu hiển thị"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hindi Maaaring I-disable"
+            "value": "Visual na Estilo"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Αδυναμία απενεργοποίησης"
+            "value": "Οπτικό στιλ"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Não é possível desativar"
+            "value": "Estilo visual"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Неможливо вимкнути"
+            "value": "Візуальний стиль"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "لا يمكن التعطيل"
+            "value": "النمط المرئي"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "نمی‌توان غیرفعال کرد"
+            "value": "سبک ظاهری"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "غیر فعال نہیں کیا جا سکتا"
+            "value": "بصری انداز"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ปิดใช้ไม่ได้"
+            "value": "สไตล์การแสดงผล"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "बंद नहीं कर सकते"
+            "value": "विज़ुअल स्टाइल"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "無効にできません"
+            "value": "表示スタイル"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사용 중지할 수 없음"
+            "value": "비주얼 스타일"
           }
         }
       },
-      "comment": "Alert title when disabling the last language"
+      "comment": "Header for keyboard visual style options"
     },
-    "OK": {
+    "Wide": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Breit"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Large"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Ancho"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Largo"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "ОК"
+            "value": "Широкие"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Szerokie"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Bred"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Leveä"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "U redu"
+            "value": "Široko"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "אישור"
+            "value": "רחב"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Rộng"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Malapad"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Πλατύ"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Largo"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Широке"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "موافق"
+            "value": "عريض"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "تأیید"
+            "value": "پهن"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "ٹھیک ہے"
+            "value": "چوڑا"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ตกลง"
+            "value": "กว้าง"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "ठीक है"
+            "value": "चौड़ा"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "ワイド"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "확인"
+            "value": "넓게"
           }
         }
       },
-      "comment": "Alert confirmation button"
+      "comment": "Slider tick label (wider keys)"
     },
-    "At least one language must be enabled.": {
+    "extra symbols": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mindestens eine Sprache muss aktiviert sein."
+            "value": "Zusatzsymbole"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Au moins une langue doit être activée."
+            "value": "symboles supplémentaires"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Al menos un idioma debe estar activado."
+            "value": "símbolos adicionales"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Almeno una lingua deve essere attiva."
+            "value": "simboli extra"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Хотя бы один язык должен быть включён."
+            "value": "дополнительные символы"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Co najmniej jeden język musi być włączony."
+            "value": "symbole dodatkowe"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Minst ett språk måste vara aktiverat."
+            "value": "extra symboler"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vähintään yhden kielen on oltava käytössä."
+            "value": "lisäsymbolit"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Najmanje jedan jezik mora biti omogućen."
+            "value": "dodatni simboli"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "לפחות שפה אחת חייבת להיות מופעלת."
+            "value": "סמלים נוספים"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Phải bật ít nhất một ngôn ngữ."
+            "value": "ký hiệu bổ sung"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kailangang naka-enable ang kahit isang wika."
+            "value": "mga dagdag na simbolo"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Πρέπει να είναι ενεργοποιημένη τουλάχιστον μία γλώσσα."
+            "value": "επιπλέον σύμβολα"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "É necessário ativar pelo menos um idioma."
+            "value": "símbolos extra"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Має бути увімкнена принаймні одна мова."
+            "value": "додаткові символи"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "يجب تفعيل لغة واحدة على الأقل."
+            "value": "الرموز الإضافية"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "دست‌کم یک زبان باید فعال باشد."
+            "value": "نمادهای اضافی"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "کم از کم ایک زبان فعال ہونی چاہیے۔"
+            "value": "اضافی علامتیں"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ต้องเปิดใช้อย่างน้อยหนึ่งภาษา"
+            "value": "สัญลักษณ์เพิ่มเติม"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "कम से कम एक भाषा चालू होनी चाहिए।"
+            "value": "अतिरिक्त सिंबल"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "少なくとも1つの言語を有効にする必要があります。"
+            "value": "追加記号"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "언어를 하나 이상 사용해야 합니다."
+            "value": "추가 기호"
           }
         }
       },
-      "comment": "Alert message when disabling the last language"
+      "comment": "Label visibility list item"
     },
-    "Swipe right on the globe key to switch languages. Tap a language to set it as the default startup language.": {
+    "letters": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wische auf der Globus-Taste nach rechts, um die Sprache zu wechseln. Tippe auf eine Sprache, um sie als Standard-Startsprache festzulegen."
+            "value": "Buchstaben"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Balayez vers la droite sur la touche globe pour changer de langue. Touchez une langue pour la définir comme langue par défaut au démarrage."
+            "value": "lettres"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desliza hacia la derecha sobre la tecla del globo para cambiar de idioma. Toca un idioma para establecerlo como idioma predeterminado de inicio."
+            "value": "letras"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scorri verso destra sul tasto globo per cambiare lingua. Tocca una lingua per impostarla come lingua predefinita all'avvio."
+            "value": "lettere"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Смахните вправо по клавише глобуса, чтобы переключить язык. Нажмите на язык, чтобы сделать его языком по умолчанию при запуске."
+            "value": "буквы"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Przesuń w prawo po klawiszu globusa, aby przełączyć język. Stuknij język, aby ustawić go jako domyślny język startowy."
+            "value": "litery"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Svep åt höger på jordglobstangenten för att byta språk. Tryck på ett språk för att ange det som standardspråk vid start."
+            "value": "bokstäver"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vaihda kieltä pyyhkäisemällä maapallonäppäintä oikealle. Aseta kieli oletuskieleksi napauttamalla sitä."
+            "value": "kirjaimet"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prijeđi udesno po tipki globusa za promjenu jezika. Dodirni jezik da ga postaviš kao zadani početni jezik."
+            "value": "slova"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "החלק ימינה על מקש הגלובוס כדי להחליף שפה. הקש על שפה כדי להגדיר אותה כשפת ברירת המחדל בהפעלה."
+            "value": "אותיות"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vuốt sang phải trên phím địa cầu để chuyển ngôn ngữ. Chạm vào một ngôn ngữ để đặt làm ngôn ngữ mặc định khi khởi động."
+            "value": "chữ cái"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mag-swipe pakanan sa globe key para magpalit ng wika. I-tap ang isang wika para gawin itong default na panimulang wika."
+            "value": "mga letra"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Σαρώστε δεξιά στο πλήκτρο της υδρογείου για εναλλαγή γλωσσών. Πατήστε μια γλώσσα για να την ορίσετε ως προεπιλεγμένη γλώσσα εκκίνησης."
+            "value": "γράμματα"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Deslize para a direita na tecla do globo para mudar de idioma. Toque num idioma para o definir como idioma de arranque predefinido."
+            "value": "letras"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Проведіть праворуч по клавіші глобуса, щоб перемкнути мови. Торкніться мови, щоб зробити її мовою запуску за замовчуванням."
+            "value": "літери"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "مرِّر يمينًا على مفتاح الكرة الأرضية لتبديل اللغات. اضغط على لغة لتعيينها كلغة البدء الافتراضية."
+            "value": "الحروف"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "روی کلید کره به راست بکشید تا زبان‌ها را عوض کنید. روی یک زبان ضربه بزنید تا آن را به‌عنوان زبان پیش‌فرض هنگام شروع تنظیم کنید."
+            "value": "حروف"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "زبانیں تبدیل کرنے کے لیے گلوب کی پر دائیں سوائپ کریں۔ کسی زبان کو طے شدہ آغازی زبان مقرر کرنے کے لیے اس پر ٹیپ کریں۔"
+            "value": "حروف"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ปัดขวาที่ปุ่มลูกโลกเพื่อสลับภาษา แตะภาษาเพื่อตั้งเป็นภาษาเริ่มต้นเมื่อเปิดใช้งาน"
+            "value": "ตัวอักษร"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "भाषाएँ बदलने के लिए ग्लोब की पर दाईं ओर स्वाइप करें। किसी भाषा को डिफ़ॉल्ट स्टार्टअप भाषा बनाने के लिए उस पर टैप करें।"
+            "value": "अक्षर"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "地球儀キーを右にスワイプすると言語を切り替えられます。言語をタップすると、起動時のデフォルト言語に設定されます。"
+            "value": "文字"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "지구본 키를 오른쪽으로 스와이프하여 언어를 전환하세요. 언어를 탭하면 기본 시작 언어로 설정됩니다."
+            "value": "문자"
           }
         }
       },
-      "comment": "Footer on the language selection screen"
+      "comment": "Label visibility list item"
     },
-    "Gesture Trail": {
+    "standard symbols": {
       "extractionState": "manual",
       "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "أثر الإيماءة"
-          }
-        },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wischspur"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ίχνος κίνησης"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estela del gesto"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "رد اشاره"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eleen jälki"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bakas ng galaw"
+            "value": "Standardsymbole"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tracé du geste"
+            "value": "symboles standard"
           }
         },
-        "he": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "שובל התנועה"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "इशारे का निशान"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trag geste"
+            "value": "símbolos estándar"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scia del gesto"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ジェスチャの軌跡"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제스처 궤적"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ślad gestu"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rasto do gesto"
+            "value": "simboli standard"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "След жеста"
+            "value": "стандартные символы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "symbole standardowe"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestspår"
+            "value": "standardsymboler"
           }
         },
-        "th": {
+        "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "เส้นทางการปัด"
+            "value": "vakiosymbolit"
           }
         },
-        "uk": {
+        "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Слід жесту"
+            "value": "standardni simboli"
           }
         },
-        "ur": {
+        "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "اشارے کا نشان"
+            "value": "סמלים רגילים"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vệt vuốt"
+            "value": "ký hiệu chuẩn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mga karaniwang simbolo"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "τυπικά σύμβολα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "símbolos padrão"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "стандартні символи"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الرموز القياسية"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمادهای استاندارد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معیاری علامتیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สัญลักษณ์มาตรฐาน"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मानक सिंबल"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標準記号"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 기호"
           }
         }
       },
-      "comment": "Toggle title: draws a fading trail under the finger while it swipes"
-    },
-    "Draw the path your finger takes": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يرسم المسار الذي يسلكه إصبعك"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zeichnet den Weg deines Fingers nach"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Σχεδιάζει τη διαδρομή που ακολουθεί το δάχτυλο"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dibuja el recorrido de tu dedo"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مسیری را که انگشت شما طی می‌کند رسم می‌کند"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piirtää sormesi kulkeman reitin"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iguguhit ang dinaanan ng iyong daliri"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trace le chemin parcouru par votre doigt"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מצייר את המסלול שהאצבע עוברת"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आपकी उंगली के रास्ते को दिखाता है"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Crta putanju kojom prolazi prst"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disegna il percorso del tuo dito"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "指がなぞった軌跡を描きます"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "손가락이 지나간 경로를 그립니다"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rysuje ścieżkę, którą pokonuje palec"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desenha o caminho percorrido pelo dedo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Рисует путь, по которому движется палец"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ritar vägen som fingret tar"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "วาดเส้นทางที่นิ้วของคุณลากผ่าน"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Малює шлях, яким рухається палець"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "آپ کی انگلی جس راستے سے گزرے، اسے کھینچتا ہے"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vẽ đường đi của ngón tay bạn"
-          }
-        }
-      },
-      "comment": "Toggle subtitle explaining the gesture trail"
-    },
-    "Cut All by Circling": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قص الكل بحركة دائرية"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alles ausschneiden per Kreis"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αποκοπή όλων με κυκλική κίνηση"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar todo con un círculo"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برش همه با حرکت دایره‌ای"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leikkaa kaikki ympyröimällä"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gupitin lahat sa pamamagitan ng pag-ikot"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tout couper en traçant un cercle"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גזירת הכול בתנועה מעגלית"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "गोला बनाकर सब कुछ काटें"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Izreži sve kružnim pokretom"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taglia tutto con un cerchio"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "円を描いてすべて切り取り"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "원을 그려 전체 잘라내기"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wytnij wszystko kółkiem"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar tudo com um círculo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вырезать всё круговым жестом"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klipp ut allt med en cirkel"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตัดทั้งหมดด้วยการวนนิ้ว"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вирізати все круговим жестом"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "دائرہ بنا کر سب کاٹیں"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cắt tất cả bằng vòng tròn"
-          }
-        }
-      }
-    },
-    "Cutting to the clipboard requires Full Access": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يتطلب القص إلى الحافظة الوصول الكامل"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ausschneiden in die Zwischenablage erfordert Vollzugriff"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Η αποκοπή στο πρόχειρο απαιτεί πλήρη πρόσβαση"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar al portapapeles requiere acceso completo"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برش به کلیپ‌بورد به دسترسی کامل نیاز دارد"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leikkaaminen leikepöydälle vaatii täyden käyttöoikeuden"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kailangan ng Full Access para gupitin papunta sa clipboard"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couper vers le presse-papiers nécessite l'accès complet"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גזירה ללוח דורשת גישה מלאה"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "क्लिपबोर्ड में काटने के लिए पूर्ण एक्सेस ज़रूरी है"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Izrezivanje u međuspremnik zahtijeva puni pristup"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Il taglio negli appunti richiede l'accesso completo"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クリップボードへの切り取りにはフルアクセスが必要です"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "클립보드로 잘라내려면 전체 접근이 필요합니다"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wycinanie do schowka wymaga pełnego dostępu"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar para a área de transferência requer acesso total"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вырезание в буфер обмена требует полного доступа"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Att klippa ut till urklipp kräver fullständig åtkomst"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตัดไปยังคลิปบอร์ดต้องใช้การเข้าถึงเต็มรูปแบบ"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вирізання в буфер обміну потребує повного доступу"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کلپ بورڈ میں کاٹنے کے لیے مکمل رسائی درکار ہے"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cắt vào bảng nhớ tạm yêu cầu Truy cập đầy đủ"
-          }
-        }
-      }
-    },
-    "Circle the 123 key to cut the text around the cursor. Swipe down on the same key to paste it back. Both gestures stay on the key after it switches the keyboard to numbers.": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ارسم دائرة على مفتاح 123 لقص النص حول المؤشر. اسحب لأسفل على المفتاح نفسه للصقه مرة أخرى. تبقى الإيماءتان على المفتاح بعد أن يبدّل لوحة المفاتيح إلى الأرقام."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kreise die 123-Taste ein, um den Text um den Cursor auszuschneiden. Streiche auf derselben Taste nach unten, um ihn wieder einzufügen. Beide Gesten bleiben auf der Taste, auch nachdem sie die Tastatur auf Zahlen umgestellt hat."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Κάντε κυκλική κίνηση στο πλήκτρο 123 για αποκοπή του κειμένου γύρω από τον δρομέα. Σύρετε προς τα κάτω στο ίδιο πλήκτρο για να το επικολλήσετε ξανά. Και οι δύο κινήσεις παραμένουν στο πλήκτρο αφού αυτό αλλάξει το πληκτρολόγιο σε αριθμούς."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Traza un círculo en la tecla 123 para cortar el texto alrededor del cursor. Desliza hacia abajo en la misma tecla para volver a pegarlo. Ambos gestos siguen en la tecla después de que cambie el teclado a números."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "روی کلید 123 دایره بکشید تا متن اطراف مکان‌نما بریده شود. برای چسباندن دوباره، روی همان کلید به پایین بکشید. هر دو حرکت پس از آنکه کلید صفحه‌کلید را به اعداد تغییر دهد، روی همان کلید باقی می‌مانند."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piirrä ympyrä 123-näppäimeen, niin kohdistimen ympärillä oleva teksti leikataan. Liu’uta samaa näppäintä alaspäin liittääksesi sen takaisin. Molemmat eleet säilyvät näppäimellä sen jälkeen, kun se on vaihtanut näppäimistön numeroihin."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Umikot sa 123 key para gupitin ang teksto sa paligid ng cursor. Mag-swipe pababa sa parehong key para i-paste ito ulit. Nananatili ang dalawang galaw sa key kahit matapos nitong palitan ang keyboard sa mga numero."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tracez un cercle sur la touche 123 pour couper le texte autour du curseur. Balayez vers le bas sur la même touche pour le recoller. Les deux gestes restent sur la touche après qu’elle a basculé le clavier sur les chiffres."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "שרטטו מעגל על מקש 123 כדי לגזור את הטקסט סביב הסמן. החליקו מטה על אותו מקש כדי להדביק אותו בחזרה. שתי המחוות נשארות על המקש גם אחרי שהוא מחליף את המקלדת למספרים."
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कर्सर के आसपास का टेक्स्ट काटने के लिए 123 कुंजी पर गोला बनाएँ। उसे वापस चिपकाने के लिए उसी कुंजी पर नीचे स्वाइप करें। कुंजी द्वारा कीबोर्ड को अंकों पर बदलने के बाद भी दोनों हावभाव उसी कुंजी पर बने रहते हैं।"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Napravi kružni pokret po tipki 123 za izrezivanje teksta oko pokazivača. Povuci prema dolje po istoj tipki da ga zalijepiš natrag. Obje geste ostaju na tipki i nakon što ona prebaci tipkovnicu na brojke."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Traccia un cerchio sul tasto 123 per tagliare il testo attorno al cursore. Scorri verso il basso sullo stesso tasto per incollarlo di nuovo. Entrambi i gesti restano sul tasto anche dopo che ha portato la tastiera ai numeri."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "123キーで円を描くと、カーソル周辺のテキストを切り取ります。同じキーを下にスワイプすると貼り付け直せます。 このキーがキーボードを数字に切り替えたあとも、両方のジェスチャーはそのまま使えます。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "123 키에서 원을 그리면 커서 주변 텍스트를 잘라냅니다. 같은 키를 아래로 쓸어내리면 다시 붙여넣습니다. 이 키가 키보드를 숫자로 전환한 뒤에도 두 제스처는 그대로 유지됩니다."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zakreśl kółko na klawiszu 123, aby wyciąć tekst wokół kursora. Przesuń w dół na tym samym klawiszu, aby wkleić go z powrotem. Oba gesty pozostają na klawiszu także po przełączeniu klawiatury na cyfry."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trace um círculo na tecla 123 para cortar o texto à volta do cursor. Deslize para baixo na mesma tecla para o colar de novo. Ambos os gestos permanecem na tecla depois de esta mudar o teclado para números."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Обведите клавишу 123, чтобы вырезать текст вокруг курсора. Свайп вниз по той же клавише вернёт его. Оба жеста остаются на клавише и после переключения на цифры."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rita en cirkel på 123-tangenten för att klippa ut texten runt markören. Svep nedåt på samma tangent för att klistra in den igen. Båda gesterna finns kvar på tangenten även efter att den växlat tangentbordet till siffror."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "วนนิ้วบนปุ่ม 123 เพื่อตัดข้อความรอบเคอร์เซอร์ ปัดลงบนปุ่มเดียวกันเพื่อวางกลับ ทั้งสองท่าทางยังคงอยู่บนปุ่มนี้แม้หลังจากที่ปุ่มสลับแป้นพิมพ์เป็นตัวเลขแล้ว"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Обведіть клавішу 123, щоб вирізати текст навколо курсора. Проведіть вниз по тій самій клавіші, щоб вставити його назад. Обидва жести залишаються на клавіші й після перемикання на цифри."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کرسر کے ارد گرد متن کاٹنے کے لیے 123 کلید پر دائرہ بنائیں۔ اسے واپس چسپاں کرنے کے لیے اسی کلید پر نیچے سوائپ کریں۔ کلید کے کی بورڈ کو ہندسوں پر بدلنے کے بعد بھی دونوں اشارے اسی کلید پر برقرار رہتے ہیں۔"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vẽ vòng tròn trên phím 123 để cắt văn bản quanh con trỏ. Vuốt xuống trên cùng phím đó để dán lại. Cả hai cử chỉ vẫn nằm trên phím sau khi phím chuyển bàn phím sang số."
-          }
-        }
-      }
-    },
-    "Gestures": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإيماءات"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gesten"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Χειρονομίες"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gestos"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اشاره‌ها"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eleet"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga Galaw"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gestes"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מחוות"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "जेस्चर"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geste"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gesti"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ジェスチャ"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제스처"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gesty"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gestos"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Жесты"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gester"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ท่าทาง"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Жести"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اشارے"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cử chỉ"
-          }
-        }
-      }
+      "comment": "Label visibility list item"
     }
   },
   "version": "1.0"

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -19669,6 +19669,66 @@
             "state": "translated",
             "value": "Madilim"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوضع الداكن"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σκοτεινή λειτουργία"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حالت تیره"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डार्क मोड"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダークモード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다크 모드"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escuro"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โหมดมืด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темний режим"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈارک موڈ"
+          }
         }
       }
     },
@@ -19747,6 +19807,66 @@
             "state": "translated",
             "value": "I-edit ang hitsura"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المظهر قيد التحرير"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επεξεργασία εμφάνισης"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ظاهر در حال ویرایش"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "दिखावट एडिट करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編集中の外観"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집 중인 외관"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar aspeto"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รูปลักษณ์ที่กำลังแก้ไข"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Редагований вигляд"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زیرِ ترمیم ظاہری شکل"
+          }
         }
       }
     },
@@ -19824,6 +19944,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Maliwanag"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوضع الفاتح"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Φωτεινή λειτουργία"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حالت روشن"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लाइट मोड"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライトモード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "라이트 모드"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claro"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โหมดสว่าง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Світлий режим"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لائٹ موڈ"
           }
         }
       }
@@ -20040,6 +20220,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gumamit ng ibang tema sa Dark Mode"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استخدام سمة مختلفة في الوضع الداكن"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Χρήση διαφορετικού θέματος στη σκοτεινή λειτουργία"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استفاده از پوستهٔ متفاوت در حالت تیره"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डार्क मोड में अलग थीम इस्तेमाल करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダークモードでは別のテーマを使う"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다크 모드에서 다른 테마 사용"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar um tema diferente no modo escuro"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ใช้ธีมอื่นในโหมดมืด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Окрема тема для темного режиму"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈارک موڈ میں مختلف تھیم استعمال کریں"
           }
         }
       }

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -20283,6 +20283,2112 @@
           }
         }
       }
+    },
+    "%@ Copy": {
+      "comment": "Theme editor: default name for a duplicated theme (base name + Copy)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopie"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copie"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ копия"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopia"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopia"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopio"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopija"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ עותק"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ bản sao"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopya"
+          }
+        }
+      }
+    },
+    "%@ Copy %lld": {
+      "comment": "Theme editor: duplicated theme name disambiguated with a number",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopie %lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copie %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia %lld"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia %lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ копия %lld"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopia %lld"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopia %lld"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopio %lld"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopija %lld"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ עותק %lld"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ bản sao %lld"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopya %lld"
+          }
+        }
+      }
+    },
+    "Border color": {
+      "comment": "Theme editor: key border color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rahmenfarbe"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couleur de bordure"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color del borde"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colore del bordo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цвет границы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kolor obramowania"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kantfärg"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reunuksen väri"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Boja ruba"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "צבע מסגרת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Màu viền"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kulay ng border"
+          }
+        }
+      }
+    },
+    "Border width": {
+      "comment": "Theme editor: key border width",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rahmenbreite"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Épaisseur de bordure"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ancho del borde"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spessore del bordo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Толщина границы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Szerokość obramowania"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kantbredd"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reunuksen leveys"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Širina ruba"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "רוחב מסגרת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Độ rộng viền"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lapad ng border"
+          }
+        }
+      }
+    },
+    "Cancel": {
+      "comment": "Theme editor: cancel button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмена"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anuluj"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avbryt"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Peruuta"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odustani"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ביטול"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hủy"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kanselahin"
+          }
+        }
+      }
+    },
+    "Corner radius": {
+      "comment": "Theme editor: key corner radius",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eckenradius"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rayon des coins"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radio de esquina"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raggio degli angoli"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Радиус скругления"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Promień narożnika"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hörnradie"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kulman pyöristys"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radijus kuta"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "רדיוס פינה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bán kính góc"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radius ng sulok"
+          }
+        }
+      }
+    },
+    "Delete Theme": {
+      "comment": "Theme editor: delete button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme löschen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer le thème"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar tema"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimina tema"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить тему"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń motyw"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radera tema"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista teema"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izbriši temu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מחק ערכת נושא"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa chủ đề"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tanggalin ang tema"
+          }
+        }
+      }
+    },
+    "Delete this theme?": {
+      "comment": "Theme editor: delete confirmation title",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Theme löschen?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer ce thème ?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Eliminar este tema?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminare questo tema?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить эту тему?"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usunąć ten motyw?"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radera detta tema?"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poistetaanko tämä teema?"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izbrisati ovu temu?"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "למחוק ערכת נושא זו?"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa chủ đề này?"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tanggalin ang temang ito?"
+          }
+        }
+      }
+    },
+    "Duplicate": {
+      "comment": "Theme gallery: context menu action to copy a theme",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplizieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dupliquer"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplicar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplica"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дублировать"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplikuj"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplicera"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monista"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dupliciraj"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שכפל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhân bản"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-duplicate"
+          }
+        }
+      }
+    },
+    "Edit": {
+      "comment": "Theme gallery: context menu action to edit a user theme",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bearbeiten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменить"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edytuj"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redigera"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muokkaa"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uredi"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "עריכה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chỉnh sửa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-edit"
+          }
+        }
+      }
+    },
+    "Edit Theme": {
+      "comment": "Theme editor: navigation title",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme bearbeiten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier le thème"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar tema"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica tema"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Редактировать тему"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edytuj motyw"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redigera tema"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muokkaa teemaa"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uredi temu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "עריכת ערכת נושא"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chỉnh sửa chủ đề"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-edit ang tema"
+          }
+        }
+      }
+    },
+    "Function label": {
+      "comment": "Theme editor: function/utility label color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funktionsbeschriftung"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Étiquette de fonction"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiqueta de función"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etichetta funzione"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подпись функции"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etykieta funkcji"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funktionsetikett"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toimintomerkintä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oznaka funkcije"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תווית פונקציה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhãn chức năng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Label ng function"
+          }
+        }
+      }
+    },
+    "Hint letter": {
+      "comment": "Theme editor: hint letter color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinweis-Buchstabe"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettre d’indice"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letra de sugerencia"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettera suggerimento"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Буква подсказки"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Litera podpowiedzi"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipsbokstav"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vihjekirjain"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slovo natuknice"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אות רמז"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chữ gợi ý"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Titik ng hint"
+          }
+        }
+      }
+    },
+    "Hint symbol": {
+      "comment": "Theme editor: hint symbol color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinweis-Symbol"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbole d’indice"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Símbolo de sugerencia"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simbolo suggerimento"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Символ подсказки"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol podpowiedzi"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipssymbol"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vihjesymboli"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simbol natuknice"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סמל רמז"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ký hiệu gợi ý"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simbolo ng hint"
+          }
+        }
+      }
+    },
+    "Key": {
+      "comment": "Theme editor: key fill color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taste"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touche"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tecla"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавиша"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klawisz"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangent"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäin"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipka"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקש"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Key"
+          }
+        }
+      }
+    },
+    "Key (pressed)": {
+      "comment": "Theme editor: pressed key fill color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taste (gedrückt)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touche (enfoncée)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tecla (pulsada)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasto (premuto)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавиша (нажата)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klawisz (naciśnięty)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangent (nedtryckt)"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäin (painettuna)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipka (pritisnuta)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקש (לחוץ)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím (đang nhấn)"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Key (pinindot)"
+          }
+        }
+      }
+    },
+    "Key border": {
+      "comment": "Theme editor: toggle to show a key border",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenrahmen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bordure de touche"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borde de tecla"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bordo del tasto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Граница клавиши"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obramowanie klawisza"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangentkant"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäimen reunus"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rub tipke"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מסגרת מקש"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Viền phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Border ng key"
+          }
+        }
+      }
+    },
+    "Keyboard background": {
+      "comment": "Theme editor: board background color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastatur-Hintergrund"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrière-plan du clavier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fondo del teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sfondo della tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Фон клавиатуры"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tło klawiatury"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangentbordsbakgrund"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäimistön tausta"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pozadina tipkovnice"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "רקע המקלדת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nền bàn phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Background ng keyboard"
+          }
+        }
+      }
+    },
+    "Labels": {
+      "comment": "Theme editor: section header for label colors",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beschriftungen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Étiquettes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiquetas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etichette"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Надписи"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etykiety"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiketter"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Merkinnät"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oznake"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תוויות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhãn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Label"
+          }
+        }
+      }
+    },
+    "Main letter": {
+      "comment": "Theme editor: main label color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hauptbuchstabe"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettre principale"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letra principal"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettera principale"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Основная буква"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Główna litera"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Huvudbokstav"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pääkirjain"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Glavno slovo"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אות ראשית"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chữ cái chính"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pangunahing titik"
+          }
+        }
+      }
+    },
+    "My Themes": {
+      "comment": "Theme gallery: section header for user-created themes",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meine Themes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mes thèmes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mis temas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I miei temi"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мои темы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moje motywy"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mina teman"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omat teemat"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moje teme"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ערכות הנושא שלי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chủ đề của tôi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aking mga tema"
+          }
+        }
+      }
+    },
+    "Name": {
+      "comment": "Theme editor: name field section header",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Имя"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nazwa"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Namn"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nimi"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naziv"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שם"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tên"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pangalan"
+          }
+        }
+      }
+    },
+    "Prominent icon": {
+      "comment": "Theme editor: prominent icon hint color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Betontes Symbol"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icône proéminente"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icono destacado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icona in evidenza"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заметный значок"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyróżniona ikona"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Framträdande ikon"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korostettu kuvake"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Istaknuta ikona"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סמל בולט"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biểu tượng nổi bật"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prominenteng icon"
+          }
+        }
+      }
+    },
+    "Save": {
+      "comment": "Theme editor: save button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sichern"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salva"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранить"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zapisz"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spara"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tallenna"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spremi"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שמור"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lưu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-save"
+          }
+        }
+      }
+    },
+    "Subtle icon": {
+      "comment": "Theme editor: subtle icon hint color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dezentes Symbol"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icône discrète"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icono sutil"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icona discreta"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неброский значок"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Subtelna ikona"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diskret ikon"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hillitty kuvake"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suptilna ikona"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סמל עדין"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biểu tượng tinh tế"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Banayad na icon"
+          }
+        }
+      }
+    },
+    "Surfaces": {
+      "comment": "Theme editor: section header for surface fills",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flächen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surfaces"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superficies"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superfici"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхности"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Powierzchnie"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ytor"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pinnat"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Površine"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משטחים"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bề mặt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Ibabaw"
+          }
+        }
+      }
+    },
+    "Theme name": {
+      "comment": "Theme editor: placeholder for the theme name field",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme-Name"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom du thème"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre del tema"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome del tema"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Название темы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nazwa motywu"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temanamn"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teeman nimi"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naziv teme"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שם ערכת הנושא"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tên chủ đề"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pangalan ng tema"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -34,8 +34,8 @@ struct SettingsView: View {
     @AppStorage(SettingsKey.cursorMovementStyle.rawValue, store: SharedDefaults.store)
     private var cursorMovementTypeRaw = CursorMovementType.continuous.rawValue
 
-    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
-    private var keyboardStyleRaw = KeyboardStyle.classic.rawValue
+    @AppStorage(SettingsKey.selectedThemeLight.rawValue, store: SharedDefaults.store)
+    private var selectedThemeLight = BuiltInThemes.classic.id
 
     @AppStorage(SettingsKey.autoCapitalizeEnabled.rawValue, store: SharedDefaults.store)
     private var autoCapitalizeEnabled = false
@@ -334,8 +334,8 @@ struct SettingsView: View {
     }
 
     private var keyboardStyleDescription: String {
-        let style = KeyboardStyle(rawValue: keyboardStyleRaw) ?? .classic
-        return style.displayName
+        let theme = ThemeStore.theme(id: selectedThemeLight) ?? BuiltInThemes.classic
+        return theme.displayName
     }
 
     private var labelVisibilityDescription: String {

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -34,8 +34,8 @@ struct SettingsView: View {
     @AppStorage(SettingsKey.cursorMovementStyle.rawValue, store: SharedDefaults.store)
     private var cursorMovementStyleRaw = CursorMovementStyle.continuous.rawValue
 
-    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
-    private var keyboardStyleRaw = KeyboardStyle.classic.rawValue
+    @AppStorage(SettingsKey.selectedThemeLight.rawValue, store: SharedDefaults.store)
+    private var selectedThemeLight = BuiltInThemes.classic.id
 
     @AppStorage(SettingsKey.autoCapitalizeEnabled.rawValue, store: SharedDefaults.store)
     private var autoCapitalizeEnabled = false
@@ -307,8 +307,8 @@ struct SettingsView: View {
     }
 
     private var keyboardStyleDescription: String {
-        let style = KeyboardStyle(rawValue: keyboardStyleRaw) ?? .classic
-        return style.displayName
+        let theme = ThemeStore.theme(id: selectedThemeLight) ?? BuiltInThemes.classic
+        return theme.displayName
     }
 
     private var labelVisibilityDescription: String {

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -40,6 +40,15 @@ struct StyleSettingsView: View {
                         ForEach(BuiltInThemes.all) { theme in
                             themeOption(theme)
                         }
+
+                        if selectedThemeLight == BuiltInThemes.liquidGlass.id {
+                            if #unavailable(iOS 26.0) {
+                                Text("Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.")
+                                    .font(.caption)
+                                    .foregroundColor(.orange)
+                                    .padding(.horizontal, 16)
+                            }
+                        }
                     }
                 }
                 .padding(.vertical, 8)

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -265,7 +265,7 @@ private struct ThemeSwatch: View {
         let resolved = theme.resolved()
         ZStack {
             RoundedRectangle(cornerRadius: 8)
-                .fill(keyColor(resolved.keyFill))
+                .fill(resolved.keyColor)
 
             Text(verbatim: "a")
                 .font(.system(size: 20, weight: .semibold, design: .rounded))
@@ -285,15 +285,6 @@ private struct ThemeSwatch: View {
                     lineWidth: isSelected ? 2.5 : 0.5
                 )
         )
-    }
-
-    /// The swatch fill color. Palettes are always color fills; the material
-    /// fallback is only a safety net (styles aren't shown as swatches).
-    private func keyColor(_ fill: ResolvedFill) -> Color {
-        if case let .color(color) = fill {
-            return color
-        }
-        return Color(.secondarySystemBackground)
     }
 }
 

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -7,6 +7,18 @@
 
 import SwiftUI
 
+/// What a theme row in the gallery offers. Built-ins are immutable templates,
+/// so the list is derived once (`StyleSettingsView.rowActions(for:)`) instead
+/// of being re-decided by every control — one shared row builder serves both
+/// sections, which is exactly where an edit or delete control could otherwise
+/// leak onto a built-in.
+enum ThemeRowAction {
+    case select
+    case duplicate
+    case edit
+    case delete
+}
+
 struct StyleSettingsView: View {
     @AppStorage(SettingsKey.selectedThemeLight.rawValue, store: SharedDefaults.store)
     private var selectedThemeLight = BuiltInThemes.classic.id
@@ -30,20 +42,37 @@ struct StyleSettingsView: View {
     @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
     private var previewPosition = DeviceLayout.defaultKeyboardPosition
 
-    /// Grid columns for the color-palette swatches.
-    private let paletteColumns = [GridItem(.adaptive(minimum: 64), spacing: 10)]
-
     /// User-created themes, reloaded from the store after every edit.
     @State private var userThemes: [KeyboardThemeDefinition] = ThemeStore.userThemes()
 
-    /// The theme currently open in the editor sheet.
-    @State private var editingTheme: KeyboardThemeDefinition?
+    /// The theme open in the editor sheet, if any.
+    @State private var editSession: ThemeEditSession?
+
+    /// The user theme the row-level delete button is asking about.
+    @State private var themePendingDeletion: KeyboardThemeDefinition?
+
+    /// A theme handed to the editor. A duplicate is *not* persisted before the
+    /// editor opens — Save creates it — so cancelling leaves no orphaned
+    /// "… Copy" behind, and the editor needs to know which case it is in.
+    private struct ThemeEditSession: Identifiable {
+        var theme: KeyboardThemeDefinition
+        var isNewTheme: Bool
+
+        var id: String {
+            theme.id
+        }
+    }
 
     /// The theme id the gallery currently reflects: the dark slot while editing
     /// dark mode, otherwise the light slot (which both slots share when the
     /// separate-dark-slot toggle is off).
     private var activeThemeId: String {
         separateDarkSlot && editingAppearance == .dark ? selectedThemeDark : selectedThemeLight
+    }
+
+    /// Everything the gallery lists, built-ins first.
+    private var allThemes: [KeyboardThemeDefinition] {
+        BuiltInThemes.all + userThemes
     }
 
     var body: some View {
@@ -61,7 +90,7 @@ struct StyleSettingsView: View {
             ScrollView {
                 VStack(spacing: 24) {
                     appearanceSection
-                    stylesSection
+                    builtInSection
                     userThemesSection
                 }
                 .padding(.vertical, 8)
@@ -70,18 +99,26 @@ struct StyleSettingsView: View {
         .padding(.vertical, 20)
         .navigationTitle("Style")
         .navigationBarTitleDisplayMode(.inline)
-        .sheet(item: $editingTheme) { theme in
+        .sheet(item: $editSession) { session in
             ThemeEditorView(
-                theme: theme,
-                onSave: { updated in
-                    ThemeStore.saveUserTheme(updated)
-                    reloadUserThemes()
-                },
-                onDelete: { id in
-                    ThemeStore.deleteUserTheme(id: id)
-                    reloadUserThemes()
-                }
+                theme: session.theme,
+                isNewTheme: session.isNewTheme,
+                onSave: { updated in save(updated, isNewTheme: session.isNewTheme) },
+                onDelete: { id in delete(id: id) }
             )
+        }
+        .confirmationDialog(
+            "Delete this theme?",
+            isPresented: Binding(
+                get: { themePendingDeletion != nil },
+                set: { if !$0 { themePendingDeletion = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete Theme", role: .destructive) {
+                if let theme = themePendingDeletion { delete(id: theme.id) }
+                themePendingDeletion = nil
+            }
         }
     }
 
@@ -110,18 +147,21 @@ struct StyleSettingsView: View {
         }
     }
 
-    /// Adaptive/material styles (Classic, Liquid Glass) as descriptive cards.
-    private var stylesSection: some View {
+    /// The three compiled-in themes. They are templates: selectable and
+    /// duplicable, never editable.
+    private var builtInSection: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Visual Style")
                 .font(.headline)
                 .padding(.horizontal, 16)
 
             ForEach(BuiltInThemes.all) { theme in
-                themeOption(theme)
+                themeRow(theme)
             }
 
-            if activeThemeId == BuiltInThemes.liquidGlass.id {
+            // Keyed off the resolved surface style, not the built-in id: a user
+            // copy with glass keys hits the same fallback.
+            if activeTheme.resolved().hasGlassKeys {
                 if #unavailable(iOS 26.0) {
                     Text("Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.")
                         .font(.caption)
@@ -129,125 +169,242 @@ struct StyleSettingsView: View {
                         .padding(.horizontal, 16)
                 }
             }
-        }
-    }
 
-    /// User-created themes as a swatch grid, with edit/delete in the menu.
-    /// Hidden until the user duplicates their first theme.
-    @ViewBuilder private var userThemesSection: some View {
-        if !userThemes.isEmpty {
-            VStack(alignment: .leading, spacing: 12) {
-                Text("My Themes")
-                    .font(.headline)
-                    .padding(.horizontal, 16)
-
-                LazyVGrid(columns: paletteColumns, spacing: 10) {
-                    ForEach(userThemes) { theme in
-                        swatchButton(theme)
-                    }
-                }
+            Text("Included themes can't be changed. Duplicate one to make a theme you can edit.")
+                .font(.caption)
+                .foregroundColor(.secondary)
                 .padding(.horizontal, 16)
+        }
+    }
+
+    /// User-created themes. Shown even while empty, so the section the
+    /// immutability footer points at actually exists.
+    private var userThemesSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("My Themes")
+                .font(.headline)
+                .padding(.horizontal, 16)
+
+            ForEach(userThemes) { theme in
+                themeRow(theme)
             }
         }
     }
 
-    /// A selectable swatch with the shared theme context menu.
-    private func swatchButton(_ theme: KeyboardThemeDefinition) -> some View {
-        Button {
-            select(theme)
-        } label: {
-            ThemeSwatch(theme: theme, isSelected: activeThemeId == theme.id)
+    /// The theme the gallery currently shows as selected, or Classic when the
+    /// stored id no longer resolves.
+    private var activeTheme: KeyboardThemeDefinition {
+        allThemes.first { $0.id == activeThemeId } ?? BuiltInThemes.classic
+    }
+
+    // MARK: - Rows
+
+    /// The controls a row offers for `theme`. Built-ins are immutable
+    /// templates, so duplicating is the only route from one to a theme the
+    /// user can change.
+    static func rowActions(for theme: KeyboardThemeDefinition) -> [ThemeRowAction] {
+        theme.isBuiltIn ? [.select, .duplicate] : [.select, .duplicate, .edit, .delete]
+    }
+
+    /// One theme row, shared by both sections: swatch, name, selection state,
+    /// and one visible icon button per action the theme allows. The context
+    /// menu repeats them as a second route.
+    private func themeRow(_ theme: KeyboardThemeDefinition) -> some View {
+        let actions = Self.rowActions(for: theme)
+        let isSelected = activeThemeId == theme.id
+        return HStack(spacing: 8) {
+            Button {
+                select(theme)
+            } label: {
+                selectLabel(theme, isSelected: isSelected)
+            }
+            .buttonStyle(.plain)
+            // The checkmark is purely visual; VoiceOver needs the trait.
+            .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+
+            ForEach(actions.filter { $0 != .select }, id: \.self) { action in
+                rowActionButton(action, for: theme)
+            }
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel(theme.displayName)
+        .padding(.horizontal, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+        )
+        .padding(.horizontal, 8)
         .contextMenu { themeMenu(for: theme) }
     }
 
-    /// Assigns the theme to the slot being edited. With the separate-dark-slot
-    /// toggle off, both slots follow one selection.
-    private func select(_ theme: KeyboardThemeDefinition) {
-        if separateDarkSlot {
-            if editingAppearance == .dark {
-                selectedThemeDark = theme.id
-            } else {
-                selectedThemeLight = theme.id
+    private func selectLabel(_ theme: KeyboardThemeDefinition, isSelected: Bool) -> some View {
+        HStack(spacing: 12) {
+            ThemeSwatch(theme: theme)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(theme.displayName)
+                    .font(.body)
+                    .foregroundColor(.primary)
+
+                if let description = theme.displayDescription {
+                    Text(description)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
             }
-        } else {
-            selectedThemeLight = theme.id
-            selectedThemeDark = theme.id
+
+            Spacer()
+
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .foregroundColor(.accentColor)
+                    .fontWeight(.semibold)
+            }
+        }
+        .padding(.vertical, 10)
+        .contentShape(Rectangle())
+    }
+
+    /// A visible affordance for one row action. Duplicating used to live in the
+    /// context menu only — a long press with no hint — and it is now the only
+    /// route to an editable theme.
+    @ViewBuilder private func rowActionButton(
+        _ action: ThemeRowAction,
+        for theme: KeyboardThemeDefinition
+    ) -> some View {
+        switch action {
+        case .select:
+            EmptyView()
+        case .duplicate:
+            iconButton("plus.square.on.square") { duplicate(theme) }
+                .accessibilityLabel("Duplicate")
+        case .edit:
+            iconButton("pencil") { editSession = ThemeEditSession(theme: theme, isNewTheme: false) }
+                .accessibilityLabel("Edit")
+        case .delete:
+            iconButton("trash") { themePendingDeletion = theme }
+                .foregroundStyle(.red)
+                .accessibilityLabel("Delete")
         }
     }
 
-    private func themeOption(_ theme: KeyboardThemeDefinition) -> some View {
-        Button {
-            select(theme)
-        } label: {
-            HStack {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(theme.displayName)
-                        .font(.body)
-                        .foregroundColor(.primary)
-
-                    if let description = theme.displayDescription {
-                        Text(description)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-
-                Spacer()
-
-                if activeThemeId == theme.id {
-                    Image(systemName: "checkmark")
-                        .foregroundColor(.accentColor)
-                        .fontWeight(.semibold)
-                }
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(activeThemeId == theme.id ? Color.accentColor.opacity(0.1) : Color.clear)
-            )
+    /// A glyph-only control with a hit area around it — the icons sit next to
+    /// each other and a bare SF Symbol is far under the 44 pt minimum.
+    private func iconButton(_ systemImage: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .frame(width: 36, height: 44)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, 16)
-        .contextMenu { themeMenu(for: theme) }
+        .foregroundStyle(Color.accentColor)
     }
 
     // MARK: - Theme actions
 
-    /// Shared context menu: any theme can be duplicated into an editable copy;
-    /// user themes can also be edited and deleted (built-ins cannot).
-    @ViewBuilder private func themeMenu(for theme: KeyboardThemeDefinition) -> some View {
-        Button {
-            duplicate(theme)
-        } label: {
-            Label("Duplicate", systemImage: "plus.square.on.square")
-        }
-
-        if !theme.isBuiltIn {
-            Button {
-                editingTheme = theme
-            } label: {
-                Label("Edit", systemImage: "pencil")
-            }
-
-            Button(role: .destructive) {
-                ThemeStore.deleteUserTheme(id: theme.id)
-                reloadUserThemes()
-            } label: {
-                Label("Delete", systemImage: "trash")
+    /// Second route to the same actions, from the same list, so the menu can
+    /// never offer more than the row does.
+    private func themeMenu(for theme: KeyboardThemeDefinition) -> some View {
+        ForEach(Self.rowActions(for: theme).filter { $0 != .select }, id: \.self) { action in
+            switch action {
+            case .select:
+                EmptyView()
+            case .duplicate:
+                Button {
+                    duplicate(theme)
+                } label: {
+                    Label("Duplicate", systemImage: "plus.square.on.square")
+                }
+            case .edit:
+                Button {
+                    editSession = ThemeEditSession(theme: theme, isNewTheme: false)
+                } label: {
+                    Label("Edit", systemImage: "pencil")
+                }
+            case .delete:
+                Button(role: .destructive) {
+                    themePendingDeletion = theme
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
             }
         }
     }
 
-    /// Creates a user-owned copy and opens it in the editor immediately.
+    /// Opens a user-owned copy in the editor without persisting it. Saving
+    /// creates it; cancelling leaves the store untouched.
     private func duplicate(_ theme: KeyboardThemeDefinition) {
-        let copy = ThemeStore.duplicate(theme, existing: userThemes)
-        ThemeStore.saveUserTheme(copy)
+        editSession = ThemeEditSession(
+            theme: ThemeStore.duplicate(theme, existing: userThemes),
+            isNewTheme: true
+        )
+    }
+
+    private func save(_ theme: KeyboardThemeDefinition, isNewTheme: Bool) {
+        ThemeStore.saveUserTheme(theme)
         reloadUserThemes()
-        editingTheme = copy
+        applySlots(Self.slots(
+            afterSaving: theme.id,
+            isNewTheme: isNewTheme,
+            light: selectedThemeLight,
+            dark: selectedThemeDark,
+            separateDarkSlot: separateDarkSlot,
+            editingAppearance: editingAppearance
+        ))
+    }
+
+    private func delete(id: String) {
+        ThemeStore.deleteUserTheme(id: id)
+        reloadUserThemes()
+    }
+
+    /// Assigns the theme to the slot being edited.
+    private func select(_ theme: KeyboardThemeDefinition) {
+        applySlots(Self.slots(
+            selecting: theme.id,
+            light: selectedThemeLight,
+            dark: selectedThemeDark,
+            separateDarkSlot: separateDarkSlot,
+            editingAppearance: editingAppearance
+        ))
+    }
+
+    private func applySlots(_ slots: (light: String, dark: String)) {
+        selectedThemeLight = slots.light
+        selectedThemeDark = slots.dark
+    }
+
+    /// The two slot ids after assigning `themeId` to the slot being edited.
+    /// With the separate-dark-slot toggle off, both slots follow one selection.
+    static func slots(
+        selecting themeId: String,
+        light: String,
+        dark: String,
+        separateDarkSlot: Bool,
+        editingAppearance: ColorScheme
+    ) -> (light: String, dark: String) {
+        guard separateDarkSlot else { return (themeId, themeId) }
+        return editingAppearance == .dark ? (light, themeId) : (themeId, dark)
+    }
+
+    /// The two slot ids after saving. A new theme is always a fresh duplicate,
+    /// and selecting it is the only visible result duplicating has — but an
+    /// edit must leave the selection alone, or editing a theme parked in the
+    /// dark slot would silently steal the light one.
+    static func slots(
+        afterSaving themeId: String,
+        isNewTheme: Bool,
+        light: String,
+        dark: String,
+        separateDarkSlot: Bool,
+        editingAppearance: ColorScheme
+    ) -> (light: String, dark: String) {
+        guard isNewTheme else { return (light, dark) }
+        return slots(
+            selecting: themeId,
+            light: light,
+            dark: dark,
+            separateDarkSlot: separateDarkSlot,
+            editingAppearance: editingAppearance
+        )
     }
 
     private func reloadUserThemes() {
@@ -255,36 +412,58 @@ struct StyleSettingsView: View {
     }
 }
 
-/// Miniature key rendering a palette: key fill, main letter, hint dot. Draws
-/// from the theme's own resolved colors, so it always matches the keyboard.
+/// Miniature key over the theme's own board, rendered through the same
+/// resolved values and surface styles the keyboard uses. It has to draw the
+/// board and the glass material, not just a fill: with glass a per-surface
+/// style, a glass copy and a Classic copy of the same palette carry identical
+/// colors and would otherwise be indistinguishable in the list.
 private struct ThemeSwatch: View {
     let theme: KeyboardThemeDefinition
-    let isSelected: Bool
+
+    /// Mirrors `KeyView.glassTint`, which is private to the keyboard: without
+    /// it the swatch's glass reads as an empty hole at this size.
+    private static let glassTint = Color.gray.opacity(0.12)
+
+    private static let size: CGFloat = 44
+    private static let keyInset: CGFloat = 7
+    private static let keyRadius: CGFloat = 6
 
     var body: some View {
         let resolved = theme.resolved()
         ZStack {
-            RoundedRectangle(cornerRadius: 8)
-                .fill(resolved.keyColor)
-
-            Text(verbatim: "a")
-                .font(.system(size: 20, weight: .semibold, design: .rounded))
-                .foregroundStyle(resolved.mainLabel)
-
-            Circle()
-                .fill(resolved.hintLetter)
-                .frame(width: 5, height: 5)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
-                .padding(6)
+            resolved.boardBackground
+            key(resolved)
+                .padding(Self.keyInset)
         }
-        .frame(height: 48)
+        .frame(width: Self.size, height: Self.size)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
         .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .strokeBorder(
-                    isSelected ? Color.accentColor : Color.primary.opacity(0.12),
-                    lineWidth: isSelected ? 2.5 : 0.5
-                )
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(Color.primary.opacity(0.12), lineWidth: 0.5)
         )
+        // Decoration beside a label that already names the theme.
+        .accessibilityHidden(true)
+    }
+
+    /// The same two branches `KeyView` renders: native Liquid Glass on iOS 26,
+    /// the `.bar` material below it, a plain fill for a color key.
+    @ViewBuilder private func key(_ resolved: ResolvedTheme) -> some View {
+        let shape = RoundedRectangle(cornerRadius: Self.keyRadius)
+        if resolved.hasGlassKeys, #available(iOS 26.0, *) {
+            letter(resolved)
+                .glassEffect(.regular.tint(Self.glassTint), in: shape)
+        } else if resolved.hasGlassKeys {
+            shape.fill(.bar).overlay(letter(resolved))
+        } else {
+            shape.fill(resolved.keyColor).overlay(letter(resolved))
+        }
+    }
+
+    private func letter(_ resolved: ResolvedTheme) -> some View {
+        Text(verbatim: "a")
+            .font(.system(size: 16, weight: .semibold, design: .rounded))
+            .foregroundStyle(resolved.mainLabel)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -2,14 +2,17 @@
 //  StyleSettingsView.swift
 //  wurstfinger
 //
-//  Visual style settings for the keyboard appearance
+//  Theme selection for the keyboard appearance.
 //
 
 import SwiftUI
 
 struct StyleSettingsView: View {
-    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
-    private var keyboardStyleRaw = KeyboardStyle.classic.rawValue
+    @AppStorage(SettingsKey.selectedThemeLight.rawValue, store: SharedDefaults.store)
+    private var selectedThemeLight = BuiltInThemes.classic.id
+
+    @AppStorage(SettingsKey.selectedThemeDark.rawValue, store: SharedDefaults.store)
+    private var selectedThemeDark = BuiltInThemes.classic.id
 
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var previewAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
@@ -28,23 +31,14 @@ struct StyleSettingsView: View {
 
             ScrollView {
                 VStack(spacing: 24) {
-                    // Style Selection
+                    // Theme Selection
                     VStack(alignment: .leading, spacing: 16) {
                         Text("Visual Style")
                             .font(.headline)
                             .padding(.horizontal, 16)
 
-                        ForEach(KeyboardStyle.allCases, id: \.self) { style in
-                            styleOption(style)
-                        }
-
-                        if keyboardStyleRaw == KeyboardStyle.liquidGlass.rawValue {
-                            if #unavailable(iOS 26.0) {
-                                Text("Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.")
-                                    .font(.caption)
-                                    .foregroundColor(.orange)
-                                    .padding(.horizontal, 16)
-                            }
+                        ForEach(BuiltInThemes.all) { theme in
+                            themeOption(theme)
                         }
                     }
                 }
@@ -56,24 +50,29 @@ struct StyleSettingsView: View {
         .navigationBarTitleDisplayMode(.inline)
     }
 
-    private func styleOption(_ style: KeyboardStyle) -> some View {
+    private func themeOption(_ theme: KeyboardThemeDefinition) -> some View {
         Button {
-            keyboardStyleRaw = style.rawValue
+            // Both appearance slots follow one selection until the gallery
+            // gains its separate light/dark assignment (milestone M2).
+            selectedThemeLight = theme.id
+            selectedThemeDark = theme.id
         } label: {
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(style.displayName)
+                    Text(theme.displayName)
                         .font(.body)
                         .foregroundColor(.primary)
 
-                    Text(style.description)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                    if let description = theme.displayDescription {
+                        Text(description)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
                 }
 
                 Spacer()
 
-                if keyboardStyleRaw == style.rawValue {
+                if selectedThemeLight == theme.id {
                     Image(systemName: "checkmark")
                         .foregroundColor(.accentColor)
                         .fontWeight(.semibold)
@@ -83,31 +82,11 @@ struct StyleSettingsView: View {
             .padding(.vertical, 12)
             .background(
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(keyboardStyleRaw == style.rawValue ? Color.accentColor.opacity(0.1) : Color.clear)
+                    .fill(selectedThemeLight == theme.id ? Color.accentColor.opacity(0.1) : Color.clear)
             )
         }
         .buttonStyle(.plain)
         .padding(.horizontal, 16)
-    }
-}
-
-extension KeyboardStyle {
-    /// User-facing style name. Lives in the host app target: the extension's
-    /// own catalog carries only the strings the keyboard itself displays, so a
-    /// settings-only name must not be looked up from extension code.
-    var displayName: String {
-        switch self {
-        case .classic: String(localized: "Classic")
-        case .liquidGlass: String(localized: "Liquid Glass")
-        }
-    }
-
-    /// One-line explanation shown under the style name.
-    var description: String {
-        switch self {
-        case .classic: String(localized: "Traditional opaque keys")
-        case .liquidGlass: String(localized: "Transparent glass effect (iOS 26+)")
-        }
     }
 }
 

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -30,6 +30,15 @@ struct StyleSettingsView: View {
     @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
     private var previewPosition = DeviceLayout.defaultKeyboardPosition
 
+    /// Grid columns for the color-palette swatches.
+    private let paletteColumns = [GridItem(.adaptive(minimum: 64), spacing: 10)]
+
+    /// User-created themes, reloaded from the store after every edit.
+    @State private var userThemes: [KeyboardThemeDefinition] = ThemeStore.userThemes()
+
+    /// The theme currently open in the editor sheet.
+    @State private var editingTheme: KeyboardThemeDefinition?
+
     /// The theme id the gallery currently reflects: the dark slot while editing
     /// dark mode, otherwise the light slot (which both slots share when the
     /// separate-dark-slot toggle is off).
@@ -53,6 +62,7 @@ struct StyleSettingsView: View {
                 VStack(spacing: 24) {
                     appearanceSection
                     stylesSection
+                    userThemesSection
                 }
                 .padding(.vertical, 8)
             }
@@ -60,6 +70,19 @@ struct StyleSettingsView: View {
         .padding(.vertical, 20)
         .navigationTitle("Style")
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $editingTheme) { theme in
+            ThemeEditorView(
+                theme: theme,
+                onSave: { updated in
+                    ThemeStore.saveUserTheme(updated)
+                    reloadUserThemes()
+                },
+                onDelete: { id in
+                    ThemeStore.deleteUserTheme(id: id)
+                    reloadUserThemes()
+                }
+            )
+        }
     }
 
     /// Toggle for assigning a separate dark-mode theme, plus the light/dark
@@ -87,7 +110,7 @@ struct StyleSettingsView: View {
         }
     }
 
-    /// The built-in themes as descriptive cards.
+    /// Adaptive/material styles (Classic, Liquid Glass) as descriptive cards.
     private var stylesSection: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Visual Style")
@@ -107,6 +130,37 @@ struct StyleSettingsView: View {
                 }
             }
         }
+    }
+
+    /// User-created themes as a swatch grid, with edit/delete in the menu.
+    /// Hidden until the user duplicates their first theme.
+    @ViewBuilder private var userThemesSection: some View {
+        if !userThemes.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("My Themes")
+                    .font(.headline)
+                    .padding(.horizontal, 16)
+
+                LazyVGrid(columns: paletteColumns, spacing: 10) {
+                    ForEach(userThemes) { theme in
+                        swatchButton(theme)
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+        }
+    }
+
+    /// A selectable swatch with the shared theme context menu.
+    private func swatchButton(_ theme: KeyboardThemeDefinition) -> some View {
+        Button {
+            select(theme)
+        } label: {
+            ThemeSwatch(theme: theme, isSelected: activeThemeId == theme.id)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(theme.displayName)
+        .contextMenu { themeMenu(for: theme) }
     }
 
     /// Assigns the theme to the slot being edited. With the separate-dark-slot
@@ -158,6 +212,88 @@ struct StyleSettingsView: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal, 16)
+        .contextMenu { themeMenu(for: theme) }
+    }
+
+    // MARK: - Theme actions
+
+    /// Shared context menu: any theme can be duplicated into an editable copy;
+    /// user themes can also be edited and deleted (built-ins cannot).
+    @ViewBuilder private func themeMenu(for theme: KeyboardThemeDefinition) -> some View {
+        Button {
+            duplicate(theme)
+        } label: {
+            Label("Duplicate", systemImage: "plus.square.on.square")
+        }
+
+        if !theme.isBuiltIn {
+            Button {
+                editingTheme = theme
+            } label: {
+                Label("Edit", systemImage: "pencil")
+            }
+
+            Button(role: .destructive) {
+                ThemeStore.deleteUserTheme(id: theme.id)
+                reloadUserThemes()
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+
+    /// Creates a user-owned copy and opens it in the editor immediately.
+    private func duplicate(_ theme: KeyboardThemeDefinition) {
+        let copy = ThemeStore.duplicate(theme, existing: userThemes)
+        ThemeStore.saveUserTheme(copy)
+        reloadUserThemes()
+        editingTheme = copy
+    }
+
+    private func reloadUserThemes() {
+        userThemes = ThemeStore.userThemes()
+    }
+}
+
+/// Miniature key rendering a palette: key fill, main letter, hint dot. Draws
+/// from the theme's own resolved colors, so it always matches the keyboard.
+private struct ThemeSwatch: View {
+    let theme: KeyboardThemeDefinition
+    let isSelected: Bool
+
+    var body: some View {
+        let resolved = theme.resolved()
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(keyColor(resolved.keyFill))
+
+            Text(verbatim: "a")
+                .font(.system(size: 20, weight: .semibold, design: .rounded))
+                .foregroundStyle(resolved.mainLabel)
+
+            Circle()
+                .fill(resolved.hintLetter)
+                .frame(width: 5, height: 5)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+                .padding(6)
+        }
+        .frame(height: 48)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(
+                    isSelected ? Color.accentColor : Color.primary.opacity(0.12),
+                    lineWidth: isSelected ? 2.5 : 0.5
+                )
+        )
+    }
+
+    /// The swatch fill color. Palettes are always color fills; the material
+    /// fallback is only a safety net (styles aren't shown as swatches).
+    private func keyColor(_ fill: ResolvedFill) -> Color {
+        if case let .color(color) = fill {
+            return color
+        }
+        return Color(.secondarySystemBackground)
     }
 }
 

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// of being re-decided by every control — one shared row builder serves both
 /// sections, which is exactly where an edit or delete control could otherwise
 /// leak onto a built-in.
-enum ThemeRowAction {
+enum ThemeRowAction: CaseIterable {
     case select
     case duplicate
     case edit
@@ -27,10 +27,11 @@ struct StyleSettingsView: View {
     private var selectedThemeDark = BuiltInThemes.classic.id
 
     @AppStorage(SettingsKey.themeSeparateDarkSlot.rawValue, store: SharedDefaults.store)
-    private var separateDarkSlot = false
+    private var hasSeparateDarkSlot = false
 
     /// Which slot the gallery currently edits and previews. Only meaningful
-    /// while `separateDarkSlot` is on; otherwise selection writes both slots.
+    /// while `hasSeparateDarkSlot` is on; otherwise everything reads and writes
+    /// the light slot and the dark one is left untouched.
     @State private var editingAppearance: ColorScheme = .light
 
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
@@ -42,6 +43,9 @@ struct StyleSettingsView: View {
     @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
     private var previewPosition = DeviceLayout.defaultKeyboardPosition
 
+    /// 44 pt grown with the user's text size; clamped by `iconTargetSide(scaledFrom:)`.
+    @ScaledMetric(relativeTo: .body) private var scaledIconTarget: CGFloat = 44
+
     /// User-created themes, reloaded from the store after every edit.
     @State private var userThemes: [KeyboardThemeDefinition] = ThemeStore.userThemes()
 
@@ -51,10 +55,13 @@ struct StyleSettingsView: View {
     /// The user theme the row-level delete button is asking about.
     @State private var themePendingDeletion: KeyboardThemeDefinition?
 
+    /// The row a save just created, so the gallery can scroll it into view.
+    @State private var themeToRevealId: String?
+
     /// A theme handed to the editor. A duplicate is *not* persisted before the
     /// editor opens — Save creates it — so cancelling leaves no orphaned
     /// "… Copy" behind, and the editor needs to know which case it is in.
-    private struct ThemeEditSession: Identifiable {
+    struct ThemeEditSession: Identifiable, Equatable {
         var theme: KeyboardThemeDefinition
         var isNewTheme: Bool
 
@@ -64,10 +71,44 @@ struct StyleSettingsView: View {
     }
 
     /// The theme id the gallery currently reflects: the dark slot while editing
-    /// dark mode, otherwise the light slot (which both slots share when the
-    /// separate-dark-slot toggle is off).
+    /// dark mode, otherwise the light slot (the only slot the resolver reads
+    /// while the separate-dark-slot toggle is off).
+    ///
+    /// Static, like the write side in `slots(selecting:…)`: this decides which
+    /// row wears the checkmark and which theme the preview renders, so getting
+    /// the flag wrong here shows the user a theme they are not editing.
+    static func activeThemeId(
+        light: String,
+        dark: String,
+        hasSeparateDarkSlot: Bool,
+        editingAppearance: ColorScheme
+    ) -> String {
+        hasSeparateDarkSlot && editingAppearance == .dark ? dark : light
+    }
+
+    /// The appearance the gallery previews and the editor designs against, or
+    /// nil while one theme serves both slots (then the device decides).
+    ///
+    /// Static for the same reason, and this one is load-bearing twice over:
+    /// every color well in the editor is seeded from the theme *as it renders
+    /// in this appearance*, and the well freezes what it was seeded with as a
+    /// fixed hex. Returning `.light` where nil belongs would hand a user on a
+    /// dark device a whole palette of light-mode values, permanently.
+    static func appearanceOverride(hasSeparateDarkSlot: Bool, editingAppearance: ColorScheme) -> ColorScheme? {
+        hasSeparateDarkSlot ? editingAppearance : nil
+    }
+
     private var activeThemeId: String {
-        separateDarkSlot && editingAppearance == .dark ? selectedThemeDark : selectedThemeLight
+        Self.activeThemeId(
+            light: selectedThemeLight,
+            dark: selectedThemeDark,
+            hasSeparateDarkSlot: hasSeparateDarkSlot,
+            editingAppearance: editingAppearance
+        )
+    }
+
+    private var appearanceOverride: ColorScheme? {
+        Self.appearanceOverride(hasSeparateDarkSlot: hasSeparateDarkSlot, editingAppearance: editingAppearance)
     }
 
     /// Everything the gallery lists, built-ins first.
@@ -83,17 +124,28 @@ struct StyleSettingsView: View {
                 aspectRatio: $previewAspectRatio,
                 width: $previewWidth,
                 position: $previewPosition,
-                appearanceOverride: separateDarkSlot ? editingAppearance : nil
+                appearanceOverride: appearanceOverride
             )
             .padding(.horizontal, 16)
 
-            ScrollView {
-                VStack(spacing: 24) {
-                    appearanceSection
-                    builtInSection
-                    userThemesSection
+            ScrollViewReader { scrollProxy in
+                ScrollView {
+                    VStack(spacing: 24) {
+                        appearanceSection
+                        builtInSection
+                        userThemesSection
+                    }
+                    .padding(.vertical, 8)
                 }
-                .padding(.vertical, 8)
+                // A theme saved from the editor is appended to "My Themes",
+                // which on a phone sits below the fold: without this the only
+                // visible result of Duplicate → Save is the checkmark leaving
+                // the built-in row it was copied from.
+                .onChange(of: themeToRevealId) { _, id in
+                    guard let id else { return }
+                    withAnimation { scrollProxy.scrollTo(id, anchor: .center) }
+                    themeToRevealId = nil
+                }
             }
         }
         .padding(.vertical, 20)
@@ -103,21 +155,33 @@ struct StyleSettingsView: View {
             ThemeEditorView(
                 theme: session.theme,
                 isNewTheme: session.isNewTheme,
+                // The editor designs for one slot and has to render in that
+                // slot's appearance and the user's real geometry — otherwise a
+                // dark-slot theme is judged against a light board at stock
+                // width, and every color picked there is wrong where it lands.
+                appearanceOverride: appearanceOverride,
+                previewAspectRatio: $previewAspectRatio,
+                previewWidth: $previewWidth,
+                previewPosition: $previewPosition,
                 onSave: { updated in save(updated, isNewTheme: session.isNewTheme) },
                 onDelete: { id in delete(id: id) }
             )
         }
+        // `presenting:` rather than reading `themePendingDeletion` back inside
+        // the action: the derived `isPresented` binding nils the state, and
+        // nothing defines whether SwiftUI writes it before or after the button
+        // runs. Captured payload, no ordering assumption.
         .confirmationDialog(
             "Delete this theme?",
             isPresented: Binding(
                 get: { themePendingDeletion != nil },
                 set: { if !$0 { themePendingDeletion = nil } }
             ),
-            titleVisibility: .visible
-        ) {
-            Button("Delete Theme", role: .destructive) {
-                if let theme = themePendingDeletion { delete(id: theme.id) }
-                themePendingDeletion = nil
+            titleVisibility: .visible,
+            presenting: themePendingDeletion
+        ) { theme in
+            Button(String(localized: "Delete \(theme.displayName)"), role: .destructive) {
+                delete(id: theme.id)
             }
         }
     }
@@ -126,17 +190,18 @@ struct StyleSettingsView: View {
     /// segment that picks which slot the gallery edits.
     private var appearanceSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Toggle("Use a different theme in Dark Mode", isOn: $separateDarkSlot)
+            Toggle("Use a different theme in Dark Mode", isOn: $hasSeparateDarkSlot)
                 .padding(.horizontal, 16)
-                .onChange(of: separateDarkSlot) { _, isOn in
-                    if !isOn {
-                        // Collapse back to one selection.
-                        selectedThemeDark = selectedThemeLight
-                        editingAppearance = .light
-                    }
+                .onChange(of: hasSeparateDarkSlot) { _, isOn in
+                    // Only the editing focus resets. The dark slot is left
+                    // exactly as it is: the resolver ignores it while the flag
+                    // is off (`ThemeStore.theme(lightId:darkId:hasSeparateDarkSlot:for:)`),
+                    // so collapsing it into the light id would buy nothing and
+                    // cost the user their dark assignment on a single tap.
+                    if !isOn { editingAppearance = .light }
                 }
 
-            if separateDarkSlot {
+            if hasSeparateDarkSlot {
                 Picker("Editing appearance", selection: $editingAppearance) {
                     Label("Light Mode", systemImage: "sun.max").tag(ColorScheme.light)
                     Label("Dark Mode", systemImage: "moon").tag(ColorScheme.dark)
@@ -233,6 +298,8 @@ struct StyleSettingsView: View {
         )
         .padding(.horizontal, 8)
         .contextMenu { themeMenu(for: theme) }
+        // Scroll anchor for a freshly saved theme (see `themeToRevealId`).
+        .id(theme.id)
     }
 
     private func selectLabel(_ theme: KeyboardThemeDefinition, isSelected: Bool) -> some View {
@@ -266,36 +333,89 @@ struct StyleSettingsView: View {
     /// A visible affordance for one row action. Duplicating used to live in the
     /// context menu only — a long press with no hint — and it is now the only
     /// route to an editable theme.
+    ///
+    /// Every label names its theme. Without it the rotor and the Item Chooser
+    /// list one "Delete" per user theme, all identical, for an action with no
+    /// undo. Same pattern as `LanguageSelectionView`'s "Disable %@".
     @ViewBuilder private func rowActionButton(
         _ action: ThemeRowAction,
         for theme: KeyboardThemeDefinition
     ) -> some View {
-        switch action {
-        case .select:
-            EmptyView()
-        case .duplicate:
-            iconButton("plus.square.on.square") { duplicate(theme) }
-                .accessibilityLabel("Duplicate")
-        case .edit:
-            iconButton("pencil") { editSession = ThemeEditSession(theme: theme, isNewTheme: false) }
-                .accessibilityLabel("Edit")
-        case .delete:
-            iconButton("trash") { themePendingDeletion = theme }
-                .foregroundStyle(.red)
-                .accessibilityLabel("Delete")
+        if let icon = Self.icon(for: action) {
+            switch action {
+            case .select:
+                EmptyView()
+            case .duplicate:
+                iconButton(icon) { duplicate(theme) }
+                    .accessibilityLabel(String(localized: "Duplicate \(theme.displayName)"))
+            case .edit:
+                iconButton(icon) { editSession = ThemeEditSession(theme: theme, isNewTheme: false) }
+                    .accessibilityLabel(String(localized: "Edit \(theme.displayName)"))
+            case .delete:
+                iconButton(icon) { themePendingDeletion = theme }
+                    .accessibilityLabel(String(localized: "Delete \(theme.displayName)"))
+            }
         }
     }
 
-    /// A glyph-only control with a hit area around it — the icons sit next to
-    /// each other and a bare SF Symbol is far under the 44 pt minimum.
-    private func iconButton(_ systemImage: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Image(systemName: systemImage)
-                .frame(width: 36, height: 44)
+    /// Glyph and tint of a row action's icon button. `.select` has none — the
+    /// whole row is its control.
+    ///
+    /// The tint belongs in this table because it has to reach `iconButton` and
+    /// be applied there, exactly once: a `.foregroundStyle` wrapped *around*
+    /// the button loses to the one inside it, which is how the destructive
+    /// trash came to render in the accent tint, indistinguishable from
+    /// duplicate and edit.
+    static func icon(for action: ThemeRowAction) -> RowIcon? {
+        switch action {
+        case .select: nil
+        case .duplicate: RowIcon(systemImage: "plus.square.on.square", tint: .accentColor)
+        case .edit: RowIcon(systemImage: "pencil", tint: .accentColor)
+        // The one irreversible, undo-less action in the row. Red is its only
+        // cue beyond the glyph.
+        case .delete: RowIcon(systemImage: "trash", tint: .red)
+        }
+    }
+
+    struct RowIcon: Equatable {
+        var systemImage: String
+        var tint: Color
+    }
+
+    /// Side of a row icon's hit area for a Dynamic-Type-scaled 44 pt, clamped.
+    ///
+    /// The lower bound holds the 44 pt minimum target at the small text sizes,
+    /// where the scaled value drops below it. The upper bound is what makes
+    /// three of these fit a phone at AX5 — a fully scaled target would be
+    /// ~137 pt wide and the row would run off the screen.
+    static func iconTargetSide(scaledFrom scaled: CGFloat) -> CGFloat {
+        min(max(scaled, 44), 64)
+    }
+
+    /// Fraction of the hit area the glyph is drawn at, so the two can never
+    /// diverge — see `iconButton`.
+    static let iconGlyphFraction: CGFloat = 0.45
+
+    /// A glyph-only control with a hit area around it.
+    ///
+    /// Both the area and the glyph scale with Dynamic Type, and the glyph is
+    /// sized *from* the area rather than from the ambient font. `.frame` does
+    /// not clip a non-resizable `Image`: with a fixed 36×44 box an AX5 glyph
+    /// rendered ~60 pt and spilled ~12 pt past each edge, so the visible trash
+    /// overlapped the pencil's hit region and tapping it opened the editor.
+    ///
+    /// The tint arrives as a parameter and is applied here and nowhere else —
+    /// see `icon(for:)`.
+    private func iconButton(_ icon: RowIcon, action: @escaping () -> Void) -> some View {
+        let side = Self.iconTargetSide(scaledFrom: scaledIconTarget)
+        return Button(action: action) {
+            Image(systemName: icon.systemImage)
+                .font(.system(size: side * Self.iconGlyphFraction))
+                .frame(width: side, height: side)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .foregroundStyle(Color.accentColor)
+        .foregroundStyle(icon.tint)
     }
 
     // MARK: - Theme actions
@@ -329,13 +449,25 @@ struct StyleSettingsView: View {
         }
     }
 
-    /// Opens a user-owned copy in the editor without persisting it. Saving
-    /// creates it; cancelling leaves the store untouched.
-    private func duplicate(_ theme: KeyboardThemeDefinition) {
-        editSession = ThemeEditSession(
-            theme: ThemeStore.duplicate(theme, existing: userThemes),
+    /// The editor session a Duplicate tap opens: a user-owned copy of `theme`
+    /// that is **not** written to `defaults`. Save creates it, so cancelling
+    /// leaves no orphaned "… Copy" behind.
+    ///
+    /// Static and defaults-injected so that promise is actually testable — the
+    /// instance method below is unreachable from a test, and asserting on
+    /// `ThemeStore.duplicate` instead only proves that a pure function is pure.
+    static func editSession(
+        duplicating theme: KeyboardThemeDefinition,
+        defaults: UserDefaults = SharedDefaults.store
+    ) -> ThemeEditSession {
+        ThemeEditSession(
+            theme: ThemeStore.duplicate(theme, existing: ThemeStore.userThemes(defaults: defaults)),
             isNewTheme: true
         )
+    }
+
+    private func duplicate(_ theme: KeyboardThemeDefinition) {
+        editSession = Self.editSession(duplicating: theme)
     }
 
     private func save(_ theme: KeyboardThemeDefinition, isNewTheme: Bool) {
@@ -346,9 +478,10 @@ struct StyleSettingsView: View {
             isNewTheme: isNewTheme,
             light: selectedThemeLight,
             dark: selectedThemeDark,
-            separateDarkSlot: separateDarkSlot,
+            hasSeparateDarkSlot: hasSeparateDarkSlot,
             editingAppearance: editingAppearance
         ))
+        themeToRevealId = theme.id
     }
 
     private func delete(id: String) {
@@ -362,7 +495,7 @@ struct StyleSettingsView: View {
             selecting: theme.id,
             light: selectedThemeLight,
             dark: selectedThemeDark,
-            separateDarkSlot: separateDarkSlot,
+            hasSeparateDarkSlot: hasSeparateDarkSlot,
             editingAppearance: editingAppearance
         ))
     }
@@ -373,15 +506,23 @@ struct StyleSettingsView: View {
     }
 
     /// The two slot ids after assigning `themeId` to the slot being edited.
-    /// With the separate-dark-slot toggle off, both slots follow one selection.
+    ///
+    /// With the separate-dark-slot toggle off only the light slot is written.
+    /// Mirroring into the dark slot would render identically — the resolver
+    /// ignores the dark slot in that state — but it would destroy a stored dark
+    /// assignment on a tap, which is the same data loss the toggle itself was
+    /// stopped from doing. Leaving the slot alone means switching the toggle
+    /// back on restores the user's earlier dark choice instead of whatever was
+    /// selected last, so a round trip through the toggle is lossless from
+    /// either side.
     static func slots(
         selecting themeId: String,
         light: String,
         dark: String,
-        separateDarkSlot: Bool,
+        hasSeparateDarkSlot: Bool,
         editingAppearance: ColorScheme
     ) -> (light: String, dark: String) {
-        guard separateDarkSlot else { return (themeId, themeId) }
+        guard hasSeparateDarkSlot else { return (themeId, dark) }
         return editingAppearance == .dark ? (light, themeId) : (themeId, dark)
     }
 
@@ -394,7 +535,7 @@ struct StyleSettingsView: View {
         isNewTheme: Bool,
         light: String,
         dark: String,
-        separateDarkSlot: Bool,
+        hasSeparateDarkSlot: Bool,
         editingAppearance: ColorScheme
     ) -> (light: String, dark: String) {
         guard isNewTheme else { return (light, dark) }
@@ -402,7 +543,7 @@ struct StyleSettingsView: View {
             selecting: themeId,
             light: light,
             dark: dark,
-            separateDarkSlot: separateDarkSlot,
+            hasSeparateDarkSlot: hasSeparateDarkSlot,
             editingAppearance: editingAppearance
         )
     }
@@ -414,19 +555,36 @@ struct StyleSettingsView: View {
 
 /// Miniature key over the theme's own board, rendered through the same
 /// resolved values and surface styles the keyboard uses. It has to draw the
-/// board and the glass material, not just a fill: with glass a per-surface
-/// style, a glass copy and a Classic copy of the same palette carry identical
-/// colors and would otherwise be indistinguishable in the list.
-private struct ThemeSwatch: View {
+/// board, the glass material, the corner radius and the border, not just a
+/// fill: with glass a per-surface style, a glass copy and a Classic copy of the
+/// same palette carry identical colors — and two copies that differ only in
+/// radius or border would read as the same grey square, which is exactly the
+/// indistinguishability this swatch exists to prevent.
+struct ThemeSwatch: View {
     let theme: KeyboardThemeDefinition
-
-    /// Mirrors `KeyView.glassTint`, which is private to the keyboard: without
-    /// it the swatch's glass reads as an empty hole at this size.
-    private static let glassTint = Color.gray.opacity(0.12)
 
     private static let size: CGFloat = 44
     private static let keyInset: CGFloat = 7
-    private static let keyRadius: CGFloat = 6
+
+    /// Side of the drawn key.
+    private static let keySize: CGFloat = size - 2 * keyInset
+
+    /// Shrink factor from a rendered key to this miniature, so the theme's
+    /// point values keep their *proportions* here. Used raw, a 12 pt radius
+    /// would turn a 30 pt key into a pill.
+    private static let keyScale = keySize / KeyboardConstants.KeyDimensions.height
+
+    /// The theme's corner radius at swatch scale.
+    static func swatchRadius(forKeyRadius radius: CGFloat) -> CGFloat {
+        radius * keyScale
+    }
+
+    /// The theme's border width at swatch scale, but never thinner than a
+    /// hairline: scaled down, a 0.5 pt border would vanish and a theme with a
+    /// border would look like one without.
+    static func swatchBorderWidth(forKeyBorderWidth width: CGFloat) -> CGFloat {
+        max(width * keyScale, 0.5)
+    }
 
     var body: some View {
         let resolved = theme.resolved()
@@ -445,17 +603,37 @@ private struct ThemeSwatch: View {
         .accessibilityHidden(true)
     }
 
-    /// The same two branches `KeyView` renders: native Liquid Glass on iOS 26,
-    /// the `.bar` material below it, a plain fill for a color key.
+    /// The same three branches `KeyView` renders, including which of them
+    /// draws the border: native Liquid Glass on iOS 26 (no border — the effect
+    /// replaces the background layer), the `.bar` material with the border
+    /// below it, a plain fill with the border for a color key.
     @ViewBuilder private func key(_ resolved: ResolvedTheme) -> some View {
-        let shape = RoundedRectangle(cornerRadius: Self.keyRadius)
+        let shape = RoundedRectangle(cornerRadius: Self.swatchRadius(forKeyRadius: resolved.cornerRadius))
         if resolved.hasGlassKeys, #available(iOS 26.0, *) {
             letter(resolved)
-                .glassEffect(.regular.tint(Self.glassTint), in: shape)
+                .glassEffect(.regular.tint(KeyView.glassTint), in: shape)
         } else if resolved.hasGlassKeys {
-            shape.fill(.bar).overlay(letter(resolved))
+            filled(shape, with: .bar, resolved: resolved).overlay(letter(resolved))
         } else {
-            shape.fill(resolved.keyColor).overlay(letter(resolved))
+            filled(shape, with: resolved.keyColor, resolved: resolved).overlay(letter(resolved))
+        }
+    }
+
+    /// Mirrors `KeyView.filled`: no border in the tree at all for a theme
+    /// without one.
+    @ViewBuilder private func filled(
+        _ shape: RoundedRectangle,
+        with fill: some ShapeStyle,
+        resolved: ResolvedTheme
+    ) -> some View {
+        if let border = resolved.keyBorder, resolved.keyBorderWidth > 0 {
+            shape.fill(fill)
+                .overlay(shape.strokeBorder(
+                    border,
+                    lineWidth: Self.swatchBorderWidth(forKeyBorderWidth: resolved.keyBorderWidth)
+                ))
+        } else {
+            shape.fill(fill)
         }
     }
 

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -14,6 +14,13 @@ struct StyleSettingsView: View {
     @AppStorage(SettingsKey.selectedThemeDark.rawValue, store: SharedDefaults.store)
     private var selectedThemeDark = BuiltInThemes.classic.id
 
+    @AppStorage(SettingsKey.themeSeparateDarkSlot.rawValue, store: SharedDefaults.store)
+    private var separateDarkSlot = false
+
+    /// Which slot the gallery currently edits and previews. Only meaningful
+    /// while `separateDarkSlot` is on; otherwise selection writes both slots.
+    @State private var editingAppearance: ColorScheme = .light
+
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var previewAspectRatio = DeviceLayout.defaultKeyAspectRatio
 
@@ -23,33 +30,29 @@ struct StyleSettingsView: View {
     @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
     private var previewPosition = DeviceLayout.defaultKeyboardPosition
 
+    /// The theme id the gallery currently reflects: the dark slot while editing
+    /// dark mode, otherwise the light slot (which both slots share when the
+    /// separate-dark-slot toggle is off).
+    private var activeThemeId: String {
+        separateDarkSlot && editingAppearance == .dark ? selectedThemeDark : selectedThemeLight
+    }
+
     var body: some View {
         VStack(spacing: 20) {
-            // Keyboard Preview
-            InteractiveKeyboardPreview(aspectRatio: $previewAspectRatio, width: $previewWidth, position: $previewPosition)
-                .padding(.horizontal, 16)
+            // Keyboard Preview — forced into the edited appearance so the dark
+            // slot can be previewed on a light device (and vice versa).
+            InteractiveKeyboardPreview(
+                aspectRatio: $previewAspectRatio,
+                width: $previewWidth,
+                position: $previewPosition,
+                appearanceOverride: separateDarkSlot ? editingAppearance : nil
+            )
+            .padding(.horizontal, 16)
 
             ScrollView {
                 VStack(spacing: 24) {
-                    // Theme Selection
-                    VStack(alignment: .leading, spacing: 16) {
-                        Text("Visual Style")
-                            .font(.headline)
-                            .padding(.horizontal, 16)
-
-                        ForEach(BuiltInThemes.all) { theme in
-                            themeOption(theme)
-                        }
-
-                        if selectedThemeLight == BuiltInThemes.liquidGlass.id {
-                            if #unavailable(iOS 26.0) {
-                                Text("Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.")
-                                    .font(.caption)
-                                    .foregroundColor(.orange)
-                                    .padding(.horizontal, 16)
-                            }
-                        }
-                    }
+                    appearanceSection
+                    stylesSection
                 }
                 .padding(.vertical, 8)
             }
@@ -59,12 +62,71 @@ struct StyleSettingsView: View {
         .navigationBarTitleDisplayMode(.inline)
     }
 
-    private func themeOption(_ theme: KeyboardThemeDefinition) -> some View {
-        Button {
-            // Both appearance slots follow one selection until the gallery
-            // gains its separate light/dark assignment (milestone M2).
+    /// Toggle for assigning a separate dark-mode theme, plus the light/dark
+    /// segment that picks which slot the gallery edits.
+    private var appearanceSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Toggle("Use a different theme in Dark Mode", isOn: $separateDarkSlot)
+                .padding(.horizontal, 16)
+                .onChange(of: separateDarkSlot) { _, isOn in
+                    if !isOn {
+                        // Collapse back to one selection.
+                        selectedThemeDark = selectedThemeLight
+                        editingAppearance = .light
+                    }
+                }
+
+            if separateDarkSlot {
+                Picker("Editing appearance", selection: $editingAppearance) {
+                    Label("Light Mode", systemImage: "sun.max").tag(ColorScheme.light)
+                    Label("Dark Mode", systemImage: "moon").tag(ColorScheme.dark)
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal, 16)
+            }
+        }
+    }
+
+    /// The built-in themes as descriptive cards.
+    private var stylesSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Visual Style")
+                .font(.headline)
+                .padding(.horizontal, 16)
+
+            ForEach(BuiltInThemes.all) { theme in
+                themeOption(theme)
+            }
+
+            if activeThemeId == BuiltInThemes.liquidGlass.id {
+                if #unavailable(iOS 26.0) {
+                    Text("Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                        .padding(.horizontal, 16)
+                }
+            }
+        }
+    }
+
+    /// Assigns the theme to the slot being edited. With the separate-dark-slot
+    /// toggle off, both slots follow one selection.
+    private func select(_ theme: KeyboardThemeDefinition) {
+        if separateDarkSlot {
+            if editingAppearance == .dark {
+                selectedThemeDark = theme.id
+            } else {
+                selectedThemeLight = theme.id
+            }
+        } else {
             selectedThemeLight = theme.id
             selectedThemeDark = theme.id
+        }
+    }
+
+    private func themeOption(_ theme: KeyboardThemeDefinition) -> some View {
+        Button {
+            select(theme)
         } label: {
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
@@ -81,7 +143,7 @@ struct StyleSettingsView: View {
 
                 Spacer()
 
-                if selectedThemeLight == theme.id {
+                if activeThemeId == theme.id {
                     Image(systemName: "checkmark")
                         .foregroundColor(.accentColor)
                         .fontWeight(.semibold)
@@ -91,7 +153,7 @@ struct StyleSettingsView: View {
             .padding(.vertical, 12)
             .background(
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(selectedThemeLight == theme.id ? Color.accentColor.opacity(0.1) : Color.clear)
+                    .fill(activeThemeId == theme.id ? Color.accentColor.opacity(0.1) : Color.clear)
             )
         }
         .buttonStyle(.plain)

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -34,6 +34,10 @@ struct StyleSettingsView: View {
     /// the light slot and the dark one is left untouched.
     @State private var editingAppearance: ColorScheme = .light
 
+    /// The device appearance, used wherever a theme is rendered while the
+    /// gallery is not pinned to one slot.
+    @Environment(\.colorScheme) private var systemColorScheme
+
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var previewAspectRatio = DeviceLayout.defaultKeyAspectRatio
 
@@ -304,7 +308,14 @@ struct StyleSettingsView: View {
 
     private func selectLabel(_ theme: KeyboardThemeDefinition, isSelected: Bool) -> some View {
         HStack(spacing: 12) {
+            // Forced into the edited appearance for the same reason the preview
+            // is: a swatch resolves the theme's semantic colors against its own
+            // trait, so on a light device editing the dark slot it would draw
+            // the light rendering of the very theme the preview above shows
+            // dark. Only the swatch is overridden — the row's own text is app
+            // chrome and follows the device.
             ThemeSwatch(theme: theme)
+                .environment(\.colorScheme, appearanceOverride ?? systemColorScheme)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(theme.displayName)

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -2,14 +2,17 @@
 //  StyleSettingsView.swift
 //  wurstfinger
 //
-//  Visual style settings for the keyboard appearance
+//  Theme selection for the keyboard appearance.
 //
 
 import SwiftUI
 
 struct StyleSettingsView: View {
-    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
-    private var keyboardStyleRaw = KeyboardStyle.classic.rawValue
+    @AppStorage(SettingsKey.selectedThemeLight.rawValue, store: SharedDefaults.store)
+    private var selectedThemeLight = BuiltInThemes.classic.id
+
+    @AppStorage(SettingsKey.selectedThemeDark.rawValue, store: SharedDefaults.store)
+    private var selectedThemeDark = BuiltInThemes.classic.id
 
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var previewAspectRatio = DeviceLayout.defaultKeyAspectRatio
@@ -28,23 +31,14 @@ struct StyleSettingsView: View {
 
             ScrollView {
                 VStack(spacing: 24) {
-                    // Style Selection
+                    // Theme Selection
                     VStack(alignment: .leading, spacing: 16) {
                         Text("Visual Style")
                             .font(.headline)
                             .padding(.horizontal, 16)
 
-                        ForEach(KeyboardStyle.allCases, id: \.self) { style in
-                            styleOption(style)
-                        }
-
-                        if keyboardStyleRaw == KeyboardStyle.liquidGlass.rawValue {
-                            if #unavailable(iOS 26.0) {
-                                Text("Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.")
-                                    .font(.caption)
-                                    .foregroundColor(.orange)
-                                    .padding(.horizontal, 16)
-                            }
+                        ForEach(BuiltInThemes.all) { theme in
+                            themeOption(theme)
                         }
                     }
                 }
@@ -56,24 +50,29 @@ struct StyleSettingsView: View {
         .navigationBarTitleDisplayMode(.inline)
     }
 
-    private func styleOption(_ style: KeyboardStyle) -> some View {
+    private func themeOption(_ theme: KeyboardThemeDefinition) -> some View {
         Button {
-            keyboardStyleRaw = style.rawValue
+            // Both appearance slots follow one selection until the gallery
+            // gains its separate light/dark assignment (milestone M2).
+            selectedThemeLight = theme.id
+            selectedThemeDark = theme.id
         } label: {
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(style.displayName)
+                    Text(theme.displayName)
                         .font(.body)
                         .foregroundColor(.primary)
 
-                    Text(style.description)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                    if let description = theme.displayDescription {
+                        Text(description)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
                 }
 
                 Spacer()
 
-                if keyboardStyleRaw == style.rawValue {
+                if selectedThemeLight == theme.id {
                     Image(systemName: "checkmark")
                         .foregroundColor(.accentColor)
                         .fontWeight(.semibold)
@@ -83,31 +82,11 @@ struct StyleSettingsView: View {
             .padding(.vertical, 12)
             .background(
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(keyboardStyleRaw == style.rawValue ? Color.accentColor.opacity(0.1) : Color.clear)
+                    .fill(selectedThemeLight == theme.id ? Color.accentColor.opacity(0.1) : Color.clear)
             )
         }
         .buttonStyle(.plain)
         .padding(.horizontal, 16)
-    }
-}
-
-extension KeyboardStyle {
-    /// User-facing style name. Lives in the host app target: the extension's
-    /// own catalog carries only the strings the keyboard itself displays, so a
-    /// settings-only name must not be looked up from extension code.
-    var displayName: String {
-        switch self {
-        case .classic: String(localized: "Classic")
-        case .liquidGlass: String(localized: "Liquid Glass")
-        }
-    }
-
-    /// One-line explanation shown under the style name.
-    var description: String {
-        switch self {
-        case .classic: String(localized: "Traditional opaque keys")
-        case .liquidGlass: String(localized: "Transparent glass effect (iOS 26+)")
-        }
     }
 }
 

--- a/wurstfinger/ThemeEditorView.swift
+++ b/wurstfinger/ThemeEditorView.swift
@@ -1,0 +1,255 @@
+//
+//  ThemeEditorView.swift
+//  wurstfinger
+//
+//  Edits a single user theme: name, surface fills, and label colors. Works on
+//  a local copy and calls back on Save/Delete, so the gallery owns
+//  persistence. A live preview renders the working copy through the same
+//  `ResolvedTheme` path as the keyboard.
+//
+
+import SwiftUI
+
+struct ThemeEditorView: View {
+    /// Working copy. Edits stay local until Save.
+    @State private var theme: KeyboardThemeDefinition
+
+    let onSave: (KeyboardThemeDefinition) -> Void
+    let onDelete: (String) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var showDeleteConfirmation = false
+
+    init(
+        theme: KeyboardThemeDefinition,
+        onSave: @escaping (KeyboardThemeDefinition) -> Void,
+        onDelete: @escaping (String) -> Void
+    ) {
+        _theme = State(initialValue: theme)
+        self.onSave = onSave
+        self.onDelete = onDelete
+    }
+
+    private var trimmedName: String {
+        theme.name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    ThemePreviewGrid(theme: theme.resolved())
+                        .frame(maxWidth: .infinity)
+                        .listRowInsets(EdgeInsets())
+                        .listRowBackground(Color.clear)
+                }
+
+                Section("Name") {
+                    TextField("Theme name", text: $theme.name)
+                }
+
+                Section("Surfaces") {
+                    fillRow("Keyboard background", fill: $theme.boardBackground)
+                    fillRow("Key", fill: $theme.keyFill)
+                    fillRow("Key (pressed)", fill: $theme.keyFillActive)
+                    borderRows
+                    cornerRadiusRow
+                }
+
+                Section("Labels") {
+                    colorRow("Main letter", color: $theme.mainLabel)
+                    colorRow("Function label", color: $theme.utilityLabel)
+                    colorRow("Hint letter", color: $theme.hintLetter)
+                    colorRow("Hint symbol", color: $theme.hintSymbol)
+                    colorRow("Prominent icon", color: $theme.hintIconProminent)
+                    colorRow("Subtle icon", color: $theme.hintIconSubtle)
+                }
+
+                Section {
+                    Button(role: .destructive) {
+                        showDeleteConfirmation = true
+                    } label: {
+                        Label("Delete Theme", systemImage: "trash")
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+            .navigationTitle("Edit Theme")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        onSave(theme)
+                        dismiss()
+                    }
+                    .disabled(trimmedName.isEmpty)
+                }
+            }
+            .confirmationDialog(
+                "Delete this theme?",
+                isPresented: $showDeleteConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Delete Theme", role: .destructive) {
+                    onDelete(theme.id)
+                    dismiss()
+                }
+            }
+        }
+    }
+
+    // MARK: - Rows
+
+    /// A color well for a label color. Reads the resolved color; writing stores
+    /// a fixed hex (a user theme is fully explicit once edited).
+    private func colorRow(_ title: LocalizedStringKey, color: Binding<ThemeColor>) -> some View {
+        ColorPicker(
+            title,
+            selection: Binding(
+                get: { color.wrappedValue.resolvedColor() ?? .gray },
+                set: { color.wrappedValue = .from($0) }
+            ),
+            supportsOpacity: true
+        )
+    }
+
+    /// A color well for a surface fill. The glass material has no single color,
+    /// so it reads as a neutral gray and picking any color converts the fill to
+    /// a solid color.
+    private func fillRow(_ title: LocalizedStringKey, fill: Binding<ThemeFill>) -> some View {
+        ColorPicker(
+            title,
+            selection: Binding(
+                get: {
+                    if case let .color(color) = fill.wrappedValue {
+                        return color.resolvedColor() ?? .gray
+                    }
+                    return .gray
+                },
+                set: { fill.wrappedValue = .color(.from($0)) }
+            ),
+            supportsOpacity: true
+        )
+    }
+
+    @ViewBuilder private var borderRows: some View {
+        Toggle("Key border", isOn: Binding(
+            get: { theme.keyBorder != nil },
+            set: { isOn in
+                theme.keyBorder = isOn ? (theme.keyBorder ?? .fixed(hex: "#00000030")) : nil
+                if isOn, theme.keyBorderWidth == 0 { theme.keyBorderWidth = 0.5 }
+            }
+        ))
+
+        if let border = theme.keyBorder {
+            ColorPicker(
+                "Border color",
+                selection: Binding(
+                    get: { border.resolvedColor() ?? .gray },
+                    set: { theme.keyBorder = .from($0) }
+                ),
+                supportsOpacity: true
+            )
+
+            HStack {
+                Text("Border width")
+                Spacer()
+                Text(theme.keyBorderWidth, format: .number.precision(.fractionLength(1)))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            Slider(value: $theme.keyBorderWidth, in: 0.5 ... 4, step: 0.5)
+        }
+    }
+
+    private var cornerRadiusRow: some View {
+        VStack {
+            HStack {
+                Text("Corner radius")
+                Spacer()
+                Text(theme.cornerRadius, format: .number.precision(.fractionLength(0)))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            Slider(value: $theme.cornerRadius, in: 0 ... 24, step: 1)
+        }
+    }
+}
+
+// MARK: - Preview grid
+
+/// A static, representative slice of the keyboard rendered from a resolved
+/// theme: the board fill behind a small grid of keys, with a pressed key and a
+/// couple of hint glyphs so every editable role is visible at a glance.
+struct ThemePreviewGrid: View {
+    let theme: ResolvedTheme
+
+    private let letters = [["a", "n", "i"], ["h", "d", "r"], ["t", "e", "s"]]
+    /// The center key renders in the pressed fill to preview `keyFillActive`.
+    private let pressed = (row: 1, column: 1)
+
+    var body: some View {
+        VStack(spacing: 6) {
+            ForEach(Array(letters.enumerated()), id: \.offset) { rowIndex, row in
+                HStack(spacing: 6) {
+                    ForEach(Array(row.enumerated()), id: \.offset) { columnIndex, letter in
+                        key(letter, isPressed: rowIndex == pressed.row && columnIndex == pressed.column)
+                    }
+                }
+            }
+        }
+        .padding(10)
+        .background { fill(theme.boardBackground) }
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .padding(.vertical, 4)
+    }
+
+    private func key(_ letter: String, isPressed: Bool) -> some View {
+        ZStack {
+            fill(isPressed ? theme.keyFillActive : theme.keyFill)
+                .clipShape(RoundedRectangle(cornerRadius: theme.cornerRadius))
+                .overlay(
+                    RoundedRectangle(cornerRadius: theme.cornerRadius)
+                        .strokeBorder(theme.keyBorder ?? .clear, lineWidth: theme.keyBorderWidth)
+                )
+
+            Text(verbatim: letter)
+                .font(.system(size: 22, weight: .semibold, design: .rounded))
+                .foregroundStyle(theme.mainLabel)
+
+            // Corner hints preview the hint roles.
+            Text(verbatim: "+")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(theme.hintLetter)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            Text(verbatim: "!")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(theme.hintSymbol)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+        }
+        .frame(width: 52, height: 52)
+    }
+
+    @ViewBuilder private func fill(_ resolved: ResolvedFill) -> some View {
+        switch resolved {
+        case let .color(color): color
+        case .material: Rectangle().fill(.regularMaterial)
+        }
+    }
+}
+
+#Preview {
+    ThemeEditorView(
+        theme: {
+            var copy = BuiltInThemes.darkGold
+            copy.id = "preview-user"
+            copy.name = "My Theme"
+            return copy
+        }(),
+        onSave: { _ in },
+        onDelete: { _ in }
+    )
+}

--- a/wurstfinger/ThemeEditorView.swift
+++ b/wurstfinger/ThemeEditorView.swift
@@ -20,6 +20,20 @@ struct ThemeEditorView: View {
     /// word for keyboard state.
     let isNewTheme: Bool
 
+    /// The appearance the edited theme is destined for, or nil when it serves
+    /// both. Everything that shows a color has to be judged in it: a theme
+    /// bound for the dark slot but previewed light invites label colors that
+    /// are near-invisible where they actually render — and the color wells
+    /// freeze whatever they were seeded with.
+    let appearanceOverride: ColorScheme?
+
+    /// The user's real keyboard geometry, threaded through from the gallery so
+    /// the preview here matches the one there — and so the corner-radius
+    /// slider is judged against the key size the user actually types on.
+    @Binding var previewAspectRatio: Double
+    @Binding var previewWidth: Double
+    @Binding var previewPosition: Double
+
     let onSave: (KeyboardThemeDefinition) -> Void
     let onDelete: (String) -> Void
 
@@ -30,23 +44,38 @@ struct ThemeEditorView: View {
     private var gestureTrailEnabled = false
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var systemColorScheme
     @State private var showDeleteConfirmation = false
     @FocusState private var isNameFocused: Bool
 
     init(
         theme: KeyboardThemeDefinition,
         isNewTheme: Bool,
+        appearanceOverride: ColorScheme? = nil,
+        previewAspectRatio: Binding<Double> = .constant(DeviceLayoutUtils.defaultKeyAspectRatio),
+        previewWidth: Binding<Double> = .constant(DeviceLayoutUtils.defaultKeyboardWidth),
+        previewPosition: Binding<Double> = .constant(DeviceLayoutUtils.defaultKeyboardPosition),
         onSave: @escaping (KeyboardThemeDefinition) -> Void,
         onDelete: @escaping (String) -> Void
     ) {
         _theme = State(initialValue: theme)
         self.isNewTheme = isNewTheme
+        self.appearanceOverride = appearanceOverride
+        _previewAspectRatio = previewAspectRatio
+        _previewWidth = previewWidth
+        _previewPosition = previewPosition
         self.onSave = onSave
         self.onDelete = onDelete
     }
 
     private var trimmedName: String {
         theme.name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// The appearance every color in this editor is judged in: the slot's own
+    /// when the theme is bound to one, the device's otherwise.
+    private var editedAppearance: ColorScheme {
+        appearanceOverride ?? systemColorScheme
     }
 
     var body: some View {
@@ -56,9 +85,15 @@ struct ThemeEditorView: View {
                     // The real renderer, not a mock: it is the only way to
                     // preview glass on glass, and because it mounts the actual
                     // grid, swiping over it draws the trail in the edited color.
-                    InteractiveKeyboardPreview(themeOverride: theme)
-                        .listRowInsets(EdgeInsets())
-                        .listRowBackground(Color.clear)
+                    InteractiveKeyboardPreview(
+                        aspectRatio: $previewAspectRatio,
+                        width: $previewWidth,
+                        position: $previewPosition,
+                        appearanceOverride: appearanceOverride,
+                        themeOverride: theme
+                    )
+                    .listRowInsets(EdgeInsets())
+                    .listRowBackground(Color.clear)
                 }
 
                 Section("Name") {
@@ -125,7 +160,7 @@ struct ThemeEditorView: View {
         Section {
             Toggle("Liquid Glass", isOn: Binding(
                 get: { theme.keySurface == .glass },
-                set: { theme.keySurface = $0 ? .glass : .color }
+                set: { theme.setGlassKeys($0) }
             ))
             // Both surfaces carry the same visible label in different
             // sections; for VoiceOver the accessibility label is the only
@@ -148,13 +183,23 @@ struct ThemeEditorView: View {
             Text("Keys")
         } footer: {
             if theme.keySurface == .glass {
-                // The literal has to stay on one line: a comment between
-                // `Text(` and it would hide the key from the localization
-                // coverage test.
+                // Split per OS: the border controls stay live on both, but only
+                // the pre-iOS-26 fallback actually draws the border. Stating
+                // that unconditionally told an iOS 26 user — a VoiceOver one in
+                // particular — that three controls do something they do not.
+                // The literals have to stay on one line each: a comment between
+                // `Text(` and the string would hide the key from the
+                // localization coverage test.
                 // swiftlint:disable line_length
-                Text(
-                    "Glass keys take their color from what is behind the keyboard, so the key colors do not apply. Corner radius still shapes them. The border shows only before iOS 26, where a simplified translucent style stands in for Liquid Glass."
-                )
+                if #available(iOS 26.0, *) {
+                    Text(
+                        "Glass keys take their color from what is behind the keyboard, so the key colors do not apply. Corner radius still shapes them. Liquid Glass draws no border, so the border settings only take effect if this theme is used on a device before iOS 26."
+                    )
+                } else {
+                    Text(
+                        "Glass keys take their color from what is behind the keyboard, so the key colors do not apply. Corner radius and border still apply: this system renders a simplified translucent style instead of Liquid Glass."
+                    )
+                }
                 // swiftlint:enable line_length
             }
         }
@@ -166,7 +211,7 @@ struct ThemeEditorView: View {
         Section {
             Toggle("Liquid Glass", isOn: Binding(
                 get: { theme.boardSurface == .glass },
-                set: { theme.boardSurface = $0 ? .glass : .color }
+                set: { theme.setGlassBoard($0) }
             ))
             .accessibilityLabel("Liquid Glass background")
 
@@ -211,13 +256,15 @@ struct ThemeEditorView: View {
 
     // MARK: - Rows
 
-    /// A color well for one theme role. Reads the resolved color; writing
-    /// stores a fixed hex (a user theme is fully explicit once edited).
+    /// A color well for one theme role. Seeds from the color as it renders in
+    /// the edited appearance — not as it renders in the sheet the user happens
+    /// to be looking at — because writing freezes the pick as a fixed hex (a
+    /// user theme is fully explicit once edited) and there is no way back.
     private func colorRow(title: LocalizedStringKey, color: Binding<ThemeColor>) -> some View {
         ColorPicker(
             title,
             selection: Binding(
-                get: { color.wrappedValue.resolvedColor() ?? .gray },
+                get: { color.wrappedValue.resolvedColor(in: editedAppearance) ?? .gray },
                 set: { color.wrappedValue = .from($0) }
             ),
             supportsOpacity: true
@@ -225,19 +272,19 @@ struct ThemeEditorView: View {
     }
 
     @ViewBuilder private var borderRows: some View {
+        // The coupled write (a border switched on needs a width to render)
+        // lives in the model, so the rule is testable — see
+        // `KeyboardThemeDefinition.setKeyBorder(_:)`.
         Toggle("Key border", isOn: Binding(
             get: { theme.keyBorder != nil },
-            set: { isOn in
-                theme.keyBorder = isOn ? (theme.keyBorder ?? .fixed(hex: "#00000030")) : nil
-                if isOn, theme.keyBorderWidth == 0 { theme.keyBorderWidth = 0.5 }
-            }
+            set: { theme.setKeyBorder($0) }
         ))
 
         if let border = theme.keyBorder {
             ColorPicker(
                 "Border color",
                 selection: Binding(
-                    get: { border.resolvedColor() ?? .gray },
+                    get: { border.resolvedColor(in: editedAppearance) ?? .gray },
                     set: { theme.keyBorder = .from($0) }
                 ),
                 supportsOpacity: true
@@ -250,7 +297,7 @@ struct ThemeEditorView: View {
                     .foregroundStyle(.secondary)
                     .monospacedDigit()
             }
-            Slider(value: $theme.keyBorderWidth, in: 0.5 ... 4, step: 0.5)
+            Slider(value: $theme.keyBorderWidth, in: KeyboardThemeDefinition.minimumKeyBorderWidth ... 4, step: 0.5)
         }
     }
 

--- a/wurstfinger/ThemeEditorView.swift
+++ b/wurstfinger/ThemeEditorView.swift
@@ -52,9 +52,9 @@ struct ThemeEditorView: View {
         theme: KeyboardThemeDefinition,
         isNewTheme: Bool,
         appearanceOverride: ColorScheme? = nil,
-        previewAspectRatio: Binding<Double> = .constant(DeviceLayoutUtils.defaultKeyAspectRatio),
-        previewWidth: Binding<Double> = .constant(DeviceLayoutUtils.defaultKeyboardWidth),
-        previewPosition: Binding<Double> = .constant(DeviceLayoutUtils.defaultKeyboardPosition),
+        previewAspectRatio: Binding<Double> = .constant(DeviceLayout.defaultKeyAspectRatio),
+        previewWidth: Binding<Double> = .constant(DeviceLayout.defaultKeyboardWidth),
+        previewPosition: Binding<Double> = .constant(DeviceLayout.defaultKeyboardPosition),
         onSave: @escaping (KeyboardThemeDefinition) -> Void,
         onDelete: @escaping (String) -> Void
     ) {

--- a/wurstfinger/ThemeEditorView.swift
+++ b/wurstfinger/ThemeEditorView.swift
@@ -49,9 +49,9 @@ struct ThemeEditorView: View {
                 }
 
                 Section("Surfaces") {
-                    fillRow("Keyboard background", fill: $theme.boardBackground)
-                    fillRow("Key", fill: $theme.keyFill)
-                    fillRow("Key (pressed)", fill: $theme.keyFillActive)
+                    colorRow("Keyboard background", color: $theme.boardColor)
+                    colorRow("Key", color: $theme.keyColor)
+                    colorRow("Key (pressed)", color: $theme.keyColorActive)
                     borderRows
                     cornerRadiusRow
                 }
@@ -116,25 +116,6 @@ struct ThemeEditorView: View {
         )
     }
 
-    /// A color well for a surface fill. The glass material has no single color,
-    /// so it reads as a neutral gray and picking any color converts the fill to
-    /// a solid color.
-    private func fillRow(_ title: LocalizedStringKey, fill: Binding<ThemeFill>) -> some View {
-        ColorPicker(
-            title,
-            selection: Binding(
-                get: {
-                    if case let .color(color) = fill.wrappedValue {
-                        return color.resolvedColor() ?? .gray
-                    }
-                    return .gray
-                },
-                set: { fill.wrappedValue = .color(.from($0)) }
-            ),
-            supportsOpacity: true
-        )
-    }
-
     @ViewBuilder private var borderRows: some View {
         Toggle("Key border", isOn: Binding(
             get: { theme.keyBorder != nil },
@@ -188,7 +169,7 @@ struct ThemePreviewGrid: View {
     let theme: ResolvedTheme
 
     private let letters = [["a", "n", "i"], ["h", "d", "r"], ["t", "e", "s"]]
-    /// The center key renders in the pressed fill to preview `keyFillActive`.
+    /// The center key renders in the pressed fill to preview `keyColorActive`.
     private let pressed = (row: 1, column: 1)
 
     var body: some View {
@@ -202,14 +183,14 @@ struct ThemePreviewGrid: View {
             }
         }
         .padding(10)
-        .background { fill(theme.boardBackground) }
+        .background { theme.boardBackground }
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .padding(.vertical, 4)
     }
 
     private func key(_ letter: String, isPressed: Bool) -> some View {
         ZStack {
-            fill(isPressed ? theme.keyFillActive : theme.keyFill)
+            (isPressed ? theme.keyColorActive : theme.keyColor)
                 .clipShape(RoundedRectangle(cornerRadius: theme.cornerRadius))
                 .overlay(
                     RoundedRectangle(cornerRadius: theme.cornerRadius)
@@ -231,13 +212,6 @@ struct ThemePreviewGrid: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
         }
         .frame(width: 52, height: 52)
-    }
-
-    @ViewBuilder private func fill(_ resolved: ResolvedFill) -> some View {
-        switch resolved {
-        case let .color(color): color
-        case .material: Rectangle().fill(.regularMaterial)
-        }
     }
 }
 

--- a/wurstfinger/ThemeEditorView.swift
+++ b/wurstfinger/ThemeEditorView.swift
@@ -2,10 +2,10 @@
 //  ThemeEditorView.swift
 //  wurstfinger
 //
-//  Edits a single user theme: name, surface fills, and label colors. Works on
-//  a local copy and calls back on Save/Delete, so the gallery owns
-//  persistence. A live preview renders the working copy through the same
-//  `ResolvedTheme` path as the keyboard.
+//  Edits a single user theme: name, the two surfaces, label colors, and the
+//  gesture-trail color. Works on a local copy and calls back on Save/Delete,
+//  so the gallery owns persistence. The live preview is the real keyboard
+//  renderer, driven by the working copy through `themeOverride`.
 //
 
 import SwiftUI
@@ -14,18 +14,33 @@ struct ThemeEditorView: View {
     /// Working copy. Edits stay local until Save.
     @State private var theme: KeyboardThemeDefinition
 
+    /// Whether Save *creates* the theme. A new theme is an unpersisted
+    /// duplicate: Cancel has to leave no trace, and there is nothing to delete
+    /// yet. A `Bool` rather than a `…Mode` enum — the glossary reserves that
+    /// word for keyboard state.
+    let isNewTheme: Bool
+
     let onSave: (KeyboardThemeDefinition) -> Void
     let onDelete: (String) -> Void
 
+    /// The trail color only renders when the user has the trail switched on,
+    /// so the editor discloses that instead of offering a control that
+    /// silently does nothing.
+    @AppStorage(SettingsKey.gestureTrailEnabled.rawValue, store: SharedDefaults.store)
+    private var gestureTrailEnabled = false
+
     @Environment(\.dismiss) private var dismiss
     @State private var showDeleteConfirmation = false
+    @FocusState private var isNameFocused: Bool
 
     init(
         theme: KeyboardThemeDefinition,
+        isNewTheme: Bool,
         onSave: @escaping (KeyboardThemeDefinition) -> Void,
         onDelete: @escaping (String) -> Void
     ) {
         _theme = State(initialValue: theme)
+        self.isNewTheme = isNewTheme
         self.onSave = onSave
         self.onDelete = onDelete
     }
@@ -38,43 +53,37 @@ struct ThemeEditorView: View {
         NavigationStack {
             Form {
                 Section {
-                    ThemePreviewGrid(theme: theme.resolved())
-                        .frame(maxWidth: .infinity)
+                    // The real renderer, not a mock: it is the only way to
+                    // preview glass on glass, and because it mounts the actual
+                    // grid, swiping over it draws the trail in the edited color.
+                    InteractiveKeyboardPreview(themeOverride: theme)
                         .listRowInsets(EdgeInsets())
                         .listRowBackground(Color.clear)
                 }
 
                 Section("Name") {
                     TextField("Theme name", text: $theme.name)
+                        .focused($isNameFocused)
                 }
 
-                Section("Surfaces") {
-                    colorRow("Keyboard background", color: $theme.boardColor)
-                    colorRow("Key", color: $theme.keyColor)
-                    colorRow("Key (pressed)", color: $theme.keyColorActive)
-                    borderRows
-                    cornerRadiusRow
-                }
+                keysSection
+                backgroundSection
 
                 Section("Labels") {
-                    colorRow("Main letter", color: $theme.mainLabel)
-                    colorRow("Function label", color: $theme.utilityLabel)
-                    colorRow("Hint letter", color: $theme.hintLetter)
-                    colorRow("Hint symbol", color: $theme.hintSymbol)
-                    colorRow("Prominent icon", color: $theme.hintIconProminent)
-                    colorRow("Subtle icon", color: $theme.hintIconSubtle)
+                    colorRow(title: "Main letter", color: $theme.mainLabel)
+                    colorRow(title: "Function label", color: $theme.utilityLabel)
+                    colorRow(title: "Hint letter", color: $theme.hintLetter)
+                    colorRow(title: "Hint symbol", color: $theme.hintSymbol)
+                    colorRow(title: "Prominent icon", color: $theme.hintIconProminent)
+                    colorRow(title: "Subtle icon", color: $theme.hintIconSubtle)
                 }
 
-                Section {
-                    Button(role: .destructive) {
-                        showDeleteConfirmation = true
-                    } label: {
-                        Label("Delete Theme", systemImage: "trash")
-                            .frame(maxWidth: .infinity)
-                    }
-                }
+                gestureTrailSection
+                deleteSection
             }
-            .navigationTitle("Edit Theme")
+            // Passed as `Text` rather than a ternary over two string literals
+            // so the localization coverage test can see both keys.
+            .navigationTitle(isNewTheme ? Text("New Theme") : Text("Edit Theme"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -98,14 +107,113 @@ struct ThemeEditorView: View {
                     dismiss()
                 }
             }
+            .onAppear {
+                guard isNewTheme else { return }
+                // A sheet's text field is not in the responder chain yet on the
+                // run-loop pass that presents it, so the focus request has to
+                // wait for the next one.
+                DispatchQueue.main.async { isNameFocused = true }
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    /// Keys: the glass switch, the key colors it replaces, and the shape
+    /// controls that apply either way.
+    private var keysSection: some View {
+        Section {
+            Toggle("Liquid Glass", isOn: Binding(
+                get: { theme.keySurface == .glass },
+                set: { theme.keySurface = $0 ? .glass : .color }
+            ))
+            // Both surfaces carry the same visible label in different
+            // sections; for VoiceOver the accessibility label is the only
+            // thing that tells the two switches apart.
+            .accessibilityLabel("Liquid Glass keys")
+
+            // Hidden rather than disabled: a disabled color well still shows a
+            // swatch and reads as a control that does something. The footer
+            // carries the explanation, which VoiceOver reads with the section.
+            if theme.keySurface == .color {
+                colorRow(title: "Key", color: $theme.keyColor)
+                colorRow(title: "Key (pressed)", color: $theme.keyColorActive)
+            }
+
+            // Border and radius stay visible in every state: the radius shapes
+            // glass too, and the border is drawn on the pre-iOS-26 fallback.
+            borderRows
+            cornerRadiusRow
+        } header: {
+            Text("Keys")
+        } footer: {
+            if theme.keySurface == .glass {
+                // The literal has to stay on one line: a comment between
+                // `Text(` and it would hide the key from the localization
+                // coverage test.
+                // swiftlint:disable line_length
+                Text(
+                    "Glass keys take their color from what is behind the keyboard, so the key colors do not apply. Corner radius still shapes them. The border shows only before iOS 26, where a simplified translucent style stands in for Liquid Glass."
+                )
+                // swiftlint:enable line_length
+            }
+        }
+    }
+
+    /// Background: the board behind the keys, which is either a color or
+    /// near-clear glass.
+    private var backgroundSection: some View {
+        Section {
+            Toggle("Liquid Glass", isOn: Binding(
+                get: { theme.boardSurface == .glass },
+                set: { theme.boardSurface = $0 ? .glass : .color }
+            ))
+            .accessibilityLabel("Liquid Glass background")
+
+            if theme.boardSurface == .color {
+                colorRow(title: "Keyboard background", color: $theme.boardColor)
+            }
+        } header: {
+            Text("Background")
+        } footer: {
+            if theme.boardSurface == .glass {
+                Text("A glass background lets the app behind the keyboard show through, so the background color does not apply.")
+            }
+        }
+    }
+
+    private var gestureTrailSection: some View {
+        Section {
+            colorRow(title: "Trail color", color: $theme.gestureTrail)
+        } header: {
+            Text("Gesture Trail")
+        } footer: {
+            if !gestureTrailEnabled {
+                Text("Turn on Gesture Trail in Settings to draw this color while you swipe.")
+            }
+        }
+    }
+
+    /// Absent while the theme is new — there is nothing persisted to delete,
+    /// and Cancel already discards it.
+    @ViewBuilder private var deleteSection: some View {
+        if !isNewTheme {
+            Section {
+                Button(role: .destructive) {
+                    showDeleteConfirmation = true
+                } label: {
+                    Label("Delete Theme", systemImage: "trash")
+                        .frame(maxWidth: .infinity)
+                }
+            }
         }
     }
 
     // MARK: - Rows
 
-    /// A color well for a label color. Reads the resolved color; writing stores
-    /// a fixed hex (a user theme is fully explicit once edited).
-    private func colorRow(_ title: LocalizedStringKey, color: Binding<ThemeColor>) -> some View {
+    /// A color well for one theme role. Reads the resolved color; writing
+    /// stores a fixed hex (a user theme is fully explicit once edited).
+    private func colorRow(title: LocalizedStringKey, color: Binding<ThemeColor>) -> some View {
         ColorPicker(
             title,
             selection: Binding(
@@ -160,61 +268,6 @@ struct ThemeEditorView: View {
     }
 }
 
-// MARK: - Preview grid
-
-/// A static, representative slice of the keyboard rendered from a resolved
-/// theme: the board fill behind a small grid of keys, with a pressed key and a
-/// couple of hint glyphs so every editable role is visible at a glance.
-struct ThemePreviewGrid: View {
-    let theme: ResolvedTheme
-
-    private let letters = [["a", "n", "i"], ["h", "d", "r"], ["t", "e", "s"]]
-    /// The center key renders in the pressed fill to preview `keyColorActive`.
-    private let pressed = (row: 1, column: 1)
-
-    var body: some View {
-        VStack(spacing: 6) {
-            ForEach(Array(letters.enumerated()), id: \.offset) { rowIndex, row in
-                HStack(spacing: 6) {
-                    ForEach(Array(row.enumerated()), id: \.offset) { columnIndex, letter in
-                        key(letter, isPressed: rowIndex == pressed.row && columnIndex == pressed.column)
-                    }
-                }
-            }
-        }
-        .padding(10)
-        .background { theme.boardBackground }
-        .clipShape(RoundedRectangle(cornerRadius: 14))
-        .padding(.vertical, 4)
-    }
-
-    private func key(_ letter: String, isPressed: Bool) -> some View {
-        ZStack {
-            (isPressed ? theme.keyColorActive : theme.keyColor)
-                .clipShape(RoundedRectangle(cornerRadius: theme.cornerRadius))
-                .overlay(
-                    RoundedRectangle(cornerRadius: theme.cornerRadius)
-                        .strokeBorder(theme.keyBorder ?? .clear, lineWidth: theme.keyBorderWidth)
-                )
-
-            Text(verbatim: letter)
-                .font(.system(size: 22, weight: .semibold, design: .rounded))
-                .foregroundStyle(theme.mainLabel)
-
-            // Corner hints preview the hint roles.
-            Text(verbatim: "+")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(theme.hintLetter)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            Text(verbatim: "!")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(theme.hintSymbol)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
-        }
-        .frame(width: 52, height: 52)
-    }
-}
-
 #Preview {
     ThemeEditorView(
         theme: {
@@ -223,6 +276,7 @@ struct ThemePreviewGrid: View {
             copy.name = "My Theme"
             return copy
         }(),
+        isNewTheme: false,
         onSave: { _ in },
         onDelete: { _ in }
     )

--- a/wurstfinger/wurstfingerApp.swift
+++ b/wurstfinger/wurstfingerApp.swift
@@ -36,6 +36,7 @@ struct wurstfingerApp: App {
             SettingsKey.keyboardHorizontalPosition.rawValue: DeviceLayout.defaultKeyboardPosition
         ]
         SharedDefaults.store.register(defaults: defaults)
+        ThemeStore.migrateIfNeeded()
 
         // Determine screenshot mode from launch arguments
         let args = ProcessInfo.processInfo.arguments

--- a/wurstfinger/wurstfingerApp.swift
+++ b/wurstfinger/wurstfingerApp.swift
@@ -36,6 +36,7 @@ struct wurstfingerApp: App {
             SettingsKey.keyboardHorizontalPosition.rawValue: DeviceLayoutUtils.defaultKeyboardPosition
         ]
         SharedDefaults.store.register(defaults: defaults)
+        ThemeStore.migrateIfNeeded()
 
         // Determine screenshot mode from launch arguments
         let args = ProcessInfo.processInfo.arguments

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -490,7 +490,8 @@ final class KeyboardViewController: UIInputViewController {
     /// delivery for the inter-key gaps comes from the SwiftUI board fill,
     /// because a keyboard extension delivers touches over SwiftUI-rendered
     /// pixels, not over this UIKit backdrop behind them (see
-    /// `DataDrivenKeyboardRootView.keyboardBackground` + #198). It is left
+    /// `ResolvedTheme.boardBackground` /
+    /// `KeyboardThemeDefinition.minimumBoardOpacity` + #198). It is left
     /// interactive only so it never swallows a stray touch itself; the SwiftUI
     /// content above always wins the hit-test.
     ///

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -19,7 +19,7 @@ final class KeyboardViewController: UIInputViewController {
     /// while the host app is backgrounded (see `installSuspensionPlaceholder`).
     private var suspensionPlaceholder: UIView?
     /// System-keyboard backdrop behind the SwiftUI content
-    /// (see `installBackdropIfNeeded`). Outlives hosting teardowns.
+    /// (see `installBackdropIfNeeded`). Torn down with the hosting graph.
     private var backdropView: UIInputView?
 
     /// The language selected in the host app, normalised to an id that is
@@ -314,6 +314,20 @@ final class KeyboardViewController: UIInputViewController {
         controller.view.removeFromSuperview()
         controller.removeFromParent()
         hostingController = nil
+        // The backdrop goes with it. Loading it from a nib (see `makeBackdrop`)
+        // is not enough on its own: it is a subview of the controller's root
+        // view, and iOS keeps that view alive long after the controller itself
+        // is gone — measured on device as 25 root views created and none
+        // released. A subview cannot outlive its superview's grip, so the blur
+        // layer has to leave the hierarchy here to be freed at all.
+        // `installBackdropIfNeeded()` rebuilds it on the next appearance; it
+        // guards on nil, so nothing stacks.
+        //
+        // Cost: the app-switcher stand-in installed just above snapshots only
+        // the SwiftUI content, so a card taken after this point shows the keys
+        // without their blur backing. A frozen card is worth a released layer.
+        backdropView?.removeFromSuperview()
+        backdropView = nil
     }
 
     /// Covers the case where the host app itself backgrounds while the
@@ -492,18 +506,45 @@ final class KeyboardViewController: UIInputViewController {
     /// pixels, not over this UIKit backdrop behind them (see
     /// `ResolvedTheme.boardBackground` /
     /// `KeyboardThemeDefinition.minimumBoardOpacity` + #198). It is left
-    /// interactive only so it never swallows a stray touch itself; the SwiftUI
-    /// content above always wins the hit-test.
+    /// non-interactive so it can never take a touch off a key.
     ///
-    /// Installed once and kept across hosting teardowns: the suspension shedding
-    /// releases only the SwiftUI view graph, so rebuilding hosting must not
-    /// stack a second input view behind the keys on every resume.
+    /// Rebuilt per hosting cycle: `teardownHosting()` takes the backdrop out of
+    /// the view hierarchy so its blur layer can actually be released (see there
+    /// for why removal, not just deallocatability, is what frees it). The nil
+    /// guard is what keeps a resume from stacking a second input view behind
+    /// the keys.
+    ///
+    /// ## Why this comes from a nib
+    ///
+    /// A `UIInputView` created *programmatically* never deallocates:
+    /// `_InputViewContent` retains it and it retains `_InputViewContent` back.
+    /// One backdrop is built per host app, and this one spans the whole
+    /// keyboard with a blur layer, so the leak compounds with every app the
+    /// keyboard has ever been used in — measured on device as a permanent
+    /// ~4.5 MB per host generation, which is what walks the extension into the
+    /// per-process jetsam limit and makes the keyboard silently stop appearing.
+    /// Decoding the same view from a nib deallocates normally, which is the
+    /// workaround Apple's own forum thread arrives at.
+    ///
+    /// `inputViewStyle` is `readonly` and set by the designated initializer, so
+    /// a plainly decoded view comes back `.default` and draws nothing like the
+    /// system keyboard. `KeyboardBackdrop.xib` therefore carries a User Defined
+    /// Runtime Attribute that sets it via KVC after decoding. Both halves —
+    /// deallocation *and* the resulting style — are pinned by
+    /// `KeyboardBackdropTests`; do not "simplify" this back to an initializer
+    /// without running them.
+    ///
+    /// - Bug: Apple Developer Forums 807619 and 781520 (`UIInputView` is not
+    ///   deallocated). No Apple fix as of the date below.
+    /// - Last verified present: **2026-08-30** (Xcode 26.1, iOS 26.6).
+    ///   `KeyboardBackdropTests.programmaticInputViewStillLeaks` re-checks this
+    ///   on every test run and fails once Apple fixes it — at which point this
+    ///   whole detour, the nib, and that test should be deleted in favour of
+    ///   `UIInputView(frame:inputViewStyle:)`. Update the date when you confirm
+    ///   the bug still exists.
     private func installBackdropIfNeeded() {
         guard backdropView == nil else { return }
-        let backdrop = UIInputView(frame: .zero, inputViewStyle: .keyboard)
-        // Visual only. It spans the whole input view behind the SwiftUI
-        // content, and touch delivery in an extension is the fragile part
-        // (#198) — nothing here should be able to take a touch off a key.
+        let backdrop = Self.makeBackdrop()
         backdrop.isUserInteractionEnabled = false
         backdrop.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(backdrop)
@@ -514,5 +555,31 @@ final class KeyboardViewController: UIInputViewController {
             backdrop.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
         backdropView = backdrop
+    }
+
+    /// Name of the nib holding the keyboard-styled backdrop. Shared with the
+    /// tests so a rename cannot silently fall back to the leaking path.
+    static let backdropNibName = "KeyboardBackdrop"
+
+    /// Decodes the backdrop from `KeyboardBackdrop.xib`, falling back to the
+    /// leaking initializer if the nib is missing.
+    ///
+    /// The fallback is deliberate and deliberately *not* a `fatalError`: a
+    /// missing resource must degrade to a keyboard that leaks, never to one
+    /// that does not appear. `backdropComesFromNib` lets the tests assert the
+    /// fallback is not silently the normal path.
+    static func makeBackdrop() -> UIInputView {
+        if let view = Bundle(for: KeyboardViewController.self)
+            .loadNibNamed(backdropNibName, owner: nil)?
+            .compactMap({ $0 as? UIInputView })
+            .first {
+            return view
+        }
+        return UIInputView(frame: .zero, inputViewStyle: .keyboard)
+    }
+
+    /// Whether the nib actually resolved. Test seam for the fallback above.
+    static var backdropComesFromNib: Bool {
+        Bundle(for: KeyboardViewController.self).path(forResource: backdropNibName, ofType: "nib") != nil
     }
 }

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -484,12 +484,15 @@ final class KeyboardViewController: UIInputViewController {
     /// Installs the system-keyboard backdrop behind the SwiftUI content.
     ///
     /// A `.keyboard`-style input view renders the real system-keyboard backdrop
-    /// (blur + adaptive tint). It sits behind the SwiftUI content as a genuine
-    /// rendered surface, so themes with a transparent board (Liquid Glass) show
-    /// through to a background that matches the system keyboard, and — because a
-    /// keyboard extension only delivers touches over rendered pixels — the
-    /// inter-key gaps stay tappable without the near-invisible board fill that
-    /// used to be needed (#198).
+    /// (blur + adaptive tint) behind the SwiftUI content, so a theme with a
+    /// near-transparent board (Liquid Glass) shows through to a background that
+    /// matches the system keyboard row. This is purely the *look*: touch
+    /// delivery for the inter-key gaps comes from the SwiftUI board fill,
+    /// because a keyboard extension delivers touches over SwiftUI-rendered
+    /// pixels, not over this UIKit backdrop behind them (see
+    /// `DataDrivenKeyboardRootView.keyboardBackground` + #198). It is left
+    /// interactive only so it never swallows a stray touch itself; the SwiftUI
+    /// content above always wins the hit-test.
     ///
     /// Installed once and kept across hosting teardowns: the suspension shedding
     /// releases only the SwiftUI view graph, so rebuilding hosting must not
@@ -498,11 +501,6 @@ final class KeyboardViewController: UIInputViewController {
         guard backdropView == nil else { return }
         let backdrop = UIInputView(frame: .zero, inputViewStyle: .keyboard)
         backdrop.translatesAutoresizingMaskIntoConstraints = false
-        // Interactive on purpose: a keyboard extension only delivers touches
-        // over an interactive, rendered surface. Left non-interactive, the
-        // gaps between keys go dead again (#198). The SwiftUI key cells sit
-        // above this and win the hit-test wherever they tile, so the backdrop
-        // only ever receives touches that fall outside every key.
         view.addSubview(backdrop)
         NSLayoutConstraint.activate([
             backdrop.topAnchor.constraint(equalTo: view.topAnchor),

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -18,6 +18,9 @@ final class KeyboardViewController: UIInputViewController {
     /// Render-server snapshot standing in for the torn-down hosting view
     /// while the host app is backgrounded (see `installSuspensionPlaceholder`).
     private var suspensionPlaceholder: UIView?
+    /// System-keyboard backdrop behind the SwiftUI content
+    /// (see `installBackdropIfNeeded`). Outlives hosting teardowns.
+    private var backdropView: UIInputView?
 
     /// The language selected in the host app, normalised to an id that is
     /// guaranteed to exist in the registry (falling back to the system language,
@@ -451,6 +454,8 @@ final class KeyboardViewController: UIInputViewController {
         Self.pendingSettledSample?.cancel()
         Self.pendingSettledSample = nil
         guard hostingController == nil else { return }
+        installBackdropIfNeeded()
+
         let rootView = DataDrivenKeyboardRootView(viewModel: viewModel)
         let controller = UIHostingController(rootView: rootView)
         controller.view.translatesAutoresizingMaskIntoConstraints = false
@@ -474,5 +479,37 @@ final class KeyboardViewController: UIInputViewController {
         // can slip in between.
         suspensionPlaceholder?.removeFromSuperview()
         suspensionPlaceholder = nil
+    }
+
+    /// Installs the system-keyboard backdrop behind the SwiftUI content.
+    ///
+    /// A `.keyboard`-style input view renders the real system-keyboard backdrop
+    /// (blur + adaptive tint). It sits behind the SwiftUI content as a genuine
+    /// rendered surface, so themes with a transparent board (Liquid Glass) show
+    /// through to a background that matches the system keyboard, and — because a
+    /// keyboard extension only delivers touches over rendered pixels — the
+    /// inter-key gaps stay tappable without the near-invisible board fill that
+    /// used to be needed (#198).
+    ///
+    /// Installed once and kept across hosting teardowns: the suspension shedding
+    /// releases only the SwiftUI view graph, so rebuilding hosting must not
+    /// stack a second input view behind the keys on every resume.
+    private func installBackdropIfNeeded() {
+        guard backdropView == nil else { return }
+        let backdrop = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        backdrop.translatesAutoresizingMaskIntoConstraints = false
+        // Interactive on purpose: a keyboard extension only delivers touches
+        // over an interactive, rendered surface. Left non-interactive, the
+        // gaps between keys go dead again (#198). The SwiftUI key cells sit
+        // above this and win the hit-test wherever they tile, so the backdrop
+        // only ever receives touches that fall outside every key.
+        view.addSubview(backdrop)
+        NSLayoutConstraint.activate([
+            backdrop.topAnchor.constraint(equalTo: view.topAnchor),
+            backdrop.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            backdrop.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            backdrop.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        backdropView = backdrop
     }
 }

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -403,12 +403,15 @@ final class KeyboardViewController: UIInputViewController {
     /// Installs the system-keyboard backdrop behind the SwiftUI content.
     ///
     /// A `.keyboard`-style input view renders the real system-keyboard backdrop
-    /// (blur + adaptive tint). It sits behind the SwiftUI content as a genuine
-    /// rendered surface, so themes with a transparent board (Liquid Glass) show
-    /// through to a background that matches the system keyboard, and — because a
-    /// keyboard extension only delivers touches over rendered pixels — the
-    /// inter-key gaps stay tappable without the near-invisible board fill that
-    /// used to be needed (#198).
+    /// (blur + adaptive tint) behind the SwiftUI content, so a theme with a
+    /// near-transparent board (Liquid Glass) shows through to a background that
+    /// matches the system keyboard row. This is purely the *look*: touch
+    /// delivery for the inter-key gaps comes from the SwiftUI board fill,
+    /// because a keyboard extension delivers touches over SwiftUI-rendered
+    /// pixels, not over this UIKit backdrop behind them (see
+    /// `DataDrivenKeyboardRootView.keyboardBackground` + #198). It is left
+    /// interactive only so it never swallows a stray touch itself; the SwiftUI
+    /// content above always wins the hit-test.
     ///
     /// Installed once and kept across hosting teardowns: the suspension shedding
     /// releases only the SwiftUI view graph, so rebuilding hosting must not
@@ -417,11 +420,6 @@ final class KeyboardViewController: UIInputViewController {
         guard backdropView == nil else { return }
         let backdrop = UIInputView(frame: .zero, inputViewStyle: .keyboard)
         backdrop.translatesAutoresizingMaskIntoConstraints = false
-        // Interactive on purpose: a keyboard extension only delivers touches
-        // over an interactive, rendered surface. Left non-interactive, the
-        // gaps between keys go dead again (#198). The SwiftUI key cells sit
-        // above this and win the hit-test wherever they tile, so the backdrop
-        // only ever receives touches that fall outside every key.
         view.addSubview(backdrop)
         NSLayoutConstraint.activate([
             backdrop.topAnchor.constraint(equalTo: view.topAnchor),

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -51,6 +51,10 @@ final class KeyboardViewController: UIInputViewController {
         // Set background immediately to avoid flash
         view.backgroundColor = .clear
 
+        // Migrate the legacy style selection to the theme assignment before
+        // the root view reads it. Idempotent; the host app runs it too.
+        ThemeStore.migrateIfNeeded()
+
         // Wire up the data-driven pipeline
         let target = DocumentProxyTarget(controller: self)
         documentProxyTarget = target

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -18,6 +18,9 @@ final class KeyboardViewController: UIInputViewController {
     /// Render-server snapshot standing in for the torn-down hosting view
     /// while the host app is backgrounded (see `installSuspensionPlaceholder`).
     private var suspensionPlaceholder: UIView?
+    /// System-keyboard backdrop behind the SwiftUI content
+    /// (see `installBackdropIfNeeded`). Outlives hosting teardowns.
+    private var backdropView: UIInputView?
 
     /// The language selected in the host app, normalised to an id that is
     /// guaranteed to exist in the registry (falling back to the system language,
@@ -370,6 +373,8 @@ final class KeyboardViewController: UIInputViewController {
     /// jetsam budget.
     private func configureHosting() {
         guard hostingController == nil else { return }
+        installBackdropIfNeeded()
+
         let rootView = DataDrivenKeyboardRootView(viewModel: viewModel)
         let controller = UIHostingController(rootView: rootView)
         controller.view.translatesAutoresizingMaskIntoConstraints = false
@@ -393,5 +398,37 @@ final class KeyboardViewController: UIInputViewController {
         // can slip in between.
         suspensionPlaceholder?.removeFromSuperview()
         suspensionPlaceholder = nil
+    }
+
+    /// Installs the system-keyboard backdrop behind the SwiftUI content.
+    ///
+    /// A `.keyboard`-style input view renders the real system-keyboard backdrop
+    /// (blur + adaptive tint). It sits behind the SwiftUI content as a genuine
+    /// rendered surface, so themes with a transparent board (Liquid Glass) show
+    /// through to a background that matches the system keyboard, and — because a
+    /// keyboard extension only delivers touches over rendered pixels — the
+    /// inter-key gaps stay tappable without the near-invisible board fill that
+    /// used to be needed (#198).
+    ///
+    /// Installed once and kept across hosting teardowns: the suspension shedding
+    /// releases only the SwiftUI view graph, so rebuilding hosting must not
+    /// stack a second input view behind the keys on every resume.
+    private func installBackdropIfNeeded() {
+        guard backdropView == nil else { return }
+        let backdrop = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        backdrop.translatesAutoresizingMaskIntoConstraints = false
+        // Interactive on purpose: a keyboard extension only delivers touches
+        // over an interactive, rendered surface. Left non-interactive, the
+        // gaps between keys go dead again (#198). The SwiftUI key cells sit
+        // above this and win the hit-test wherever they tile, so the backdrop
+        // only ever receives touches that fall outside every key.
+        view.addSubview(backdrop)
+        NSLayoutConstraint.activate([
+            backdrop.topAnchor.constraint(equalTo: view.topAnchor),
+            backdrop.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            backdrop.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            backdrop.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        backdropView = backdrop
     }
 }

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -501,6 +501,10 @@ final class KeyboardViewController: UIInputViewController {
     private func installBackdropIfNeeded() {
         guard backdropView == nil else { return }
         let backdrop = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        // Visual only. It spans the whole input view behind the SwiftUI
+        // content, and touch delivery in an extension is the fragile part
+        // (#198) — nothing here should be able to take a touch off a key.
+        backdrop.isUserInteractionEnabled = false
         backdrop.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(backdrop)
         NSLayoutConstraint.activate([

--- a/wurstfingerKeyboard/Localizable.xcstrings
+++ b/wurstfingerKeyboard/Localizable.xcstrings
@@ -3168,6 +3168,280 @@
           }
         }
       }
+    },
+    "%@ Copy": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخة من %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopie"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ αντίγραφο"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کپی"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopio"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopya"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copie"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ עותק"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ कॉपी"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopija"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@のコピー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 복사본"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (kopia)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ cópia"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (копия)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopia"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ สำเนา"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (копія)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کی کاپی"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ bản sao"
+          }
+        }
+      }
+    },
+    "%@ Copy %lld": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخة %2$lld من %1$@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopie %lld"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ αντίγραφο %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia %lld"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کپی %lld"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopio %lld"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopya %lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copie %lld"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ עותק %lld"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ कॉपी %lld"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopija %lld"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@のコピー %lld"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 복사본 %lld"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (kopia %lld)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ cópia %lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (копия %lld)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopia %lld"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ สำเนา %lld"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (копія %lld)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کی کاپی %lld"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ bản sao %lld"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/wurstfingerKeyboard/Localizable.xcstrings
+++ b/wurstfingerKeyboard/Localizable.xcstrings
@@ -1380,6 +1380,828 @@
         }
       },
       "comment": "ACCESSIBILITY label for the space bar (VoiceOver)"
+    },
+    "Classic": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كلاسيكي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisch"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κλασικό"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clásico"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلاسیک"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassinen"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasiko"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classique"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "קלאסי"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्लासिक"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasično"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classico"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラシック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클래식"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasyczny"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clássico"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Классический"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisk"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คลาสสิก"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Класичний"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلاسک"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cổ điển"
+          }
+        }
+      }
+    },
+    "Dark Gold": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ذهبي داكن"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σκούρο χρυσό"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oro oscuro"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "طلایی تیره"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Or sombre"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "זהב כהה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डार्क गोल्ड"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamno zlatno"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oro scuro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダークゴールド"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다크 골드"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemne złoto"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouro escuro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмное золото"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทองเข้ม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темне золото"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈارک گولڈ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vàng sẫm"
+          }
+        }
+      }
+    },
+    "Dark keys with golden letters": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفاتيح داكنة بحروف ذهبية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dunkle Tasten mit goldenen Buchstaben"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σκούρα πλήκτρα με χρυσά γράμματα"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas oscuras con letras doradas"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدهای تیره با حروف طلایی"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tummat näppäimet ja kultaiset kirjaimet"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Madilim na mga key na may gintong mga titik"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touches sombres aux lettres dorées"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקשים כהים עם אותיות זהובות"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सुनहरे अक्षरों वाली गहरी कीज़"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamne tipke sa zlatnim slovima"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasti scuri con lettere dorate"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暗いキーに金色の文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "어두운 키에 금색 글자"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemne klawisze ze złotymi literami"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas escuras com letras douradas"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмные клавиши с золотыми буквами"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mörka tangenter med gyllene bokstäver"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่มสีเข้มพร้อมตัวอักษรสีทอง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темні клавіші із золотими літерами"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سنہری حروف کے ساتھ گہری کیز"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím tối với chữ vàng"
+          }
+        }
+      }
+    },
+    "Liquid Glass": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        }
+      }
+    },
+    "Traditional opaque keys": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفاتيح تقليدية مُعتِمة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traditionelle deckende Tasten"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Παραδοσιακά αδιαφανή πλήκτρα"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas opacas tradicionales"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدهای مات سنتی"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Perinteiset läpinäkymättömät näppäimet"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tradisyonal na opaque na mga key"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touches opaques traditionnelles"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקשים אטומים מסורתיים"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पारंपरिक अपारदर्शी कीज़"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tradicionalne neprozirne tipke"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasti opachi tradizionali"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "従来の不透明なキー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기존의 불투명한 키"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tradycyjne nieprzezroczyste klawisze"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas opacas tradicionais"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Традиционные непрозрачные клавиши"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traditionella ogenomskinliga tangenter"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่มทึบแบบดั้งเดิม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Традиційні непрозорі клавіші"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روایتی غیر شفاف کیز"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím đục truyền thống"
+          }
+        }
+      }
+    },
+    "Transparent glass effect (iOS 26+)": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تأثير زجاجي شفاف (iOS 26 وأحدث)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transparenter Glaseffekt (iOS 26+)"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διαφανές γυάλινο εφέ (iOS 26+)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Efecto de cristal transparente (iOS 26+)"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افکت شیشه‌ای شفاف (iOS 26+)"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läpinäkyvä lasiefekti (iOS 26+)"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transparent na glass effect (iOS 26+)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effet de verre transparent (iOS 26+)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אפקט זכוכית שקופה (iOS 26+)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पारदर्शी ग्लास इफ़ेक्ट (iOS 26+)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Efekt prozirnog stakla (iOS 26+)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effetto vetro trasparente (iOS 26+)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透明なガラス効果（iOS 26以降）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "투명한 유리 효과 (iOS 26 이상)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Efekt przezroczystego szkła (iOS 26+)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Efeito de vidro transparente (iOS 26+)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эффект прозрачного стекла (iOS 26+)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genomskinlig glaseffekt (iOS 26+)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เอฟเฟกต์กระจกโปร่งใส (iOS 26 ขึ้นไป)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Прозорий скляний ефект (iOS 26+)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شفاف گلاس ایفیکٹ (iOS 26+)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiệu ứng kính trong suốt (iOS 26+)"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/wurstfingerKeyboard/Localizable.xcstrings
+++ b/wurstfingerKeyboard/Localizable.xcstrings
@@ -2346,6 +2346,828 @@
         }
       },
       "comment": "ACCESSIBILITY action name for the question-mark swipe; the Arabic script substitutes ؟ (VoiceOver)"
+    },
+    "Classic": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كلاسيكي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisch"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κλασικό"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clásico"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلاسیک"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassinen"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasiko"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classique"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "קלאסי"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्लासिक"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasično"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classico"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラシック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클래식"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasyczny"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clássico"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Классический"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisk"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คลาสสิก"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Класичний"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلاسک"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cổ điển"
+          }
+        }
+      }
+    },
+    "Dark Gold": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ذهبي داكن"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σκούρο χρυσό"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oro oscuro"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "طلایی تیره"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Or sombre"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "זהב כהה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डार्क गोल्ड"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamno zlatno"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oro scuro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダークゴールド"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다크 골드"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemne złoto"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouro escuro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмное золото"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทองเข้ม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темне золото"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈارک گولڈ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vàng sẫm"
+          }
+        }
+      }
+    },
+    "Dark keys with golden letters": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفاتيح داكنة بحروف ذهبية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dunkle Tasten mit goldenen Buchstaben"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σκούρα πλήκτρα με χρυσά γράμματα"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas oscuras con letras doradas"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدهای تیره با حروف طلایی"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tummat näppäimet ja kultaiset kirjaimet"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Madilim na mga key na may gintong mga titik"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touches sombres aux lettres dorées"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקשים כהים עם אותיות זהובות"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सुनहरे अक्षरों वाली गहरी कीज़"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamne tipke sa zlatnim slovima"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasti scuri con lettere dorate"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暗いキーに金色の文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "어두운 키에 금색 글자"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemne klawisze ze złotymi literami"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas escuras com letras douradas"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмные клавиши с золотыми буквами"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mörka tangenter med gyllene bokstäver"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่มสีเข้มพร้อมตัวอักษรสีทอง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темні клавіші із золотими літерами"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سنہری حروف کے ساتھ گہری کیز"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím tối với chữ vàng"
+          }
+        }
+      }
+    },
+    "Liquid Glass": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        }
+      }
+    },
+    "Traditional opaque keys": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفاتيح تقليدية مُعتِمة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traditionelle deckende Tasten"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Παραδοσιακά αδιαφανή πλήκτρα"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas opacas tradicionales"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدهای مات سنتی"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Perinteiset läpinäkymättömät näppäimet"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tradisyonal na opaque na mga key"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touches opaques traditionnelles"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקשים אטומים מסורתיים"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पारंपरिक अपारदर्शी कीज़"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tradicionalne neprozirne tipke"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasti opachi tradizionali"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "従来の不透明なキー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기존의 불투명한 키"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tradycyjne nieprzezroczyste klawisze"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas opacas tradicionais"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Традиционные непрозрачные клавиши"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traditionella ogenomskinliga tangenter"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่มทึบแบบดั้งเดิม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Традиційні непрозорі клавіші"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روایتی غیر شفاف کیز"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím đục truyền thống"
+          }
+        }
+      }
+    },
+    "Transparent glass effect (iOS 26+)": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تأثير زجاجي شفاف (iOS 26 وأحدث)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transparenter Glaseffekt (iOS 26+)"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διαφανές γυάλινο εφέ (iOS 26+)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Efecto de cristal transparente (iOS 26+)"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افکت شیشه‌ای شفاف (iOS 26+)"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läpinäkyvä lasiefekti (iOS 26+)"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transparent na glass effect (iOS 26+)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effet de verre transparent (iOS 26+)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אפקט זכוכית שקופה (iOS 26+)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पारदर्शी ग्लास इफ़ेक्ट (iOS 26+)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Efekt prozirnog stakla (iOS 26+)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effetto vetro trasparente (iOS 26+)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透明なガラス効果（iOS 26以降）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "투명한 유리 효과 (iOS 26 이상)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Efekt przezroczystego szkła (iOS 26+)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Efeito de vidro transparente (iOS 26+)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эффект прозрачного стекла (iOS 26+)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genomskinlig glaseffekt (iOS 26+)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เอฟเฟกต์กระจกโปร่งใส (iOS 26 ขึ้นไป)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Прозорий скляний ефект (iOS 26+)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شفاف گلاس ایفیکٹ (iOS 26+)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiệu ứng kính trong suốt (iOS 26+)"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
@@ -33,7 +33,11 @@ enum BuiltInThemes {
     static let liquidGlass = KeyboardThemeDefinition(
         id: "liquid-glass",
         name: "Liquid Glass",
-        boardBackground: .color(.semantic(.systemBackground, opacity: 0.02)),
+        // A faint neutral board: it reads as clear over the
+        // `UIInputView(.keyboard)` backdrop (so the keyboard matches the system
+        // row) while staying just opaque enough to keep the inter-key gaps
+        // tappable (see `keyboardBackground` / `minimumBoardOpacity`, #198).
+        boardBackground: .color(.semantic(.gray, opacity: 0.02)),
         keyFill: .material,
         keyFillActive: .material,
         keyBorder: .semantic(.primary, opacity: 0.1),

--- a/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
@@ -1,0 +1,100 @@
+//
+//  BuiltInThemes.swift
+//  Wurstfinger
+//
+//  The compiled-in themes. Their ids are API — persisted selections and
+//  future export codes reference them — and must never change.
+//
+
+import Foundation
+
+enum BuiltInThemes {
+    /// System-color theme matching the pre-engine "classic" style.
+    static let classic = KeyboardThemeDefinition(
+        id: "classic",
+        name: "Classic",
+        boardBackground: .color(.semantic(.systemBackground)),
+        keyFill: .color(.semantic(.secondarySystemBackground)),
+        keyFillActive: .color(.semantic(.tertiarySystemFill)),
+        keyBorder: nil,
+        keyBorderWidth: 0,
+        cornerRadius: Double(KeyboardConstants.KeyDimensions.cornerRadius),
+        mainLabel: .semantic(.primary),
+        utilityLabel: .semantic(.primary),
+        hintLetter: .semantic(.primary, opacity: 0.65),
+        hintSymbol: .semantic(.secondary, opacity: 0.55),
+        hintIconProminent: .semantic(.primary, opacity: 0.5),
+        hintIconSubtle: .semantic(.secondary, opacity: 0.45)
+    )
+
+    /// Bar-material theme matching the pre-engine "liquidGlass" style. The
+    /// board is a near-invisible color fill, not a material — that is the
+    /// touch fix from #198 (see DataDrivenKeyboardRootView).
+    static let liquidGlass = KeyboardThemeDefinition(
+        id: "liquid-glass",
+        name: "Liquid Glass",
+        boardBackground: .color(.semantic(.systemBackground, opacity: 0.02)),
+        keyFill: .material,
+        keyFillActive: .material,
+        keyBorder: .semantic(.primary, opacity: 0.1),
+        keyBorderWidth: 0.5,
+        cornerRadius: Double(KeyboardConstants.KeyDimensions.cornerRadius),
+        mainLabel: .semantic(.primary),
+        utilityLabel: .semantic(.primary),
+        hintLetter: .semantic(.primary, opacity: 0.65),
+        hintSymbol: .semantic(.secondary, opacity: 0.55),
+        hintIconProminent: .semantic(.primary, opacity: 0.5),
+        hintIconSubtle: .semantic(.secondary, opacity: 0.45)
+    )
+
+    /// Fixed dark-slate/gold palette. Identical in light and dark mode by
+    /// design. Hint roles carry their prominence as alpha (0.9/0.7/0.5/0.45
+    /// of white), mirroring Classic's opacity hierarchy.
+    static let darkGold = KeyboardThemeDefinition(
+        id: "dark-gold",
+        name: "Dark Gold",
+        boardBackground: .color(.fixed(hex: "#252A34")),
+        keyFill: .color(.fixed(hex: "#333A48")),
+        keyFillActive: .color(.fixed(hex: "#4A5468")),
+        keyBorder: .fixed(hex: "#FFFFFF1F"),
+        keyBorderWidth: 0.5,
+        cornerRadius: Double(KeyboardConstants.KeyDimensions.cornerRadius),
+        mainLabel: .fixed(hex: "#D1AA05"),
+        utilityLabel: .fixed(hex: "#FFFFFF"),
+        hintLetter: .fixed(hex: "#FFFFFFE6"),
+        hintSymbol: .fixed(hex: "#FFFFFFB3"),
+        hintIconProminent: .fixed(hex: "#FFFFFF80"),
+        hintIconSubtle: .fixed(hex: "#FFFFFF73")
+    )
+
+    static let all: [KeyboardThemeDefinition] = [classic, liquidGlass, darkGold]
+
+    static let ids: Set<String> = Set(all.map(\.id))
+
+    static func theme(id: String) -> KeyboardThemeDefinition? {
+        all.first { $0.id == id }
+    }
+}
+
+extension KeyboardThemeDefinition {
+    /// Localized display name for built-ins; user themes show their stored
+    /// name verbatim.
+    var displayName: String {
+        switch id {
+        case BuiltInThemes.classic.id: String(localized: "Classic")
+        case BuiltInThemes.liquidGlass.id: String(localized: "Liquid Glass")
+        case BuiltInThemes.darkGold.id: String(localized: "Dark Gold")
+        default: name
+        }
+    }
+
+    /// Short description shown in the theme list (built-ins only).
+    var displayDescription: String? {
+        switch id {
+        case BuiltInThemes.classic.id: String(localized: "Traditional opaque keys")
+        case BuiltInThemes.liquidGlass.id: String(localized: "Transparent glass effect (iOS 26+)")
+        case BuiltInThemes.darkGold.id: String(localized: "Dark keys with golden letters")
+        default: nil
+        }
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
@@ -13,9 +13,11 @@ enum BuiltInThemes {
     static let classic = KeyboardThemeDefinition(
         id: "classic",
         name: "Classic",
-        boardBackground: .color(.semantic(.systemBackground)),
-        keyFill: .color(.semantic(.secondarySystemBackground)),
-        keyFillActive: .color(.semantic(.tertiarySystemFill)),
+        boardSurface: .color,
+        boardColor: .semantic(.systemBackground),
+        keySurface: .color,
+        keyColor: .semantic(.secondarySystemBackground),
+        keyColorActive: .semantic(.tertiarySystemFill),
         keyBorder: nil,
         keyBorderWidth: 0,
         cornerRadius: Double(KeyboardConstants.KeyDimensions.cornerRadius),
@@ -24,22 +26,29 @@ enum BuiltInThemes {
         hintLetter: .semantic(.primary, opacity: 0.65),
         hintSymbol: .semantic(.secondary, opacity: 0.55),
         hintIconProminent: .semantic(.primary, opacity: 0.5),
-        hintIconSubtle: .semantic(.secondary, opacity: 0.45)
+        hintIconSubtle: .semantic(.secondary, opacity: 0.45),
+        // The pre-engine trail color, now a theme role. Its alpha is used as
+        // it stands: `GestureTrailOverlay` multiplies in the fade-out only.
+        gestureTrail: .semantic(.primary, opacity: KeyboardConstants.GestureTrail.opacity)
     )
 
-    /// Bar-material theme matching the pre-engine "liquidGlass" style. The
-    /// board is a near-invisible color fill, not a material — that is the
-    /// touch fix from #198 (see DataDrivenKeyboardRootView).
+    /// Glass theme matching the pre-engine "liquidGlass" style: native Liquid
+    /// Glass keys over a board that is a near-invisible color fill rather than
+    /// a material — that is the touch fix from #198 (see
+    /// `ResolvedTheme.boardBackground` / `KeyboardThemeDefinition.minimumBoardOpacity`).
+    ///
+    /// The color fields are real fallbacks, not placeholders: switching either
+    /// surface back to `.color` has to yield a usable keyboard, so the board
+    /// carries Classic's opaque background (a 2% gray would make the toggle
+    /// look dead) and the keys carry Classic's key colors.
     static let liquidGlass = KeyboardThemeDefinition(
         id: "liquid-glass",
         name: "Liquid Glass",
-        // A faint neutral board: it reads as clear over the
-        // `UIInputView(.keyboard)` backdrop (so the keyboard matches the system
-        // row) while staying just opaque enough to keep the inter-key gaps
-        // tappable (see `keyboardBackground` / `minimumBoardOpacity`, #198).
-        boardBackground: .color(.semantic(.gray, opacity: 0.02)),
-        keyFill: .material,
-        keyFillActive: .material,
+        boardSurface: .glass,
+        boardColor: .semantic(.systemBackground),
+        keySurface: .glass,
+        keyColor: .semantic(.secondarySystemBackground),
+        keyColorActive: .semantic(.tertiarySystemFill),
         keyBorder: .semantic(.primary, opacity: 0.1),
         keyBorderWidth: 0.5,
         cornerRadius: Double(KeyboardConstants.KeyDimensions.cornerRadius),
@@ -48,7 +57,8 @@ enum BuiltInThemes {
         hintLetter: .semantic(.primary, opacity: 0.65),
         hintSymbol: .semantic(.secondary, opacity: 0.55),
         hintIconProminent: .semantic(.primary, opacity: 0.5),
-        hintIconSubtle: .semantic(.secondary, opacity: 0.45)
+        hintIconSubtle: .semantic(.secondary, opacity: 0.45),
+        gestureTrail: .semantic(.primary, opacity: KeyboardConstants.GestureTrail.opacity)
     )
 
     /// Fixed dark-slate/gold palette. Identical in light and dark mode by
@@ -57,9 +67,11 @@ enum BuiltInThemes {
     static let darkGold = KeyboardThemeDefinition(
         id: "dark-gold",
         name: "Dark Gold",
-        boardBackground: .color(.fixed(hex: "#252A34")),
-        keyFill: .color(.fixed(hex: "#333A48")),
-        keyFillActive: .color(.fixed(hex: "#4A5468")),
+        boardSurface: .color,
+        boardColor: .fixed(hex: "#252A34"),
+        keySurface: .color,
+        keyColor: .fixed(hex: "#333A48"),
+        keyColorActive: .fixed(hex: "#4A5468"),
         keyBorder: .fixed(hex: "#FFFFFF1F"),
         keyBorderWidth: 0.5,
         cornerRadius: Double(KeyboardConstants.KeyDimensions.cornerRadius),
@@ -68,7 +80,12 @@ enum BuiltInThemes {
         hintLetter: .fixed(hex: "#FFFFFFE6"),
         hintSymbol: .fixed(hex: "#FFFFFFB3"),
         hintIconProminent: .fixed(hex: "#FFFFFF80"),
-        hintIconSubtle: .fixed(hex: "#FFFFFF73")
+        hintIconSubtle: .fixed(hex: "#FFFFFF73"),
+        // Gold at 0xA6 (0.65). Measured per WCAG over the key color #333A48:
+        // gold at 0.38 reaches only 1.95:1 and disappears under the finger,
+        // 0.65 reaches 3.06:1. White at 0.38 would give a comparable 3.09:1 but
+        // collides with the already-white `utilityLabel` / `hintLetter` roles.
+        gestureTrail: .fixed(hex: "#D1AA05A6")
     )
 
     static let all: [KeyboardThemeDefinition] = [classic, liquidGlass, darkGold]

--- a/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
@@ -81,6 +81,12 @@ enum BuiltInThemes {
 }
 
 extension KeyboardThemeDefinition {
+    /// Whether this theme is compiled in. Derived from the id, never trusted
+    /// from persisted data — built-ins are not editable or deletable.
+    var isBuiltIn: Bool {
+        BuiltInThemes.ids.contains(id)
+    }
+
     /// Localized display name for built-ins; user themes show their stored
     /// name verbatim.
     var displayName: String {

--- a/wurstfingerKeyboard/Runtime/Theme/HexColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/HexColor.swift
@@ -57,13 +57,16 @@ enum HexColor {
         )
     }
 
-    /// Formats as `#RRGGBB`, appending the alpha byte (`#RRGGBBAA`) only
-    /// when it is below 1.
+    /// Formats as `#RRGGBB`, appending the alpha byte (`#RRGGBBAA`) only when
+    /// it is not fully opaque. The opacity check is made on the rounded byte,
+    /// not the raw value: an alpha like 0.999 rounds to 0xFF, and emitting
+    /// `#RRGGBBFF` would re-parse to 1.0 anyway — so it is formatted as the
+    /// opaque `#RRGGBB`, keeping the round-trip idempotent.
     static func string(from components: Components) -> String {
-        if components.alpha >= 1 {
+        let alphaByte = UInt32((min(max(components.alpha, 0), 1) * 255).rounded())
+        if alphaByte >= 255 {
             return String(format: "#%06X", components.rgb)
         }
-        let alphaByte = UInt32((min(max(components.alpha, 0), 1) * 255).rounded())
         return String(format: "#%06X%02X", components.rgb, alphaByte)
     }
 
@@ -82,24 +85,5 @@ enum HexColor {
         }
         let rgb = (byte(red) << 16) | (byte(green) << 8) | byte(blue)
         return string(from: Components(rgb: rgb, alpha: Double(alpha)))
-    }
-
-    /// Relative luminance (0...1), sufficient for light/dark decisions.
-    static func luminance(of rgb: UInt32) -> Double {
-        let red = Double((rgb >> 16) & 0xFF) / 255
-        let green = Double((rgb >> 8) & 0xFF) / 255
-        let blue = Double(rgb & 0xFF) / 255
-        return 0.2126 * red + 0.7152 * green + 0.0722 * blue
-    }
-
-    /// Multiplies each RGB channel by `factor`, clamping to 0...255.
-    static func scaled(_ rgb: UInt32, by factor: Double) -> UInt32 {
-        func scale(_ channel: UInt32) -> UInt32 {
-            UInt32(min(max(Double(channel) * factor, 0), 255))
-        }
-        let red = scale((rgb >> 16) & 0xFF)
-        let green = scale((rgb >> 8) & 0xFF)
-        let blue = scale(rgb & 0xFF)
-        return (red << 16) | (green << 8) | blue
     }
 }

--- a/wurstfingerKeyboard/Runtime/Theme/HexColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/HexColor.swift
@@ -1,0 +1,105 @@
+//
+//  HexColor.swift
+//  Wurstfinger
+//
+//  Parsing and formatting of hex color strings, the storage format for
+//  fixed theme colors.
+//
+
+import SwiftUI
+import UIKit
+
+/// Parses and formats `#RRGGBB` / `#RRGGBBAA` strings.
+enum HexColor {
+    /// A parsed hex color: packed RGB plus separate alpha (0...1).
+    struct Components: Equatable {
+        var rgb: UInt32
+        var alpha: Double
+    }
+
+    /// Parses `#RRGGBB` or `#RRGGBBAA` (case-insensitive, `#` optional).
+    static func parse(_ string: String) -> Components? {
+        var hex = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        if hex.hasPrefix("#") {
+            hex.removeFirst()
+        }
+        switch hex.count {
+        case 6:
+            guard let value = UInt32(hex, radix: 16) else { return nil }
+            return Components(rgb: value, alpha: 1)
+        case 8:
+            guard let value = UInt64(hex, radix: 16) else { return nil }
+            return Components(rgb: UInt32(value >> 8), alpha: Double(value & 0xFF) / 255)
+        default:
+            return nil
+        }
+    }
+
+    static func color(from string: String) -> Color? {
+        parse(string).map(color(from:))
+    }
+
+    static func color(from components: Components) -> Color {
+        Color(
+            red: Double((components.rgb >> 16) & 0xFF) / 255,
+            green: Double((components.rgb >> 8) & 0xFF) / 255,
+            blue: Double(components.rgb & 0xFF) / 255,
+            opacity: components.alpha
+        )
+    }
+
+    static func uiColor(from components: Components) -> UIColor {
+        UIColor(
+            red: Double((components.rgb >> 16) & 0xFF) / 255,
+            green: Double((components.rgb >> 8) & 0xFF) / 255,
+            blue: Double(components.rgb & 0xFF) / 255,
+            alpha: components.alpha
+        )
+    }
+
+    /// Formats as `#RRGGBB`, appending the alpha byte (`#RRGGBBAA`) only
+    /// when it is below 1.
+    static func string(from components: Components) -> String {
+        if components.alpha >= 1 {
+            return String(format: "#%06X", components.rgb)
+        }
+        let alphaByte = UInt32((min(max(components.alpha, 0), 1) * 255).rounded())
+        return String(format: "#%06X%02X", components.rgb, alphaByte)
+    }
+
+    /// Formats a runtime color, or nil when its components cannot be
+    /// resolved into RGB (e.g. pattern-based colors).
+    static func string(from color: Color) -> String? {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        guard UIColor(color).getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+            return nil
+        }
+        func byte(_ value: CGFloat) -> UInt32 {
+            UInt32((min(max(value, 0), 1) * 255).rounded())
+        }
+        let rgb = (byte(red) << 16) | (byte(green) << 8) | byte(blue)
+        return string(from: Components(rgb: rgb, alpha: Double(alpha)))
+    }
+
+    /// Relative luminance (0...1), sufficient for light/dark decisions.
+    static func luminance(of rgb: UInt32) -> Double {
+        let red = Double((rgb >> 16) & 0xFF) / 255
+        let green = Double((rgb >> 8) & 0xFF) / 255
+        let blue = Double(rgb & 0xFF) / 255
+        return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+    }
+
+    /// Multiplies each RGB channel by `factor`, clamping to 0...255.
+    static func scaled(_ rgb: UInt32, by factor: Double) -> UInt32 {
+        func scale(_ channel: UInt32) -> UInt32 {
+            UInt32(min(max(Double(channel) * factor, 0), 255))
+        }
+        let red = scale((rgb >> 16) & 0xFF)
+        let green = scale((rgb >> 8) & 0xFF)
+        let blue = scale(rgb & 0xFF)
+        return (red << 16) | (green << 8) | blue
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
@@ -1,0 +1,77 @@
+//
+//  KeyboardThemeDefinition.swift
+//  Wurstfinger
+//
+//  The persisted description of a keyboard theme. A theme is data, not a
+//  code path: built-ins (Classic, Liquid Glass, Dark Gold) and user themes
+//  all render through the same resolver.
+//
+
+import Foundation
+
+struct KeyboardThemeDefinition: Identifiable, Equatable {
+    /// Built-ins use stable string ids ("classic", …); user themes use UUID
+    /// strings. Whether a theme is built-in is derived from the id — it is
+    /// never trusted from persisted data.
+    var id: String
+    var name: String
+
+    // Surfaces
+    /// Fill behind the whole keyboard; shows through the gaps between keys.
+    var boardBackground: ThemeFill
+    var keyFill: ThemeFill
+    /// Key fill while pressed.
+    var keyFillActive: ThemeFill
+    /// nil = no border overlay at all (Classic).
+    var keyBorder: ThemeColor?
+    var keyBorderWidth: Double
+    var cornerRadius: Double
+
+    // Labels
+    var mainLabel: ThemeColor
+    var utilityLabel: ThemeColor
+    var hintLetter: ThemeColor
+    var hintSymbol: ThemeColor
+    /// Globe/dismiss icon hints and the language label.
+    var hintIconProminent: ThemeColor
+    /// Copy/cut/paste icon hints.
+    var hintIconSubtle: ThemeColor
+}
+
+/// Tolerant, stable persistence: explicit keys, and every field except
+/// id/name falls back to its Classic value, so themes written by newer app
+/// versions (with additional fields) still decode.
+extension KeyboardThemeDefinition: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case id, name
+        case boardBackground, keyFill, keyFillActive
+        case keyBorder, keyBorderWidth, cornerRadius
+        case mainLabel, utilityLabel
+        case hintLetter, hintSymbol, hintIconProminent, hintIconSubtle
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let fallback = BuiltInThemes.classic
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        boardBackground = try container.decodeIfPresent(ThemeFill.self, forKey: .boardBackground)
+            ?? fallback.boardBackground
+        keyFill = try container.decodeIfPresent(ThemeFill.self, forKey: .keyFill) ?? fallback.keyFill
+        keyFillActive = try container.decodeIfPresent(ThemeFill.self, forKey: .keyFillActive)
+            ?? fallback.keyFillActive
+        keyBorder = try container.decodeIfPresent(ThemeColor.self, forKey: .keyBorder)
+        keyBorderWidth = try container.decodeIfPresent(Double.self, forKey: .keyBorderWidth)
+            ?? fallback.keyBorderWidth
+        cornerRadius = try container.decodeIfPresent(Double.self, forKey: .cornerRadius) ?? fallback.cornerRadius
+        mainLabel = try container.decodeIfPresent(ThemeColor.self, forKey: .mainLabel) ?? fallback.mainLabel
+        utilityLabel = try container.decodeIfPresent(ThemeColor.self, forKey: .utilityLabel)
+            ?? fallback.utilityLabel
+        hintLetter = try container.decodeIfPresent(ThemeColor.self, forKey: .hintLetter) ?? fallback.hintLetter
+        hintSymbol = try container.decodeIfPresent(ThemeColor.self, forKey: .hintSymbol) ?? fallback.hintSymbol
+        hintIconProminent = try container.decodeIfPresent(ThemeColor.self, forKey: .hintIconProminent)
+            ?? fallback.hintIconProminent
+        hintIconSubtle = try container.decodeIfPresent(ThemeColor.self, forKey: .hintIconSubtle)
+            ?? fallback.hintIconSubtle
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
@@ -39,8 +39,9 @@ struct KeyboardThemeDefinition: Identifiable, Equatable {
 }
 
 /// Tolerant, stable persistence: explicit keys, and every field except
-/// id/name falls back to its Classic value, so themes written by newer app
-/// versions (with additional fields) still decode.
+/// id/name and the optional `keyBorder` falls back to its Classic value, so
+/// themes written by newer app versions (with additional fields) still decode.
+/// `keyBorder` is optional — an absent key means "no border", matching Classic.
 extension KeyboardThemeDefinition: Codable {
     private enum CodingKeys: String, CodingKey {
         case id, name

--- a/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
@@ -144,7 +144,15 @@ extension KeyboardThemeDefinition: Codable {
         keyColorActive = container.decodeIfReadable(ThemeColor.self, forKey: .keyColorActive)
             ?? legacy.keyColorActive ?? fallback.keyColorActive
         keyBorder = container.decodeIfReadable(ThemeColor.self, forKey: .keyBorder)
-        keyBorderWidth = container.decodeIfReadable(Double.self, forKey: .keyBorderWidth) ?? fallback.keyBorderWidth
+        let storedBorderWidth = container.decodeIfReadable(Double.self, forKey: .keyBorderWidth)
+            ?? fallback.keyBorderWidth
+        // A theme that names a border colour but stores a width of zero (or
+        // less) would show an enabled, permanently invisible border in the
+        // editor: `KeyView.filled` only strokes for a positive width, and
+        // `setKeyBorder(_:)` only repairs an exact zero.
+        keyBorderWidth = keyBorder == nil
+            ? storedBorderWidth
+            : max(storedBorderWidth, Self.minimumKeyBorderWidth)
         cornerRadius = container.decodeIfReadable(Double.self, forKey: .cornerRadius) ?? fallback.cornerRadius
         mainLabel = container.decodeIfReadable(ThemeColor.self, forKey: .mainLabel) ?? fallback.mainLabel
         utilityLabel = container.decodeIfReadable(ThemeColor.self, forKey: .utilityLabel) ?? fallback.utilityLabel

--- a/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
@@ -16,18 +16,33 @@ struct KeyboardThemeDefinition: Identifiable, Equatable {
     var id: String
     var name: String
 
-    // Surfaces
-    /// Fill behind the whole keyboard; shows through the gaps between keys.
-    var boardBackground: ThemeFill
-    var keyFill: ThemeFill
-    /// Key fill while pressed.
-    var keyFillActive: ThemeFill
+    // MARK: Surfaces
+
+    // Surface style and surface color are independent, and the colors stay in
+    // the model even while glass is switched on: **the key color is never the
+    // glass tint** (that is the constant `KeyView.glassTint`). Toggling glass
+    // off therefore restores the user's own color losslessly, and the editor
+    // needs no shadow copy of the palette. Serving one value as both would
+    // render wrong in both directions — a Classic copy with glass on would
+    // become an opaque tinted pane with no glass in it, and a Liquid Glass copy
+    // with glass off would leave nearly invisible keys.
+
+    var boardSurface: BoardSurfaceStyle
+    /// Board fill for `boardSurface == .color`; shows through the gaps between
+    /// keys. A glass board paints `Self.glassBoardColor` instead.
+    var boardColor: ThemeColor
+    var keySurface: KeySurfaceStyle
+    /// Key fill for `keySurface == .color`.
+    var keyColor: ThemeColor
+    /// Key fill while pressed. Glass keys have no visible pressed state.
+    var keyColorActive: ThemeColor
     /// nil = no border overlay at all (Classic).
     var keyBorder: ThemeColor?
     var keyBorderWidth: Double
     var cornerRadius: Double
 
-    // Labels
+    // MARK: Labels
+
     var mainLabel: ThemeColor
     var utilityLabel: ThemeColor
     var hintLetter: ThemeColor
@@ -36,6 +51,10 @@ struct KeyboardThemeDefinition: Identifiable, Equatable {
     var hintIconProminent: ThemeColor
     /// Copy/cut/paste icon hints.
     var hintIconSubtle: ThemeColor
+
+    /// Color of the swipe trail. Its alpha is used literally — the draw path
+    /// multiplies in the fade-out and nothing else.
+    var gestureTrail: ThemeColor
 }
 
 /// Tolerant, stable persistence: explicit keys, and every field except
@@ -45,10 +64,12 @@ struct KeyboardThemeDefinition: Identifiable, Equatable {
 extension KeyboardThemeDefinition: Codable {
     private enum CodingKeys: String, CodingKey {
         case id, name
-        case boardBackground, keyFill, keyFillActive
+        case boardSurface, boardColor
+        case keySurface, keyColor, keyColorActive
         case keyBorder, keyBorderWidth, cornerRadius
         case mainLabel, utilityLabel
         case hintLetter, hintSymbol, hintIconProminent, hintIconSubtle
+        case gestureTrail
     }
 
     init(from decoder: Decoder) throws {
@@ -56,11 +77,20 @@ extension KeyboardThemeDefinition: Codable {
         let fallback = BuiltInThemes.classic
         id = try container.decode(String.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
-        boardBackground = try container.decodeIfPresent(ThemeFill.self, forKey: .boardBackground)
-            ?? fallback.boardBackground
-        keyFill = try container.decodeIfPresent(ThemeFill.self, forKey: .keyFill) ?? fallback.keyFill
-        keyFillActive = try container.decodeIfPresent(ThemeFill.self, forKey: .keyFillActive)
-            ?? fallback.keyFillActive
+        // Surface styles decode through their raw string rather than through
+        // the enum: `decodeIfPresent(BoardSurfaceStyle.self)` *throws* on an
+        // unknown value, and `ThemeStore.Archive.FailableTheme` swallows that
+        // throw by discarding the whole theme — one unreadable field would cost
+        // the user every color in it, contradicting the tolerance the rest of
+        // this initializer promises.
+        let boardRaw = (try? container.decodeIfPresent(String.self, forKey: .boardSurface)) ?? nil
+        boardSurface = boardRaw.flatMap(BoardSurfaceStyle.init(rawValue:)) ?? fallback.boardSurface
+        let keyRaw = (try? container.decodeIfPresent(String.self, forKey: .keySurface)) ?? nil
+        keySurface = keyRaw.flatMap(KeySurfaceStyle.init(rawValue:)) ?? fallback.keySurface
+        boardColor = try container.decodeIfPresent(ThemeColor.self, forKey: .boardColor) ?? fallback.boardColor
+        keyColor = try container.decodeIfPresent(ThemeColor.self, forKey: .keyColor) ?? fallback.keyColor
+        keyColorActive = try container.decodeIfPresent(ThemeColor.self, forKey: .keyColorActive)
+            ?? fallback.keyColorActive
         keyBorder = try container.decodeIfPresent(ThemeColor.self, forKey: .keyBorder)
         keyBorderWidth = try container.decodeIfPresent(Double.self, forKey: .keyBorderWidth)
             ?? fallback.keyBorderWidth
@@ -74,5 +104,7 @@ extension KeyboardThemeDefinition: Codable {
             ?? fallback.hintIconProminent
         hintIconSubtle = try container.decodeIfPresent(ThemeColor.self, forKey: .hintIconSubtle)
             ?? fallback.hintIconSubtle
+        gestureTrail = try container.decodeIfPresent(ThemeColor.self, forKey: .gestureTrail)
+            ?? fallback.gestureTrail
     }
 }

--- a/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
@@ -55,6 +55,52 @@ struct KeyboardThemeDefinition: Identifiable, Equatable {
     /// Color of the swipe trail. Its alpha is used literally — the draw path
     /// multiplies in the fade-out and nothing else.
     var gestureTrail: ThemeColor
+
+    // MARK: Surface switches
+
+    /// Switches the keys between the glass material and their own color.
+    ///
+    /// The editor's glass toggle writes through here rather than assigning
+    /// `keySurface` inline, so the promise that switching glass on keeps the
+    /// palette intact lives in the model and can be tested there. A test that
+    /// re-implements the assignment tests Swift, not this rule.
+    mutating func setGlassKeys(_ isOn: Bool) {
+        keySurface = isOn ? .glass : .color
+    }
+
+    /// Switches the board between near-clear glass and its own color. Same
+    /// reasoning as `setGlassKeys(_:)`.
+    mutating func setGlassBoard(_ isOn: Bool) {
+        boardSurface = isOn ? .glass : .color
+    }
+
+    /// Border color a theme without one gets when the border is switched on.
+    static let defaultKeyBorder: ThemeColor = .fixed(hex: "#00000030")
+
+    /// Thinnest border that actually renders, and the editor slider's minimum.
+    static let minimumKeyBorderWidth = 0.5
+
+    /// Switches the key border on or off.
+    ///
+    /// Unlike the two glass switches this one is a *coupled* write, which is
+    /// why it lives here rather than inline in the editor's binding: turning
+    /// the border on has to bring a width with it. `KeyView.filled` draws no
+    /// border at all at width 0, so a Classic copy (no border, width 0) would
+    /// switch the border on and see nothing change — and the width slider would
+    /// be handed a stored 0 that sits below its own range.
+    ///
+    /// A width the user already picked is kept, and so is a color the theme
+    /// already carries, so switching on never overwrites either.
+    mutating func setKeyBorder(_ isOn: Bool) {
+        guard isOn else {
+            keyBorder = nil
+            return
+        }
+        keyBorder = keyBorder ?? Self.defaultKeyBorder
+        if keyBorderWidth == 0 {
+            keyBorderWidth = Self.minimumKeyBorderWidth
+        }
+    }
 }
 
 /// Tolerant, stable persistence: explicit keys, and every field except

--- a/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
@@ -58,9 +58,11 @@ struct KeyboardThemeDefinition: Identifiable, Equatable {
 }
 
 /// Tolerant, stable persistence: explicit keys, and every field except
-/// id/name and the optional `keyBorder` falls back to its Classic value, so
-/// themes written by newer app versions (with additional fields) still decode.
-/// `keyBorder` is optional — an absent key means "no border", matching Classic.
+/// id/name and the optional `keyBorder` falls back to its Classic value, so a
+/// theme written by another app version — with additional fields, unknown enum
+/// cases, or a role it stores differently — still decodes.
+/// `keyBorder` is optional — an absent or unreadable value means "no border",
+/// which is Classic's value for that role.
 extension KeyboardThemeDefinition: Codable {
     private enum CodingKeys: String, CodingKey {
         case id, name
@@ -75,36 +77,116 @@ extension KeyboardThemeDefinition: Codable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let fallback = BuiltInThemes.classic
+        let legacy = LegacySurfaces(decoder: decoder)
+        // Only id and name may fail the decode. Everything else reads through
+        // `decodeIfReadable`, which degrades a malformed value the same way a
+        // missing one degrades: `ThemeStore.Archive.FailableTheme` turns any
+        // throw in here into the loss of the whole theme, and the next
+        // save/delete rewrites the archive from that lossy read — so one
+        // unreadable field would cost the user every color in the theme,
+        // permanently.
         id = try container.decode(String.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
-        // Surface styles decode through their raw string rather than through
-        // the enum: `decodeIfPresent(BoardSurfaceStyle.self)` *throws* on an
-        // unknown value, and `ThemeStore.Archive.FailableTheme` swallows that
-        // throw by discarding the whole theme — one unreadable field would cost
-        // the user every color in it, contradicting the tolerance the rest of
-        // this initializer promises.
-        let boardRaw = (try? container.decodeIfPresent(String.self, forKey: .boardSurface)) ?? nil
-        boardSurface = boardRaw.flatMap(BoardSurfaceStyle.init(rawValue:)) ?? fallback.boardSurface
-        let keyRaw = (try? container.decodeIfPresent(String.self, forKey: .keySurface)) ?? nil
-        keySurface = keyRaw.flatMap(KeySurfaceStyle.init(rawValue:)) ?? fallback.keySurface
-        boardColor = try container.decodeIfPresent(ThemeColor.self, forKey: .boardColor) ?? fallback.boardColor
-        keyColor = try container.decodeIfPresent(ThemeColor.self, forKey: .keyColor) ?? fallback.keyColor
-        keyColorActive = try container.decodeIfPresent(ThemeColor.self, forKey: .keyColorActive)
-            ?? fallback.keyColorActive
-        keyBorder = try container.decodeIfPresent(ThemeColor.self, forKey: .keyBorder)
-        keyBorderWidth = try container.decodeIfPresent(Double.self, forKey: .keyBorderWidth)
-            ?? fallback.keyBorderWidth
-        cornerRadius = try container.decodeIfPresent(Double.self, forKey: .cornerRadius) ?? fallback.cornerRadius
-        mainLabel = try container.decodeIfPresent(ThemeColor.self, forKey: .mainLabel) ?? fallback.mainLabel
-        utilityLabel = try container.decodeIfPresent(ThemeColor.self, forKey: .utilityLabel)
-            ?? fallback.utilityLabel
-        hintLetter = try container.decodeIfPresent(ThemeColor.self, forKey: .hintLetter) ?? fallback.hintLetter
-        hintSymbol = try container.decodeIfPresent(ThemeColor.self, forKey: .hintSymbol) ?? fallback.hintSymbol
-        hintIconProminent = try container.decodeIfPresent(ThemeColor.self, forKey: .hintIconProminent)
+        boardSurface = container.decodeIfReadable(BoardSurfaceStyle.self, forKey: .boardSurface)
+            ?? legacy.boardSurface ?? fallback.boardSurface
+        boardColor = container.decodeIfReadable(ThemeColor.self, forKey: .boardColor)
+            ?? legacy.boardColor ?? fallback.boardColor
+        keySurface = container.decodeIfReadable(KeySurfaceStyle.self, forKey: .keySurface)
+            ?? legacy.keySurface ?? fallback.keySurface
+        keyColor = container.decodeIfReadable(ThemeColor.self, forKey: .keyColor)
+            ?? legacy.keyColor ?? fallback.keyColor
+        keyColorActive = container.decodeIfReadable(ThemeColor.self, forKey: .keyColorActive)
+            ?? legacy.keyColorActive ?? fallback.keyColorActive
+        keyBorder = container.decodeIfReadable(ThemeColor.self, forKey: .keyBorder)
+        keyBorderWidth = container.decodeIfReadable(Double.self, forKey: .keyBorderWidth) ?? fallback.keyBorderWidth
+        cornerRadius = container.decodeIfReadable(Double.self, forKey: .cornerRadius) ?? fallback.cornerRadius
+        mainLabel = container.decodeIfReadable(ThemeColor.self, forKey: .mainLabel) ?? fallback.mainLabel
+        utilityLabel = container.decodeIfReadable(ThemeColor.self, forKey: .utilityLabel) ?? fallback.utilityLabel
+        hintLetter = container.decodeIfReadable(ThemeColor.self, forKey: .hintLetter) ?? fallback.hintLetter
+        hintSymbol = container.decodeIfReadable(ThemeColor.self, forKey: .hintSymbol) ?? fallback.hintSymbol
+        hintIconProminent = container.decodeIfReadable(ThemeColor.self, forKey: .hintIconProminent)
             ?? fallback.hintIconProminent
-        hintIconSubtle = try container.decodeIfPresent(ThemeColor.self, forKey: .hintIconSubtle)
+        hintIconSubtle = container.decodeIfReadable(ThemeColor.self, forKey: .hintIconSubtle)
             ?? fallback.hintIconSubtle
-        gestureTrail = try container.decodeIfPresent(ThemeColor.self, forKey: .gestureTrail)
-            ?? fallback.gestureTrail
+        gestureTrail = container.decodeIfReadable(ThemeColor.self, forKey: .gestureTrail) ?? fallback.gestureTrail
+    }
+}
+
+extension KeyedDecodingContainer {
+    /// The value for `key`, or nil when the key is absent **or its value is
+    /// unreadable**. `decodeIfPresent` only tolerates the first of those; in
+    /// the theme model both have to degrade the same way, because a throw
+    /// discards the whole theme (see `KeyboardThemeDefinition.init(from:)`).
+    fileprivate func decodeIfReadable<Value: Decodable>(_ type: Value.Type, forKey key: Key) -> Value? {
+        (try? decodeIfPresent(type, forKey: key)) ?? nil
+    }
+}
+
+// MARK: - Pre-Rework Surface Keys
+
+/// The surfaces as unreleased dev builds (M2/M3) persisted them: one
+/// `ThemeFill` union per surface under `boardBackground` / `keyFill` /
+/// `keyFillActive`, encoded as `{"type": "color", "color": …}` or
+/// `{"type": "material"}`.
+///
+/// Read as a last-resort fallback before Classic. Ignoring these keys is not a
+/// clean degradation: the label roles decode fine, so an old Dark Gold copy
+/// would come back as gold labels on Classic's near-white key — about 2.2:1 —
+/// and the next save would persist that. Deliberately absent from
+/// `KeyboardThemeDefinition.CodingKeys`, so nothing ever writes the shape back.
+/// Delete once no dev install predates the surface rework.
+private struct LegacySurfaces {
+    private enum CodingKeys: String, CodingKey {
+        case boardBackground, keyFill, keyFillActive
+    }
+
+    private enum FillKeys: String, CodingKey {
+        case type, color
+    }
+
+    /// One legacy fill: the color it carried, if any, and whether it asked for
+    /// the material — which the rework turned into the `glass` surface style.
+    private struct Fill {
+        var isMaterial: Bool
+        var color: ThemeColor?
+    }
+
+    private var board: Fill?
+    private var key: Fill?
+    private var keyActive: Fill?
+
+    init(decoder: Decoder) {
+        guard let container = try? decoder.container(keyedBy: CodingKeys.self) else { return }
+        board = Self.fill(in: container, forKey: .boardBackground)
+        key = Self.fill(in: container, forKey: .keyFill)
+        keyActive = Self.fill(in: container, forKey: .keyFillActive)
+    }
+
+    var boardSurface: BoardSurfaceStyle? {
+        board.map { $0.isMaterial ? .glass : .color }
+    }
+
+    var boardColor: ThemeColor? {
+        board?.color
+    }
+
+    var keySurface: KeySurfaceStyle? {
+        key.map { $0.isMaterial ? .glass : .color }
+    }
+
+    var keyColor: ThemeColor? {
+        key?.color
+    }
+
+    var keyColorActive: ThemeColor? {
+        keyActive?.color
+    }
+
+    private static func fill(in container: KeyedDecodingContainer<CodingKeys>, forKey key: CodingKeys) -> Fill? {
+        guard let fill = try? container.nestedContainer(keyedBy: FillKeys.self, forKey: key) else { return nil }
+        return Fill(
+            isMaterial: fill.decodeIfReadable(String.self, forKey: .type) == "material",
+            color: fill.decodeIfReadable(ThemeColor.self, forKey: .color)
+        )
     }
 }

--- a/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeEnvironment.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeEnvironment.swift
@@ -1,0 +1,13 @@
+//
+//  KeyboardThemeEnvironment.swift
+//  Wurstfinger
+//
+//  Environment plumbing for the resolved theme.
+//
+
+import SwiftUI
+
+extension EnvironmentValues {
+    /// The resolved theme, injected once by `DataDrivenKeyboardRootView`.
+    @Entry var keyboardTheme: ResolvedTheme = BuiltInThemes.classic.resolved()
+}

--- a/wurstfingerKeyboard/Runtime/Theme/ResolvedTheme.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ResolvedTheme.swift
@@ -30,6 +30,12 @@ struct ResolvedTheme: Equatable {
     let hintSymbol: Color
     let hintIconProminent: Color
     let hintIconSubtle: Color
+
+    /// Whether any key fill is the bar/glass material, so the grid wraps its
+    /// keys in a `GlassEffectContainer` on iOS 26 (shared sampling region).
+    var usesGlassMaterial: Bool {
+        keyFill == .material || keyFillActive == .material
+    }
 }
 
 extension KeyboardThemeDefinition {

--- a/wurstfingerKeyboard/Runtime/Theme/ResolvedTheme.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ResolvedTheme.swift
@@ -1,0 +1,92 @@
+//
+//  ResolvedTheme.swift
+//  Wurstfinger
+//
+//  The flat, render-ready form of a theme. Resolved once per keyboard root,
+//  injected via Environment, and Equatable so SwiftUI can skip re-renders.
+//
+
+import SwiftUI
+
+/// A resolved fill. Deliberately not `AnyShapeStyle` (which is not
+/// Equatable, and whose wrapping shifts how `.bar` samples its backdrop);
+/// the view layer switches on this and applies `.bar` directly.
+enum ResolvedFill: Equatable {
+    case color(Color)
+    case material
+}
+
+struct ResolvedTheme: Equatable {
+    let boardBackground: ResolvedFill
+    let keyFill: ResolvedFill
+    let keyFillActive: ResolvedFill
+    /// nil = no border overlay in the view tree.
+    let keyBorder: Color?
+    let keyBorderWidth: CGFloat
+    let cornerRadius: CGFloat
+    let mainLabel: Color
+    let utilityLabel: Color
+    let hintLetter: Color
+    let hintSymbol: Color
+    let hintIconProminent: Color
+    let hintIconSubtle: Color
+}
+
+extension KeyboardThemeDefinition {
+    /// Minimum board alpha that still receives touches. A keyboard
+    /// extension's input view only delivers touches on rendered surfaces, so
+    /// a fully transparent board would drop taps between keys (#198).
+    static let minimumBoardOpacity = 0.02
+
+    /// Resolves the definition into renderable values. Unparsable hex colors
+    /// fall back to the Classic value of the same role, so a broken user
+    /// theme degrades gracefully instead of rendering invisibly.
+    func resolved() -> ResolvedTheme {
+        let fallback = BuiltInThemes.classic
+        return ResolvedTheme(
+            boardBackground: boardBackground
+                .withMinimumOpacity(Self.minimumBoardOpacity)
+                .resolvedFill(fallback: fallback.boardBackground),
+            keyFill: keyFill.resolvedFill(fallback: fallback.keyFill),
+            keyFillActive: keyFillActive.resolvedFill(fallback: fallback.keyFillActive),
+            keyBorder: keyBorder.flatMap { $0.resolvedColor() },
+            keyBorderWidth: CGFloat(keyBorderWidth),
+            cornerRadius: CGFloat(cornerRadius),
+            mainLabel: mainLabel.resolvedColor(fallback: fallback.mainLabel),
+            utilityLabel: utilityLabel.resolvedColor(fallback: fallback.utilityLabel),
+            hintLetter: hintLetter.resolvedColor(fallback: fallback.hintLetter),
+            hintSymbol: hintSymbol.resolvedColor(fallback: fallback.hintSymbol),
+            hintIconProminent: hintIconProminent.resolvedColor(fallback: fallback.hintIconProminent),
+            hintIconSubtle: hintIconSubtle.resolvedColor(fallback: fallback.hintIconSubtle)
+        )
+    }
+}
+
+extension ThemeColor {
+    /// Resolves, falling back to another theme color (whose own resolution
+    /// is expected to be infallible — built-ins only use valid values).
+    fileprivate func resolvedColor(fallback: ThemeColor) -> Color {
+        resolvedColor() ?? fallback.resolvedColor() ?? .primary
+    }
+}
+
+extension ThemeFill {
+    fileprivate func withMinimumOpacity(_ minimum: Double) -> ThemeFill {
+        switch self {
+        case let .color(color): .color(color.withMinimumOpacity(minimum))
+        case .material: .material
+        }
+    }
+
+    fileprivate func resolvedFill(fallback: ThemeFill) -> ResolvedFill {
+        switch self {
+        case let .color(color):
+            if let resolved = color.resolvedColor() {
+                return .color(resolved)
+            }
+            return fallback.resolvedFill(fallback: .color(.semantic(.secondarySystemBackground)))
+        case .material:
+            return .material
+        }
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Theme/ResolvedTheme.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ResolvedTheme.swift
@@ -8,18 +8,10 @@
 
 import SwiftUI
 
-/// A resolved fill. Deliberately not `AnyShapeStyle` (which is not
-/// Equatable, and whose wrapping shifts how `.bar` samples its backdrop);
-/// the view layer switches on this and applies `.bar` directly.
-enum ResolvedFill: Equatable {
-    case color(Color)
-    case material
-}
-
 struct ResolvedTheme: Equatable {
-    let boardBackground: ResolvedFill
-    let keyFill: ResolvedFill
-    let keyFillActive: ResolvedFill
+    let boardBackground: Color
+    let keyColor: Color
+    let keyColorActive: Color
     /// nil = no border overlay in the view tree.
     let keyBorder: Color?
     let keyBorderWidth: CGFloat
@@ -30,12 +22,14 @@ struct ResolvedTheme: Equatable {
     let hintSymbol: Color
     let hintIconProminent: Color
     let hintIconSubtle: Color
+    let gestureTrail: Color
 
-    /// Whether any key fill is the bar/glass material, so the grid wraps its
-    /// keys in a `GlassEffectContainer` on iOS 26 (shared sampling region).
-    var usesGlassMaterial: Bool {
-        keyFill == .material || keyFillActive == .material
-    }
+    /// Whether the keys render as the bar/glass material, so the grid wraps
+    /// them in a `GlassEffectContainer` on iOS 26 (glass cannot sample other
+    /// glass) and each key applies the effect instead of a fill. Stored rather
+    /// than derived from a resolved `keySurface`: that field would have no
+    /// reader other than its own getter.
+    let hasGlassKeys: Bool
 }
 
 extension KeyboardThemeDefinition {
@@ -44,17 +38,24 @@ extension KeyboardThemeDefinition {
     /// a fully transparent board would drop taps between keys (#198).
     static let minimumBoardOpacity = 0.02
 
+    /// The board a glass theme paints: nearly clear so the backdrop comes
+    /// through, but still rendered (#198). The literal is the value of the
+    /// shipped Liquid Glass look; that it coincides with `minimumBoardOpacity`
+    /// is a coincidence, not a derivation.
+    static let glassBoardColor: ThemeColor = .semantic(.gray, opacity: 0.02)
+
     /// Resolves the definition into renderable values. Unparsable hex colors
     /// fall back to the Classic value of the same role, so a broken user
     /// theme degrades gracefully instead of rendering invisibly.
     func resolved() -> ResolvedTheme {
         let fallback = BuiltInThemes.classic
+        let board: ThemeColor = boardSurface == .glass
+            ? Self.glassBoardColor
+            : boardColor.withMinimumOpacity(Self.minimumBoardOpacity)
         return ResolvedTheme(
-            boardBackground: boardBackground
-                .withMinimumOpacity(Self.minimumBoardOpacity)
-                .resolvedFill(fallback: fallback.boardBackground),
-            keyFill: keyFill.resolvedFill(fallback: fallback.keyFill),
-            keyFillActive: keyFillActive.resolvedFill(fallback: fallback.keyFillActive),
+            boardBackground: board.resolvedColor(fallback: fallback.boardColor),
+            keyColor: keyColor.resolvedColor(fallback: fallback.keyColor),
+            keyColorActive: keyColorActive.resolvedColor(fallback: fallback.keyColorActive),
             keyBorder: keyBorder.flatMap { $0.resolvedColor() },
             keyBorderWidth: CGFloat(keyBorderWidth),
             cornerRadius: CGFloat(cornerRadius),
@@ -63,7 +64,9 @@ extension KeyboardThemeDefinition {
             hintLetter: hintLetter.resolvedColor(fallback: fallback.hintLetter),
             hintSymbol: hintSymbol.resolvedColor(fallback: fallback.hintSymbol),
             hintIconProminent: hintIconProminent.resolvedColor(fallback: fallback.hintIconProminent),
-            hintIconSubtle: hintIconSubtle.resolvedColor(fallback: fallback.hintIconSubtle)
+            hintIconSubtle: hintIconSubtle.resolvedColor(fallback: fallback.hintIconSubtle),
+            gestureTrail: gestureTrail.resolvedColor(fallback: fallback.gestureTrail),
+            hasGlassKeys: keySurface == .glass
         )
     }
 }
@@ -73,26 +76,5 @@ extension ThemeColor {
     /// is expected to be infallible — built-ins only use valid values).
     fileprivate func resolvedColor(fallback: ThemeColor) -> Color {
         resolvedColor() ?? fallback.resolvedColor() ?? .primary
-    }
-}
-
-extension ThemeFill {
-    fileprivate func withMinimumOpacity(_ minimum: Double) -> ThemeFill {
-        switch self {
-        case let .color(color): .color(color.withMinimumOpacity(minimum))
-        case .material: .material
-        }
-    }
-
-    fileprivate func resolvedFill(fallback: ThemeFill) -> ResolvedFill {
-        switch self {
-        case let .color(color):
-            if let resolved = color.resolvedColor() {
-                return .color(resolved)
-            }
-            return fallback.resolvedFill(fallback: .color(.semantic(.secondarySystemBackground)))
-        case .material:
-            return .material
-        }
     }
 }

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
@@ -70,6 +70,13 @@ enum ThemeColor: Equatable {
         }
     }
 
+    /// Builds a fixed color from a SwiftUI color — the form the editor's color
+    /// wells write. A color with no RGB representation (e.g. a pattern) falls
+    /// back to opaque black rather than dropping the edit.
+    static func from(_ color: Color) -> ThemeColor {
+        .fixed(hex: HexColor.string(from: color) ?? "#000000")
+    }
+
     /// The same color with its opacity raised to at least `minimum`. Used to
     /// keep the board fill touchable (a keyboard extension's input view only
     /// delivers touches on rendered surfaces; see DataDrivenKeyboardRootView).

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
@@ -1,0 +1,174 @@
+//
+//  ThemeColor.swift
+//  Wurstfinger
+//
+//  Color and fill primitives of the theme engine.
+//
+
+import SwiftUI
+import UIKit
+
+// MARK: - Semantic Tokens
+
+/// Semantic system colors a theme can reference. These stay trait-dynamic —
+/// themes built from them (like Classic) follow light/dark and other
+/// appearance traits exactly like the previously hardcoded system colors.
+enum ThemeSemanticToken: String, Codable, CaseIterable {
+    case primary
+    case secondary
+    case systemBackground
+    case secondarySystemBackground
+    case tertiarySystemFill
+
+    var color: Color {
+        switch self {
+        case .primary: .primary
+        case .secondary: .secondary
+        case .systemBackground: Color(.systemBackground)
+        case .secondarySystemBackground: Color(.secondarySystemBackground)
+        case .tertiarySystemFill: Color(.tertiarySystemFill)
+        }
+    }
+}
+
+// MARK: - ThemeColor
+
+/// A theme color: a semantic system color with an opacity, a fixed hex value
+/// (identical in light and dark mode), or an explicit light/dark hex pair.
+enum ThemeColor: Equatable {
+    case semantic(ThemeSemanticToken, opacity: Double)
+    case fixed(hex: String)
+    case adaptive(light: String, dark: String)
+
+    /// Convenience for full-opacity semantic colors (enum cases cannot carry
+    /// default associated values).
+    static func semantic(_ token: ThemeSemanticToken) -> ThemeColor {
+        .semantic(token, opacity: 1)
+    }
+
+    /// Resolves to a renderable color. Semantic and adaptive colors remain
+    /// trait-dynamic, so nothing needs to re-resolve on appearance changes.
+    /// Returns nil when a hex value does not parse.
+    func resolvedColor() -> Color? {
+        switch self {
+        case let .semantic(token, opacity):
+            // Skip the .opacity wrapper at 1 so Classic renders through the
+            // exact same color values as before the theme engine.
+            return opacity >= 1 ? token.color : token.color.opacity(opacity)
+        case let .fixed(hex):
+            return HexColor.color(from: hex)
+        case let .adaptive(light, dark):
+            guard let lightComponents = HexColor.parse(light),
+                  let darkComponents = HexColor.parse(dark) else { return nil }
+            return Color(UIColor { traits in
+                traits.userInterfaceStyle == .dark
+                    ? HexColor.uiColor(from: darkComponents)
+                    : HexColor.uiColor(from: lightComponents)
+            })
+        }
+    }
+
+    /// The same color with its opacity raised to at least `minimum`. Used to
+    /// keep the board fill touchable (a keyboard extension's input view only
+    /// delivers touches on rendered surfaces; see DataDrivenKeyboardRootView).
+    func withMinimumOpacity(_ minimum: Double) -> ThemeColor {
+        switch self {
+        case let .semantic(token, opacity):
+            return .semantic(token, opacity: max(opacity, minimum))
+        case let .fixed(hex):
+            guard let components = HexColor.parse(hex), components.alpha < minimum else { return self }
+            return .fixed(hex: HexColor.string(from: .init(rgb: components.rgb, alpha: minimum)))
+        case let .adaptive(light, dark):
+            let raise = { (hex: String) -> String in
+                guard let components = HexColor.parse(hex), components.alpha < minimum else { return hex }
+                return HexColor.string(from: .init(rgb: components.rgb, alpha: minimum))
+            }
+            return .adaptive(light: raise(light), dark: raise(dark))
+        }
+    }
+}
+
+/// Explicit, stable persisted form: `{"type": "semantic"|"fixed"|"adaptive", …}`.
+/// The encoding is the future export wire format — keep it disciplined.
+extension ThemeColor: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type, token, opacity, hex, light, dark
+    }
+
+    private enum Kind: String, Codable {
+        case semantic, fixed, adaptive
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .type) {
+        case .semantic:
+            let token = try container.decode(ThemeSemanticToken.self, forKey: .token)
+            let opacity = try container.decodeIfPresent(Double.self, forKey: .opacity) ?? 1
+            self = .semantic(token, opacity: opacity)
+        case .fixed:
+            self = try .fixed(hex: container.decode(String.self, forKey: .hex))
+        case .adaptive:
+            self = try .adaptive(
+                light: container.decode(String.self, forKey: .light),
+                dark: container.decode(String.self, forKey: .dark)
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .semantic(token, opacity):
+            try container.encode(Kind.semantic, forKey: .type)
+            try container.encode(token, forKey: .token)
+            try container.encode(opacity, forKey: .opacity)
+        case let .fixed(hex):
+            try container.encode(Kind.fixed, forKey: .type)
+            try container.encode(hex, forKey: .hex)
+        case let .adaptive(light, dark):
+            try container.encode(Kind.adaptive, forKey: .type)
+            try container.encode(light, forKey: .light)
+            try container.encode(dark, forKey: .dark)
+        }
+    }
+}
+
+// MARK: - ThemeFill
+
+/// A fill: either a theme color or the system bar material (Liquid Glass).
+enum ThemeFill: Equatable {
+    case color(ThemeColor)
+    case material
+}
+
+extension ThemeFill: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type, color
+    }
+
+    private enum Kind: String, Codable {
+        case color, material
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .type) {
+        case .color:
+            self = try .color(container.decode(ThemeColor.self, forKey: .color))
+        case .material:
+            self = .material
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .color(color):
+            try container.encode(Kind.color, forKey: .type)
+            try container.encode(color, forKey: .color)
+        case .material:
+            try container.encode(Kind.material, forKey: .type)
+        }
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
@@ -16,6 +16,7 @@ import UIKit
 enum ThemeSemanticToken: String, Codable, CaseIterable {
     case primary
     case secondary
+    case gray
     case systemBackground
     case secondarySystemBackground
     case tertiarySystemFill
@@ -24,6 +25,7 @@ enum ThemeSemanticToken: String, Codable, CaseIterable {
         switch self {
         case .primary: .primary
         case .secondary: .secondary
+        case .gray: .gray
         case .systemBackground: Color(.systemBackground)
         case .secondarySystemBackground: Color(.secondarySystemBackground)
         case .tertiarySystemFill: Color(.tertiarySystemFill)

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
@@ -158,13 +158,13 @@ extension ThemeColor: Codable {
         case type, token, opacity, hex, light, dark
     }
 
-    private enum Kind: String, Codable {
+    private enum EncodedType: String, Codable {
         case semantic, fixed, adaptive
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        switch try container.decode(Kind.self, forKey: .type) {
+        switch try container.decode(EncodedType.self, forKey: .type) {
         case .semantic:
             let token = try container.decode(ThemeSemanticToken.self, forKey: .token)
             let opacity = try container.decodeIfPresent(Double.self, forKey: .opacity) ?? 1
@@ -183,14 +183,14 @@ extension ThemeColor: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
         case let .semantic(token, opacity):
-            try container.encode(Kind.semantic, forKey: .type)
+            try container.encode(EncodedType.semantic, forKey: .type)
             try container.encode(token, forKey: .token)
             try container.encode(opacity, forKey: .opacity)
         case let .fixed(hex):
-            try container.encode(Kind.fixed, forKey: .type)
+            try container.encode(EncodedType.fixed, forKey: .type)
             try container.encode(hex, forKey: .hex)
         case let .adaptive(light, dark):
-            try container.encode(Kind.adaptive, forKey: .type)
+            try container.encode(EncodedType.adaptive, forKey: .type)
             try container.encode(light, forKey: .light)
             try container.encode(dark, forKey: .dark)
         }

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
@@ -2,7 +2,7 @@
 //  ThemeColor.swift
 //  Wurstfinger
 //
-//  Color and fill primitives of the theme engine.
+//  Color primitives of the theme engine.
 //
 
 import SwiftUI
@@ -139,45 +139,6 @@ extension ThemeColor: Codable {
             try container.encode(Kind.adaptive, forKey: .type)
             try container.encode(light, forKey: .light)
             try container.encode(dark, forKey: .dark)
-        }
-    }
-}
-
-// MARK: - ThemeFill
-
-/// A fill: either a theme color or the system bar material (Liquid Glass).
-enum ThemeFill: Equatable {
-    case color(ThemeColor)
-    case material
-}
-
-extension ThemeFill: Codable {
-    private enum CodingKeys: String, CodingKey {
-        case type, color
-    }
-
-    private enum Kind: String, Codable {
-        case color, material
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        switch try container.decode(Kind.self, forKey: .type) {
-        case .color:
-            self = try .color(container.decode(ThemeColor.self, forKey: .color))
-        case .material:
-            self = .material
-        }
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        switch self {
-        case let .color(color):
-            try container.encode(Kind.color, forKey: .type)
-            try container.encode(color, forKey: .color)
-        case .material:
-            try container.encode(Kind.material, forKey: .type)
         }
     }
 }

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
@@ -60,13 +60,8 @@ enum ThemeColor: Equatable {
         case let .fixed(hex):
             return HexColor.color(from: hex)
         case let .adaptive(light, dark):
-            guard let lightComponents = HexColor.parse(light),
-                  let darkComponents = HexColor.parse(dark) else { return nil }
-            return Color(UIColor { traits in
-                traits.userInterfaceStyle == .dark
-                    ? HexColor.uiColor(from: darkComponents)
-                    : HexColor.uiColor(from: lightComponents)
-            })
+            guard let color = AdaptiveColors.color(light: light, dark: dark) else { return nil }
+            return Color(color)
         }
     }
 
@@ -94,6 +89,51 @@ enum ThemeColor: Equatable {
             }
             return .adaptive(light: raise(light), dark: raise(dark))
         }
+    }
+}
+
+// MARK: - Adaptive Colors
+
+/// The trait-dynamic colors behind `ThemeColor.adaptive`, one per light/dark
+/// hex pair.
+///
+/// They have to be shared rather than rebuilt: `UIColor(dynamicProvider:)`
+/// hands back a fresh object every call and two of those never compare equal,
+/// so resolving one theme twice would yield two unequal `ResolvedTheme`s —
+/// every root body evaluation would then read as a theme change and invalidate
+/// the grid plus every key in it.
+///
+/// A color is fully determined by its pair, so entries never go stale and the
+/// table only grows with the number of distinct pairs across the user's themes
+/// (no UI writes adaptive colors today). Host app and extension are separate
+/// processes with their own table; the lock guards against resolution off the
+/// main thread.
+private enum AdaptiveColors {
+    private struct Pair: Hashable {
+        var light: String
+        var dark: String
+    }
+
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var colors: [Pair: UIColor] = [:]
+
+    /// The dynamic color for a hex pair, or nil when either hex is unparsable.
+    static func color(light: String, dark: String) -> UIColor? {
+        let pair = Pair(light: light, dark: dark)
+        lock.lock()
+        defer { lock.unlock() }
+        if let cached = colors[pair] {
+            return cached
+        }
+        guard let lightComponents = HexColor.parse(light),
+              let darkComponents = HexColor.parse(dark) else { return nil }
+        let color = UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? HexColor.uiColor(from: darkComponents)
+                : HexColor.uiColor(from: lightComponents)
+        }
+        colors[pair] = color
+        return color
     }
 }
 

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
@@ -65,6 +65,20 @@ enum ThemeColor: Equatable {
         }
     }
 
+    /// The color as it renders in one specific appearance, frozen to a static
+    /// value.
+    ///
+    /// The editor's color wells need this. A semantic or adaptive color
+    /// resolves against the environment it is *displayed* in, so a well drawn
+    /// in a light-mode sheet would show a dark-slot theme's label in its light
+    /// value — and because the well's setter freezes whatever it was seeded
+    /// with, that wrong reading gets written into the theme permanently.
+    func resolvedColor(in colorScheme: ColorScheme) -> Color? {
+        guard let color = resolvedColor() else { return nil }
+        let traits = UITraitCollection(userInterfaceStyle: colorScheme == .dark ? .dark : .light)
+        return Color(UIColor(color).resolvedColor(with: traits))
+    }
+
     /// Builds a fixed color from a SwiftUI color — the form the editor's color
     /// wells write. A color with no RGB representation (e.g. a pattern) falls
     /// back to opaque black rather than dropping the edit.

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
@@ -85,6 +85,65 @@ enum ThemeStore {
         return theme(lightId: lightId, darkId: darkId, for: colorScheme, defaults: defaults)
     }
 
+    // MARK: - Editing
+
+    /// A user-owned copy of any theme: a fresh UUID id, an un-taken " Copy"
+    /// name, and the source's colors. Built-in status is derived from the id,
+    /// so the copy is automatically editable and deletable.
+    static func duplicate(
+        _ source: KeyboardThemeDefinition,
+        existing: [KeyboardThemeDefinition]
+    ) -> KeyboardThemeDefinition {
+        var copy = source
+        copy.id = UUID().uuidString
+        copy.name = uniqueCopyName(base: source.displayName, existing: existing)
+        return copy
+    }
+
+    /// "<name> Copy", disambiguated with a numeric suffix if that name is
+    /// already taken, so duplicating twice never yields two identical names.
+    private static func uniqueCopyName(base: String, existing: [KeyboardThemeDefinition]) -> String {
+        let taken = Set(existing.map(\.name))
+        let first = String(format: String(localized: "%@ Copy"), base)
+        guard taken.contains(first) else { return first }
+        var index = 2
+        while taken.contains(String(format: String(localized: "%@ Copy %lld"), base, index)) {
+            index += 1
+        }
+        return String(format: String(localized: "%@ Copy %lld"), base, index)
+    }
+
+    /// Replaces the theme with the same id, or appends it. Built-in ids are
+    /// rejected (they can never become user themes).
+    static func upsert(
+        _ theme: KeyboardThemeDefinition,
+        into list: [KeyboardThemeDefinition]
+    ) -> [KeyboardThemeDefinition] {
+        guard !BuiltInThemes.ids.contains(theme.id) else { return list }
+        var list = list
+        if let index = list.firstIndex(where: { $0.id == theme.id }) {
+            list[index] = theme
+        } else {
+            list.append(theme)
+        }
+        return list
+    }
+
+    /// Inserts or updates a user theme in defaults.
+    static func saveUserTheme(_ theme: KeyboardThemeDefinition, defaults: UserDefaults = SharedDefaults.store) {
+        writeUserThemes(upsert(theme, into: userThemes(defaults: defaults)), defaults: defaults)
+    }
+
+    /// Removes a user theme and repoints any slot that selected it back to
+    /// Classic, so a deleted theme never leaves a slot resolving to nothing.
+    static func deleteUserTheme(id: String, defaults: UserDefaults = SharedDefaults.store) {
+        writeUserThemes(userThemes(defaults: defaults).filter { $0.id != id }, defaults: defaults)
+        let slots = [SettingsKey.selectedThemeLight, SettingsKey.selectedThemeDark]
+        for key in slots where defaults.string(forKey: key.rawValue) == id {
+            defaults.set(BuiltInThemes.classic.id, forKey: key.rawValue)
+        }
+    }
+
     // MARK: - Migration
 
     /// One-time migration from the legacy `keyboardStyle` setting to the

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
@@ -56,33 +56,54 @@ enum ThemeStore {
         return userThemes(defaults: defaults).first { $0.id == id }
     }
 
-    /// The theme for the given appearance, applying the fallback cascade:
-    /// assigned slot → other slot → Classic.
-    static func selectedTheme(
+    /// Resolves the theme for the given appearance from two explicit slot ids,
+    /// applying the fallback cascade: assigned slot → other slot → Classic.
+    /// This is the single source of truth for slot selection; both the live
+    /// keyboard (`DataDrivenKeyboardRootView`) and `selectedTheme(for:)` call it
+    /// so the tested path is the rendered path.
+    static func theme(
+        lightId: String,
+        darkId: String,
         for colorScheme: ColorScheme,
         defaults: UserDefaults = SharedDefaults.store
     ) -> KeyboardThemeDefinition {
-        let lightId = defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) ?? BuiltInThemes.classic.id
-        let darkId = defaults.string(forKey: SettingsKey.selectedThemeDark.rawValue) ?? lightId
         let (primary, secondary) = colorScheme == .dark ? (darkId, lightId) : (lightId, darkId)
         return theme(id: primary, defaults: defaults)
             ?? theme(id: secondary, defaults: defaults)
             ?? BuiltInThemes.classic
     }
 
+    /// The theme for the given appearance, reading the slot ids from defaults.
+    /// An unset dark slot follows the light slot (both slots track one
+    /// selection until the gallery adds separate assignment in M2).
+    static func selectedTheme(
+        for colorScheme: ColorScheme,
+        defaults: UserDefaults = SharedDefaults.store
+    ) -> KeyboardThemeDefinition {
+        let lightId = defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) ?? BuiltInThemes.classic.id
+        let darkId = defaults.string(forKey: SettingsKey.selectedThemeDark.rawValue) ?? lightId
+        return theme(lightId: lightId, darkId: darkId, for: colorScheme, defaults: defaults)
+    }
+
     // MARK: - Migration
 
     /// One-time migration from the legacy `keyboardStyle` setting to the
-    /// theme assignment. Idempotent and race-safe: host app and extension may
-    /// both run this concurrently — both derive the same deterministic values
-    /// and only write when the new keys are still absent.
+    /// light/dark theme assignment. Idempotent for sequential runs (host app
+    /// and extension both run it); the derived values are deterministic, so a
+    /// second run is a no-op. A concurrent first run has a narrow theoretical
+    /// TOCTOU window, but it only opens on the very first launch before any
+    /// theme is stored, so it is not reachable in practice.
     static func migrateIfNeeded(defaults: UserDefaults = SharedDefaults.store) {
         guard let legacy = defaults.string(forKey: SettingsKey.keyboardStyle.rawValue) else {
             return
         }
+        // Only seed the slots if no selection exists yet; if another run (or the
+        // user) already set one, leave it and just drop the stale legacy key.
         if defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == nil {
             let id = switch legacy {
             case "liquidGlass": BuiltInThemes.liquidGlass.id
+            // "darkGold" never shipped as a keyboardStyle value; kept so an
+            // unreleased dev build's stored value still migrates sensibly.
             case "darkGold": BuiltInThemes.darkGold.id
             default: BuiltInThemes.classic.id
             }

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
@@ -1,0 +1,123 @@
+//
+//  ThemeStore.swift
+//  Wurstfinger
+//
+//  Theme lookup, user-theme persistence, and legacy migration.
+//
+//  Cross-process note: App-Group defaults do NOT deliver live updates between
+//  host app and extension. The extension re-reads on every appearance (its
+//  root view resolves per launch); only same-process observers (previews) are
+//  live via @AppStorage.
+//
+
+import Foundation
+import SwiftUI
+
+enum ThemeStore {
+    // MARK: - Persistence Format
+
+    /// Envelope around persisted user themes. `schemaVersion` starts at 1;
+    /// this format doubles as the future export wire format, so encode with
+    /// sorted keys and decode tolerantly.
+    struct Archive: Equatable {
+        var schemaVersion: Int
+        var themes: [KeyboardThemeDefinition]
+
+        static let currentSchemaVersion = 1
+    }
+
+    /// Decodes the archive from defaults. Lossy on purpose: a corrupt entry
+    /// is skipped instead of destroying all user themes, and entries claiming
+    /// a built-in id are dropped (built-in status is derived, never trusted).
+    static func userThemes(defaults: UserDefaults = SharedDefaults.store) -> [KeyboardThemeDefinition] {
+        guard let data = defaults.data(forKey: SettingsKey.userThemes.rawValue) else {
+            return []
+        }
+        let archive = try? JSONDecoder().decode(Archive.self, from: data)
+        return archive?.themes ?? []
+    }
+
+    static func writeUserThemes(_ themes: [KeyboardThemeDefinition], defaults: UserDefaults = SharedDefaults.store) {
+        let archive = Archive(schemaVersion: Archive.currentSchemaVersion, themes: themes)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        guard let data = try? encoder.encode(archive) else { return }
+        defaults.set(data, forKey: SettingsKey.userThemes.rawValue)
+    }
+
+    // MARK: - Lookup
+
+    /// Built-ins never touch the user-theme blob, so the common case decodes
+    /// nothing on extension launch.
+    static func theme(id: String, defaults: UserDefaults = SharedDefaults.store) -> KeyboardThemeDefinition? {
+        if let builtIn = BuiltInThemes.theme(id: id) {
+            return builtIn
+        }
+        return userThemes(defaults: defaults).first { $0.id == id }
+    }
+
+    /// The theme for the given appearance, applying the fallback cascade:
+    /// assigned slot → other slot → Classic.
+    static func selectedTheme(
+        for colorScheme: ColorScheme,
+        defaults: UserDefaults = SharedDefaults.store
+    ) -> KeyboardThemeDefinition {
+        let lightId = defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) ?? BuiltInThemes.classic.id
+        let darkId = defaults.string(forKey: SettingsKey.selectedThemeDark.rawValue) ?? lightId
+        let (primary, secondary) = colorScheme == .dark ? (darkId, lightId) : (lightId, darkId)
+        return theme(id: primary, defaults: defaults)
+            ?? theme(id: secondary, defaults: defaults)
+            ?? BuiltInThemes.classic
+    }
+
+    // MARK: - Migration
+
+    /// One-time migration from the legacy `keyboardStyle` setting to the
+    /// theme assignment. Idempotent and race-safe: host app and extension may
+    /// both run this concurrently — both derive the same deterministic values
+    /// and only write when the new keys are still absent.
+    static func migrateIfNeeded(defaults: UserDefaults = SharedDefaults.store) {
+        guard let legacy = defaults.string(forKey: SettingsKey.keyboardStyle.rawValue) else {
+            return
+        }
+        if defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == nil {
+            let id = switch legacy {
+            case "liquidGlass": BuiltInThemes.liquidGlass.id
+            case "darkGold": BuiltInThemes.darkGold.id
+            default: BuiltInThemes.classic.id
+            }
+            defaults.set(id, forKey: SettingsKey.selectedThemeLight.rawValue)
+            defaults.set(id, forKey: SettingsKey.selectedThemeDark.rawValue)
+        }
+        defaults.removeObject(forKey: SettingsKey.keyboardStyle.rawValue)
+    }
+}
+
+extension ThemeStore.Archive: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion, themes
+    }
+
+    /// Wrapper that swallows per-element decode failures.
+    private struct FailableTheme: Decodable {
+        let value: KeyboardThemeDefinition?
+
+        init(from decoder: Decoder) {
+            value = try? KeyboardThemeDefinition(from: decoder)
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion)
+            ?? Self.currentSchemaVersion
+        let raw = try container.decodeIfPresent([FailableTheme].self, forKey: .themes) ?? []
+        themes = raw.compactMap(\.value).filter { !BuiltInThemes.ids.contains($0.id) }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(themes, forKey: .themes)
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
@@ -82,28 +82,45 @@ enum ThemeStore {
     /// This is the single source of truth for slot selection; both the live
     /// keyboard (`DataDrivenKeyboardRootView`) and `selectedTheme(for:)` call it
     /// so the tested path is the rendered path.
+    ///
+    /// `hasSeparateDarkSlot` is what makes the dark slot *mean* anything: with
+    /// it off the dark slot is ignored and both appearances render the light
+    /// one. That is the whole reason the flag is honoured here rather than
+    /// collapsed into the stored ids by the settings screen — overwriting the
+    /// dark id would destroy the user's dark assignment on one toggle tap,
+    /// while ignoring it keeps the assignment intact for when the flag comes
+    /// back on.
     static func theme(
         lightId: String,
         darkId: String,
+        hasSeparateDarkSlot: Bool,
         for colorScheme: ColorScheme,
         defaults: UserDefaults = SharedDefaults.store
     ) -> KeyboardThemeDefinition {
+        guard hasSeparateDarkSlot else {
+            return theme(id: lightId, defaults: defaults) ?? BuiltInThemes.classic
+        }
         let (primary, secondary) = colorScheme == .dark ? (darkId, lightId) : (lightId, darkId)
         return theme(id: primary, defaults: defaults)
             ?? theme(id: secondary, defaults: defaults)
             ?? BuiltInThemes.classic
     }
 
-    /// The theme for the given appearance, reading the slot ids from defaults.
-    /// An unset dark slot follows the light slot (both slots track one
-    /// selection until the gallery adds separate assignment in M2).
+    /// The theme for the given appearance, reading the slot ids and the
+    /// separate-dark-slot flag from defaults.
     static func selectedTheme(
         for colorScheme: ColorScheme,
         defaults: UserDefaults = SharedDefaults.store
     ) -> KeyboardThemeDefinition {
         let lightId = defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) ?? BuiltInThemes.classic.id
         let darkId = defaults.string(forKey: SettingsKey.selectedThemeDark.rawValue) ?? lightId
-        return theme(lightId: lightId, darkId: darkId, for: colorScheme, defaults: defaults)
+        return theme(
+            lightId: lightId,
+            darkId: darkId,
+            hasSeparateDarkSlot: defaults.bool(forKey: SettingsKey.themeSeparateDarkSlot.rawValue),
+            for: colorScheme,
+            defaults: defaults
+        )
     }
 
     // MARK: - Editing

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
@@ -32,15 +32,36 @@ enum ThemeStore {
         var schemaVersion: Int?
     }
 
+    /// The last decoded archive, keyed by the bytes it was decoded from.
+    ///
+    /// Keyed by the raw data rather than invalidated by the writers, because
+    /// the host app and the keyboard extension are separate processes: a
+    /// write-invalidated cache would go stale in whichever one did not perform
+    /// the write. Re-reading `Data` from `UserDefaults` and comparing it is
+    /// cheap; the `JSONDecoder` pass is the part worth skipping.
+    private static let cacheLock = NSLock()
+    private nonisolated(unsafe) static var decodedArchive: (data: Data, themes: [KeyboardThemeDefinition])?
+
     /// Decodes the archive from defaults. Lossy on purpose: a corrupt entry
     /// is skipped instead of destroying all user themes, and entries claiming
     /// a built-in id are dropped (built-in status is derived, never trusted).
+    ///
+    /// Called from render paths — the gallery list, and the keyboard's own root
+    /// view whenever a slot names a user theme — so repeated calls with
+    /// unchanged defaults must not re-decode.
     static func userThemes(defaults: UserDefaults = SharedDefaults.store) -> [KeyboardThemeDefinition] {
         guard let data = defaults.data(forKey: SettingsKey.userThemes.rawValue) else {
             return []
         }
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        if let cached = decodedArchive, cached.data == data {
+            return cached.themes
+        }
         let archive = try? JSONDecoder().decode(Archive.self, from: data)
-        return archive?.themes ?? []
+        let themes = archive?.themes ?? []
+        decodedArchive = (data, themes)
+        return themes
     }
 
     /// Writes the archive — unless defaults already hold one from a schema

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
@@ -191,6 +191,14 @@ extension ThemeStore.Archive: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion)
             ?? Self.currentSchemaVersion
+        // A blob from a future schema may give the same field names different
+        // meanings. Decoding it field by field would yield a plausible but
+        // wrong theme, and the next save would write that back over the
+        // original — so drop the themes wholesale instead.
+        guard schemaVersion <= Self.currentSchemaVersion else {
+            themes = []
+            return
+        }
         let raw = try container.decodeIfPresent([FailableTheme].self, forKey: .themes) ?? []
         themes = raw.compactMap(\.value).filter { !BuiltInThemes.ids.contains($0.id) }
     }

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
@@ -26,6 +26,12 @@ enum ThemeStore {
         static let currentSchemaVersion = 1
     }
 
+    /// Just the envelope of a stored archive, so the write guard can read the
+    /// schema version without decoding — and thereby discarding — the themes.
+    private struct SchemaEnvelope: Decodable {
+        var schemaVersion: Int?
+    }
+
     /// Decodes the archive from defaults. Lossy on purpose: a corrupt entry
     /// is skipped instead of destroying all user themes, and entries claiming
     /// a built-in id are dropped (built-in status is derived, never trusted).
@@ -37,12 +43,27 @@ enum ThemeStore {
         return archive?.themes ?? []
     }
 
+    /// Writes the archive — unless defaults already hold one from a schema
+    /// this build does not understand. Such a blob reads as "no themes"
+    /// (`Archive.init(from:)`), so writing this build's list over it would
+    /// delete exactly the themes that read-side guard is protecting. The two
+    /// guards only work as a pair.
     static func writeUserThemes(_ themes: [KeyboardThemeDefinition], defaults: UserDefaults = SharedDefaults.store) {
+        guard !storedArchiveIsFromANewerSchema(defaults: defaults) else { return }
         let archive = Archive(schemaVersion: Archive.currentSchemaVersion, themes: themes)
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys
         guard let data = try? encoder.encode(archive) else { return }
         defaults.set(data, forKey: SettingsKey.userThemes.rawValue)
+    }
+
+    private static func storedArchiveIsFromANewerSchema(defaults: UserDefaults) -> Bool {
+        guard let data = defaults.data(forKey: SettingsKey.userThemes.rawValue),
+              let envelope = try? JSONDecoder().decode(SchemaEnvelope.self, from: data),
+              let version = envelope.schemaVersion else {
+            return false
+        }
+        return version > Archive.currentSchemaVersion
     }
 
     // MARK: - Lookup
@@ -193,8 +214,10 @@ extension ThemeStore.Archive: Codable {
             ?? Self.currentSchemaVersion
         // A blob from a future schema may give the same field names different
         // meanings. Decoding it field by field would yield a plausible but
-        // wrong theme, and the next save would write that back over the
-        // original — so drop the themes wholesale instead.
+        // wrong theme, so drop the themes wholesale instead. What keeps the
+        // originals safe is the matching write guard in
+        // `ThemeStore.writeUserThemes`, which refuses to overwrite the blob;
+        // dropping them here alone would only hide them until the next save.
         guard schemaVersion <= Self.currentSchemaVersion else {
             themes = []
             return

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeSurface.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeSurface.swift
@@ -17,7 +17,7 @@ import Foundation
 /// a *rendered* surface — a keyboard extension only receives touches over
 /// rendered pixels, so a truly transparent board would drop every tap that
 /// lands in the gaps between keys (#198).
-enum BoardSurfaceStyle: String, Codable, CaseIterable {
+enum BoardSurfaceStyle: String, Codable {
     case color
     case glass
 }
@@ -26,7 +26,7 @@ enum BoardSurfaceStyle: String, Codable, CaseIterable {
 ///
 /// Here `glass` *is* a material: native Liquid Glass on iOS 26, the `.bar`
 /// material on older systems.
-enum KeySurfaceStyle: String, Codable, CaseIterable {
+enum KeySurfaceStyle: String, Codable {
     case color
     case glass
 }

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeSurface.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeSurface.swift
@@ -1,0 +1,32 @@
+//
+//  ThemeSurface.swift
+//  Wurstfinger
+//
+//  How a theme paints its two surfaces: the board behind the keys, and the
+//  keys themselves. Separate enums because "glass" means something different
+//  on each — see below.
+//
+
+import Foundation
+
+/// How the board behind the keys is painted.
+///
+/// `glass` is deliberately **not** a material. It paints
+/// `KeyboardThemeDefinition.glassBoardColor`, a nearly clear constant color, so
+/// the `UIInputView(.keyboard)` backdrop reads through it while the board stays
+/// a *rendered* surface — a keyboard extension only receives touches over
+/// rendered pixels, so a truly transparent board would drop every tap that
+/// lands in the gaps between keys (#198).
+enum BoardSurfaceStyle: String, Codable, CaseIterable {
+    case color
+    case glass
+}
+
+/// How a key is painted.
+///
+/// Here `glass` *is* a material: native Liquid Glass on iOS 26, the `.bar`
+/// material on older systems.
+enum KeySurfaceStyle: String, Codable, CaseIterable {
+    case color
+    case glass
+}

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -18,14 +18,16 @@ struct DataDrivenKeyboardRootView: View {
     /// When nil, falls back to `viewModel.viewWidth`.
     var overrideWidth: CGFloat?
 
+    /// Explicit theme for showcase/screenshot rendering. When set, the
+    /// stored selection is bypassed entirely — screenshots can never be
+    /// recolored by leftover simulator state.
+    var themeOverride: KeyboardThemeDefinition?
+
     // Single read site for the per-key render settings: one observation per
     // setting for the whole keyboard rather than one per key view. The root
     // re-renders on changes and passes fresh values down. The unstored-value
     // defaults come from `KeyRenderSettings.stock`, so this site and the
     // snapshot type agree on what an untouched installation renders.
-    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
-    private var keyboardStyle: KeyboardStyle = KeyRenderSettings.stock.keyboardStyle
-
     @AppStorage(SettingsKey.hideLetters.rawValue, store: SharedDefaults.store)
     private var hideLetters = KeyRenderSettings.stock.hideLetters
 
@@ -38,14 +40,39 @@ struct DataDrivenKeyboardRootView: View {
     @AppStorage(SettingsKey.longPressNumbersEnabled.rawValue, store: SharedDefaults.store)
     private var longPressNumbersEnabled = KeyRenderSettings.stock.longPressNumbersEnabled
 
+    // The theme selection is observed at the same single site, for the same
+    // reason: the resolved theme is handed down through the environment
+    // instead of being re-read by every key.
+    @AppStorage(SettingsKey.selectedThemeLight.rawValue, store: SharedDefaults.store)
+    private var selectedThemeLight = BuiltInThemes.classic.id
+
+    @AppStorage(SettingsKey.selectedThemeDark.rawValue, store: SharedDefaults.store)
+    private var selectedThemeDark = BuiltInThemes.classic.id
+
+    @Environment(\.colorScheme) private var colorScheme
+
     private var renderSettings: KeyRenderSettings {
         KeyRenderSettings(
-            keyboardStyle: keyboardStyle,
             hideLetters: hideLetters,
             hideStandardSymbols: hideStandardSymbols,
             hideExtraSymbols: hideExtraSymbols,
             longPressNumbersEnabled: longPressNumbersEnabled
         )
+    }
+
+    /// Resolved once here for the whole keyboard; key views read it from the
+    /// environment. Fallback cascade: assigned slot → other slot → Classic.
+    private var resolvedTheme: ResolvedTheme {
+        if let themeOverride {
+            return themeOverride.resolved()
+        }
+        let (primaryId, secondaryId) = colorScheme == .dark
+            ? (selectedThemeDark, selectedThemeLight)
+            : (selectedThemeLight, selectedThemeDark)
+        let definition = ThemeStore.theme(id: primaryId)
+            ?? ThemeStore.theme(id: secondaryId)
+            ?? BuiltInThemes.classic
+        return definition.resolved()
     }
 
     var body: some View {
@@ -58,8 +85,9 @@ struct DataDrivenKeyboardRootView: View {
         let availableSpace = currentWidth - metrics.keyboardWidth
         let horizontalOffset = availableSpace * (viewModel.keyboardHorizontalPosition - 0.5)
 
+        let theme = resolvedTheme
         ZStack {
-            keyboardBackground
+            keyboardBackground(theme.boardBackground)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             if let mode = viewModel.activeModeFromDefinition,
@@ -101,24 +129,29 @@ struct DataDrivenKeyboardRootView: View {
         // directions. A lone hint glyph is direction-agnostic, so RTL text
         // still renders correctly. (Finding #4.)
         .environment(\.layoutDirection, .leftToRight)
+        .environment(\.keyboardTheme, theme)
     }
 
     // MARK: - Background
 
+    /// A keyboard extension's input view only delivers touches that land on
+    /// a rendered surface; fully transparent regions pass through and would
+    /// drop taps in the gaps between keys. The resolver therefore clamps
+    /// color board fills to a near-invisible minimum alpha
+    /// (`KeyboardThemeDefinition.minimumBoardOpacity`), so every theme's
+    /// board is a real touch surface while the keys on top win the hit-test.
+    ///
+    /// Color fills render as a plain `Color`, matching the pre-engine board
+    /// exactly: `Color` and `Rectangle().fill` have different ideal sizes, and
+    /// in the height-free showcase layout that difference would shift the whole
+    /// keyboard. Only the bar material genuinely needs a shape.
     @ViewBuilder
-    private var keyboardBackground: some View {
-        switch keyboardStyle {
-        case .classic:
-            Color(.systemBackground)
-        case .liquidGlass:
-            // A keyboard extension's input view only delivers touches that land
-            // on a rendered surface; fully transparent regions pass through. A
-            // `Color.clear` root would drop taps that fall in the gaps between
-            // keys, so paint a near-invisible fill instead: the whole keyboard
-            // becomes a real surface that receives those touches while the keys
-            // on top still win the hit-test. ~2% over the glass backdrop reads
-            // as clear.
-            Color(.systemBackground).opacity(0.02)
+    private func keyboardBackground(_ fill: ResolvedFill) -> some View {
+        switch fill {
+        case let .color(color):
+            color
+        case .material:
+            Rectangle().fill(.bar)
         }
     }
 }

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -92,7 +92,20 @@ struct DataDrivenKeyboardRootView: View {
 
         let theme = resolvedTheme
         ZStack {
-            keyboardBackground(theme)
+            // The board is never fully transparent, whatever the theme asks
+            // for: a keyboard extension only delivers touches over rendered
+            // pixels and UIKit hit-testing ignores `alpha <= 0.01`, so a clear
+            // board would drop every tap that lands in an inter-key gap (#198).
+            // The resolver floors a color board to
+            // `KeyboardThemeDefinition.minimumBoardOpacity` and paints a glass
+            // board as `glassBoardColor` — faint enough to read as clear over
+            // the `UIInputView(.keyboard)` backdrop, opaque enough to stay live.
+            //
+            // It renders as a plain `Color`, matching the pre-engine board
+            // exactly: `Color` and `Rectangle().fill` have different ideal
+            // sizes, and in the height-free showcase layout that difference
+            // would shift the whole keyboard.
+            theme.boardBackground
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             if let mode = viewModel.activeModeFromDefinition,
@@ -135,30 +148,5 @@ struct DataDrivenKeyboardRootView: View {
         // still renders correctly. (Finding #4.)
         .environment(\.layoutDirection, .leftToRight)
         .environment(\.keyboardTheme, theme)
-    }
-
-    // MARK: - Background
-
-    /// The board behind the keys — always the theme's own resolved
-    /// `boardBackground`. The resolver floors a color board to
-    /// `KeyboardThemeDefinition.minimumBoardOpacity` so it stays a rendered,
-    /// tappable surface: a keyboard extension only delivers touches over
-    /// rendered pixels, and UIKit hit-testing ignores `alpha <= 0.01`, so a
-    /// fully transparent board would drop taps in the inter-key gaps (#198).
-    /// Glass themes therefore declare a faint neutral board that reads as clear
-    /// over the `UIInputView(.keyboard)` backdrop while keeping the gaps live.
-    ///
-    /// A color fill renders as a plain `Color`, matching the pre-engine board
-    /// exactly: `Color` and `Rectangle().fill` have different ideal sizes, and
-    /// in the height-free showcase layout the difference would shift the whole
-    /// keyboard, so only the (currently unused) material board needs a shape.
-    @ViewBuilder
-    private func keyboardBackground(_ theme: ResolvedTheme) -> some View {
-        switch theme.boardBackground {
-        case let .color(color):
-            color
-        case .material:
-            Rectangle().fill(.bar)
-        }
     }
 }

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -87,7 +87,7 @@ struct DataDrivenKeyboardRootView: View {
 
         let theme = resolvedTheme
         ZStack {
-            keyboardBackground(theme.boardBackground)
+            keyboardBackground(theme)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             if let mode = viewModel.activeModeFromDefinition,
@@ -134,24 +134,34 @@ struct DataDrivenKeyboardRootView: View {
 
     // MARK: - Background
 
-    /// A keyboard extension's input view only delivers touches that land on
-    /// a rendered surface; fully transparent regions pass through and would
-    /// drop taps in the gaps between keys. The resolver therefore clamps
-    /// color board fills to a near-invisible minimum alpha
-    /// (`KeyboardThemeDefinition.minimumBoardOpacity`), so every theme's
-    /// board is a real touch surface while the keys on top win the hit-test.
+    /// Minimum board opacity that still receives touches. A keyboard extension
+    /// only delivers touches over rendered pixels, and UIKit hit-testing
+    /// ignores anything with `alpha <= 0.01`, so a glass theme's board can't be
+    /// fully transparent or the inter-key gaps go dead (#198). This is just
+    /// above that threshold: enough to stay tappable, faint enough that the
+    /// `UIInputView(.keyboard)` backdrop shows through essentially unchanged.
+    private static let glassBoardOpacity = 0.02
+
+    /// The board behind the keys.
     ///
-    /// Color fills render as a plain `Color`, matching the pre-engine board
-    /// exactly: `Color` and `Rectangle().fill` have different ideal sizes, and
-    /// in the height-free showcase layout that difference would shift the whole
-    /// keyboard. Only the bar material genuinely needs a shape.
+    /// Glass themes paint an almost-invisible neutral fill over the
+    /// `UIInputView(.keyboard)` backdrop: the backdrop supplies the system
+    /// keyboard look, while this thin fill keeps the gaps tappable (see
+    /// `glassBoardOpacity`). Color themes paint their board as a plain `Color`
+    /// — matching the pre-engine board exactly, since `Color` and
+    /// `Rectangle().fill` have different ideal sizes and the difference would
+    /// shift the whole keyboard in the height-free showcase layout.
     @ViewBuilder
-    private func keyboardBackground(_ fill: ResolvedFill) -> some View {
-        switch fill {
-        case let .color(color):
-            color
-        case .material:
-            Rectangle().fill(.bar)
+    private func keyboardBackground(_ theme: ResolvedTheme) -> some View {
+        if theme.usesGlassMaterial {
+            Color.gray.opacity(Self.glassBoardOpacity)
+        } else {
+            switch theme.boardBackground {
+            case let .color(color):
+                color
+            case .material:
+                Rectangle().fill(.bar)
+            }
         }
     }
 }

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -49,6 +49,12 @@ struct DataDrivenKeyboardRootView: View {
     @AppStorage(SettingsKey.selectedThemeDark.rawValue, store: SharedDefaults.store)
     private var selectedThemeDark = BuiltInThemes.classic.id
 
+    /// The keyboard follows the system color scheme. A keyboard extension can
+    /// also be asked for a specific appearance via
+    /// `textDocumentProxy.keyboardAppearance`; wiring the slot selection to
+    /// that instead of `colorScheme` is deferred to M2, when the gallery lets
+    /// the light/dark slots actually diverge (today both hold one selection,
+    /// so the distinction is a no-op).
     @Environment(\.colorScheme) private var colorScheme
 
     private var renderSettings: KeyRenderSettings {
@@ -61,18 +67,17 @@ struct DataDrivenKeyboardRootView: View {
     }
 
     /// Resolved once here for the whole keyboard; key views read it from the
-    /// environment. Fallback cascade: assigned slot → other slot → Classic.
+    /// environment. Slot selection uses the shared `ThemeStore` cascade so the
+    /// rendered path is the one the tests exercise.
     private var resolvedTheme: ResolvedTheme {
         if let themeOverride {
             return themeOverride.resolved()
         }
-        let (primaryId, secondaryId) = colorScheme == .dark
-            ? (selectedThemeDark, selectedThemeLight)
-            : (selectedThemeLight, selectedThemeDark)
-        let definition = ThemeStore.theme(id: primaryId)
-            ?? ThemeStore.theme(id: secondaryId)
-            ?? BuiltInThemes.classic
-        return definition.resolved()
+        return ThemeStore.theme(
+            lightId: selectedThemeLight,
+            darkId: selectedThemeDark,
+            for: colorScheme
+        ).resolved()
     }
 
     var body: some View {
@@ -134,34 +139,26 @@ struct DataDrivenKeyboardRootView: View {
 
     // MARK: - Background
 
-    /// Minimum board opacity that still receives touches. A keyboard extension
-    /// only delivers touches over rendered pixels, and UIKit hit-testing
-    /// ignores anything with `alpha <= 0.01`, so a glass theme's board can't be
-    /// fully transparent or the inter-key gaps go dead (#198). This is just
-    /// above that threshold: enough to stay tappable, faint enough that the
-    /// `UIInputView(.keyboard)` backdrop shows through essentially unchanged.
-    private static let glassBoardOpacity = 0.02
-
-    /// The board behind the keys.
+    /// The board behind the keys — always the theme's own resolved
+    /// `boardBackground`. The resolver floors a color board to
+    /// `KeyboardThemeDefinition.minimumBoardOpacity` so it stays a rendered,
+    /// tappable surface: a keyboard extension only delivers touches over
+    /// rendered pixels, and UIKit hit-testing ignores `alpha <= 0.01`, so a
+    /// fully transparent board would drop taps in the inter-key gaps (#198).
+    /// Glass themes therefore declare a faint neutral board that reads as clear
+    /// over the `UIInputView(.keyboard)` backdrop while keeping the gaps live.
     ///
-    /// Glass themes paint an almost-invisible neutral fill over the
-    /// `UIInputView(.keyboard)` backdrop: the backdrop supplies the system
-    /// keyboard look, while this thin fill keeps the gaps tappable (see
-    /// `glassBoardOpacity`). Color themes paint their board as a plain `Color`
-    /// — matching the pre-engine board exactly, since `Color` and
-    /// `Rectangle().fill` have different ideal sizes and the difference would
-    /// shift the whole keyboard in the height-free showcase layout.
+    /// A color fill renders as a plain `Color`, matching the pre-engine board
+    /// exactly: `Color` and `Rectangle().fill` have different ideal sizes, and
+    /// in the height-free showcase layout the difference would shift the whole
+    /// keyboard, so only the (currently unused) material board needs a shape.
     @ViewBuilder
     private func keyboardBackground(_ theme: ResolvedTheme) -> some View {
-        if theme.usesGlassMaterial {
-            Color.gray.opacity(Self.glassBoardOpacity)
-        } else {
-            switch theme.boardBackground {
-            case let .color(color):
-                color
-            case .material:
-                Rectangle().fill(.bar)
-            }
+        switch theme.boardBackground {
+        case let .color(color):
+            color
+        case .material:
+            Rectangle().fill(.bar)
         }
     }
 }

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -49,12 +49,16 @@ struct DataDrivenKeyboardRootView: View {
     @AppStorage(SettingsKey.selectedThemeDark.rawValue, store: SharedDefaults.store)
     private var selectedThemeDark = BuiltInThemes.classic.id
 
+    /// Observed here rather than read once from defaults: the flag decides
+    /// whether the dark slot is honoured at all, so the keyboard has to
+    /// re-render when the settings screen flips it.
+    @AppStorage(SettingsKey.themeSeparateDarkSlot.rawValue, store: SharedDefaults.store)
+    private var hasSeparateDarkSlot = false
+
     /// The keyboard follows the system color scheme. A keyboard extension can
     /// also be asked for a specific appearance via
     /// `textDocumentProxy.keyboardAppearance`; wiring the slot selection to
-    /// that instead of `colorScheme` is deferred to M2, when the gallery lets
-    /// the light/dark slots actually diverge (today both hold one selection,
-    /// so the distinction is a no-op).
+    /// that instead of `colorScheme` is still open.
     @Environment(\.colorScheme) private var colorScheme
 
     private var renderSettings: KeyRenderSettings {
@@ -76,6 +80,7 @@ struct DataDrivenKeyboardRootView: View {
         return ThemeStore.theme(
             lightId: selectedThemeLight,
             darkId: selectedThemeDark,
+            hasSeparateDarkSlot: hasSeparateDarkSlot,
             for: colorScheme
         ).resolved()
     }

--- a/wurstfingerKeyboard/Runtime/View/GestureTrailOverlay.swift
+++ b/wurstfingerKeyboard/Runtime/View/GestureTrailOverlay.swift
@@ -20,13 +20,23 @@ struct GestureTrailOverlay: View {
     /// `headWidth(for:)`.
     let headWidth: CGFloat
 
+    /// The active theme's `gestureTrail` color, passed in rather than read
+    /// from `@Environment` here: `TimelineView` calls the `Canvas` renderer
+    /// once per frame *without* re-evaluating `body`, so a property-wrapper
+    /// access from that escaping closure is the "Accessing Environment outside
+    /// of being installed on a View" trap — and a stale value would stay wrong
+    /// for the whole gesture.
+    let trailColor: Color
+
     var body: some View {
         // Nothing is rendered — and no display-linked timer runs — unless a
         // trail is in flight.
         if recorder.isVisible {
+            // Captured as a plain value here, outside the per-frame closure.
+            let color = trailColor
             TimelineView(.animation) { timeline in
                 Canvas { context, _ in
-                    draw(in: &context, at: timeline.date.timeIntervalSinceReferenceDate)
+                    draw(in: &context, at: timeline.date.timeIntervalSinceReferenceDate, color: color)
                 }
             }
             .allowsHitTesting(false)
@@ -48,7 +58,14 @@ struct GestureTrailOverlay: View {
         )
     }
 
-    private func draw(in context: inout GraphicsContext, at now: TimeInterval) {
+    /// The color one frame fills with: the theme's own alpha, dimmed only by
+    /// the fade-out. Separate from `draw` because a `GraphicsContext` cannot be
+    /// built outside a `Canvas`, so this is the only testable seam.
+    static func fillColor(_ base: Color, fade: Double) -> Color {
+        base.opacity(fade)
+    }
+
+    private func draw(in context: inout GraphicsContext, at now: TimeInterval, color: Color) {
         let trail = recorder.trail
         // The recorder drops a faded-out trail from a main-queue work item, so
         // a busy main thread can hand this a trail whose fade already expired.
@@ -61,7 +78,6 @@ struct GestureTrailOverlay: View {
         let path = GestureTrailGeometry.shape(through: points, headWidth: headWidth)
         // One fill of one closed contour, so the alpha is uniform even where
         // the path crosses itself.
-        context.opacity = KeyboardConstants.GestureTrail.opacity * trail.fadeOpacity(at: now)
-        context.fill(path, with: .color(.primary))
+        context.fill(path, with: .color(Self.fillColor(color, fade: trail.fadeOpacity(at: now))))
     }
 }

--- a/wurstfingerKeyboard/Runtime/View/GestureTrailOverlay.swift
+++ b/wurstfingerKeyboard/Runtime/View/GestureTrailOverlay.swift
@@ -13,6 +13,23 @@ import SwiftUI
 /// Sits in an `.overlay` on the grid layout, which is also where the recorder's
 /// coordinate space is registered — so the recorded points map onto this view's
 /// bounds one to one, with no padding or offset correction.
+///
+/// ## Why this is a `Shape` and not a `Canvas`
+///
+/// It was a `Canvas`, which is the obvious tool for immediate-mode drawing and
+/// the wrong one here. `Canvas` exists to draw *many* elements without paying
+/// for a view each; this draws exactly one filled contour. What it cost
+/// instead, measured on device across three independent keyboard appearances:
+/// **+27 to +31 MB, one frame after the first rendered trail**, released again
+/// only when the SwiftUI graph is torn down — so every single appearance paid
+/// it anew. In an extension with a ~177 MB per-process jetsam limit that is
+/// most of the budget, and it is what made the keyboard silently stop
+/// appearing after a while. The trail also drew unreliably, which is the same
+/// story from the other side: near the limit the allocation cannot be
+/// satisfied and the trail stays blank.
+///
+/// A `Shape` never touches that rendering path. `GestureTrailGeometry` already
+/// returns a `Path`, so the change is only in who fills it.
 struct GestureTrailOverlay: View {
     @ObservedObject var recorder: GestureTrailRecorder
 
@@ -20,24 +37,19 @@ struct GestureTrailOverlay: View {
     /// `headWidth(for:)`.
     let headWidth: CGFloat
 
-    /// The active theme's `gestureTrail` color, passed in rather than read
-    /// from `@Environment` here: `TimelineView` calls the `Canvas` renderer
-    /// once per frame *without* re-evaluating `body`, so a property-wrapper
-    /// access from that escaping closure is the "Accessing Environment outside
-    /// of being installed on a View" trap — and a stale value would stay wrong
-    /// for the whole gesture.
+    /// The active theme's `gestureTrail` color.
     let trailColor: Color
 
     var body: some View {
         // Nothing is rendered — and no display-linked timer runs — unless a
         // trail is in flight.
         if recorder.isVisible {
-            // Captured as a plain value here, outside the per-frame closure.
-            let color = trailColor
-            TimelineView(.animation) { timeline in
-                Canvas { context, _ in
-                    draw(in: &context, at: timeline.date.timeIntervalSinceReferenceDate, color: color)
-                }
+            // Capped rather than free-running: `.animation` alone redraws at
+            // the display's rate, which is 120 Hz on this hardware, and the
+            // trail is a soft shape whose motion nobody can read at that rate.
+            // Half of it looks identical and halves the work per gesture.
+            TimelineView(.animation(minimumInterval: KeyboardConstants.GestureTrail.minimumFrameInterval)) { timeline in
+                frame(at: timeline.date.timeIntervalSinceReferenceDate)
             }
             .allowsHitTesting(false)
             // Purely decorative: it echoes a gesture the user is making right
@@ -45,6 +57,24 @@ struct GestureTrailOverlay: View {
             // VoiceOver and the keys underneath.
             .accessibilityHidden(true)
         }
+    }
+
+    /// One rendered frame of the trail.
+    ///
+    /// Deliberately not a `@ViewBuilder`: the sample selection is ordinary code
+    /// that wants statements, and an empty point list already renders as an
+    /// empty path, so there is nothing for a conditional branch to do.
+    private func frame(at now: TimeInterval) -> some View {
+        let trail = recorder.trail
+        // The recorder drops a faded-out trail from a main-queue work item, so
+        // a busy main thread can hand this a trail whose fade already expired.
+        // Those frames would build the full ribbon only to fill it at zero
+        // opacity; skip the geometry instead.
+        let points = trail.isFinished(at: now) ? [] : trail.visiblePoints(at: now)
+        // One fill of one closed contour, so the alpha is uniform even where
+        // the path crosses itself.
+        return GestureTrailShape(points: points, headWidth: headWidth)
+            .fill(Self.fillColor(trailColor, fade: trail.fadeOpacity(at: now)))
     }
 
     /// Head width for a rendered key size, clamped so the trail stays
@@ -59,25 +89,24 @@ struct GestureTrailOverlay: View {
     }
 
     /// The color one frame fills with: the theme's own alpha, dimmed only by
-    /// the fade-out. Separate from `draw` because a `GraphicsContext` cannot be
-    /// built outside a `Canvas`, so this is the only testable seam.
+    /// the fade-out. Kept as a static seam so the fade stays unit-testable
+    /// without rendering anything.
     static func fillColor(_ base: Color, fade: Double) -> Color {
         base.opacity(fade)
     }
+}
 
-    private func draw(in context: inout GraphicsContext, at now: TimeInterval, color: Color) {
-        let trail = recorder.trail
-        // The recorder drops a faded-out trail from a main-queue work item, so
-        // a busy main thread can hand this a trail whose fade already expired.
-        // Those frames would build the full ribbon only to fill it at zero
-        // opacity; bail before the geometry instead.
-        guard !trail.isFinished(at: now) else { return }
-        let points = trail.visiblePoints(at: now)
-        guard !points.isEmpty else { return }
+/// The trail's ribbon as a plain `Shape`.
+///
+/// Holds no drawing logic of its own — `GestureTrailGeometry.shape(through:
+/// headWidth:)` is the single source of the contour, shared with the geometry
+/// tests. This type exists purely to hand that `Path` to SwiftUI's retained
+/// renderer instead of to a `Canvas` (see `GestureTrailOverlay`).
+struct GestureTrailShape: Shape {
+    let points: [CGPoint]
+    let headWidth: CGFloat
 
-        let path = GestureTrailGeometry.shape(through: points, headWidth: headWidth)
-        // One fill of one closed contour, so the alpha is uniform even where
-        // the path crosses itself.
-        context.fill(path, with: .color(Self.fillColor(color, fade: trail.fadeOpacity(at: now))))
+    func path(in _: CGRect) -> Path {
+        GestureTrailGeometry.shape(through: points, headWidth: headWidth)
     }
 }

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -14,8 +14,11 @@ import SwiftUI
 /// The whole keyboard holds one defaults observation per setting, and the
 /// ~100 key views a mode builds hold none: the root re-renders when a
 /// setting changes and hands every key the fresh values.
+///
+/// Colors are not in here: the resolved theme travels through the
+/// `\.keyboardTheme` environment instead, because it also has to reach the
+/// board background that sits outside any key.
 struct KeyRenderSettings: Equatable {
-    var keyboardStyle: KeyboardStyle = .classic
     var hideLetters = false
     var hideStandardSymbols = false
     var hideExtraSymbols = false
@@ -66,6 +69,10 @@ struct KeyView: View {
     /// render stock settings (labels shown, long-press numbers off) instead of
     /// failing the build.
     let settings: KeyRenderSettings
+
+    /// Resolved once in `DataDrivenKeyboardRootView` and injected here — key
+    /// views never resolve theme data themselves.
+    @Environment(\.keyboardTheme) private var theme
 
     /// Resolved layout metrics injected by `KeyboardGridView` (same reasoning
     /// as there: an `@AppStorage` read desynchronizes from the width path
@@ -242,14 +249,6 @@ struct KeyView: View {
         style == .utility
     }
 
-    /// Background fill for the key.
-    static func backgroundColor(for style: KeyStyle, active: Bool = false) -> Color {
-        if active {
-            return Color(.tertiarySystemFill)
-        }
-        return Color(.secondarySystemBackground)
-    }
-
     // MARK: - Gesture Selection
 
     /// Whether this key uses slide gesture handling instead of standard
@@ -269,16 +268,36 @@ struct KeyView: View {
 
     @ViewBuilder
     private var background: some View {
-        let shape = RoundedRectangle(cornerRadius: KeyboardConstants.KeyDimensions.cornerRadius)
-        switch settings.keyboardStyle {
-        case .classic:
-            shape.fill(Self.backgroundColor(for: key.style, active: isActive))
-        case .liquidGlass:
-            shape.fill(.bar)
+        let shape = RoundedRectangle(cornerRadius: theme.cornerRadius)
+        let fill = isActive ? theme.keyFillActive : theme.keyFill
+        if let border = theme.keyBorder, theme.keyBorderWidth > 0 {
+            keyFill(shape, fill)
                 .overlay(
-                    shape.strokeBorder(Color.primary.opacity(0.1), lineWidth: 0.5)
+                    shape.strokeBorder(border, lineWidth: theme.keyBorderWidth)
                 )
+        } else {
+            // No border overlay in the view tree at all — themes without a
+            // border (Classic) render exactly as before the theme engine.
+            keyFill(shape, fill)
         }
+    }
+
+    /// Fills the key shape. The bar material is applied directly rather than
+    /// through `AnyShapeStyle`, because the wrapper changes how the material
+    /// samples its backdrop and would shift Liquid Glass off its baseline.
+    @ViewBuilder
+    private func keyFill(_ shape: RoundedRectangle, _ fill: ResolvedFill) -> some View {
+        switch fill {
+        case let .color(color):
+            shape.fill(color)
+        case .material:
+            shape.fill(.bar)
+        }
+    }
+
+    /// Center label color: utility glyphs may differ from letter keys.
+    private var labelColor: Color {
+        key.style == .utility ? theme.utilityLabel : theme.mainLabel
     }
 
     @ViewBuilder
@@ -294,11 +313,11 @@ struct KeyView: View {
             if let sfName = Self.sfSymbolMap[primaryLabel] {
                 Image(systemName: sfName)
                     .font(font)
-                    .foregroundColor(.primary)
+                    .foregroundColor(labelColor)
             } else {
                 Text(primaryLabel)
                     .font(font)
-                    .foregroundColor(.primary)
+                    .foregroundColor(labelColor)
                     // Multi-character labels ("123") outgrow the cell before
                     // the size cap does; shrink instead of wrapping.
                     .lineLimit(1)
@@ -407,7 +426,7 @@ struct KeyView: View {
                         if isLanguageLabelShown {
                             Text(languageLabel)
                                 .font(.system(size: scaledHintFontSize * 0.75, weight: .semibold, design: .rounded))
-                                .foregroundStyle(Color.primary.opacity(0.5))
+                                .foregroundStyle(theme.hintIconProminent)
                                 .fixedSize()
                                 .padding(Self.hintEdgePadding(for: gesture, horizontal: hPad, vertical: vPad))
                                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
@@ -441,12 +460,12 @@ struct KeyView: View {
                 // Globe / dismiss: larger, bolder for discoverability
                 Image(systemName: iconName)
                     .font(.system(size: scaledHintFontSize * 0.75, weight: .medium))
-                    .foregroundStyle(Color.primary.opacity(0.5))
+                    .foregroundStyle(theme.hintIconProminent)
             } else {
                 // Copy / paste / cut: smaller, lighter to avoid visual clutter
                 Image(systemName: iconName)
                     .font(.system(size: scaledHintFontSize * 0.6, weight: .regular))
-                    .foregroundStyle(Color.secondary.opacity(0.45))
+                    .foregroundStyle(theme.hintIconSubtle)
             }
         } else {
             // Text hint — letters get higher prominence than symbols
@@ -457,11 +476,7 @@ struct KeyView: View {
                     weight: isLetter ? .medium : .regular,
                     design: .rounded
                 ))
-                .foregroundStyle(
-                    isLetter
-                        ? Color.primary.opacity(0.65)
-                        : Color.secondary.opacity(0.55)
-                )
+                .foregroundStyle(isLetter ? theme.hintLetter : theme.hintSymbol)
                 .minimumScaleFactor(0.6)
                 .lineLimit(1)
         }

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -273,6 +273,11 @@ struct KeyView: View {
         return false
     }
 
+    /// A subtle neutral tint on the glass, so the keys gain a bit of presence
+    /// and stand out from the backdrop instead of reading as fully clear glass
+    /// — while staying native Liquid Glass that blends with the system row.
+    private static let glassTint = Color.gray.opacity(0.12)
+
     /// The stacked key layers. Native glass wraps the label/hint content with
     /// `glassEffect` (label as content = crisp); every other style keeps the
     /// pre-engine order of a background layer beneath the labels.
@@ -283,7 +288,7 @@ struct KeyView: View {
                 label
                 hintOverlay
             }
-            .glassEffect(.regular, in: RoundedRectangle(cornerRadius: theme.cornerRadius))
+            .glassEffect(.regular.tint(Self.glassTint), in: RoundedRectangle(cornerRadius: theme.cornerRadius))
         } else {
             ZStack {
                 background

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -113,7 +113,7 @@ struct KeyView: View {
 
     @ViewBuilder
     private var keyContent: some View {
-        let base = keyLayers
+        let base = keyStack
             // Inset the drawn key from the touch cell by `visualInset`, so the
             // visible key keeps its position/size while the cell itself extends into
             // the inter-key gaps (see KeyboardGridLayout.gapInsets).
@@ -302,7 +302,7 @@ struct KeyView: View {
     /// nothing at all. Without the frame the pane shrinks to the glyph and the
     /// space bar disappears entirely.
     @ViewBuilder
-    private var keyLayers: some View {
+    private var keyStack: some View {
         if usesNativeGlass, #available(iOS 26.0, *) {
             ZStack {
                 label

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -304,30 +304,25 @@ struct KeyView: View {
         let fill = isActive ? theme.keyFillActive : theme.keyFill
         switch fill {
         case let .color(color):
-            colorBackground(shape, color)
+            filled(shape, with: color)
         case .material:
             // Reached only before iOS 26 (native glass takes the other branch):
             // the bar material with a hairline border, pixel-identical to the
             // pre-engine Liquid Glass rendering.
-            if let border = theme.keyBorder, theme.keyBorderWidth > 0 {
-                shape.fill(.bar)
-                    .overlay(shape.strokeBorder(border, lineWidth: theme.keyBorderWidth))
-            } else {
-                shape.fill(.bar)
-            }
+            filled(shape, with: .bar)
         }
     }
 
-    /// Solid or translucent color fill, with an optional hairline border.
+    /// Fills `shape` and overlays the theme's hairline border when it has one.
+    /// A theme without a border (Classic) gets no overlay in the view tree at
+    /// all, so it renders exactly as before the theme engine.
     @ViewBuilder
-    private func colorBackground(_ shape: RoundedRectangle, _ color: Color) -> some View {
+    private func filled(_ shape: RoundedRectangle, with fill: some ShapeStyle) -> some View {
         if let border = theme.keyBorder, theme.keyBorderWidth > 0 {
-            shape.fill(color)
+            shape.fill(fill)
                 .overlay(shape.strokeBorder(border, lineWidth: theme.keyBorderWidth))
         } else {
-            // No border overlay in the view tree at all — themes without a
-            // border (Classic) render exactly as before the theme engine.
-            shape.fill(color)
+            shape.fill(fill)
         }
     }
 

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -14,8 +14,11 @@ import SwiftUI
 /// The whole keyboard holds one defaults observation per setting, and the
 /// ~100 key views a layer builds hold none: the root re-renders when a
 /// setting changes and hands every key the fresh values.
+///
+/// Colors are not in here: the resolved theme travels through the
+/// `\.keyboardTheme` environment instead, because it also has to reach the
+/// board background that sits outside any key.
 struct KeyRenderSettings: Equatable {
-    var keyboardStyle: KeyboardStyle = .classic
     var hideLetters = false
     var hideStandardSymbols = false
     var hideExtraSymbols = false
@@ -66,6 +69,10 @@ struct KeyView: View {
     /// render stock settings (labels shown, long-press numbers off) instead of
     /// failing the build.
     let settings: KeyRenderSettings
+
+    /// Resolved once in `DataDrivenKeyboardRootView` and injected here — key
+    /// views never resolve theme data themselves.
+    @Environment(\.keyboardTheme) private var theme
 
     /// Resolved layout metrics injected by `KeyboardGridView` (same reasoning
     /// as there: an `@AppStorage` read desynchronizes from the width path
@@ -242,14 +249,6 @@ struct KeyView: View {
         style == .utility
     }
 
-    /// Background fill for the key.
-    static func backgroundColor(for style: KeyStyle, active: Bool = false) -> Color {
-        if active {
-            return Color(.tertiarySystemFill)
-        }
-        return Color(.secondarySystemBackground)
-    }
-
     // MARK: - Gesture Selection
 
     /// Whether this key uses slide gesture handling instead of standard
@@ -269,16 +268,36 @@ struct KeyView: View {
 
     @ViewBuilder
     private var background: some View {
-        let shape = RoundedRectangle(cornerRadius: KeyboardConstants.KeyDimensions.cornerRadius)
-        switch settings.keyboardStyle {
-        case .classic:
-            shape.fill(Self.backgroundColor(for: key.style, active: isActive))
-        case .liquidGlass:
-            shape.fill(.bar)
+        let shape = RoundedRectangle(cornerRadius: theme.cornerRadius)
+        let fill = isActive ? theme.keyFillActive : theme.keyFill
+        if let border = theme.keyBorder, theme.keyBorderWidth > 0 {
+            keyFill(shape, fill)
                 .overlay(
-                    shape.strokeBorder(Color.primary.opacity(0.1), lineWidth: 0.5)
+                    shape.strokeBorder(border, lineWidth: theme.keyBorderWidth)
                 )
+        } else {
+            // No border overlay in the view tree at all — themes without a
+            // border (Classic) render exactly as before the theme engine.
+            keyFill(shape, fill)
         }
+    }
+
+    /// Fills the key shape. The bar material is applied directly rather than
+    /// through `AnyShapeStyle`, because the wrapper changes how the material
+    /// samples its backdrop and would shift Liquid Glass off its baseline.
+    @ViewBuilder
+    private func keyFill(_ shape: RoundedRectangle, _ fill: ResolvedFill) -> some View {
+        switch fill {
+        case let .color(color):
+            shape.fill(color)
+        case .material:
+            shape.fill(.bar)
+        }
+    }
+
+    /// Center label color: utility glyphs may differ from letter keys.
+    private var labelColor: Color {
+        key.style == .utility ? theme.utilityLabel : theme.mainLabel
     }
 
     @ViewBuilder
@@ -294,11 +313,11 @@ struct KeyView: View {
             if let sfName = Self.sfSymbolMap[primaryLabel] {
                 Image(systemName: sfName)
                     .font(font)
-                    .foregroundColor(.primary)
+                    .foregroundColor(labelColor)
             } else {
                 Text(primaryLabel)
                     .font(font)
-                    .foregroundColor(.primary)
+                    .foregroundColor(labelColor)
                     // Multi-character labels ("123") outgrow the cell before
                     // the size cap does; shrink instead of wrapping.
                     .lineLimit(1)
@@ -407,7 +426,7 @@ struct KeyView: View {
                         if showLanguageLabel {
                             Text(languageLabel)
                                 .font(.system(size: scaledHintFontSize * 0.75, weight: .semibold, design: .rounded))
-                                .foregroundStyle(Color.primary.opacity(0.5))
+                                .foregroundStyle(theme.hintIconProminent)
                                 .fixedSize()
                                 .padding(Self.hintEdgePadding(for: gesture, horizontal: hPad, vertical: vPad))
                                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
@@ -441,12 +460,12 @@ struct KeyView: View {
                 // Globe / dismiss: larger, bolder for discoverability
                 Image(systemName: iconName)
                     .font(.system(size: scaledHintFontSize * 0.75, weight: .medium))
-                    .foregroundStyle(Color.primary.opacity(0.5))
+                    .foregroundStyle(theme.hintIconProminent)
             } else {
                 // Copy / paste / cut: smaller, lighter to avoid visual clutter
                 Image(systemName: iconName)
                     .font(.system(size: scaledHintFontSize * 0.6, weight: .regular))
-                    .foregroundStyle(Color.secondary.opacity(0.45))
+                    .foregroundStyle(theme.hintIconSubtle)
             }
         } else {
             // Text hint — letters get higher prominence than symbols
@@ -457,11 +476,7 @@ struct KeyView: View {
                     weight: isLetter ? .medium : .regular,
                     design: .rounded
                 ))
-                .foregroundStyle(
-                    isLetter
-                        ? Color.primary.opacity(0.65)
-                        : Color.secondary.opacity(0.55)
-                )
+                .foregroundStyle(isLetter ? theme.hintLetter : theme.hintSymbol)
                 .minimumScaleFactor(0.6)
                 .lineLimit(1)
         }

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -285,7 +285,11 @@ struct KeyView: View {
     /// A subtle neutral tint on the glass, so the keys gain a bit of presence
     /// and stand out from the backdrop instead of reading as fully clear glass
     /// — while staying native Liquid Glass that blends with the system row.
-    private static let glassTint = Color.gray.opacity(0.12)
+    ///
+    /// `internal` so the theme gallery's swatch renders glass through the same
+    /// constant; a copy of the literal there would silently desynchronize the
+    /// moment this value is retuned.
+    static let glassTint = Color.gray.opacity(0.12)
 
     /// The stacked key layers. Native glass wraps the label/hint content with
     /// `glassEffect` (label as content = crisp); every other style keeps the

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -294,6 +294,13 @@ struct KeyView: View {
     /// The stacked key layers. Native glass wraps the label/hint content with
     /// `glassEffect` (label as content = crisp); every other style keeps the
     /// pre-engine order of a background layer beneath the labels.
+    ///
+    /// The glass branch has to claim the whole cell itself. The other branch
+    /// gets that for free from `background`, whose `RoundedRectangle` is a
+    /// flexible shape, but glass is applied to the content — and the content of
+    /// a key without swipe hints is only its glyph, or for the space bar
+    /// nothing at all. Without the frame the pane shrinks to the glyph and the
+    /// space bar disappears entirely.
     @ViewBuilder
     private var keyLayers: some View {
         if usesNativeGlass, #available(iOS 26.0, *) {
@@ -301,6 +308,7 @@ struct KeyView: View {
                 label
                 hintOverlay
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .glassEffect(.regular.tint(Self.glassTint), in: RoundedRectangle(cornerRadius: theme.cornerRadius))
         } else {
             ZStack {

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -263,14 +263,23 @@ struct KeyView: View {
     // MARK: - View Construction
 
     /// Whether this key should render as native Liquid Glass (iOS 26 with a
-    /// material fill). The glass then wraps the label layer directly, so the
-    /// label stays crisp and picks up glass vibrancy — applying it to a
+    /// glass key surface). The glass then wraps the label layer directly, so
+    /// the label stays crisp and picks up glass vibrancy — applying it to a
     /// separate background layer instead blurs the label.
+    ///
+    /// One surface style decides this for pressed and unpressed alike, so the
+    /// subtree structure stays stable across a key press. (Two independent
+    /// fills used to allow a half-glass state; nothing changes for the shipped
+    /// Liquid Glass theme, where both fills were the material anyway.)
     private var usesNativeGlass: Bool {
-        if #available(iOS 26.0, *) {
-            return (isActive ? theme.keyFillActive : theme.keyFill) == .material
-        }
+        if #available(iOS 26.0, *) { return theme.hasGlassKeys }
         return false
+    }
+
+    /// Glass keys on a system without native Liquid Glass — only reachable
+    /// before iOS 26.
+    private var usesGlassFallback: Bool {
+        theme.hasGlassKeys && !usesNativeGlass
     }
 
     /// A subtle neutral tint on the glass, so the keys gain a bit of presence
@@ -301,15 +310,13 @@ struct KeyView: View {
     @ViewBuilder
     private var background: some View {
         let shape = RoundedRectangle(cornerRadius: theme.cornerRadius)
-        let fill = isActive ? theme.keyFillActive : theme.keyFill
-        switch fill {
-        case let .color(color):
-            filled(shape, with: color)
-        case .material:
+        if usesGlassFallback {
             // Reached only before iOS 26 (native glass takes the other branch):
             // the bar material with a hairline border, pixel-identical to the
             // pre-engine Liquid Glass rendering.
             filled(shape, with: .bar)
+        } else {
+            filled(shape, with: isActive ? theme.keyColorActive : theme.keyColor)
         }
     }
 

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -113,37 +113,33 @@ struct KeyView: View {
 
     @ViewBuilder
     private var keyContent: some View {
-        let base = ZStack {
-            background
-            label
-            hintOverlay
-        }
-        // Inset the drawn key from the touch cell by `visualInset`, so the
-        // visible key keeps its position/size while the cell itself extends into
-        // the inter-key gaps (see KeyboardGridLayout.gapInsets).
-        .padding(visualInset)
-        // Fill the cell frame imposed by KeyboardGridLayout. The layout sizes
-        // rows from the same effective key height, so single-row keys are
-        // unchanged while a spanning key (e.g. landscape return) grows to cover
-        // multiple rows.
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityLabel)
-        .accessibilityIdentifier(key.id)
-        .accessibilityAddTraits(.isButton)
-        .modifier(KeyAccessibilityActions(key: key, onGesture: onGesture))
-        // The whole cell is the touch target. Adjacent cells tile the surface
-        // with no gaps, so a plain rectangle covers it fully.
-        .contentShape(Rectangle())
-        // Pin the key's alignment/padding surface to physical LTR so the
-        // directional hints (`hintAlignments` / `hintEdgePadding`, which use
-        // semantic leading/trailing) always match the physical swipe
-        // directions — even when a host renders this key under an RTL locale
-        // (e.g. KeyboardShowcaseView / AppStoreScreenshotView for localized
-        // screenshots, or SwiftUI previews). Defense-in-depth alongside the
-        // root pin in DataDrivenKeyboardRootView; nested identical pins are
-        // harmless.
-        .environment(\.layoutDirection, .leftToRight)
+        let base = keyLayers
+            // Inset the drawn key from the touch cell by `visualInset`, so the
+            // visible key keeps its position/size while the cell itself extends into
+            // the inter-key gaps (see KeyboardGridLayout.gapInsets).
+            .padding(visualInset)
+            // Fill the cell frame imposed by KeyboardGridLayout. The layout sizes
+            // rows from the same effective key height, so single-row keys are
+            // unchanged while a spanning key (e.g. landscape return) grows to cover
+            // multiple rows.
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityIdentifier(key.id)
+            .accessibilityAddTraits(.isButton)
+            .modifier(KeyAccessibilityActions(key: key, onGesture: onGesture))
+            // The whole cell is the touch target. Adjacent cells tile the surface
+            // with no gaps, so a plain rectangle covers it fully.
+            .contentShape(Rectangle())
+            // Pin the key's alignment/padding surface to physical LTR so the
+            // directional hints (`hintAlignments` / `hintEdgePadding`, which use
+            // semantic leading/trailing) always match the physical swipe
+            // directions — even when a host renders this key under an RTL locale
+            // (e.g. KeyboardShowcaseView / AppStoreScreenshotView for localized
+            // screenshots, or SwiftUI previews). Defense-in-depth alongside the
+            // root pin in DataDrivenKeyboardRootView; nested identical pins are
+            // harmless.
+            .environment(\.layoutDirection, .leftToRight)
 
         if usesSlideGesture {
             base.modifier(SlideGestureHandler(
@@ -266,32 +262,67 @@ struct KeyView: View {
 
     // MARK: - View Construction
 
+    /// Whether this key should render as native Liquid Glass (iOS 26 with a
+    /// material fill). The glass then wraps the label layer directly, so the
+    /// label stays crisp and picks up glass vibrancy — applying it to a
+    /// separate background layer instead blurs the label.
+    private var usesNativeGlass: Bool {
+        if #available(iOS 26.0, *) {
+            return (isActive ? theme.keyFillActive : theme.keyFill) == .material
+        }
+        return false
+    }
+
+    /// The stacked key layers. Native glass wraps the label/hint content with
+    /// `glassEffect` (label as content = crisp); every other style keeps the
+    /// pre-engine order of a background layer beneath the labels.
+    @ViewBuilder
+    private var keyLayers: some View {
+        if usesNativeGlass, #available(iOS 26.0, *) {
+            ZStack {
+                label
+                hintOverlay
+            }
+            .glassEffect(.regular, in: RoundedRectangle(cornerRadius: theme.cornerRadius))
+        } else {
+            ZStack {
+                background
+                label
+                hintOverlay
+            }
+        }
+    }
+
     @ViewBuilder
     private var background: some View {
         let shape = RoundedRectangle(cornerRadius: theme.cornerRadius)
         let fill = isActive ? theme.keyFillActive : theme.keyFill
-        if let border = theme.keyBorder, theme.keyBorderWidth > 0 {
-            keyFill(shape, fill)
-                .overlay(
-                    shape.strokeBorder(border, lineWidth: theme.keyBorderWidth)
-                )
-        } else {
-            // No border overlay in the view tree at all — themes without a
-            // border (Classic) render exactly as before the theme engine.
-            keyFill(shape, fill)
+        switch fill {
+        case let .color(color):
+            colorBackground(shape, color)
+        case .material:
+            // Reached only before iOS 26 (native glass takes the other branch):
+            // the bar material with a hairline border, pixel-identical to the
+            // pre-engine Liquid Glass rendering.
+            if let border = theme.keyBorder, theme.keyBorderWidth > 0 {
+                shape.fill(.bar)
+                    .overlay(shape.strokeBorder(border, lineWidth: theme.keyBorderWidth))
+            } else {
+                shape.fill(.bar)
+            }
         }
     }
 
-    /// Fills the key shape. The bar material is applied directly rather than
-    /// through `AnyShapeStyle`, because the wrapper changes how the material
-    /// samples its backdrop and would shift Liquid Glass off its baseline.
+    /// Solid or translucent color fill, with an optional hairline border.
     @ViewBuilder
-    private func keyFill(_ shape: RoundedRectangle, _ fill: ResolvedFill) -> some View {
-        switch fill {
-        case let .color(color):
+    private func colorBackground(_ shape: RoundedRectangle, _ color: Color) -> some View {
+        if let border = theme.keyBorder, theme.keyBorderWidth > 0 {
             shape.fill(color)
-        case .material:
-            shape.fill(.bar)
+                .overlay(shape.strokeBorder(border, lineWidth: theme.keyBorderWidth))
+        } else {
+            // No border overlay in the view tree at all — themes without a
+            // border (Classic) render exactly as before the theme engine.
+            shape.fill(color)
         }
     }
 

--- a/wurstfingerKeyboard/Runtime/View/KeyboardBackdrop.xib
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardBackdrop.xib
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="bkd-rp-001" customClass="UIInputView">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="216"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <userDefinedRuntimeAttributes>
+                <userDefinedRuntimeAttribute type="number" keyPath="inputViewStyle">
+                    <integer key="value" value="1"/>
+                </userDefinedRuntimeAttribute>
+            </userDefinedRuntimeAttributes>
+            <point key="canvasLocation" x="0" y="0"/>
+        </view>
+    </objects>
+</document>

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -35,6 +35,8 @@ struct KeyboardGridView: View {
     /// settings.
     let renderSettings: KeyRenderSettings
 
+    @Environment(\.keyboardTheme) private var theme
+
     /// Resolved layout metrics injected by `DataDrivenKeyboardRootView` from
     /// the view model rather than read via `@AppStorage`: the root view
     /// derives the keyboard *width* from the same metrics, and reading the
@@ -58,15 +60,17 @@ struct KeyboardGridView: View {
     var body: some View {
         let cells = GridLayoutSolver.solve(arrangement)
         let totalRows = cells.map { $0.row + $0.rowSpan }.max() ?? 0
-        KeyboardGridLayout(
-            cells: cells,
-            columns: arrangement.columns,
-            rowHeight: metrics.rowHeight,
-            horizontalSpacing: KeyboardConstants.Layout.gridHorizontalSpacing,
-            verticalSpacing: KeyboardConstants.Layout.gridVerticalSpacing
-        ) {
-            ForEach(Array(cells.enumerated()), id: \.offset) { _, cell in
-                cellContent(for: cell, totalRows: totalRows)
+        glassWrapped {
+            KeyboardGridLayout(
+                cells: cells,
+                columns: arrangement.columns,
+                rowHeight: metrics.rowHeight,
+                horizontalSpacing: KeyboardConstants.Layout.gridHorizontalSpacing,
+                verticalSpacing: KeyboardConstants.Layout.gridVerticalSpacing
+            ) {
+                ForEach(Array(cells.enumerated()), id: \.offset) { _, cell in
+                    cellContent(for: cell, totalRows: totalRows)
+                }
             }
         }
         // Registered here rather than on the root view so it exists wherever a
@@ -79,6 +83,19 @@ struct KeyboardGridView: View {
                 recorder: gestureTrail,
                 headWidth: GestureTrailOverlay.headWidth(for: metrics)
             )
+        }
+    }
+
+    /// Wraps the key grid in a `GlassEffectContainer` when the active theme
+    /// uses the glass material, so all keys share one sampling region on
+    /// iOS 26 (glass cannot sample other glass). Color themes (Classic, Dark
+    /// Gold) and older systems render the grid unwrapped, unchanged.
+    @ViewBuilder
+    private func glassWrapped(@ViewBuilder _ content: () -> some View) -> some View {
+        if theme.usesGlassMaterial, #available(iOS 26.0, *) {
+            GlassEffectContainer { content() }
+        } else {
+            content()
         }
     }
 

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -81,18 +81,19 @@ struct KeyboardGridView: View {
         .overlay {
             GestureTrailOverlay(
                 recorder: gestureTrail,
-                headWidth: GestureTrailOverlay.headWidth(for: metrics)
+                headWidth: GestureTrailOverlay.headWidth(for: metrics),
+                trailColor: theme.gestureTrail
             )
         }
     }
 
     /// Wraps the key grid in a `GlassEffectContainer` when the active theme
-    /// uses the glass material, so all keys share one sampling region on
-    /// iOS 26 (glass cannot sample other glass). Color themes (Classic, Dark
-    /// Gold) and older systems render the grid unwrapped, unchanged.
+    /// uses glass keys, so all keys share one sampling region on iOS 26 (glass
+    /// cannot sample other glass). Color themes (Classic, Dark Gold) and older
+    /// systems render the grid unwrapped, unchanged.
     @ViewBuilder
     private func glassWrapped(@ViewBuilder _ content: () -> some View) -> some View {
-        if theme.usesGlassMaterial, #available(iOS 26.0, *) {
+        if theme.hasGlassKeys, #available(iOS 26.0, *) {
             GlassEffectContainer { content() }
         } else {
             content()

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -134,6 +134,14 @@ enum KeyboardConstants {
         /// painting its entire route.
         static let visibleDuration: TimeInterval = 0.55
 
+        /// Shortest gap between two rendered trail frames, i.e. a 60 Hz cap.
+        ///
+        /// `TimelineView(.animation)` on its own redraws at the display's rate,
+        /// which is 120 Hz on ProMotion hardware. The trail is a soft, wide
+        /// shape whose motion is not legible at that rate, so the second half
+        /// of those frames buys nothing and costs a full path rebuild each.
+        static let minimumFrameInterval: TimeInterval = 1.0 / 60.0
+
         /// How long the frozen trail takes to fade out after the finger lifts.
         /// Tuned on device: 0.22 read as an abrupt blink once the press dot
         /// made single keystrokes draw; the longer glow lets the mark register

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -177,8 +177,11 @@ enum KeyboardConstants {
         /// interpolation those would draw as a visible polyline.
         static let smoothingSubdivisions: Int = 6
 
-        /// Opacity of the ribbon. Translucent enough to keep the key labels
-        /// underneath readable while the finger passes over them.
+        /// Default alpha of the `gestureTrail` role in the built-in themes.
+        /// Translucent enough to keep the key labels underneath readable while
+        /// the finger passes over them. Not applied at draw time any more: the
+        /// theme color's own alpha counts literally, so a theme that asks for a
+        /// fully opaque ribbon gets one.
         static let opacity: Double = 0.38
     }
 

--- a/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
@@ -109,9 +109,7 @@ struct KeyboardHealthLog {
         qos: .utility
     )
 
-    #if DEBUG
-        private static let logger = Logger(subsystem: "de.akator.wurstfinger", category: "memory")
-    #endif
+    private static let logger = Logger(subsystem: "de.akator.wurstfinger", category: "memory")
 
     init(fileURL: URL?, maxEntries: Int = KeyboardHealthLog.defaultMaxEntries) {
         self.init(fileURLProvider: { fileURL }, maxEntries: maxEntries)
@@ -259,8 +257,14 @@ struct KeyboardHealthLog {
     /// a `seekToEnd` + `write` — O(1), no full-file read on the hot path.
     /// Must only run on `ioQueue`.
     private func appendEntry(_ entry: Entry) {
-        guard let fileURL = fileURLProvider(),
-              let encoded = try? JSONEncoder().encode(entry) else { return }
+        guard let fileURL = fileURLProvider() else {
+            Self.recordFailure("no container URL")
+            return
+        }
+        guard let encoded = try? JSONEncoder().encode(entry) else {
+            Self.recordFailure("encode failed")
+            return
+        }
         if let handle = try? FileHandle(forWritingTo: fileURL) {
             defer { try? handle.close() }
             let end = (try? handle.seekToEnd()) ?? 0
@@ -268,15 +272,58 @@ struct KeyboardHealthLog {
             // Separate the new line from a prior line or legacy array bytes.
             if end > 0 { payload.append(0x0A) }
             payload.append(encoded)
-            try? handle.write(contentsOf: payload)
+            do {
+                try handle.write(contentsOf: payload)
+            } catch {
+                Self.recordFailure("append: \(error)")
+            }
         } else if !FileManager.default.fileExists(atPath: fileURL.path) {
             // First write only. A handle can also fail on an *existing* file
             // (an unwritable container while the device is locked), and
             // overwriting then would discard exactly the history a
             // resume-jetsam investigation needs — drop the entry instead.
-            try? encoded.write(to: fileURL, options: .atomic)
+            do {
+                try encoded.write(to: fileURL, options: .atomic)
+            } catch {
+                Self.recordFailure("create: \(error)")
+            }
+        } else {
+            // The file exists but could not be opened for writing. Silent
+            // before; counted now, because this is the branch that quietly
+            // turned the log off for six weeks.
+            Self.recordFailure("unwritable existing file")
         }
         compactIfNeeded(fileURL)
+    }
+
+    /// Why the log stopped writing, kept where a person can actually see it.
+    ///
+    /// Every write path above used to be a `try?`. The result was a diagnostic
+    /// tool that failed silently and stayed failed: on 2026-08-30 the device
+    /// carried no `keyboard-health-log.json` at all while `record` was
+    /// demonstrably being called — six weeks of incidents with no telemetry,
+    /// and no way to tell that apart from "nothing happened". A failure
+    /// counter is the minimum a self-reporting instrument owes its reader.
+    ///
+    /// Deliberately in `SharedDefaults` rather than in the log file: the file
+    /// is exactly what is unavailable when this matters.
+    private static func recordFailure(_ reason: String) {
+        let store = SharedDefaults.store
+        store.set(store.integer(forKey: failureCountKey) + 1, forKey: failureCountKey)
+        store.set(reason, forKey: lastFailureKey)
+        #if DEBUG
+            logger.error("health log write failed: \(reason, privacy: .public)")
+        #endif
+    }
+
+    static let failureCountKey = "healthLog.writeFailureCount"
+    static let lastFailureKey = "healthLog.lastWriteFailure"
+
+    /// Number of writes that never reached disk, and why the last one failed,
+    /// so an empty log is distinguishable from a broken one.
+    static var writeFailures: (count: Int, lastReason: String?) {
+        let store = SharedDefaults.store
+        return (store.integer(forKey: failureCountKey), store.string(forKey: lastFailureKey))
     }
 
     /// Physically rewrites the file to the last `maxEntries` entries once it

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -42,9 +42,11 @@ enum SettingsKey: String, CaseIterable {
     case keyboardStyle
     case selectedThemeLight
     case selectedThemeDark
-    /// Whether the user assigns a separate theme for dark mode. Settings-UI
-    /// only: the keyboard always resolves per-slot; this just governs whether
-    /// the two slots are edited together or independently.
+    /// Whether the user assigns a separate theme for dark mode. Read by the
+    /// resolver (`ThemeStore.theme(lightId:darkId:hasSeparateDarkSlot:for:)`),
+    /// not just by the settings screen: with the flag off the dark slot is
+    /// ignored rather than overwritten, so turning the toggle off and on again
+    /// gives the user their dark assignment back.
     case themeSeparateDarkSlot
     case userThemes
     case keyboardFullAccess

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -42,6 +42,10 @@ enum SettingsKey: String, CaseIterable {
     case keyboardStyle
     case selectedThemeLight
     case selectedThemeDark
+    /// Whether the user assigns a separate theme for dark mode. Settings-UI
+    /// only: the keyboard always resolves per-slot; this just governs whether
+    /// the two slots are edited together or independently.
+    case themeSeparateDarkSlot
     case userThemes
     case keyboardFullAccess
     case cursorMovementStyle

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -37,7 +37,12 @@ enum SettingsKey: String, CaseIterable {
     case pinnedLanguageId
     case autoCapitalizeEnabled
     case expertModeEnabled
+    /// Legacy style selection — only read by `ThemeStore.migrateIfNeeded`,
+    /// then removed.
     case keyboardStyle
+    case selectedThemeLight
+    case selectedThemeDark
+    case userThemes
     case keyboardFullAccess
     case cursorMovementStyle
     case hideLetters
@@ -342,12 +347,4 @@ enum NumpadType: String, CaseIterable {
 enum CursorMovementType: String, CaseIterable {
     case continuous // Joystick-style: drag distance controls cursor position
     case discrete // MessagEase-style: one swipe = one character, return-swipe = one word
-}
-
-// MARK: - Keyboard Style
-
-/// Visual style for the keyboard appearance
-enum KeyboardStyle: String, CaseIterable {
-    case classic // Traditional opaque key backgrounds
-    case liquidGlass // iOS 26+ Liquid Glass effect (renders as a simplified translucent style on older iOS)
 }

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -35,7 +35,12 @@ enum SettingsKey: String, CaseIterable {
     case pinnedLanguageId
     case autoCapitalizeEnabled
     case expertModeEnabled
+    /// Legacy style selection — only read by `ThemeStore.migrateIfNeeded`,
+    /// then removed.
     case keyboardStyle
+    case selectedThemeLight
+    case selectedThemeDark
+    case userThemes
     case keyboardFullAccess
     case cursorMovementStyle
     case hideLetters
@@ -340,12 +345,4 @@ enum NumpadStyle: String, CaseIterable {
 enum CursorMovementStyle: String, CaseIterable {
     case continuous // Joystick-style: drag distance controls cursor position
     case discrete // MessagEase-style: one swipe = one character, return-swipe = one word
-}
-
-// MARK: - Keyboard Style
-
-/// Visual style for the keyboard appearance
-enum KeyboardStyle: String, CaseIterable {
-    case classic // Traditional opaque key backgrounds
-    case liquidGlass // iOS 26+ Liquid Glass effect (renders as a simplified translucent style on older iOS)
 }

--- a/wurstfingerTests/GestureTrailTests.swift
+++ b/wurstfingerTests/GestureTrailTests.swift
@@ -546,6 +546,30 @@ struct GestureTrailRecorderTests {
     }
 }
 
+// MARK: - Overlay Fill Color
+
+struct GestureTrailFillColorTests {
+    private func alpha(of color: Color) throws -> Double {
+        let hex = try #require(HexColor.string(from: color))
+        return try #require(HexColor.parse(hex)).alpha
+    }
+
+    @Test func fadeIsTheOnlyMultiplierOnTheThemeAlpha() throws {
+        // The theme's own alpha counts literally — the pre-engine 0.38 is no
+        // longer multiplied on top, so a 100% pick draws at 100%.
+        let opaque = try #require(HexColor.color(from: "#D1AA05"))
+        #expect(try alpha(of: GestureTrailOverlay.fillColor(opaque, fade: 1)) == 1)
+        #expect(try abs(alpha(of: GestureTrailOverlay.fillColor(opaque, fade: 0.5)) - 0.5) < 0.01)
+    }
+
+    @Test func fadeScalesATranslucentTrail() throws {
+        let translucent = try #require(HexColor.color(from: "#D1AA0580"))
+        #expect(try abs(alpha(of: GestureTrailOverlay.fillColor(translucent, fade: 1)) - 0.502) < 0.01)
+        #expect(try abs(alpha(of: GestureTrailOverlay.fillColor(translucent, fade: 0.5)) - 0.251) < 0.01)
+        #expect(try alpha(of: GestureTrailOverlay.fillColor(translucent, fade: 0)) == 0)
+    }
+}
+
 // MARK: - Overlay Sizing
 
 struct GestureTrailOverlaySizingTests {

--- a/wurstfingerTests/KeyboardBackdropTests.swift
+++ b/wurstfingerTests/KeyboardBackdropTests.swift
@@ -1,0 +1,75 @@
+//
+//  KeyboardBackdropTests.swift
+//  WurstfingerTests
+//
+//  Pins the nib workaround for the UIInputView leak, and its expiry date.
+//
+
+import Testing
+import UIKit
+@testable import WurstfingerApp
+
+/// Guards the backdrop workaround described in
+/// `KeyboardViewController.installBackdropIfNeeded()`.
+///
+/// The workaround exists only because a programmatically created
+/// `UIInputView` never deallocates (Apple Developer Forums 807619 / 781520).
+/// That is someone else's bug, so this suite is written to notice when it goes
+/// away: `programmaticInputViewStillLeaks` asserts the *bug*, not the fix, and
+/// turns red the day Apple ships a correction — which is the signal to delete
+/// the nib, this suite, and the detour in the view controller.
+@Suite(.serialized)
+struct KeyboardBackdropTests {
+    /// Fails once Apple fixes the leak. That failure is the point: it is the
+    /// scheduled review of the workaround, not a regression in this codebase.
+    ///
+    /// When it fails, verify on a real device too, then replace
+    /// `KeyboardViewController.makeBackdrop()` with
+    /// `UIInputView(frame: .zero, inputViewStyle: .keyboard)`, delete
+    /// `KeyboardBackdrop.xib` and delete this suite.
+    ///
+    /// Last confirmed present: 2026-08-30, Xcode 26.1 / iOS 26.6 simulator.
+    @Test func programmaticInputViewStillLeaks() {
+        weak var weakView: UIInputView?
+        autoreleasepool {
+            weakView = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        }
+        #expect(
+            weakView != nil,
+            """
+            A programmatically created UIInputView now deallocates — the UIKit bug \
+            behind the backdrop nib appears to be fixed. Re-verify on device, then \
+            remove the workaround (see KeyboardViewController.installBackdropIfNeeded).
+            """
+        )
+    }
+
+    /// The reason the workaround is worth its complexity: the decoded view is
+    /// released, so a backdrop no longer outlives every host app the keyboard
+    /// was used in.
+    @Test func nibBackdropDeallocates() {
+        weak var weakView: UIInputView?
+        autoreleasepool {
+            weakView = KeyboardViewController.makeBackdrop()
+        }
+        #expect(weakView == nil, "The backdrop from the nib leaked — the workaround is not working.")
+    }
+
+    /// Decoding alone is not enough: `inputViewStyle` is `readonly`, so the nib
+    /// sets it through a User Defined Runtime Attribute. Without that the
+    /// backdrop would come back `.default` and quietly stop looking like the
+    /// system keyboard — a silent visual regression rather than a build error.
+    @Test func nibBackdropIsKeyboardStyled() {
+        let backdrop = KeyboardViewController.makeBackdrop()
+        #expect(backdrop.inputViewStyle == .keyboard)
+    }
+
+    /// `makeBackdrop()` falls back to the leaking initializer when the nib is
+    /// missing, so that a lost resource degrades to a leak rather than to a
+    /// keyboard that never appears. This asserts the fallback is not silently
+    /// the everyday path — otherwise the two tests above would pass for the
+    /// wrong reason.
+    @Test func backdropNibIsBundled() {
+        #expect(KeyboardViewController.backdropComesFromNib)
+    }
+}

--- a/wurstfingerTests/KeyboardGridRenderingTests.swift
+++ b/wurstfingerTests/KeyboardGridRenderingTests.swift
@@ -221,7 +221,7 @@ struct KeyViewStyleTests {
     }
 
     /// The stock snapshot describes what an untouched installation renders:
-    /// nothing hidden, classic style, long-press numbers off. It is what keys
+    /// nothing hidden, long-press numbers off. It is what keys
     /// built without a store render with (tests, previews) *and* what
     /// `DataDrivenKeyboardRootView` seeds its `@AppStorage` wrappers with, so a
     /// silent change here would move both at once.
@@ -234,9 +234,8 @@ struct KeyViewStyleTests {
         #expect(stock.hideStandardSymbols == store.bool(forKey: SettingsKey.hideStandardSymbols.rawValue))
         #expect(stock.hideExtraSymbols == store.bool(forKey: SettingsKey.hideExtraSymbols.rawValue))
         #expect(stock.longPressNumbersEnabled == store.bool(forKey: SettingsKey.longPressNumbersEnabled.rawValue))
-        // No stored style either, so the enum default is what renders.
-        #expect(store.string(forKey: SettingsKey.keyboardStyle.rawValue) == nil)
-        #expect(stock.keyboardStyle == .classic)
+        // Colors are no longer part of the snapshot — they come from the
+        // theme environment. `ThemeResolverTests` covers their defaults.
     }
 
     // MARK: - Label sizing

--- a/wurstfingerTests/LocalizationCompletenessTests.swift
+++ b/wurstfingerTests/LocalizationCompletenessTests.swift
@@ -81,6 +81,11 @@ struct LocalizationCompletenessTests {
         var problems: [String] = []
 
         for (key, entry) in catalog.strings {
+            // Entries marked "shouldTranslate": false stay in the source
+            // language everywhere (e.g. proper names like "Dark Gold").
+            if entry["shouldTranslate"] as? Bool == false {
+                continue
+            }
             let localizations = entry["localizations"] as? [String: Any] ?? [:]
             let present = Set(localizations.keys)
 

--- a/wurstfingerTests/LocalizationCompletenessTests.swift
+++ b/wurstfingerTests/LocalizationCompletenessTests.swift
@@ -338,7 +338,10 @@ private let untranslatedProperNouns: Set<String> = ["GitHub", "MIT", "Wurstfinge
 /// `LocalizationUsageTests` cannot see: a bare literal carries no
 /// `String(localized:)` marker.
 private let viewLiteralRegex: NSRegularExpression = {
-    let inits = "Text|Button|Toggle|TextField|Section|Label|Picker|Link|Stepper|NavigationLink"
+    // `ColorPicker` is listed separately: `\bPicker\(` cannot match inside the
+    // word, so without its own alternative every color-well label in the theme
+    // editor would be invisible to this test.
+    let inits = "Text|Button|Toggle|TextField|Section|Label|ColorPicker|Picker|Link|Stepper|NavigationLink"
     let modifiers = "navigationTitle|accessibilityLabel|accessibilityHint|alert|confirmationDialog"
     let pattern = #"(?:\b(?:"# + inits + #")\(|\.(?:"# + modifiers + #")\()\s*"(?!"")((?:[^"\\]|\\.)*)""#
     guard let regex = try? NSRegularExpression(pattern: pattern) else {

--- a/wurstfingerTests/ThemeContrast.swift
+++ b/wurstfingerTests/ThemeContrast.swift
@@ -1,0 +1,51 @@
+//
+//  ThemeContrast.swift
+//  WurstfingerTests
+//
+//  WCAG luminance and contrast over resolved theme colors. Shared by the two
+//  assertions that keep a palette change from making something invisible: the
+//  gesture trail against its key, and the key against its board.
+//
+//  Ratios, not luminance deltas. The two diverge at the light end — a #F2F2F7
+//  key with a 6 %-black trail is a delta of ~0.11 but a ratio of ~1.13:1, i.e.
+//  invisible — and the ratio is the number the palette was tuned against.
+//
+
+import SwiftUI
+import Testing
+@testable import WurstfingerApp
+
+enum ThemeContrast {
+    /// The color's rendered components in one specific appearance. Explicit,
+    /// because a semantic role resolves against the ambient trait collection
+    /// otherwise and the test would silently measure only one of the two.
+    static func components(of color: ThemeColor, in colorScheme: ColorScheme) -> HexColor.Components? {
+        guard let resolved = color.resolvedColor(in: colorScheme),
+              let hex = HexColor.string(from: resolved) else { return nil }
+        return HexColor.parse(hex)
+    }
+
+    /// WCAG relative luminance of `components` composited over the opaque
+    /// `background`.
+    static func luminance(of components: HexColor.Components, over background: UInt32) -> Double {
+        func channel(_ packed: UInt32, _ shift: UInt32) -> Double {
+            Double((packed >> shift) & 0xFF) / 255
+        }
+        func linear(_ value: Double) -> Double {
+            value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+        }
+        let weights: [(UInt32, Double)] = [(16, 0.2126), (8, 0.7152), (0, 0.0722)]
+        return weights.reduce(0) { total, entry in
+            let mixed = components.alpha * channel(components.rgb, entry.0)
+                + (1 - components.alpha) * channel(background, entry.0)
+            return total + entry.1 * linear(mixed)
+        }
+    }
+
+    /// WCAG contrast ratio of `foreground` drawn over the opaque `background`.
+    static func ratio(of foreground: HexColor.Components, over background: HexColor.Components) -> Double {
+        let front = luminance(of: foreground, over: background.rgb)
+        let back = luminance(of: background, over: background.rgb)
+        return (max(front, back) + 0.05) / (min(front, back) + 0.05)
+    }
+}

--- a/wurstfingerTests/ThemeEditingTests.swift
+++ b/wurstfingerTests/ThemeEditingTests.swift
@@ -9,6 +9,7 @@
 
 import SwiftUI
 import Testing
+import UIKit
 @testable import WurstfingerApp
 
 // MARK: - Row affordances
@@ -28,6 +29,22 @@ struct ThemeRowActionTests {
         theme.id = UUID().uuidString
         #expect(StyleSettingsView.rowActions(for: theme) == [.select, .duplicate, .edit, .delete])
     }
+
+    /// Delete is the only irreversible action in the row and the tint is its
+    /// only cue apart from the glyph. It has to reach the button as data, since
+    /// a `.foregroundStyle` wrapped around the button is overridden by the one
+    /// applied inside it.
+    @Test func onlyTheDestructiveActionCarriesADistinctTint() throws {
+        #expect(StyleSettingsView.icon(for: .select) == nil)
+        let delete = try #require(StyleSettingsView.icon(for: .delete))
+        let duplicate = try #require(StyleSettingsView.icon(for: .duplicate))
+        let edit = try #require(StyleSettingsView.icon(for: .edit))
+        #expect(delete.tint == .red)
+        #expect(duplicate.tint == .accentColor)
+        #expect(edit.tint == .accentColor)
+        #expect(delete.tint != duplicate.tint)
+        #expect(delete.tint != edit.tint)
+    }
 }
 
 // MARK: - Glass switches
@@ -35,29 +52,23 @@ struct ThemeRowActionTests {
 /// The editor's two glass toggles write nothing but the surface style, which
 /// is what makes them losslessly reversible and lets the editor work without a
 /// shadow copy of the palette.
+///
+/// These exercise `KeyboardThemeDefinition.setGlassKeys(_:)` /
+/// `setGlassBoard(_:)` — the functions the editor's bindings call. A test that
+/// re-implemented the assignment would pass no matter what the editor did.
 struct ThemeGlassToggleTests {
-    /// Mirrors the editor's binding setter, so the test exercises the same
-    /// write the toggle performs.
-    private func setGlassKeys(_ isOn: Bool, on theme: inout KeyboardThemeDefinition) {
-        theme.keySurface = isOn ? .glass : .color
-    }
-
-    private func setGlassBoard(_ isOn: Bool, on theme: inout KeyboardThemeDefinition) {
-        theme.boardSurface = isOn ? .glass : .color
-    }
-
     @Test func togglingGlassKeysKeepsTheKeyColors() {
         var theme = BuiltInThemes.darkGold
         theme.id = UUID().uuidString
         let original = theme
 
-        setGlassKeys(true, on: &theme)
+        theme.setGlassKeys(true)
         #expect(theme.keySurface == .glass)
         #expect(theme.keyColor == original.keyColor)
         #expect(theme.keyColorActive == original.keyColorActive)
         #expect(theme.boardColor == original.boardColor)
 
-        setGlassKeys(false, on: &theme)
+        theme.setGlassKeys(false)
         #expect(theme == original)
     }
 
@@ -66,32 +77,71 @@ struct ThemeGlassToggleTests {
         theme.id = UUID().uuidString
         let original = theme
 
-        setGlassBoard(true, on: &theme)
+        theme.setGlassBoard(true)
         #expect(theme.boardSurface == .glass)
         #expect(theme.boardColor == original.boardColor)
         #expect(theme.keyColor == original.keyColor)
         #expect(theme.keyColorActive == original.keyColorActive)
 
-        setGlassBoard(false, on: &theme)
+        theme.setGlassBoard(false)
         #expect(theme == original)
+    }
+
+    /// Each switch owns exactly one surface: turning glass on for the keys must
+    /// not drag the board along, or the editor's two toggles would fight.
+    @Test func eachGlassSwitchTouchesOnlyItsOwnSurface() {
+        var theme = BuiltInThemes.darkGold
+        theme.id = UUID().uuidString
+
+        theme.setGlassKeys(true)
+        #expect(theme.boardSurface == .color)
+
+        theme.setGlassKeys(false)
+        theme.setGlassBoard(true)
+        #expect(theme.keySurface == .color)
     }
 
     /// A copy of the glass built-in has to survive the same round trip, since
     /// its colors are the fallbacks the toggle restores.
-    @Test func glassBuiltInCopyRestoresItsColorsWhenGlassIsSwitchedOff() {
+    @Test func glassBuiltInCopySurvivesTheRoundTrip() {
         var theme = BuiltInThemes.liquidGlass
         theme.id = UUID().uuidString
         let original = theme
 
-        setGlassKeys(false, on: &theme)
-        setGlassBoard(false, on: &theme)
-        #expect(theme.keyColor == original.keyColor)
-        #expect(theme.boardColor == original.boardColor)
+        theme.setGlassKeys(false)
+        theme.setGlassBoard(false)
         #expect(!theme.resolved().hasGlassKeys)
 
-        setGlassKeys(true, on: &theme)
-        setGlassBoard(true, on: &theme)
+        theme.setGlassKeys(true)
+        theme.setGlassBoard(true)
         #expect(theme == original)
+    }
+
+    /// `BuiltInThemes` promises that switching either surface back to `.color`
+    /// yields a *usable* keyboard, so the color fields are real fallbacks and
+    /// not placeholders. Measured absolutely, in both appearances: comparing a
+    /// built-in's colors to themselves would hold for an invisible palette too.
+    ///
+    /// Measured floor of the shipped palettes: opaque keys and boards
+    /// throughout, key-vs-board 1.12:1 (Classic/Liquid Glass light), 1.23:1
+    /// (dark) and 1.26:1 (Dark Gold). A key edge is a shape cue, not text, so
+    /// the bar is "visibly separate", far below a WCAG text ratio — but well
+    /// above the 1.0 an invisible or board-colored key produces.
+    @Test(arguments: [ColorScheme.light, .dark])
+    func everyBuiltInStaysUsableWithBothSurfacesSetToColor(appearance: ColorScheme) throws {
+        for builtIn in BuiltInThemes.all {
+            var theme = builtIn
+            theme.id = UUID().uuidString
+            theme.setGlassKeys(false)
+            theme.setGlassBoard(false)
+
+            let key = try #require(ThemeContrast.components(of: theme.keyColor, in: appearance))
+            let board = try #require(ThemeContrast.components(of: theme.boardColor, in: appearance))
+            #expect(key.alpha >= 0.9, "\(builtIn.id) has near-transparent keys without glass")
+            #expect(board.alpha >= 0.9, "\(builtIn.id) has a near-transparent board without glass")
+            let ratio = ThemeContrast.ratio(of: key, over: board)
+            #expect(ratio >= 1.1, "\(builtIn.id) keys disappear into their board (\(ratio):1)")
+        }
     }
 }
 
@@ -105,14 +155,35 @@ struct ThemeEditingFlowTests {
         return defaults
     }
 
-    /// Cancelling the editor must leave no orphaned "… Copy": duplicating only
-    /// builds the copy in memory, and nothing writes it until Save.
-    @Test func cancelledNewThemeIsNotPersisted() throws {
+    /// Cancelling the editor must leave no orphaned "… Copy": the gallery's
+    /// Duplicate action only opens an edit session, and nothing writes until
+    /// Save. Exercises the gallery's own seam, not `ThemeStore.duplicate` — the
+    /// latter takes no defaults and so could not fail this assertion.
+    @Test func duplicatingOpensAnUnsavedEditSession() throws {
         let defaults = try isolatedDefaults()
-        let copy = ThemeStore.duplicate(BuiltInThemes.darkGold, existing: ThemeStore.userThemes(defaults: defaults))
 
+        let session = StyleSettingsView.editSession(duplicating: BuiltInThemes.darkGold, defaults: defaults)
+
+        #expect(session.isNewTheme)
+        #expect(!session.theme.isBuiltIn)
+        #expect(session.theme.keyColor == BuiltInThemes.darkGold.keyColor)
+        // Nothing persisted, and not even an empty archive written.
+        #expect(defaults.data(forKey: SettingsKey.userThemes.rawValue) == nil)
         #expect(ThemeStore.userThemes(defaults: defaults).isEmpty)
-        #expect(ThemeStore.theme(id: copy.id, defaults: defaults) == nil)
+        #expect(ThemeStore.theme(id: session.theme.id, defaults: defaults) == nil)
+    }
+
+    /// The copy is named against what is already stored, so duplicating the
+    /// same theme twice cannot produce two rows with one name.
+    @Test func duplicatingTwiceYieldsDistinctNames() throws {
+        let defaults = try isolatedDefaults()
+
+        let first = StyleSettingsView.editSession(duplicating: BuiltInThemes.darkGold, defaults: defaults)
+        ThemeStore.saveUserTheme(first.theme, defaults: defaults)
+        let second = StyleSettingsView.editSession(duplicating: BuiltInThemes.darkGold, defaults: defaults)
+
+        #expect(first.theme.name != second.theme.name)
+        #expect(first.theme.id != second.theme.id)
     }
 
     @Test func savedNewThemeIsPersisted() throws {
@@ -129,12 +200,14 @@ struct ThemeEditingFlowTests {
             afterSaving: "user-new",
             isNewTheme: true,
             light: BuiltInThemes.classic.id,
-            dark: BuiltInThemes.classic.id,
-            separateDarkSlot: false,
+            dark: BuiltInThemes.darkGold.id,
+            hasSeparateDarkSlot: false,
             editingAppearance: .light
         )
         #expect(slots.light == "user-new")
-        #expect(slots.dark == "user-new")
+        // Saving follows the same rule as selecting: with the slots joined the
+        // dark one is not written, so a stored dark assignment survives.
+        #expect(slots.dark == BuiltInThemes.darkGold.id)
     }
 
     @Test func savingAnEditLeavesTheSelectionAlone() {
@@ -143,7 +216,7 @@ struct ThemeEditingFlowTests {
             isNewTheme: false,
             light: BuiltInThemes.classic.id,
             dark: BuiltInThemes.darkGold.id,
-            separateDarkSlot: true,
+            hasSeparateDarkSlot: true,
             editingAppearance: .light
         )
         #expect(slots.light == BuiltInThemes.classic.id)
@@ -158,22 +231,321 @@ struct ThemeEditingFlowTests {
             isNewTheme: true,
             light: BuiltInThemes.classic.id,
             dark: BuiltInThemes.darkGold.id,
-            separateDarkSlot: true,
+            hasSeparateDarkSlot: true,
             editingAppearance: .dark
         )
         #expect(slots.light == BuiltInThemes.classic.id)
         #expect(slots.dark == "user-new")
     }
 
-    @Test func selectingWritesBothSlotsWhileTheyShareOneSelection() {
+    /// The mirror of the case above, and the one the light branch is actually
+    /// exercised by: with Light=Classic, Dark=Dark Gold and the segment on
+    /// Light, saving must not drag the dark assignment along.
+    @Test func savingANewThemeWhileEditingLightTouchesOnlyTheLightSlot() {
         let slots = StyleSettingsView.slots(
-            selecting: BuiltInThemes.darkGold.id,
+            afterSaving: "user-new",
+            isNewTheme: true,
             light: BuiltInThemes.classic.id,
-            dark: BuiltInThemes.classic.id,
-            separateDarkSlot: false,
+            dark: BuiltInThemes.darkGold.id,
+            hasSeparateDarkSlot: true,
             editingAppearance: .light
         )
-        #expect(slots.light == BuiltInThemes.darkGold.id)
+        #expect(slots.light == "user-new")
         #expect(slots.dark == BuiltInThemes.darkGold.id)
+    }
+
+    @Test func selectingWhileEditingLightTouchesOnlyTheLightSlot() {
+        let slots = StyleSettingsView.slots(
+            selecting: BuiltInThemes.liquidGlass.id,
+            light: BuiltInThemes.classic.id,
+            dark: BuiltInThemes.darkGold.id,
+            hasSeparateDarkSlot: true,
+            editingAppearance: .light
+        )
+        #expect(slots.light == BuiltInThemes.liquidGlass.id)
+        #expect(slots.dark == BuiltInThemes.darkGold.id)
+    }
+
+    @Test func selectingWhileEditingDarkTouchesOnlyTheDarkSlot() {
+        let slots = StyleSettingsView.slots(
+            selecting: BuiltInThemes.liquidGlass.id,
+            light: BuiltInThemes.classic.id,
+            dark: BuiltInThemes.darkGold.id,
+            hasSeparateDarkSlot: true,
+            editingAppearance: .dark
+        )
+        #expect(slots.light == BuiltInThemes.classic.id)
+        #expect(slots.dark == BuiltInThemes.liquidGlass.id)
+    }
+
+    /// While the slots share one selection, selecting writes the light slot
+    /// only. Mirroring into the dark slot renders identically — the resolver
+    /// ignores it in that state — but it destroys a stored dark assignment on a
+    /// tap, which is the loss the toggle itself was already stopped from doing.
+    @Test func selectingWhileTheSlotsShareOneSelectionLeavesTheDarkSlotAlone() {
+        let slots = StyleSettingsView.slots(
+            selecting: BuiltInThemes.liquidGlass.id,
+            light: BuiltInThemes.classic.id,
+            dark: BuiltInThemes.darkGold.id,
+            hasSeparateDarkSlot: false,
+            editingAppearance: .light
+        )
+        #expect(slots.light == BuiltInThemes.liquidGlass.id)
+        #expect(slots.dark == BuiltInThemes.darkGold.id)
+    }
+}
+
+// MARK: - The separate-dark-slot flag
+
+/// The flag is semantic, not a shortcut for "both slots hold the same id":
+/// while it is off the resolver ignores the dark slot, which is what lets the
+/// dark assignment survive the toggle being switched off and on again.
+struct SeparateDarkSlotTests {
+    private func isolatedDefaults() throws -> UserDefaults {
+        let name = "separate-dark-slot-tests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: name))
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
+    @Test func darkSlotIsIgnoredWhileTheFlagIsOff() {
+        let resolved = ThemeStore.theme(
+            lightId: BuiltInThemes.classic.id,
+            darkId: BuiltInThemes.darkGold.id,
+            hasSeparateDarkSlot: false,
+            for: .dark
+        )
+        #expect(resolved.id == BuiltInThemes.classic.id)
+    }
+
+    @Test func darkSlotAppliesWhileTheFlagIsOn() {
+        let resolved = ThemeStore.theme(
+            lightId: BuiltInThemes.classic.id,
+            darkId: BuiltInThemes.darkGold.id,
+            hasSeparateDarkSlot: true,
+            for: .dark
+        )
+        #expect(resolved.id == BuiltInThemes.darkGold.id)
+    }
+
+    /// The regression: turning the toggle off used to overwrite the dark slot
+    /// with the light id, so the user's dark theme was gone for good.
+    @Test func darkAssignmentSurvivesARoundTripThroughTheToggle() throws {
+        let defaults = try isolatedDefaults()
+        defaults.set(BuiltInThemes.classic.id, forKey: SettingsKey.selectedThemeLight.rawValue)
+        defaults.set(BuiltInThemes.darkGold.id, forKey: SettingsKey.selectedThemeDark.rawValue)
+        defaults.set(true, forKey: SettingsKey.themeSeparateDarkSlot.rawValue)
+
+        // Off: the keyboard renders the light slot in both appearances…
+        defaults.set(false, forKey: SettingsKey.themeSeparateDarkSlot.rawValue)
+        #expect(ThemeStore.selectedTheme(for: .dark, defaults: defaults).id == BuiltInThemes.classic.id)
+        #expect(ThemeStore.selectedTheme(for: .light, defaults: defaults).id == BuiltInThemes.classic.id)
+
+        // …and back on, the dark assignment is still there.
+        defaults.set(true, forKey: SettingsKey.themeSeparateDarkSlot.rawValue)
+        #expect(ThemeStore.selectedTheme(for: .dark, defaults: defaults).id == BuiltInThemes.darkGold.id)
+        #expect(ThemeStore.selectedTheme(for: .light, defaults: defaults).id == BuiltInThemes.classic.id)
+    }
+
+    /// An unresolvable light slot still falls back to Classic with the flag
+    /// off — the guard must not skip the fallback along with the dark slot.
+    @Test func deletedLightThemeFallsBackToClassicWithTheFlagOff() {
+        let resolved = ThemeStore.theme(
+            lightId: "deleted-user-theme",
+            darkId: BuiltInThemes.darkGold.id,
+            hasSeparateDarkSlot: false,
+            for: .light
+        )
+        #expect(resolved.id == BuiltInThemes.classic.id)
+    }
+
+    /// The read side of the same flag. Nil is not "light": it means the device
+    /// decides, and it is what keeps the preview and every color well following
+    /// the user's actual appearance. Returning `.light` instead would seed a
+    /// dark-device user's whole palette from light-mode values — and the wells
+    /// freeze what they are seeded with as fixed hex.
+    @Test func theGalleryPreviewsTheDeviceAppearanceWhileTheSlotsShareOneSelection() {
+        #expect(StyleSettingsView.appearanceOverride(hasSeparateDarkSlot: false, editingAppearance: .light) == nil)
+        #expect(StyleSettingsView.appearanceOverride(hasSeparateDarkSlot: false, editingAppearance: .dark) == nil)
+    }
+
+    @Test func theGalleryPreviewsTheEditedSlotWhileTheSlotsAreSeparate() {
+        #expect(StyleSettingsView.appearanceOverride(hasSeparateDarkSlot: true, editingAppearance: .light) == .light)
+        #expect(StyleSettingsView.appearanceOverride(hasSeparateDarkSlot: true, editingAppearance: .dark) == .dark)
+    }
+
+    /// Which row wears the checkmark, and which theme the preview and the
+    /// editor open on.
+    @Test func theActiveThemeIsTheEditedSlot() {
+        let light = BuiltInThemes.classic.id
+        let dark = BuiltInThemes.darkGold.id
+        func active(_ hasSeparateDarkSlot: Bool, _ editingAppearance: ColorScheme) -> String {
+            StyleSettingsView.activeThemeId(
+                light: light,
+                dark: dark,
+                hasSeparateDarkSlot: hasSeparateDarkSlot,
+                editingAppearance: editingAppearance
+            )
+        }
+        #expect(active(true, .dark) == dark)
+        #expect(active(true, .light) == light)
+        // Joined, the dark slot is not what renders — showing it selected would
+        // point at a theme the keyboard is not using.
+        #expect(active(false, .dark) == light)
+        #expect(active(false, .light) == light)
+    }
+}
+
+// MARK: - Row controls
+
+struct ThemeRowControlTests {
+    /// The hit area has to stay a real target at the small text sizes and stay
+    /// on screen at the large ones: three unclamped AX5 targets do not fit a
+    /// phone's width.
+    @Test func iconTargetStaysWithinItsBounds() {
+        #expect(StyleSettingsView.iconTargetSide(scaledFrom: 36) == 44)
+        #expect(StyleSettingsView.iconTargetSide(scaledFrom: 44) == 44)
+        #expect(StyleSettingsView.iconTargetSide(scaledFrom: 137) == 64)
+    }
+
+    /// The glyph must fit inside its own hit area, or it overflows into the
+    /// neighbouring button's — the bug that let a tap on the trash open the
+    /// editor.
+    ///
+    /// Measured on the rendered symbol, not on the point size: `.frame` does
+    /// not clip a non-resizable `Image`, and an SF Symbol's bounding box runs
+    /// to roughly 1.3× its point size (`plus.square.on.square` is the widest of
+    /// the three at ~1.30, `trash` the tallest at ~1.24). Comparing the point
+    /// size to the side it was derived from would hold for any fraction below
+    /// 1 and miss exactly that overflow.
+    @Test func iconGlyphFitsItsTargetAtEveryTextSize() throws {
+        let icons = ThemeRowAction.allCases.compactMap(StyleSettingsView.icon(for:))
+        #expect(icons.count == 3)
+        for scaled in stride(from: CGFloat(20), through: 200, by: 10) {
+            let side = StyleSettingsView.iconTargetSide(scaledFrom: scaled)
+            let configuration = UIImage.SymbolConfiguration(pointSize: side * StyleSettingsView.iconGlyphFraction)
+            for icon in icons {
+                let rendered = try #require(UIImage(systemName: icon.systemImage, withConfiguration: configuration))
+                #expect(rendered.size.width <= side, "\(icon.systemImage) is \(rendered.size.width) pt wide in a \(side) pt target")
+                #expect(rendered.size.height <= side, "\(icon.systemImage) is \(rendered.size.height) pt tall in a \(side) pt target")
+            }
+        }
+    }
+
+    /// Two copies that differ only in radius or border must not render as the
+    /// same grey square in the list.
+    @Test func swatchScalesRadiusAndBorderToItsKey() {
+        #expect(ThemeSwatch.swatchRadius(forKeyRadius: 0) == 0)
+        #expect(ThemeSwatch.swatchRadius(forKeyRadius: 24) > ThemeSwatch.swatchRadius(forKeyRadius: 8))
+        // 24 pt is the slider maximum; scaled it must stay under half the
+        // 30 pt key, or every rounded theme collapses into the same pill.
+        #expect(ThemeSwatch.swatchRadius(forKeyRadius: 24) < 15)
+        // A hairline border stays visible instead of scaling into nothing.
+        #expect(ThemeSwatch.swatchBorderWidth(forKeyBorderWidth: 0.5) >= 0.5)
+        #expect(ThemeSwatch.swatchBorderWidth(forKeyBorderWidth: 4) > ThemeSwatch.swatchBorderWidth(forKeyBorderWidth: 0.5))
+    }
+}
+
+// MARK: - Key border
+
+/// The border toggle is the editor's one *coupled* write: switching it on has
+/// to bring a width with it. It lives on the model so the coupling is testable
+/// — inline in the binding, deleting it broke nothing.
+struct KeyBorderToggleTests {
+    @Test func turningTheBorderOnGivesAThemeWithoutOneAVisibleWidth() {
+        var theme = BuiltInThemes.classic
+        theme.id = UUID().uuidString
+        #expect(theme.keyBorder == nil)
+        #expect(theme.keyBorderWidth == 0)
+
+        theme.setKeyBorder(true)
+        #expect(theme.keyBorder != nil)
+        // `KeyView.filled` draws no border at width 0, and the width slider's
+        // range starts here — a stored 0 sits outside it.
+        #expect(theme.keyBorderWidth >= KeyboardThemeDefinition.minimumKeyBorderWidth)
+    }
+
+    @Test func turningTheBorderOffRemovesIt() {
+        var theme = BuiltInThemes.darkGold
+        theme.id = UUID().uuidString
+
+        theme.setKeyBorder(false)
+        #expect(theme.keyBorder == nil)
+        // Only the border is switched off; nothing else in the theme moves.
+        #expect(theme.keyColor == BuiltInThemes.darkGold.keyColor)
+        #expect(theme.keyBorderWidth == BuiltInThemes.darkGold.keyBorderWidth)
+    }
+
+    @Test func turningTheBorderOnKeepsTheColorAndWidthTheThemeAlreadyHas() {
+        var theme = BuiltInThemes.darkGold
+        theme.id = UUID().uuidString
+        theme.keyBorderWidth = 3
+
+        theme.setKeyBorder(true)
+        #expect(theme.keyBorder == BuiltInThemes.darkGold.keyBorder)
+        // The width only gets a floor when there is none to keep.
+        #expect(theme.keyBorderWidth == 3)
+    }
+}
+
+// MARK: - Color wells
+
+/// The editor's wells seed from the appearance the theme is *destined for*,
+/// because the setter freezes the pick as a fixed hex.
+struct ThemeColorAppearanceTests {
+    @Test func semanticColorsResolveDifferentlyPerAppearance() throws {
+        let light = try #require(ThemeColor.semantic(.systemBackground).resolvedColor(in: .light))
+        let dark = try #require(ThemeColor.semantic(.systemBackground).resolvedColor(in: .dark))
+        #expect(HexColor.string(from: light) != HexColor.string(from: dark))
+    }
+
+    /// `.systemBackground` alone proves little: it is a bridged UIKit color to
+    /// begin with, so it survives `UIColor(_:)` by construction. The roles the
+    /// wells actually read are SwiftUI-native semantic colors carrying an
+    /// opacity, where the bridge is documented best-effort and could flatten to
+    /// the ambient trait — and if it did, a dark slot would be seeded, and then
+    /// frozen, with light-mode values.
+    @Test func semanticColorsWithOpacityStillResolvePerAppearance() throws {
+        // The three the built-ins actually use: hint letter, hint symbol, trail.
+        let roles: [ThemeColor] = [
+            .semantic(.primary, opacity: 0.65),
+            .semantic(.secondary, opacity: 0.55),
+            .semantic(.primary, opacity: KeyboardConstants.GestureTrail.opacity),
+        ]
+        for color in roles {
+            let light = try #require(ThemeContrast.components(of: color, in: .light))
+            let dark = try #require(ThemeContrast.components(of: color, in: .dark))
+            #expect(light.rgb != dark.rgb, "\(color) flattened to one value across appearances")
+            // The opacity has to survive the bridge too, or an inverted but
+            // opaque value would pass the inequality above.
+            #expect(light.alpha < 1)
+            #expect(abs(light.alpha - dark.alpha) < 0.01)
+        }
+    }
+
+    /// One absolute pin, so a bridge that flattened *both* sides to the same
+    /// ambient value could not pass by merely differing.
+    @Test func primaryResolvesNearBlackInLightAndNearWhiteInDark() throws {
+        let color = ThemeColor.semantic(.primary)
+        let light = try #require(ThemeContrast.components(of: color, in: .light))
+        let dark = try #require(ThemeContrast.components(of: color, in: .dark))
+        #expect(ThemeContrast.luminance(of: light, over: light.rgb) < 0.05)
+        #expect(ThemeContrast.luminance(of: dark, over: dark.rgb) > 0.9)
+    }
+
+    @Test func fixedColorsAreAppearanceIndependent() throws {
+        let color = ThemeColor.fixed(hex: "#D1AA05")
+        let light = try #require(color.resolvedColor(in: .light))
+        let dark = try #require(color.resolvedColor(in: .dark))
+        #expect(HexColor.string(from: light) == "#D1AA05")
+        #expect(HexColor.string(from: dark) == "#D1AA05")
+    }
+
+    @Test func adaptiveColorsTakeTheirSideOfThePair() throws {
+        let color = ThemeColor.adaptive(light: "#000000", dark: "#FFFFFF")
+        let light = try #require(color.resolvedColor(in: .light))
+        let dark = try #require(color.resolvedColor(in: .dark))
+        #expect(HexColor.string(from: light) == "#000000")
+        #expect(HexColor.string(from: dark) == "#FFFFFF")
     }
 }

--- a/wurstfingerTests/ThemeEditingTests.swift
+++ b/wurstfingerTests/ThemeEditingTests.swift
@@ -1,0 +1,179 @@
+//
+//  ThemeEditingTests.swift
+//  WurstfingerTests
+//
+//  The editing rules the style screen and the theme editor are built on:
+//  built-ins are immutable templates, glass is a reversible per-surface
+//  switch, and a duplicate only becomes real when it is saved.
+//
+
+import SwiftUI
+import Testing
+@testable import WurstfingerApp
+
+// MARK: - Row affordances
+
+struct ThemeRowActionTests {
+    @Test func builtInOffersNeitherEditNorDelete() {
+        for theme in BuiltInThemes.all {
+            let actions = StyleSettingsView.rowActions(for: theme)
+            #expect(actions == [.select, .duplicate])
+            #expect(!actions.contains(.edit))
+            #expect(!actions.contains(.delete))
+        }
+    }
+
+    @Test func userThemeOffersEveryAction() {
+        var theme = BuiltInThemes.darkGold
+        theme.id = UUID().uuidString
+        #expect(StyleSettingsView.rowActions(for: theme) == [.select, .duplicate, .edit, .delete])
+    }
+}
+
+// MARK: - Glass switches
+
+/// The editor's two glass toggles write nothing but the surface style, which
+/// is what makes them losslessly reversible and lets the editor work without a
+/// shadow copy of the palette.
+struct ThemeGlassToggleTests {
+    /// Mirrors the editor's binding setter, so the test exercises the same
+    /// write the toggle performs.
+    private func setGlassKeys(_ isOn: Bool, on theme: inout KeyboardThemeDefinition) {
+        theme.keySurface = isOn ? .glass : .color
+    }
+
+    private func setGlassBoard(_ isOn: Bool, on theme: inout KeyboardThemeDefinition) {
+        theme.boardSurface = isOn ? .glass : .color
+    }
+
+    @Test func togglingGlassKeysKeepsTheKeyColors() {
+        var theme = BuiltInThemes.darkGold
+        theme.id = UUID().uuidString
+        let original = theme
+
+        setGlassKeys(true, on: &theme)
+        #expect(theme.keySurface == .glass)
+        #expect(theme.keyColor == original.keyColor)
+        #expect(theme.keyColorActive == original.keyColorActive)
+        #expect(theme.boardColor == original.boardColor)
+
+        setGlassKeys(false, on: &theme)
+        #expect(theme == original)
+    }
+
+    @Test func togglingGlassBackgroundKeepsTheBoardColor() {
+        var theme = BuiltInThemes.darkGold
+        theme.id = UUID().uuidString
+        let original = theme
+
+        setGlassBoard(true, on: &theme)
+        #expect(theme.boardSurface == .glass)
+        #expect(theme.boardColor == original.boardColor)
+        #expect(theme.keyColor == original.keyColor)
+        #expect(theme.keyColorActive == original.keyColorActive)
+
+        setGlassBoard(false, on: &theme)
+        #expect(theme == original)
+    }
+
+    /// A copy of the glass built-in has to survive the same round trip, since
+    /// its colors are the fallbacks the toggle restores.
+    @Test func glassBuiltInCopyRestoresItsColorsWhenGlassIsSwitchedOff() {
+        var theme = BuiltInThemes.liquidGlass
+        theme.id = UUID().uuidString
+        let original = theme
+
+        setGlassKeys(false, on: &theme)
+        setGlassBoard(false, on: &theme)
+        #expect(theme.keyColor == original.keyColor)
+        #expect(theme.boardColor == original.boardColor)
+        #expect(!theme.resolved().hasGlassKeys)
+
+        setGlassKeys(true, on: &theme)
+        setGlassBoard(true, on: &theme)
+        #expect(theme == original)
+    }
+}
+
+// MARK: - Duplicate → edit → save
+
+struct ThemeEditingFlowTests {
+    private func isolatedDefaults() throws -> UserDefaults {
+        let name = "theme-editing-flow-tests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: name))
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
+    /// Cancelling the editor must leave no orphaned "… Copy": duplicating only
+    /// builds the copy in memory, and nothing writes it until Save.
+    @Test func cancelledNewThemeIsNotPersisted() throws {
+        let defaults = try isolatedDefaults()
+        let copy = ThemeStore.duplicate(BuiltInThemes.darkGold, existing: ThemeStore.userThemes(defaults: defaults))
+
+        #expect(ThemeStore.userThemes(defaults: defaults).isEmpty)
+        #expect(ThemeStore.theme(id: copy.id, defaults: defaults) == nil)
+    }
+
+    @Test func savedNewThemeIsPersisted() throws {
+        let defaults = try isolatedDefaults()
+        let copy = ThemeStore.duplicate(BuiltInThemes.darkGold, existing: ThemeStore.userThemes(defaults: defaults))
+
+        ThemeStore.saveUserTheme(copy, defaults: defaults)
+
+        #expect(ThemeStore.userThemes(defaults: defaults).map(\.id) == [copy.id])
+    }
+
+    @Test func savingANewThemeSelectsIt() {
+        let slots = StyleSettingsView.slots(
+            afterSaving: "user-new",
+            isNewTheme: true,
+            light: BuiltInThemes.classic.id,
+            dark: BuiltInThemes.classic.id,
+            separateDarkSlot: false,
+            editingAppearance: .light
+        )
+        #expect(slots.light == "user-new")
+        #expect(slots.dark == "user-new")
+    }
+
+    @Test func savingAnEditLeavesTheSelectionAlone() {
+        let slots = StyleSettingsView.slots(
+            afterSaving: "user-edited",
+            isNewTheme: false,
+            light: BuiltInThemes.classic.id,
+            dark: BuiltInThemes.darkGold.id,
+            separateDarkSlot: true,
+            editingAppearance: .light
+        )
+        #expect(slots.light == BuiltInThemes.classic.id)
+        #expect(slots.dark == BuiltInThemes.darkGold.id)
+    }
+
+    /// A new theme lands in the slot the gallery is editing, not in both, once
+    /// the two slots are allowed to diverge.
+    @Test func savingANewThemeWhileEditingDarkTouchesOnlyTheDarkSlot() {
+        let slots = StyleSettingsView.slots(
+            afterSaving: "user-new",
+            isNewTheme: true,
+            light: BuiltInThemes.classic.id,
+            dark: BuiltInThemes.darkGold.id,
+            separateDarkSlot: true,
+            editingAppearance: .dark
+        )
+        #expect(slots.light == BuiltInThemes.classic.id)
+        #expect(slots.dark == "user-new")
+    }
+
+    @Test func selectingWritesBothSlotsWhileTheyShareOneSelection() {
+        let slots = StyleSettingsView.slots(
+            selecting: BuiltInThemes.darkGold.id,
+            light: BuiltInThemes.classic.id,
+            dark: BuiltInThemes.classic.id,
+            separateDarkSlot: false,
+            editingAppearance: .light
+        )
+        #expect(slots.light == BuiltInThemes.darkGold.id)
+        #expect(slots.dark == BuiltInThemes.darkGold.id)
+    }
+}

--- a/wurstfingerTests/ThemeEngineTests.swift
+++ b/wurstfingerTests/ThemeEngineTests.swift
@@ -42,16 +42,6 @@ struct HexColorTests {
         let string = try #require(HexColor.string(from: HexColor.color(from: original)))
         #expect(HexColor.parse(string) == original)
     }
-
-    @Test func luminanceOrdersLightAndDark() {
-        #expect(HexColor.luminance(of: 0xFFFFFF) > 0.9)
-        #expect(HexColor.luminance(of: 0x000000) < 0.1)
-    }
-
-    @Test func scalingDarkensAndClamps() {
-        #expect(HexColor.scaled(0xFFFFFF, by: 0.5) == 0x7F7F7F)
-        #expect(HexColor.scaled(0xFFFFFF, by: 2.0) == 0xFFFFFF)
-    }
 }
 
 // MARK: - Codable Wire Format

--- a/wurstfingerTests/ThemeEngineTests.swift
+++ b/wurstfingerTests/ThemeEngineTests.swift
@@ -1,0 +1,241 @@
+//
+//  ThemeEngineTests.swift
+//  WurstfingerTests
+//
+//  Covers hex parsing, theme codability (the future export wire format),
+//  built-in stability, resolver fallbacks, and the legacy-style migration.
+//
+
+import SwiftUI
+import Testing
+@testable import WurstfingerApp
+
+// MARK: - HexColor
+
+struct HexColorTests {
+    @Test func parsesSixDigitHex() {
+        #expect(HexColor.parse("#333A48") == .init(rgb: 0x333A48, alpha: 1))
+        #expect(HexColor.parse("d1aa05") == .init(rgb: 0xD1AA05, alpha: 1))
+    }
+
+    @Test func parsesEightDigitHexWithAlpha() throws {
+        let parsed = try #require(HexColor.parse("#FFFFFF80"))
+        #expect(parsed.rgb == 0xFFFFFF)
+        #expect(abs(parsed.alpha - 128.0 / 255.0) < 0.001)
+    }
+
+    @Test func rejectsInvalidHex() {
+        #expect(HexColor.parse("") == nil)
+        #expect(HexColor.parse("#12345") == nil)
+        #expect(HexColor.parse("#1234567") == nil)
+        #expect(HexColor.parse("#GGGGGG") == nil)
+        #expect(HexColor.parse("not a color") == nil)
+    }
+
+    @Test func formatsWithAlphaOnlyWhenBelowOne() {
+        #expect(HexColor.string(from: .init(rgb: 0x333A48, alpha: 1)) == "#333A48")
+        #expect(HexColor.string(from: .init(rgb: 0xFFFFFF, alpha: 0.5)) == "#FFFFFF80")
+    }
+
+    @Test func colorRoundTripsThroughHexString() throws {
+        let original = HexColor.Components(rgb: 0x333A48, alpha: 1)
+        let string = try #require(HexColor.string(from: HexColor.color(from: original)))
+        #expect(HexColor.parse(string) == original)
+    }
+
+    @Test func luminanceOrdersLightAndDark() {
+        #expect(HexColor.luminance(of: 0xFFFFFF) > 0.9)
+        #expect(HexColor.luminance(of: 0x000000) < 0.1)
+    }
+
+    @Test func scalingDarkensAndClamps() {
+        #expect(HexColor.scaled(0xFFFFFF, by: 0.5) == 0x7F7F7F)
+        #expect(HexColor.scaled(0xFFFFFF, by: 2.0) == 0xFFFFFF)
+    }
+}
+
+// MARK: - Codable Wire Format
+
+struct ThemeCodableTests {
+    private func roundTrip(_ definition: KeyboardThemeDefinition) throws -> KeyboardThemeDefinition {
+        let data = try JSONEncoder().encode(definition)
+        return try JSONDecoder().decode(KeyboardThemeDefinition.self, from: data)
+    }
+
+    @Test func builtInsRoundTripLosslessly() throws {
+        for theme in BuiltInThemes.all {
+            #expect(try roundTrip(theme) == theme)
+        }
+    }
+
+    @Test func adaptiveColorRoundTrips() throws {
+        var theme = BuiltInThemes.darkGold
+        theme.id = UUID().uuidString
+        theme.mainLabel = .adaptive(light: "#111111", dark: "#EEEEEE")
+        #expect(try roundTrip(theme) == theme)
+    }
+
+    @Test func missingFieldsDecodeToClassicDefaults() throws {
+        let json = Data(#"{"id": "abc", "name": "Sparse"}"#.utf8)
+        let decoded = try JSONDecoder().decode(KeyboardThemeDefinition.self, from: json)
+        #expect(decoded.keyFill == BuiltInThemes.classic.keyFill)
+        #expect(decoded.cornerRadius == BuiltInThemes.classic.cornerRadius)
+        #expect(decoded.keyBorder == nil)
+    }
+
+    @Test func archiveDecodingIsLossy() throws {
+        // One valid theme, one corrupt entry (id missing), one entry claiming
+        // a built-in id — only the valid one must survive.
+        let json = Data("""
+        {"schemaVersion": 1, "themes": [
+            {"id": "user-1", "name": "Mine"},
+            {"name": "Broken"},
+            {"id": "classic", "name": "Impostor"}
+        ]}
+        """.utf8)
+        let archive = try JSONDecoder().decode(ThemeStore.Archive.self, from: json)
+        #expect(archive.themes.map(\.id) == ["user-1"])
+    }
+
+    @Test func archiveEncodingIsStable() throws {
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-stable"
+        let archive = ThemeStore.Archive(schemaVersion: 1, themes: [theme])
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let first = try encoder.encode(archive)
+        let second = try encoder.encode(archive)
+        #expect(first == second)
+    }
+}
+
+// MARK: - Built-ins
+
+struct BuiltInThemeTests {
+    /// The ids are API: persisted selections and future export codes
+    /// reference them. Changing one silently resets users to Classic.
+    @Test func builtInIdsArePinned() {
+        #expect(BuiltInThemes.classic.id == "classic")
+        #expect(BuiltInThemes.liquidGlass.id == "liquid-glass")
+        #expect(BuiltInThemes.darkGold.id == "dark-gold")
+        #expect(BuiltInThemes.all.count == 3)
+    }
+
+    @Test func classicHasNoBorder() {
+        #expect(BuiltInThemes.classic.resolved().keyBorder == nil)
+    }
+
+    @Test func liquidGlassUsesMaterialKeys() {
+        let resolved = BuiltInThemes.liquidGlass.resolved()
+        #expect(resolved.keyFill == .material)
+        #expect(resolved.keyFillActive == .material)
+    }
+
+    @Test func darkGoldResolvesItsFixedPalette() throws {
+        let resolved = BuiltInThemes.darkGold.resolved()
+        #expect(resolved.mainLabel == HexColor.color(from: "#D1AA05"))
+        #expect(try resolved.keyFill == .color(#require(HexColor.color(from: "#333A48"))))
+    }
+}
+
+// MARK: - Resolver
+
+struct ThemeResolverTests {
+    @Test func unparsableHexFallsBackToClassicRole() {
+        var theme = BuiltInThemes.darkGold
+        theme.mainLabel = .fixed(hex: "garbage")
+        let resolved = theme.resolved()
+        #expect(resolved.mainLabel == BuiltInThemes.classic.resolved().mainLabel)
+    }
+
+    @Test func boardOpacityIsFloored() {
+        // A fully transparent board would drop touches between keys (#198),
+        // so the resolver clamps it to the minimum.
+        let floored = ThemeColor.fixed(hex: "#00000000")
+            .withMinimumOpacity(KeyboardThemeDefinition.minimumBoardOpacity)
+        guard case let .fixed(hex) = floored else {
+            Issue.record("expected fixed color, got \(floored)")
+            return
+        }
+        let components = HexColor.parse(hex)
+        #expect((components?.alpha ?? 0) >= KeyboardThemeDefinition.minimumBoardOpacity - 0.001)
+    }
+
+    @Test func boardOpacityFloorKeepsOpaqueColors() {
+        let untouched = ThemeColor.fixed(hex: "#252A34")
+            .withMinimumOpacity(KeyboardThemeDefinition.minimumBoardOpacity)
+        #expect(untouched == .fixed(hex: "#252A34"))
+    }
+
+    @Test func semanticOpacityIsFlooredToo() {
+        let floored = ThemeColor.semantic(.systemBackground, opacity: 0)
+            .withMinimumOpacity(0.02)
+        #expect(floored == .semantic(.systemBackground, opacity: 0.02))
+    }
+}
+
+// MARK: - Migration
+
+struct ThemeMigrationTests {
+    private func isolatedDefaults() throws -> UserDefaults {
+        let name = "theme-migration-tests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: name))
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
+    @Test func migratesLegacyStyles() throws {
+        let cases: [(legacy: String, expected: String)] = [
+            ("classic", "classic"),
+            ("liquidGlass", "liquid-glass"),
+            ("darkGold", "dark-gold"),
+            ("unknown-junk", "classic"),
+        ]
+        for testCase in cases {
+            let defaults = try isolatedDefaults()
+            defaults.set(testCase.legacy, forKey: SettingsKey.keyboardStyle.rawValue)
+            ThemeStore.migrateIfNeeded(defaults: defaults)
+            #expect(defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == testCase.expected)
+            #expect(defaults.string(forKey: SettingsKey.selectedThemeDark.rawValue) == testCase.expected)
+            #expect(defaults.string(forKey: SettingsKey.keyboardStyle.rawValue) == nil)
+        }
+    }
+
+    @Test func migrationIsIdempotent() throws {
+        let defaults = try isolatedDefaults()
+        defaults.set("liquidGlass", forKey: SettingsKey.keyboardStyle.rawValue)
+        ThemeStore.migrateIfNeeded(defaults: defaults)
+        // A second run (or a racing second process after the first finished)
+        // must not change anything — even if the user re-selected meanwhile.
+        defaults.set("classic", forKey: SettingsKey.selectedThemeLight.rawValue)
+        ThemeStore.migrateIfNeeded(defaults: defaults)
+        #expect(defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == "classic")
+    }
+
+    @Test func migrationWithoutLegacyKeyWritesNothing() throws {
+        let defaults = try isolatedDefaults()
+        ThemeStore.migrateIfNeeded(defaults: defaults)
+        #expect(defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == nil)
+    }
+
+    @Test func selectionFallsBackThroughCascade() throws {
+        let defaults = try isolatedDefaults()
+        // Dark slot points at a nonexistent theme → falls back to the light
+        // slot, then Classic.
+        defaults.set("dark-gold", forKey: SettingsKey.selectedThemeLight.rawValue)
+        defaults.set("deleted-user-theme", forKey: SettingsKey.selectedThemeDark.rawValue)
+        #expect(ThemeStore.selectedTheme(for: .dark, defaults: defaults).id == "dark-gold")
+        defaults.set("also-gone", forKey: SettingsKey.selectedThemeLight.rawValue)
+        #expect(ThemeStore.selectedTheme(for: .dark, defaults: defaults).id == "classic")
+    }
+
+    @Test func userThemesPersistThroughStore() throws {
+        let defaults = try isolatedDefaults()
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-abc"
+        theme.name = "My Theme"
+        ThemeStore.writeUserThemes([theme], defaults: defaults)
+        #expect(ThemeStore.userThemes(defaults: defaults) == [theme])
+        #expect(ThemeStore.theme(id: "user-abc", defaults: defaults) == theme)
+    }
+}

--- a/wurstfingerTests/ThemeEngineTests.swift
+++ b/wurstfingerTests/ThemeEngineTests.swift
@@ -68,9 +68,33 @@ struct ThemeCodableTests {
     @Test func missingFieldsDecodeToClassicDefaults() throws {
         let json = Data(#"{"id": "abc", "name": "Sparse"}"#.utf8)
         let decoded = try JSONDecoder().decode(KeyboardThemeDefinition.self, from: json)
-        #expect(decoded.keyFill == BuiltInThemes.classic.keyFill)
+        #expect(decoded.keyColor == BuiltInThemes.classic.keyColor)
         #expect(decoded.cornerRadius == BuiltInThemes.classic.cornerRadius)
         #expect(decoded.keyBorder == nil)
+    }
+
+    @Test func unknownSurfaceStyleDecodesToColorWithoutLosingTheTheme() throws {
+        // Decoding the surface through the enum would throw here, and
+        // `Archive.FailableTheme` would drop the entire theme over one field.
+        let json = Data(#"""
+        {"id": "abc", "name": "From The Future",
+         "boardSurface": "hologram", "keySurface": "hologram",
+         "mainLabel": {"type": "fixed", "hex": "#D1AA05"}}
+        """#.utf8)
+        let decoded = try JSONDecoder().decode(KeyboardThemeDefinition.self, from: json)
+        #expect(decoded.boardSurface == .color)
+        #expect(decoded.keySurface == .color)
+        #expect(decoded.mainLabel == .fixed(hex: "#D1AA05"))
+    }
+
+    @Test func archiveFromANewerSchemaYieldsNoThemes() throws {
+        // Field-wise tolerance would invent a plausible-but-wrong theme, and
+        // the next save would write it back over the user's original.
+        let json = Data("""
+        {"schemaVersion": 99, "themes": [{"id": "user-1", "name": "Mine"}]}
+        """.utf8)
+        let archive = try JSONDecoder().decode(ThemeStore.Archive.self, from: json)
+        #expect(archive.themes.isEmpty)
     }
 
     @Test func archiveDecodingIsLossy() throws {
@@ -109,22 +133,97 @@ struct BuiltInThemeTests {
         #expect(BuiltInThemes.liquidGlass.id == "liquid-glass")
         #expect(BuiltInThemes.darkGold.id == "dark-gold")
         #expect(BuiltInThemes.all.count == 3)
+        #expect(BuiltInThemes.all.map(\.id) == ["classic", "liquid-glass", "dark-gold"])
     }
 
     @Test func classicHasNoBorder() {
         #expect(BuiltInThemes.classic.resolved().keyBorder == nil)
     }
 
-    @Test func liquidGlassUsesMaterialKeys() {
-        let resolved = BuiltInThemes.liquidGlass.resolved()
-        #expect(resolved.keyFill == .material)
-        #expect(resolved.keyFillActive == .material)
+    @Test func liquidGlassUsesGlassSurfaces() {
+        #expect(BuiltInThemes.liquidGlass.boardSurface == .glass)
+        #expect(BuiltInThemes.liquidGlass.keySurface == .glass)
+        #expect(BuiltInThemes.liquidGlass.resolved().hasGlassKeys)
+    }
+
+    @Test func aGlassBoardPaintsTheTouchableConstant() {
+        // Two assertions, not one tautology: raising the touch floor must not
+        // silently recolor every glass theme's board.
+        #expect(BuiltInThemes.liquidGlass.resolved().boardBackground == Color.gray.opacity(0.02))
+        #expect(KeyboardThemeDefinition.minimumBoardOpacity == 0.02)
     }
 
     @Test func darkGoldResolvesItsFixedPalette() throws {
         let resolved = BuiltInThemes.darkGold.resolved()
         #expect(resolved.mainLabel == HexColor.color(from: "#D1AA05"))
-        #expect(try resolved.keyFill == .color(#require(HexColor.color(from: "#333A48"))))
+        #expect(try resolved.keyColor == #require(HexColor.color(from: "#333A48")))
+    }
+
+    @Test func resolvingIsStable() {
+        // An `.adaptive` color in a built-in would break this: every
+        // `resolvedColor()` mints a fresh dynamic UIColor and two are never
+        // equal, so the resolved theme would compare unequal to itself and
+        // invalidate the grid plus every key on each root body evaluation.
+        #expect(BuiltInThemes.all.allSatisfy { $0.resolved() == $0.resolved() })
+    }
+}
+
+// MARK: - Gesture Trail Role
+
+struct ThemeGestureTrailTests {
+    @Test func classicTrailMatchesThePreEngineConstant() {
+        #expect(BuiltInThemes.classic.resolved().gestureTrail == Color.primary.opacity(0.38))
+        #expect(KeyboardConstants.GestureTrail.opacity == 0.38)
+    }
+
+    @Test func explicitTrailColorKeepsItsOwnAlpha() throws {
+        // The draw path no longer multiplies the 0.38 constant on top, so a
+        // fully opaque pick has to resolve fully opaque.
+        var theme = BuiltInThemes.darkGold
+        theme.gestureTrail = .fixed(hex: "#FF0000")
+        let hex = try #require(HexColor.string(from: theme.resolved().gestureTrail))
+        #expect(HexColor.parse(hex) == .init(rgb: 0xFF0000, alpha: 1))
+    }
+
+    @Test func unparsableTrailHexFallsBackToClassicRole() {
+        var theme = BuiltInThemes.darkGold
+        theme.gestureTrail = .fixed(hex: "garbage")
+        #expect(theme.resolved().gestureTrail == BuiltInThemes.classic.resolved().gestureTrail)
+    }
+
+    @Test func everyBuiltInTrailContrastsWithItsKeyColor() throws {
+        // Glass keys have no color of their own to measure against.
+        for theme in BuiltInThemes.all where theme.keySurface == .color {
+            let resolved = theme.resolved()
+            let key = try components(of: resolved.keyColor)
+            let trail = try components(of: resolved.gestureTrail)
+            let composited = luminance(of: trail.rgb, over: key.rgb, alpha: trail.alpha)
+            let delta = abs(composited - luminance(of: key.rgb, over: key.rgb, alpha: 1))
+            // Dark Gold's gold-over-slate sits at ~0.19 (3.06:1), Classic's
+            // ink-over-system-fill far above it.
+            #expect(delta > 0.1, "\(theme.id) trail barely differs from its key color")
+        }
+    }
+
+    private func components(of color: Color) throws -> HexColor.Components {
+        let hex = try #require(HexColor.string(from: color))
+        return try #require(HexColor.parse(hex))
+    }
+
+    /// WCAG relative luminance of `rgb` composited over the opaque `background`
+    /// at `alpha`.
+    private func luminance(of rgb: UInt32, over background: UInt32, alpha: Double) -> Double {
+        func channel(_ packed: UInt32, _ shift: UInt32) -> Double {
+            Double((packed >> shift) & 0xFF) / 255
+        }
+        func linear(_ value: Double) -> Double {
+            value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+        }
+        let weights = [(16 as UInt32, 0.2126), (8 as UInt32, 0.7152), (0 as UInt32, 0.0722)]
+        return weights.reduce(0) { total, entry in
+            let mixed = alpha * channel(rgb, entry.0) + (1 - alpha) * channel(background, entry.0)
+            return total + entry.1 * linear(mixed)
+        }
     }
 }
 
@@ -254,7 +353,7 @@ struct ThemeEditingTests {
         #expect(copy.id != source.id)
         #expect(!copy.isBuiltIn)
         // Colors carry over untouched; only identity/name change.
-        #expect(copy.keyFill == source.keyFill)
+        #expect(copy.keyColor == source.keyColor)
         #expect(copy.mainLabel == source.mainLabel)
         #expect(copy.name != source.displayName)
         #expect(copy.name.contains(source.displayName))

--- a/wurstfingerTests/ThemeEngineTests.swift
+++ b/wurstfingerTests/ThemeEngineTests.swift
@@ -65,6 +65,22 @@ struct ThemeCodableTests {
         #expect(try roundTrip(theme) == theme)
     }
 
+    @Test func roundTripPreservesTheTrailAndBothSurfaces() throws {
+        // On Classic these three roles happen to equal the decode fallbacks,
+        // so a dropped key would round-trip green there. Pick values that
+        // differ from Classic's, and the round trip has to carry them.
+        var theme = BuiltInThemes.classic
+        theme.id = "user-distinct"
+        theme.boardSurface = .glass
+        theme.keySurface = .glass
+        theme.gestureTrail = .fixed(hex: "#FF00FFAA")
+        let decoded = try roundTrip(theme)
+        #expect(decoded.boardSurface == .glass)
+        #expect(decoded.keySurface == .glass)
+        #expect(decoded.gestureTrail == .fixed(hex: "#FF00FFAA"))
+        #expect(decoded == theme)
+    }
+
     @Test func missingFieldsDecodeToClassicDefaults() throws {
         let json = Data(#"{"id": "abc", "name": "Sparse"}"#.utf8)
         let decoded = try JSONDecoder().decode(KeyboardThemeDefinition.self, from: json)
@@ -85,6 +101,116 @@ struct ThemeCodableTests {
         #expect(decoded.boardSurface == .color)
         #expect(decoded.keySurface == .color)
         #expect(decoded.mainLabel == .fixed(hex: "#D1AA05"))
+    }
+
+    /// A color role a later version writes differently, an unknown token, a
+    /// truncated payload, and a bare string where an object belongs.
+    @Test(arguments: [
+        ##"{"type": "gradient", "from": "#000000", "to": "#FFFFFF"}"##,
+        ##"{"type": "semantic", "token": "quaternaryLabel"}"##,
+        ##"{"type": "fixed"}"##,
+        ##""#FFFFFF""##,
+    ])
+    func aMalformedColorRoleDegradesToClassic(payload: String) throws {
+        // Only the one role degrades — throwing would cost the whole theme.
+        let json = Data(#"""
+        {"id": "abc", "name": "Mine", "keyColor": \#(payload),
+         "mainLabel": {"type": "fixed", "hex": "#D1AA05"}}
+        """#.utf8)
+        let decoded = try JSONDecoder().decode(KeyboardThemeDefinition.self, from: json)
+        #expect(decoded.keyColor == BuiltInThemes.classic.keyColor)
+        #expect(decoded.name == "Mine")
+        #expect(decoded.mainLabel == .fixed(hex: "#D1AA05"))
+    }
+
+    @Test func aMalformedNumberDegradesToClassic() throws {
+        let json = Data(#"""
+        {"id": "abc", "name": "Mine", "keyBorderWidth": "0.5", "cornerRadius": "big",
+         "mainLabel": {"type": "fixed", "hex": "#D1AA05"}}
+        """#.utf8)
+        let decoded = try JSONDecoder().decode(KeyboardThemeDefinition.self, from: json)
+        #expect(decoded.keyBorderWidth == BuiltInThemes.classic.keyBorderWidth)
+        #expect(decoded.cornerRadius == BuiltInThemes.classic.cornerRadius)
+        #expect(decoded.mainLabel == .fixed(hex: "#D1AA05"))
+    }
+
+    @Test func aMalformedKeyBorderBecomesNoBorder() throws {
+        // Classic's value for this role is "no border"; inventing one would
+        // stroke every key with something the user never picked.
+        let json = Data(#"""
+        {"id": "abc", "name": "Mine", "keyBorder": {"type": "fixed"}, "keyBorderWidth": 2}
+        """#.utf8)
+        let decoded = try JSONDecoder().decode(KeyboardThemeDefinition.self, from: json)
+        #expect(decoded.keyBorder == nil)
+        #expect(decoded.keyBorderWidth == 2)
+    }
+
+    @Test func aThemeWithOneMalformedFieldSurvivesTheArchive() throws {
+        // The damage path in full: `FailableTheme` would drop the theme, and
+        // the next save would write that loss back over the original.
+        let json = Data("""
+        {"schemaVersion": 1, "themes": [{"id": "user-1", "name": "Mine", "cornerRadius": "big"}]}
+        """.utf8)
+        let archive = try JSONDecoder().decode(ThemeStore.Archive.self, from: json)
+        #expect(archive.themes.map(\.id) == ["user-1"])
+    }
+
+    @Test func preReworkFillsKeepTheirColors() throws {
+        // Unreleased M2/M3 dev builds stored one `ThemeFill` per surface. The
+        // label roles still decode, so ignoring these keys would leave gold
+        // labels on Classic's near-white key (~2.2:1) — and persist it.
+        let json = Data(#"""
+        {"id": "user-1", "name": "Old Gold",
+         "boardBackground": {"type": "color", "color": {"type": "fixed", "hex": "#252A34"}},
+         "keyFill": {"type": "color", "color": {"type": "fixed", "hex": "#333A48"}},
+         "keyFillActive": {"type": "color", "color": {"type": "fixed", "hex": "#4A5468"}},
+         "keyBorder": {"type": "fixed", "hex": "#FFFFFF1F"}, "keyBorderWidth": 0.5,
+         "mainLabel": {"type": "fixed", "hex": "#D1AA05"}}
+        """#.utf8)
+        let decoded = try JSONDecoder().decode(KeyboardThemeDefinition.self, from: json)
+        #expect(decoded.boardSurface == .color)
+        #expect(decoded.boardColor == .fixed(hex: "#252A34"))
+        #expect(decoded.keySurface == .color)
+        #expect(decoded.keyColor == .fixed(hex: "#333A48"))
+        #expect(decoded.keyColorActive == .fixed(hex: "#4A5468"))
+        #expect(decoded.keyBorder == .fixed(hex: "#FFFFFF1F"))
+        #expect(decoded.mainLabel == .fixed(hex: "#D1AA05"))
+    }
+
+    @Test func preReworkMaterialFillsBecomeGlassSurfaces() throws {
+        let json = Data(#"""
+        {"id": "user-2", "name": "Old Glass",
+         "boardBackground": {"type": "material"},
+         "keyFill": {"type": "material"},
+         "keyFillActive": {"type": "material"}}
+        """#.utf8)
+        let decoded = try JSONDecoder().decode(KeyboardThemeDefinition.self, from: json)
+        #expect(decoded.boardSurface == .glass)
+        #expect(decoded.keySurface == .glass)
+        // A material carried no color, so the colors behind the glass stay
+        // Classic's — switching a surface back to `.color` must still render.
+        #expect(decoded.keyColor == BuiltInThemes.classic.keyColor)
+        #expect(decoded.boardColor == BuiltInThemes.classic.boardColor)
+    }
+
+    @Test func currentKeysWinOverPreReworkKeys() throws {
+        let json = Data(#"""
+        {"id": "user-3", "name": "Both Shapes",
+         "keySurface": "color", "keyColor": {"type": "fixed", "hex": "#111111"},
+         "keyFill": {"type": "material"}}
+        """#.utf8)
+        let decoded = try JSONDecoder().decode(KeyboardThemeDefinition.self, from: json)
+        #expect(decoded.keySurface == .color)
+        #expect(decoded.keyColor == .fixed(hex: "#111111"))
+    }
+
+    @Test func encodingNeverWritesThePreReworkShape() throws {
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-4"
+        let json = try #require(String(data: JSONEncoder().encode(theme), encoding: .utf8))
+        for legacyKey in ["boardBackground", "keyFill", "keyFillActive"] {
+            #expect(!json.contains(legacyKey), "encoder wrote the pre-rework key \(legacyKey)")
+        }
     }
 
     @Test func archiveFromANewerSchemaYieldsNoThemes() throws {
@@ -160,11 +286,15 @@ struct BuiltInThemeTests {
     }
 
     @Test func resolvingIsStable() {
-        // An `.adaptive` color in a built-in would break this: every
-        // `resolvedColor()` mints a fresh dynamic UIColor and two are never
-        // equal, so the resolved theme would compare unequal to itself and
-        // invalidate the grid plus every key on each root body evaluation.
         #expect(BuiltInThemes.all.allSatisfy { $0.resolved() == $0.resolved() })
+        // The loop above cannot fail for the reason that matters: no built-in
+        // uses `.adaptive`, the one case that resolves through a fresh dynamic
+        // UIColor per call — and two of those never compare equal, so the
+        // resolved theme would differ from itself and invalidate the grid plus
+        // every key on each root body evaluation.
+        var adaptive = BuiltInThemes.classic
+        adaptive.mainLabel = .adaptive(light: "#111111", dark: "#EEEEEE")
+        #expect(adaptive.resolved() == adaptive.resolved())
     }
 }
 
@@ -394,6 +524,22 @@ struct ThemeEditingTests {
         #expect(ThemeStore.userThemes(defaults: defaults).isEmpty)
         #expect(defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == BuiltInThemes.classic.id)
         #expect(defaults.string(forKey: SettingsKey.selectedThemeDark.rawValue) == BuiltInThemes.classic.id)
+    }
+
+    @Test func writingDoesNotClobberANewerSchemaArchive() throws {
+        let defaults = try isolatedDefaults()
+        let stored = Data("""
+        {"schemaVersion": 2, "themes": [{"id": "future-1", "name": "From The Future"}]}
+        """.utf8)
+        defaults.set(stored, forKey: SettingsKey.userThemes.rawValue)
+
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-new"
+        ThemeStore.saveUserTheme(theme, defaults: defaults)
+
+        // A newer archive reads as "no themes" on purpose; writing this
+        // build's list over it would delete every theme that guard protects.
+        #expect(defaults.data(forKey: SettingsKey.userThemes.rawValue) == stored)
     }
 
     @Test func deleteLeavesUnrelatedSelectionUntouched() throws {

--- a/wurstfingerTests/ThemeEngineTests.swift
+++ b/wurstfingerTests/ThemeEngineTests.swift
@@ -145,6 +145,26 @@ struct ThemeCodableTests {
         #expect(decoded.keyBorderWidth == 2)
     }
 
+    @Test func aBorderedThemeNeverDecodesToAnInvisibleWidth() throws {
+        // `KeyView.filled` only strokes for a positive width, so a stored zero
+        // next to a border color would show an enabled control that draws
+        // nothing — and `setKeyBorder(_:)` only repairs an exact zero, so
+        // toggling it off and on would not recover either.
+        let bordered = Data(#"""
+        {"id": "abc", "name": "Mine", "keyBorder": {"type": "fixed", "hex": "#FFFFFF1F"}, "keyBorderWidth": 0}
+        """#.utf8)
+        let decoded = try JSONDecoder().decode(KeyboardThemeDefinition.self, from: bordered)
+        #expect(decoded.keyBorder != nil)
+        #expect(decoded.keyBorderWidth == KeyboardThemeDefinition.minimumKeyBorderWidth)
+
+        // Without a border color the width is inert, and Classic legitimately
+        // stores zero there.
+        let borderless = Data(#"""
+        {"id": "abc", "name": "Mine", "keyBorderWidth": 0}
+        """#.utf8)
+        #expect(try JSONDecoder().decode(KeyboardThemeDefinition.self, from: borderless).keyBorderWidth == 0)
+    }
+
     @Test func aThemeWithOneMalformedFieldSurvivesTheArchive() throws {
         // The damage path in full: `FailableTheme` would drop the theme, and
         // the next save would write that loss back over the original.
@@ -569,6 +589,27 @@ struct ThemeEditingTests {
         #expect(ThemeStore.userThemes(defaults: defaults).isEmpty)
         #expect(defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == BuiltInThemes.classic.id)
         #expect(defaults.string(forKey: SettingsKey.selectedThemeDark.rawValue) == BuiltInThemes.classic.id)
+    }
+
+    @Test func readingUserThemesSeesAWriteFromAnotherProcess() throws {
+        // `userThemes()` memoizes the decode. The cache is keyed on the stored
+        // bytes rather than invalidated by the writers, because the host app
+        // and the keyboard extension are separate processes — a write in one
+        // must not leave the other serving a stale list.
+        let defaults = try isolatedDefaults()
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-1"
+        theme.name = "First"
+        ThemeStore.saveUserTheme(theme, defaults: defaults)
+        #expect(ThemeStore.userThemes(defaults: defaults).map(\.name) == ["First"])
+
+        // Written the way the other process would: straight into defaults,
+        // bypassing every in-process code path that could invalidate a cache.
+        let renamed = Data("""
+        {"schemaVersion": 1, "themes": [{"id": "user-1", "name": "Renamed Elsewhere"}]}
+        """.utf8)
+        defaults.set(renamed, forKey: SettingsKey.userThemes.rawValue)
+        #expect(ThemeStore.userThemes(defaults: defaults).map(\.name) == ["Renamed Elsewhere"])
     }
 
     @Test func writingDoesNotClobberANewerSchemaArchive() throws {

--- a/wurstfingerTests/ThemeEngineTests.swift
+++ b/wurstfingerTests/ThemeEngineTests.swift
@@ -229,3 +229,92 @@ struct ThemeMigrationTests {
         #expect(ThemeStore.theme(id: "user-abc", defaults: defaults) == theme)
     }
 }
+
+// MARK: - Editing
+
+struct ThemeEditingTests {
+    private func isolatedDefaults() throws -> UserDefaults {
+        let name = "theme-editing-tests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: name))
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
+    @Test func isBuiltInIsDerivedFromId() {
+        #expect(BuiltInThemes.classic.isBuiltIn)
+        #expect(BuiltInThemes.darkGold.isBuiltIn)
+        var user = BuiltInThemes.darkGold
+        user.id = UUID().uuidString
+        #expect(!user.isBuiltIn)
+    }
+
+    @Test func duplicateMakesEditableCopyPreservingColors() {
+        let source = BuiltInThemes.darkGold
+        let copy = ThemeStore.duplicate(source, existing: [])
+        #expect(copy.id != source.id)
+        #expect(!copy.isBuiltIn)
+        // Colors carry over untouched; only identity/name change.
+        #expect(copy.keyFill == source.keyFill)
+        #expect(copy.mainLabel == source.mainLabel)
+        #expect(copy.name != source.displayName)
+        #expect(copy.name.contains(source.displayName))
+    }
+
+    @Test func duplicateNamesStayUnique() {
+        let source = BuiltInThemes.darkGold
+        let first = ThemeStore.duplicate(source, existing: [])
+        let second = ThemeStore.duplicate(source, existing: [first])
+        #expect(first.name != second.name)
+    }
+
+    @Test func upsertAppendsThenReplacesById() {
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-1"
+        var list = ThemeStore.upsert(theme, into: [])
+        #expect(list.count == 1)
+        theme.name = "Renamed"
+        list = ThemeStore.upsert(theme, into: list)
+        #expect(list.count == 1)
+        #expect(list[0].name == "Renamed")
+    }
+
+    @Test func upsertRejectsBuiltInIds() {
+        let list = ThemeStore.upsert(BuiltInThemes.classic, into: [])
+        #expect(list.isEmpty)
+    }
+
+    @Test func deleteRepointsSelectedSlotsToClassic() throws {
+        let defaults = try isolatedDefaults()
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-selected"
+        ThemeStore.saveUserTheme(theme, defaults: defaults)
+        defaults.set(theme.id, forKey: SettingsKey.selectedThemeLight.rawValue)
+        defaults.set(theme.id, forKey: SettingsKey.selectedThemeDark.rawValue)
+
+        ThemeStore.deleteUserTheme(id: theme.id, defaults: defaults)
+        #expect(ThemeStore.userThemes(defaults: defaults).isEmpty)
+        #expect(defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == BuiltInThemes.classic.id)
+        #expect(defaults.string(forKey: SettingsKey.selectedThemeDark.rawValue) == BuiltInThemes.classic.id)
+    }
+
+    @Test func deleteLeavesUnrelatedSelectionUntouched() throws {
+        let defaults = try isolatedDefaults()
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-doomed"
+        ThemeStore.saveUserTheme(theme, defaults: defaults)
+        defaults.set("dark-gold", forKey: SettingsKey.selectedThemeLight.rawValue)
+
+        ThemeStore.deleteUserTheme(id: theme.id, defaults: defaults)
+        #expect(defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == "dark-gold")
+    }
+
+    @Test func colorBridgeProducesRoundTrippableFixedHex() throws {
+        let color = try #require(HexColor.color(from: "#3366CC"))
+        let bridged = ThemeColor.from(color)
+        guard case let .fixed(hex) = bridged else {
+            Issue.record("expected a fixed color, got \(bridged)")
+            return
+        }
+        #expect(HexColor.parse(hex)?.rgb == 0x3366CC)
+    }
+}

--- a/wurstfingerTests/ThemeEngineTests.swift
+++ b/wurstfingerTests/ThemeEngineTests.swift
@@ -321,45 +321,66 @@ struct ThemeGestureTrailTests {
         #expect(theme.resolved().gestureTrail == BuiltInThemes.classic.resolved().gestureTrail)
     }
 
-    @Test func everyBuiltInTrailContrastsWithItsKeyColor() throws {
+    /// Contrast *ratio*, which is what the palette was tuned against — a raw
+    /// luminance delta diverges from it at the light end, where a #F2F2F7 key
+    /// with a 6 %-black trail clears a 0.1 delta at an invisible 1.13:1.
+    ///
+    /// Measured on the shipped palettes, per appearance: Classic 2.65:1 light
+    /// and 3.56:1 dark, Dark Gold 3.06:1 in both. Classic's light-mode ink on
+    /// a near-white key is the floor, so the bound sits just under it; Dark
+    /// Gold's own tuned 3.06:1 is pinned separately below.
+    @Test(arguments: [ColorScheme.light, .dark])
+    func everyBuiltInTrailContrastsWithItsKeyColor(appearance: ColorScheme) throws {
         // Glass keys have no color of their own to measure against.
         for theme in BuiltInThemes.all where theme.keySurface == .color {
-            let resolved = theme.resolved()
-            let key = try components(of: resolved.keyColor)
-            let trail = try components(of: resolved.gestureTrail)
-            let composited = luminance(of: trail.rgb, over: key.rgb, alpha: trail.alpha)
-            let delta = abs(composited - luminance(of: key.rgb, over: key.rgb, alpha: 1))
-            // Dark Gold's gold-over-slate sits at ~0.19 (3.06:1), Classic's
-            // ink-over-system-fill far above it.
-            #expect(delta > 0.1, "\(theme.id) trail barely differs from its key color")
+            let key = try #require(ThemeContrast.components(of: theme.keyColor, in: appearance))
+            let trail = try #require(ThemeContrast.components(of: theme.gestureTrail, in: appearance))
+            let ratio = ThemeContrast.ratio(of: trail, over: key)
+            #expect(ratio >= 2.5, "\(theme.id) trail is \(ratio):1 against its key color in \(appearance)")
         }
     }
 
-    private func components(of color: Color) throws -> HexColor.Components {
-        let hex = try #require(HexColor.string(from: color))
-        return try #require(HexColor.parse(hex))
-    }
-
-    /// WCAG relative luminance of `rgb` composited over the opaque `background`
-    /// at `alpha`.
-    private func luminance(of rgb: UInt32, over background: UInt32, alpha: Double) -> Double {
-        func channel(_ packed: UInt32, _ shift: UInt32) -> Double {
-            Double((packed >> shift) & 0xFF) / 255
-        }
-        func linear(_ value: Double) -> Double {
-            value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
-        }
-        let weights = [(16 as UInt32, 0.2126), (8 as UInt32, 0.7152), (0 as UInt32, 0.0722)]
-        return weights.reduce(0) { total, entry in
-            let mixed = alpha * channel(rgb, entry.0) + (1 - alpha) * channel(background, entry.0)
-            return total + entry.1 * linear(mixed)
-        }
+    /// The bound Dark Gold's gold was actually tuned to: 0.38 alpha reached
+    /// only 1.95:1 and disappeared under the finger, 0.65 reaches 3.06:1.
+    @Test func darkGoldTrailHoldsTheRatioItsPaletteWasTunedTo() throws {
+        let key = try #require(ThemeContrast.components(of: BuiltInThemes.darkGold.keyColor, in: .dark))
+        let trail = try #require(ThemeContrast.components(of: BuiltInThemes.darkGold.gestureTrail, in: .dark))
+        #expect(ThemeContrast.ratio(of: trail, over: key) >= 3.0)
     }
 }
 
 // MARK: - Resolver
 
 struct ThemeResolverTests {
+    /// The headline capability of the surface rework: the two surfaces are
+    /// independent. Every built-in has `boardSurface == keySurface`, so nothing
+    /// else in the suite would notice the resolver reading one surface's style
+    /// for the other's decision.
+    @Test func aGlassBoardUnderColorKeysResolvesEachSurfaceOnItsOwn() {
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-glass-board"
+        theme.boardSurface = .glass
+        theme.keySurface = .color
+
+        let resolved = theme.resolved()
+        #expect(!resolved.hasGlassKeys)
+        #expect(resolved.boardBackground == Color.gray.opacity(KeyboardThemeDefinition.minimumBoardOpacity))
+        // The key still paints its own color, not the glass constant.
+        #expect(resolved.keyColor == HexColor.color(from: "#333A48"))
+    }
+
+    @Test func glassKeysOverAColorBoardResolveEachSurfaceOnItsOwn() {
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-glass-keys"
+        theme.boardSurface = .color
+        theme.keySurface = .glass
+
+        let resolved = theme.resolved()
+        #expect(resolved.hasGlassKeys)
+        #expect(resolved.boardBackground == HexColor.color(from: "#252A34"))
+        #expect(resolved.boardBackground != Color.gray.opacity(KeyboardThemeDefinition.minimumBoardOpacity))
+    }
+
     @Test func unparsableHexFallsBackToClassicRole() {
         var theme = BuiltInThemes.darkGold
         theme.mainLabel = .fixed(hex: "garbage")
@@ -439,6 +460,9 @@ struct ThemeMigrationTests {
 
     @Test func selectionFallsBackThroughCascade() throws {
         let defaults = try isolatedDefaults()
+        // The flag has to be on, or the resolver never reads the dark slot at
+        // all and the cascade below is never entered.
+        defaults.set(true, forKey: SettingsKey.themeSeparateDarkSlot.rawValue)
         // Dark slot points at a nonexistent theme → falls back to the light
         // slot, then Classic.
         defaults.set("dark-gold", forKey: SettingsKey.selectedThemeLight.rawValue)
@@ -446,6 +470,27 @@ struct ThemeMigrationTests {
         #expect(ThemeStore.selectedTheme(for: .dark, defaults: defaults).id == "dark-gold")
         defaults.set("also-gone", forKey: SettingsKey.selectedThemeLight.rawValue)
         #expect(ThemeStore.selectedTheme(for: .dark, defaults: defaults).id == "classic")
+    }
+
+    /// The same cascade with a theme that is *stored* but no longer decodes —
+    /// the archive drops the corrupt entry, so the dark slot resolves to
+    /// nothing and the light slot has to take over.
+    @Test func aDarkSlotPointingAtAnUndecodableThemeFallsBackToTheLightSlot() throws {
+        let defaults = try isolatedDefaults()
+        let stored = Data("""
+        {"schemaVersion": 1, "themes": [
+            {"id": "user-light", "name": "Mine"},
+            {"name": "user-dark"}
+        ]}
+        """.utf8)
+        defaults.set(stored, forKey: SettingsKey.userThemes.rawValue)
+        defaults.set(true, forKey: SettingsKey.themeSeparateDarkSlot.rawValue)
+        defaults.set("user-light", forKey: SettingsKey.selectedThemeLight.rawValue)
+        defaults.set("user-dark", forKey: SettingsKey.selectedThemeDark.rawValue)
+
+        #expect(ThemeStore.theme(id: "user-dark", defaults: defaults) == nil)
+        #expect(ThemeStore.selectedTheme(for: .dark, defaults: defaults).id == "user-light")
+        #expect(ThemeStore.selectedTheme(for: .light, defaults: defaults).id == "user-light")
     }
 
     @Test func userThemesPersistThroughStore() throws {


### PR DESCRIPTION
Replaces the three hardcoded `KeyboardStyle` cases with a theme engine where a theme is data rather than a code path. Classic, Liquid Glass and Dark Gold become built-in themes rendered through one resolver, the user can duplicate any of them and edit the copy, and Liquid Glass turns from a theme into a switch you can throw per surface.

This supersedes #255, #256 and #257. They were a stacked chain whose CI never ran: `pr-tests.yml` triggers only on pull requests targeting `develop`, and none of them did, so their green rollups contained nothing but CodeRabbit. Merging them into one PR also removes a hazard. Everything that touches the persisted format now lands together, so no TestFlight build can store themes in a shape a later milestone changes. #255 is dropped entirely, because the rework keeps three immutable built-ins instead of sixteen palettes and every file that PR added is deleted by it.

## The model

`KeyboardThemeDefinition` is the persisted description of a theme: two surfaces, six label roles, a border, a corner radius and the gesture-trail color. `ResolvedTheme` is its flat, `Equatable` render form, resolved once in the root view and injected through the environment, so key views no longer each read `@AppStorage`.

`ThemeColor` has three cases: `semantic` (system color plus opacity), `fixed` (`#RRGGBB` / `#RRGGBBAA`) and `adaptive` (a light/dark hex pair). Semantic and adaptive stay trait-dynamic, so nothing re-resolves on an appearance change.

Decoding is tolerant by construction: only `id` and `name` can throw, every other field degrades to its Classic value. `Archive.FailableTheme` swallows a throw by discarding the whole theme, and the next save rewrites the archive from that lossy read. Without the tolerance, one unreadable field would cost the user a whole theme, permanently.

## Liquid Glass is a surface style, not a theme

`BoardSurfaceStyle` and `KeySurfaceStyle` each hold `color` or `glass`, and the color fields stay in the model while glass is on. Switching glass off therefore restores the user's own color, and the editor needs no shadow copy of the palette.

The two `glass` cases are deliberately not the same thing. On the keys it is a material: native `glassEffect` on iOS 26, the `.bar` fallback below. On the board it is a color. The board is the surface that keeps the gaps between keys tappable (#198), so it is always rendered, and `glass` only means "get out of the way of the `UIInputView(.keyboard)` backdrop".

`keyColor` is never the glass tint. If one value served as both, a Classic copy with glass on would render an opaque tinted pane, and a Liquid Glass copy with glass off would render nearly invisible keys.

Applying glass to the label layer instead of a background layer had a consequence nobody caught until the final review: the pane was sized by its content. A key with no swipe hints has almost none, so delete and return shrank to their glyph, and the space bar (whose label is deliberately empty) rendered nothing at all while still taking touches. Fixed, and verified on an iOS 26.2 simulator before and after.

## Gesture trail

The trail color becomes a theme role. Its alpha now applies literally: the `0.38` constant is no longer multiplied in again at draw time, so a color picked at full opacity renders at full opacity instead of silently at 38 %. Dark Gold uses gold at `A6`. Gold at `0.38` measures 1.95:1 against its keys, which is too faint, and white would collide with the label roles that are already white.

## The screens

### Style

Every theme row carries visible Duplicate, Edit and Delete buttons, driven by one `rowActions(for:)` so the context menu can never offer more than the row does. Built-ins offer only select and duplicate. "My Themes" is always visible, with a footer explaining why the built-ins cannot be edited.

### Theme editor

The flat "Surfaces" section splits into Keys and Background, each with its own Liquid Glass switch. Color wells hide rather than disable while glass is on, because a disabled well still shows a swatch and implies it does something, and the footers explain what has no effect. Border and corner radius stay visible in every state: corner radius shapes glass too, and the border is drawn on the pre-iOS-26 fallback, which is a large share of installs at a deployment target of iOS 17.

The editor previews through the real renderer via `InteractiveKeyboardPreview(themeOverride:)`. The static preview grid it replaces was a second renderer that had already drifted and knew nothing about glass or the trail. The editor also inherits the gallery's appearance override and geometry, so a theme destined for the dark slot is judged in dark mode and at the user's real keyboard size.

## Persistence

The engine has never shipped, so there is no released format to keep. `ThemeStore.migrateIfNeeded` still maps the legacy `keyboardStyle` string onto theme ids and is unchanged. Themes written by a pre-rework dev build are read through a clearly marked legacy block, so they keep their surfaces instead of resetting to Classic while their labels survive, which produced gold on near-white.

`schemaVersion` stays at 1. Reading a newer archive yields no themes, and writing now refuses to overwrite one. On its own, the read-side guard only converted "write back a mangled theme" into "write back nothing".

## Localization

Fourteen new keys in 22 languages, plus three the rework orphaned. `viewLiteralRegex` could not see `ColorPicker`, because there is no word boundary inside the word and `\bPicker\(` never matched. Every color-well label was therefore invisible to CI and would have shipped as raw English with a green build.

"Dark Gold" carried `shouldTranslate: false` and a comment calling it a proper name while shipping 22 real translations that the extension's catalog already served without the flag. Keeping the translations, dropping the flag.

## Verification

- 1307 unit tests green, serial run. `swiftformat --lint`, `swiftlint --strict` and markdownlint clean.
- Classic renders pixel-identically to `develop`. Both branches generated the full documentation screenshot set on the same simulator, and all 17 images differ in 0.00000 % of pixels, well under the 0.1 % the screenshot job treats as a change.
- Liquid Glass rendered on iOS 26.2 and on iOS 18.6, through `SCREENSHOT_MODE` with `FORCE_THEME=liquid-glass`. That is how the collapsed space bar surfaced, and how the `.bar` fallback with its hairline border was confirmed.
- Every test added here was checked by mutating the production line it claims to cover and confirming it goes red.

Still to do on a device, and not reachable in the simulator: the Dark Gold trail alpha in motion, glass over real host content, the four toggle combinations on a copy of each built-in, and the #198 dead-zone check inside the real extension rather than the host preview.

## Deliberately deferred

Migrating the style screen from its hand-built `ScrollView` to a `Form` along with the remaining accessibility defects there, `keyboardStyleDescription` in `SettingsView` reading only the light slot, and a Reduce Transparency fallback for glass themes. None of them is introduced by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added keyboard appearance themes, including Classic, Liquid Glass, and Dark Gold.
  - Added separate light and dark theme assignments.
  - Added custom theme creation, editing, duplication, deletion, previews, borders, colors, and gesture-trail customization.
  - Added adaptive theme rendering across supported system versions.
  - Added reliable theme persistence and migration from previous appearance settings.
  - Added localized names and descriptions for built-in themes.

- **Improvements**
  - App Store screenshots and previews can use a consistent selected theme.
  - Keyboard backgrounds and rendering now follow the active theme more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->