### PR TITLE
Anchor Keyboard Size in Points via Single Layout Metrics Resolver

### DIFF
--- a/wurstfinger/AppStoreScreenshotView.swift
+++ b/wurstfinger/AppStoreScreenshotView.swift
@@ -26,24 +26,16 @@ struct AppStoreScreenshotView: View {
             // Text input bar directly above keyboard
             textInputBar
 
-            // Keyboard at the bottom. The grid stretches its columns to fill
-            // the width the root view derives, so pass the width at which the
-            // cells come out exactly square (the square marketing look) —
-            // works together with keyboardScale = 1.0 set in
-            // configureFromEnvironment, otherwise the scale would apply twice.
-            DataDrivenKeyboardRootView(
-                viewModel: viewModel,
-                overrideWidth: KeyboardConstants.Calculations.squareKeyboardWidth(
-                    aspectRatio: viewModel.keyAspectRatio,
-                    scale: viewModel.keyboardScale,
-                    columns: viewModel.currentArrangement?.columns ?? 4
-                )
-            )
-            .frame(maxWidth: .infinity)
-            // `.contain` promotes the per-key accessibilityIdentifiers into
-            // a queryable container so UI tests can find keys by slot id.
-            .accessibilityElement(children: .contain)
-            .accessibilityIdentifier("screenshotKeyboard")
+            // Keyboard at the bottom. Its geometry is fully forced onto the
+            // non-persisting view model in configureFromEnvironment (square
+            // cells at the full reference key height), so the standard render
+            // path applies with no extra overrides here.
+            DataDrivenKeyboardRootView(viewModel: viewModel)
+                .frame(maxWidth: .infinity)
+                // `.contain` promotes the per-key accessibilityIdentifiers into
+                // a queryable container so UI tests can find keys by slot id.
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier("screenshotKeyboard")
         }
         .ignoresSafeArea(edges: [.top, .bottom])
         .background(Color(.systemBackground))
@@ -174,14 +166,23 @@ struct AppStoreScreenshotView: View {
     private func configureFromEnvironment() {
         let env = ProcessInfo.processInfo.environment
 
-        // Unscaled keys; the keyboard width comes from squareKeyboardWidth
-        // in the body, so keys render 1:1 at full key height.
-        viewModel.keyboardScale = 1.0
-
         // Load the forced language (default: English for App Store screenshots)
         // on the view model only — the screenshot view must never persist into
         // the real shared app-group store (`shouldPersistSettings: false`).
         viewModel.loadDefinition(for: env["FORCE_LANGUAGE"] ?? "en_US")
+
+        // Square marketing cells (the marketing look): with point-anchored
+        // metrics, aspect ratio 1.0 makes the cells square at any width; the
+        // width below sizes them at exactly the full reference key height.
+        // Forcing all layout inputs on the non-persisting view model means
+        // shouldPersistSettings: false fully controls rendering — nothing is
+        // read from (or written to) the user's real settings store.
+        viewModel.keyAspectRatio = 1.0
+        viewModel.keyboardHorizontalPosition = 0.5
+        viewModel.keyboardWidth = KeyboardConstants.Calculations.squareKeyboardWidth(
+            cellSize: KeyboardConstants.Calculations.keyHeight(aspectRatio: 1.0),
+            columns: viewModel.currentArrangement?.columns ?? 4
+        )
 
         // Set keyboard mode
         if let forcedLayer = env["FORCE_LAYER"] {

--- a/wurstfinger/AspectRatioSettingsView.swift
+++ b/wurstfinger/AspectRatioSettingsView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 struct AspectRatioSettingsView: View {
     @Binding var aspectRatio: Double
 
-    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
-    private var keyboardScale = DeviceLayoutUtils.defaultKeyboardScale
+    @AppStorage(SettingsKey.keyboardWidthPoints.rawValue, store: SharedDefaults.store)
+    private var keyboardWidth = DeviceLayoutUtils.defaultKeyboardWidth
 
     @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
     private var keyboardHorizontalPosition = DeviceLayoutUtils.defaultKeyboardPosition
@@ -19,7 +19,7 @@ struct AspectRatioSettingsView: View {
     var body: some View {
         VStack(spacing: 20) {
             // Keyboard Preview
-            InteractiveKeyboardPreview(aspectRatio: $aspectRatio, scale: $keyboardScale, position: $keyboardHorizontalPosition)
+            InteractiveKeyboardPreview(aspectRatio: $aspectRatio, width: $keyboardWidth, position: $keyboardHorizontalPosition)
                 .padding(.horizontal, 16)
 
             // Slider Section

--- a/wurstfinger/ExpertSettingsView.swift
+++ b/wurstfinger/ExpertSettingsView.swift
@@ -54,13 +54,24 @@ struct ExpertSettingsView: View {
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var keyAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 
-    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
-    private var keyboardScale = DeviceLayoutUtils.defaultKeyboardScale
+    @AppStorage(SettingsKey.keyboardWidthPoints.rawValue, store: SharedDefaults.store)
+    private var keyboardWidth = DeviceLayoutUtils.defaultKeyboardWidth
 
     /// The key height the user actually sees, derived from the shared layout
-    /// calculation and the stored scale.
+    /// metrics resolved from the stored width + aspect-ratio wish. Resolved
+    /// unclamped (no container/screen context) so the indicator reflects the
+    /// device- and orientation-independent wish, matching the size slider.
     private var effectiveKeyHeight: Double {
-        KeyboardConstants.Calculations.keyHeight(aspectRatio: keyAspectRatio) * keyboardScale
+        // The MessagEase grid is 4 columns wide (matches the reference
+        // metrics); the height indicator is column-count independent in
+        // practice, but resolve() needs a concrete value.
+        Double(KeyboardLayoutMetrics.resolve(
+            wishWidth: keyboardWidth,
+            aspectRatio: keyAspectRatio,
+            columns: 4,
+            availableWidth: 0,
+            screenHeight: 0
+        ).cellHeight)
     }
 
     var body: some View {

--- a/wurstfinger/HapticSettingsView.swift
+++ b/wurstfinger/HapticSettingsView.swift
@@ -19,8 +19,8 @@ struct HapticSettingsView: View {
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var previewAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 
-    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
-    private var previewScale = DeviceLayoutUtils.defaultKeyboardScale
+    @AppStorage(SettingsKey.keyboardWidthPoints.rawValue, store: SharedDefaults.store)
+    private var previewWidth = DeviceLayoutUtils.defaultKeyboardWidth
 
     @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
     private var previewPosition = DeviceLayoutUtils.defaultKeyboardPosition
@@ -28,7 +28,7 @@ struct HapticSettingsView: View {
     var body: some View {
         VStack(spacing: 20) {
             // Keyboard Preview
-            InteractiveKeyboardPreview(aspectRatio: $previewAspectRatio, scale: $previewScale, position: $previewPosition)
+            InteractiveKeyboardPreview(aspectRatio: $previewAspectRatio, width: $previewWidth, position: $previewPosition)
                 .padding(.horizontal, 16)
 
             ScrollView {

--- a/wurstfinger/InteractiveKeyboardPreview.swift
+++ b/wurstfinger/InteractiveKeyboardPreview.swift
@@ -43,32 +43,30 @@ private class PreviewTextTarget: TextInputTarget, ObservableObject {
 
 struct InteractiveKeyboardPreview: View {
     @Binding var aspectRatio: Double
-    @Binding var scale: Double
+    /// Keyboard width wish in points (mirrors the persisted setting).
+    @Binding var width: Double
     @Binding var position: Double
 
     @StateObject private var previewViewModel = KeyboardViewModel(shouldPersistSettings: false)
     @StateObject private var previewTarget = PreviewTextTarget()
 
     init(
-        aspectRatio: Binding<Double> = .constant(1.5),
-        scale: Binding<Double> = .constant(1.0),
+        aspectRatio: Binding<Double> = .constant(1.0),
+        width: Binding<Double> = .constant(DeviceLayoutUtils.defaultKeyboardWidth),
         position: Binding<Double> = .constant(0.5)
     ) {
         _aspectRatio = aspectRatio
-        _scale = scale
+        _width = width
         _position = position
     }
 
     private var previewHeight: CGFloat {
-        // Mirror the real keyboard height: shared base-height formula, scaled.
-        // The bindings drive the preview view model, so they are the
-        // authoritative source for layout inputs here.
-        let scaledHeight = KeyboardConstants.Calculations.baseHeight(aspectRatio: aspectRatio) * scale
-
-        // Near full scale the preview reserves more minimum room so the
-        // keyboard is never squeezed below its natural size.
-        let minHeight: CGFloat = scale < 0.99 ? KeyboardConstants.Preview.minHeight : 200
-        return min(KeyboardConstants.Preview.maxHeight, max(minHeight, scaledHeight))
+        // Same metrics the keyboard itself renders from, resolved against
+        // the preview's container (the parents inset it 16 pt per side), so
+        // the frame height always matches the rendered content height.
+        let containerWidth = DeviceLayoutUtils.screenBounds.width - 32
+        let metrics = previewViewModel.layoutMetrics(forContainerWidth: containerWidth)
+        return min(KeyboardConstants.Preview.maxHeight, max(KeyboardConstants.Preview.minHeight, metrics.totalHeight))
     }
 
     var body: some View {
@@ -107,19 +105,22 @@ struct InteractiveKeyboardPreview: View {
                 ZStack(alignment: .top) {
                     Color(.systemGray6)
 
+                    // The proxy width makes the preview lay out against its
+                    // real container instead of the full screen width, so the
+                    // fit-clamp and horizontal position match the extension.
                     DataDrivenKeyboardRootView(viewModel: previewViewModel, overrideWidth: proxy.size.width)
                         .onChange(of: aspectRatio) { _, newValue in
                             previewViewModel.keyAspectRatio = newValue
                         }
-                        .onChange(of: scale) { _, newValue in
-                            previewViewModel.keyboardScale = newValue
+                        .onChange(of: width) { _, newValue in
+                            previewViewModel.keyboardWidth = newValue
                         }
                         .onChange(of: position) { _, newValue in
                             previewViewModel.keyboardHorizontalPosition = newValue
                         }
                         .onAppear {
                             previewViewModel.keyAspectRatio = aspectRatio
-                            previewViewModel.keyboardScale = scale
+                            previewViewModel.keyboardWidth = width
                             previewViewModel.keyboardHorizontalPosition = position
 
                             // Wire up preview text target and load definition
@@ -134,7 +135,7 @@ struct InteractiveKeyboardPreview: View {
             .frame(height: previewHeight)
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .animation(.easeInOut(duration: 0.2), value: aspectRatio)
-            .animation(.easeInOut(duration: 0.2), value: scale)
+            .animation(.easeInOut(duration: 0.2), value: width)
             .animation(.easeInOut(duration: 0.2), value: position)
         }
     }

--- a/wurstfinger/KeyboardSizePositionSettingsView.swift
+++ b/wurstfinger/KeyboardSizePositionSettingsView.swift
@@ -8,47 +8,59 @@
 import SwiftUI
 
 struct KeyboardSizePositionSettingsView: View {
-    @Binding var scale: Double
+    /// Keyboard width wish in points (the persisted value). The slider and
+    /// text field display it as a percentage of the device-class default.
+    @Binding var width: Double
     @Binding var position: Double
 
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var keyAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 
+    /// Slider range as percent of the device default (270 pt on iPhone):
+    /// 35 % ≈ 95 pt keeps the old 25 %-of-screen minimum reachable, 145 %
+    /// ≈ 392 pt covers a full iPhone width. Round values on purpose.
+    private static let minPercent: Double = 35
+    private static let maxPercent: Double = 145
+
+    /// Percent view onto the point-based wish width.
+    private var sizePercent: Binding<Double> {
+        Binding(
+            get: { width / DeviceLayoutUtils.defaultKeyboardWidth * 100 },
+            set: { width = $0 / 100 * DeviceLayoutUtils.defaultKeyboardWidth }
+        )
+    }
+
     var body: some View {
         VStack(spacing: 20) {
             // Keyboard Preview
-            InteractiveKeyboardPreview(aspectRatio: $keyAspectRatio, scale: $scale, position: $position)
+            InteractiveKeyboardPreview(aspectRatio: $keyAspectRatio, width: $width, position: $position)
                 .padding(.horizontal, 16)
 
-            // Scale Slider
+            // Size Slider
             VStack(spacing: 16) {
                 HStack {
-                    Text("Keyboard Scale")
+                    Text("Keyboard Size")
                         .font(.headline)
                     Spacer()
                     Spacer()
-                    TextField("Value", value: $scale, formatter: NumberFormatter.decimalFormatter(minimum: 0.25, maximum: 1.0))
-                        .keyboardType(.decimalPad)
-                        .textFieldStyle(.roundedBorder)
-                        .frame(width: 80)
-                        .multilineTextAlignment(.trailing)
+                    TextField(
+                        "Value",
+                        value: sizePercent,
+                        formatter: NumberFormatter.decimalFormatter(
+                            minimum: Self.minPercent, maximum: Self.maxPercent
+                        )
+                    )
+                    .keyboardType(.decimalPad)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 80)
+                    .multilineTextAlignment(.trailing)
                 }
 
                 VStack(spacing: 8) {
-                    Slider(value: $scale, in: 0.25 ... 1.0, step: 0.01)
-                        .onChange(of: scale) { oldValue, newValue in
-                            // Reset position to center when scale reaches 100%
-                            if newValue >= 1.0 && oldValue < 1.0 {
-                                position = 0.5
-                            }
-                        }
+                    Slider(value: sizePercent, in: Self.minPercent ... Self.maxPercent, step: 1)
 
                     HStack {
-                        Text("25%")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Spacer()
-                        Text("Compact")
+                        Text("35%")
                             .font(.caption)
                             .foregroundColor(.secondary)
                         Spacer()
@@ -56,37 +68,34 @@ struct KeyboardSizePositionSettingsView: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
                         Spacer()
-                        Text("Full Width")
+                        Text("145%")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
                 }
 
-                Text("Scale the keyboard to make it smaller. At 100% it fills the full width, at 25% it's much more compact.")
+                Text("Size relative to the standard keyboard. It stays the same in every orientation; if it does not fit, it shrinks to the screen.")
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
             .padding(.horizontal, 16)
 
-            // Position Slider (only enabled when scale < 1.0)
+            // Position Slider
             VStack(spacing: 16) {
                 HStack {
                     Text("Horizontal Position")
                         .font(.headline)
-                        .foregroundColor(scale < 1.0 ? .primary : .secondary)
                     Spacer()
                     TextField("Value", value: $position, formatter: NumberFormatter.decimalFormatter(minimum: 0.0, maximum: 1.0))
                         .keyboardType(.decimalPad)
                         .textFieldStyle(.roundedBorder)
                         .frame(width: 80)
                         .multilineTextAlignment(.trailing)
-                        .disabled(scale >= 1.0)
                 }
 
                 VStack(spacing: 8) {
                     Slider(value: $position, in: 0.0 ... 1.0, step: 0.01)
-                        .disabled(scale >= 1.0)
 
                     HStack {
                         Text("Left")
@@ -103,20 +112,12 @@ struct KeyboardSizePositionSettingsView: View {
                     }
                 }
 
-                if scale >= 1.0 {
-                    Text("Position is only available when scale is below 100%.")
-                        .font(.caption)
-                        .foregroundColor(.orange)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                } else {
-                    Text("Adjust the horizontal position of the keyboard when it's scaled below 100%.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+                Text("Adjust the horizontal position of the keyboard when it is narrower than the screen.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
             .padding(.horizontal, 16)
-            .animation(.easeInOut(duration: 0.2), value: scale >= 1.0)
 
             Spacer()
         }
@@ -126,7 +127,7 @@ struct KeyboardSizePositionSettingsView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("Reset") {
-                    scale = DeviceLayoutUtils.defaultKeyboardScale
+                    width = DeviceLayoutUtils.defaultKeyboardWidth
                     position = DeviceLayoutUtils.defaultKeyboardPosition
                 }
             }
@@ -136,6 +137,6 @@ struct KeyboardSizePositionSettingsView: View {
 
 #Preview {
     NavigationStack {
-        KeyboardSizePositionSettingsView(scale: .constant(0.7), position: .constant(0.5))
+        KeyboardSizePositionSettingsView(width: .constant(270), position: .constant(0.5))
     }
 }

--- a/wurstfinger/LabelVisibilitySettingsView.swift
+++ b/wurstfinger/LabelVisibilitySettingsView.swift
@@ -21,15 +21,15 @@ struct LabelVisibilitySettingsView: View {
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var previewAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 
-    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
-    private var previewScale = DeviceLayoutUtils.defaultKeyboardScale
+    @AppStorage(SettingsKey.keyboardWidthPoints.rawValue, store: SharedDefaults.store)
+    private var previewWidth = DeviceLayoutUtils.defaultKeyboardWidth
 
     @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
     private var previewPosition = DeviceLayoutUtils.defaultKeyboardPosition
 
     var body: some View {
         VStack(spacing: 16) {
-            InteractiveKeyboardPreview(aspectRatio: $previewAspectRatio, scale: $previewScale, position: $previewPosition)
+            InteractiveKeyboardPreview(aspectRatio: $previewAspectRatio, width: $previewWidth, position: $previewPosition)
                 .padding(.horizontal, 16)
 
             Form {

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -16,8 +16,8 @@ struct SettingsView: View {
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var keyAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 
-    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
-    private var keyboardScale = DeviceLayoutUtils.defaultKeyboardScale
+    @AppStorage(SettingsKey.keyboardWidthPoints.rawValue, store: SharedDefaults.store)
+    private var keyboardWidth = DeviceLayoutUtils.defaultKeyboardWidth
 
     @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
     private var keyboardHorizontalPosition = DeviceLayoutUtils.defaultKeyboardPosition
@@ -139,7 +139,7 @@ struct SettingsView: View {
                 )
             }
 
-            NavigationLink(destination: KeyboardSizePositionSettingsView(scale: $keyboardScale, position: $keyboardHorizontalPosition)) {
+            NavigationLink(destination: KeyboardSizePositionSettingsView(width: $keyboardWidth, position: $keyboardHorizontalPosition)) {
                 SettingsRow(
                     icon: "arrow.up.left.and.arrow.down.right",
                     color: .green,
@@ -248,7 +248,10 @@ struct SettingsView: View {
     }
 
     private var sizePositionDescription: String {
-        let scale = "\(Int(keyboardScale * 100))%"
+        // Percent relative to the device-class default width (the wish is
+        // stored in points; 100 % == DeviceLayoutUtils.defaultKeyboardWidth).
+        let percent = Int((keyboardWidth / DeviceLayoutUtils.defaultKeyboardWidth * 100).rounded())
+        let scale = "\(percent)%"
         return String(localized: "Scale: \(scale), Position: \(positionLabel(for: keyboardHorizontalPosition))")
     }
 

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -14,8 +14,8 @@ struct StyleSettingsView: View {
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var previewAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 
-    @AppStorage(SettingsKey.keyboardScale.rawValue, store: SharedDefaults.store)
-    private var previewScale = DeviceLayoutUtils.defaultKeyboardScale
+    @AppStorage(SettingsKey.keyboardWidthPoints.rawValue, store: SharedDefaults.store)
+    private var previewWidth = DeviceLayoutUtils.defaultKeyboardWidth
 
     @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
     private var previewPosition = DeviceLayoutUtils.defaultKeyboardPosition
@@ -23,7 +23,7 @@ struct StyleSettingsView: View {
     var body: some View {
         VStack(spacing: 20) {
             // Keyboard Preview
-            InteractiveKeyboardPreview(aspectRatio: $previewAspectRatio, scale: $previewScale, position: $previewPosition)
+            InteractiveKeyboardPreview(aspectRatio: $previewAspectRatio, width: $previewWidth, position: $previewPosition)
                 .padding(.horizontal, 16)
 
             ScrollView {

--- a/wurstfinger/wurstfingerApp.swift
+++ b/wurstfinger/wurstfingerApp.swift
@@ -20,9 +20,14 @@ struct wurstfingerApp: App {
     }
 
     init() {
+        // Migrate a legacy keyboardScale into keyboardWidthPoints BEFORE
+        // registering defaults: a registered width would make the key appear
+        // present and mask a pending migration.
+        LayoutSettings.migrateLegacyScaleIfNeeded(in: SharedDefaults.store)
+
         let defaults: [String: Any] = [
             SettingsKey.keyAspectRatio.rawValue: DeviceLayoutUtils.defaultKeyAspectRatio,
-            SettingsKey.keyboardScale.rawValue: DeviceLayoutUtils.defaultKeyboardScale,
+            SettingsKey.keyboardWidthPoints.rawValue: DeviceLayoutUtils.defaultKeyboardWidth,
             SettingsKey.keyboardHorizontalPosition.rawValue: DeviceLayoutUtils.defaultKeyboardPosition
         ]
         SharedDefaults.store.register(defaults: defaults)

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -192,13 +192,16 @@ final class KeyboardViewController: UIInputViewController {
     }
 
     private func updateKeyboardHeight() {
-        // Calculate keyboard height including both aspect ratio and scale
-        let baseHeight = KeyboardConstants.Calculations.baseHeight(aspectRatio: viewModel.keyAspectRatio)
-        // Apply scale to match the visual size from scaleEffect
-        let finalHeight = baseHeight * viewModel.keyboardScale
+        // Constraint height ≡ content height by construction: the metrics
+        // are the same source the SwiftUI grid renders from, so the fixed
+        // paddings/spacing are no longer scaled by the constraint while the
+        // content keeps them constant (review finding M7).
+        let finalHeight = viewModel.layoutMetrics.totalHeight
 
         if let constraint = heightConstraint {
-            constraint.constant = finalHeight
+            if constraint.constant != finalHeight {
+                constraint.constant = finalHeight
+            }
         } else {
             let constraint = view.heightAnchor.constraint(equalToConstant: finalHeight)
             constraint.priority = .defaultHigh
@@ -217,6 +220,12 @@ final class KeyboardViewController: UIInputViewController {
         // Stage Manager; UIApplication.shared is unavailable in extensions,
         // so the window is reached through the view hierarchy.
         viewModel.updateWindowBounds(view.window?.bounds)
+        // The resolved metrics depend on the container width and the
+        // current-orientation screen height (fit-clamps), so the height
+        // constraint must follow layout passes, not just viewWillAppear —
+        // rotation with the keyboard open never calls viewWillAppear.
+        // No-op when the height is unchanged.
+        updateKeyboardHeight()
     }
 
     override var needsInputModeSwitchKey: Bool {

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -43,21 +43,15 @@ struct DeviceLayoutUtils {
         UIScreen.main.bounds
     }
 
-    /// Calculates the default keyboard scale to achieve a target width of ~270pt
-    /// (which corresponds to ~67% of an iPhone 17 Pro width).
-    static var defaultKeyboardScale: Double {
-        let targetWidth: CGFloat = 270.0
-        let screenWidth = screenBounds.width
-
-        // Avoid division by zero
-        guard screenWidth > 0 else { return 1.0 }
-
-        // Calculate scale required to hit target width
-        let calculatedScale = targetWidth / screenWidth
-
-        // Clamp between reasonable min/max (e.g., 0.26 to 1.0)
-        // 0.26 is roughly iPad width (1024pt) -> 270/1024 = 0.26
-        return min(1.0, max(0.25, calculatedScale))
+    /// Default keyboard width wish per device class, in points.
+    ///
+    /// Points are the density-independent unit, so the default deliberately
+    /// never consults screen bounds: the previous screen-relative default
+    /// was orientation-dependent and halved the keyboard on a fresh install
+    /// opened in landscape (review finding H1).
+    static var defaultKeyboardWidth: Double {
+        // 320 pt on iPad is a provisional constant pending real iPad tuning.
+        UIDevice.current.userInterfaceIdiom == .pad ? 320.0 : 270.0
     }
 
     static let defaultKeyAspectRatio: Double = 1.0
@@ -147,9 +141,9 @@ final class KeyboardViewModel: ObservableObject {
         set { layoutSettings.keyAspectRatio = newValue }
     }
 
-    var keyboardScale: Double {
-        get { layoutSettings.keyboardScale }
-        set { layoutSettings.keyboardScale = newValue }
+    var keyboardWidth: Double {
+        get { layoutSettings.keyboardWidth }
+        set { layoutSettings.keyboardWidth = newValue }
     }
 
     var keyboardHorizontalPosition: Double {
@@ -274,6 +268,29 @@ final class KeyboardViewModel: ObservableObject {
     /// The active mode resolved from the current definition and mode name.
     var activeModeFromDefinition: KeyboardMode? {
         currentDefinition?.mode(activeModeName)
+    }
+
+    // MARK: - Layout Metrics
+
+    /// Resolved layout metrics for the tracked view width — the single
+    /// geometry source for the grid, key fonts, gesture classification, and
+    /// the controller's height constraint. Recomputed whenever settings
+    /// reload or `viewWidth`/`keyboardWidthCap` change (all `@Published`).
+    var layoutMetrics: KeyboardLayoutMetrics {
+        layoutMetrics(forContainerWidth: viewWidth)
+    }
+
+    /// Metrics resolved against an explicit container width, for preview and
+    /// screenshot surfaces that render at a width other than the tracked
+    /// view width. The height guard reads the *screen* bounds — the
+    /// extension's own window is only keyboard-sized and carries no usable
+    /// height information (see `updateWindowBounds`).
+    func layoutMetrics(forContainerWidth width: CGFloat) -> KeyboardLayoutMetrics {
+        layoutSettings.resolveMetrics(
+            columns: currentArrangement?.columns ?? 4,
+            availableWidth: width > 0 ? min(width, keyboardWidthCap) : keyboardWidthCap,
+            screenHeight: DeviceLayoutUtils.screenBounds.height
+        )
     }
 
     /// Pipeline hook: fires a confirmation tick for state-changing actions.

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -23,9 +23,12 @@ struct DataDrivenKeyboardRootView: View {
 
     var body: some View {
         let currentWidth = overrideWidth ?? viewModel.viewWidth
-        let baseWidth = min(currentWidth, viewModel.keyboardWidthCap)
-        let scaledWidth = baseWidth * viewModel.keyboardScale
-        let availableSpace = currentWidth - scaledWidth
+        // Single geometry source: the resolved metrics drive the keyboard
+        // width here and the row/cell sizes in the grid, so they can never
+        // desynchronize (the old split between the view-model width path and
+        // @AppStorage-read row heights was review finding M8/H3).
+        let metrics = viewModel.layoutMetrics(forContainerWidth: currentWidth)
+        let availableSpace = currentWidth - metrics.keyboardWidth
         let horizontalOffset = availableSpace * (viewModel.keyboardHorizontalPosition - 0.5)
 
         ZStack {
@@ -51,13 +54,12 @@ struct DataDrivenKeyboardRootView: View {
                     },
                     languageLabel: viewModel.currentLanguageLabel,
                     showLanguageLabel: viewModel.hasMultipleLanguages,
-                    keyboardScale: viewModel.keyboardScale,
-                    keyAspectRatio: viewModel.keyAspectRatio
+                    metrics: metrics
                 )
                 .padding(.horizontal, KeyboardConstants.Layout.horizontalPadding)
                 .padding(.top, KeyboardConstants.Layout.verticalPaddingTop)
                 .padding(.bottom, KeyboardConstants.Layout.verticalPaddingBottom)
-                .frame(width: scaledWidth)
+                .frame(width: metrics.keyboardWidth)
                 .offset(x: horizontalOffset)
             }
         }

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -37,12 +37,11 @@ struct KeyView: View {
     @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
     private var keyboardStyle: KeyboardStyle = .classic
 
-    /// Injected by `KeyboardGridView` from the view model (same reasoning as
-    /// there: an `@AppStorage` read desynchronizes from the width path when
-    /// the view model is configured programmatically). Feeds the gesture
+    /// Resolved layout metrics injected by `KeyboardGridView` (same reasoning
+    /// as there: an `@AppStorage` read desynchronizes from the width path
+    /// when the view model is configured programmatically). Feeds the gesture
     /// classification geometry and the font scaling.
-    var keyboardScale: Double = DeviceLayoutUtils.defaultKeyboardScale
-    var keyAspectRatio: Double = DeviceLayoutUtils.defaultKeyAspectRatio
+    var metrics: KeyboardLayoutMetrics = .reference
 
     /// Short language label (e.g. "DE") shown on the switch key, and whether to
     /// show it. Driven by the active keyboard locale via `KeyboardViewModel`
@@ -124,9 +123,10 @@ struct KeyView: View {
                 },
                 onTouchDown: { onTouchDown?() },
                 // Account for the spanned cell: a multi-row/-column key is not
-                // 1×1, so scale the base aspect ratio by columnSpan/rowSpan
-                // (spanRatio) to classify swipes against the real geometry.
-                aspectRatio: CGFloat(keyAspectRatio) * spanRatio,
+                // 1×1, so scale the rendered cell aspect ratio (from the same
+                // metrics that size the cell) by columnSpan/rowSpan (spanRatio)
+                // to classify swipes against the real geometry.
+                aspectRatio: metrics.cellAspectRatio * spanRatio,
                 onLongPress: longPressHandler,
                 isActive: $isActive
             ))
@@ -167,22 +167,18 @@ struct KeyView: View {
         }
     }
 
-    /// Effective key height accounting for both keyboard scale and aspect ratio.
-    private var effectiveKeyHeight: CGFloat {
-        KeyboardConstants.Calculations.keyHeight(aspectRatio: keyAspectRatio) * keyboardScale
-    }
-
-    /// Scaled font size proportional to effective key height.
+    /// Scaled font size proportional to the rendered cell height
+    /// (`metrics.fontScale` is cell height over the reference key height).
     private var scaledFontSize: CGFloat {
         let base = Self.baseFontSize(for: key.style)
-        let scaled = base * (effectiveKeyHeight / KeyboardConstants.FontSizes.mainLabelReferenceHeight)
+        let scaled = base * metrics.fontScale
         return min(max(scaled, KeyboardConstants.FontSizes.mainLabelMinSize), KeyboardConstants.FontSizes.mainLabelMaxSize)
     }
 
-    /// Scaled hint font size proportional to effective key height.
+    /// Scaled hint font size proportional to the rendered cell height.
     private var scaledHintFontSize: CGFloat {
         let base = KeyboardConstants.FontSizes.hintBaseSize
-        let scaled = base * (effectiveKeyHeight / KeyboardConstants.FontSizes.hintReferenceHeight)
+        let scaled = base * metrics.fontScale
         return min(max(scaled, KeyboardConstants.FontSizes.hintMinSize), KeyboardConstants.FontSizes.hintMaxSize)
     }
 

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -27,21 +27,13 @@ struct KeyboardGridView: View {
     var languageLabel: String = ""
     var showLanguageLabel: Bool = false
 
-    /// Scale and aspect ratio are injected by `DataDrivenKeyboardRootView`
-    /// from the view model rather than read via `@AppStorage`: the root view
-    /// derives the keyboard *width* from the view model, and reading the same
+    /// Resolved layout metrics injected by `DataDrivenKeyboardRootView` from
+    /// the view model rather than read via `@AppStorage`: the root view
+    /// derives the keyboard *width* from the same metrics, and reading the
     /// settings from a second source desynchronizes width and row height
     /// whenever the view model is configured programmatically (screenshot and
     /// showcase modes with `shouldPersistSettings: false`).
-    var keyboardScale: Double = DeviceLayoutUtils.defaultKeyboardScale
-    var keyAspectRatio: Double = DeviceLayoutUtils.defaultKeyAspectRatio
-
-    /// Height of a single grid row, matching `KeyView`'s effective key height so
-    /// portrait layouts are unchanged and a 2-row key is exactly twice as tall
-    /// (plus the inter-row spacing).
-    private var rowHeight: CGFloat {
-        KeyboardConstants.Calculations.keyHeight(aspectRatio: keyAspectRatio) * keyboardScale
-    }
+    let metrics: KeyboardLayoutMetrics
 
     var body: some View {
         let cells = GridLayoutSolver.solve(arrangement)
@@ -49,7 +41,7 @@ struct KeyboardGridView: View {
         KeyboardGridLayout(
             cells: cells,
             columns: arrangement.columns,
-            rowHeight: rowHeight,
+            rowHeight: metrics.rowHeight,
             horizontalSpacing: KeyboardConstants.Layout.gridHorizontalSpacing,
             verticalSpacing: KeyboardConstants.Layout.gridVerticalSpacing
         ) {
@@ -70,8 +62,7 @@ struct KeyboardGridView: View {
                 onLongPress: onLongPress,
                 spanRatio: CGFloat(cell.columnSpan) / CGFloat(cell.rowSpan),
                 visualInset: visualInset(for: cell, totalRows: totalRows),
-                keyboardScale: keyboardScale,
-                keyAspectRatio: keyAspectRatio,
+                metrics: metrics,
                 languageLabel: languageLabel,
                 showLanguageLabel: showLanguageLabel
             )

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -52,11 +52,11 @@ enum KeyboardConstants {
         /// Normal hint label size (for less common characters).
         static let hintNormal: CGFloat = 10
 
-        // Main label dynamic scaling
+        // Main label dynamic scaling. Font sizes scale with the rendered
+        // cell height relative to `KeyDimensions.height` (see
+        // `KeyboardLayoutMetrics.fontScale`).
         /// Base size for main label scaling calculations.
         static let mainLabelBaseSize: CGFloat = 26
-        /// Reference key height for scaling calculations.
-        static let mainLabelReferenceHeight: CGFloat = KeyDimensions.height
         /// Minimum main label size to ensure readability.
         static let mainLabelMinSize: CGFloat = 20
         /// Maximum main label size to prevent overflow.
@@ -65,8 +65,6 @@ enum KeyboardConstants {
         // Hint label dynamic scaling
         /// Base size for hint label scaling.
         static let hintBaseSize: CGFloat = 14
-        /// Reference height for hint scaling.
-        static let hintReferenceHeight: CGFloat = KeyDimensions.height
         /// Minimum hint size to ensure readability.
         static let hintMinSize: CGFloat = 10
         /// Maximum hint size to prevent visual clutter.
@@ -221,23 +219,14 @@ enum KeyboardConstants {
             KeyDimensions.height * (KeyDimensions.referenceAspectRatio / aspectRatio)
         }
 
-        /// Calculates the total keyboard base height (without scaling)
-        static func baseHeight(aspectRatio: CGFloat) -> CGFloat {
-            let keyHeight = keyHeight(aspectRatio: aspectRatio)
-            return (keyHeight * CGFloat(KeyDimensions.totalRows)) +
-                (Layout.gridVerticalSpacing * CGFloat(KeyDimensions.totalRows - 1)) +
-                Layout.verticalPaddingTop + Layout.verticalPaddingBottom
-        }
-
-        /// Keyboard width at which the grid's cells come out exactly square:
-        /// the grid stretches its columns to fill the width the root view
-        /// gives it, so square keys are a property of the chosen width, not
-        /// of the aspect-ratio setting (whose clamp range starts at 1.0).
-        /// Used by the App Store screenshot mode to reproduce the square-key
-        /// marketing look.
-        static func squareKeyboardWidth(aspectRatio: CGFloat, scale: CGFloat, columns: Int) -> CGFloat {
-            let rowHeight = keyHeight(aspectRatio: aspectRatio) * scale
-            return (rowHeight * CGFloat(columns)) +
+        /// Keyboard width at which the grid's cells come out exactly
+        /// `cellSize` wide. Under the point-anchored metrics, square cells
+        /// are simply `keyAspectRatio == 1.0`, so this only converts a
+        /// desired cell size into the outer keyboard width (cells + gaps +
+        /// paddings). Used by the App Store screenshot mode to reproduce the
+        /// MessagEase marketing look at the full reference key height.
+        static func squareKeyboardWidth(cellSize: CGFloat, columns: Int) -> CGFloat {
+            (cellSize * CGFloat(columns)) +
                 (Layout.gridHorizontalSpacing * CGFloat(columns - 1)) +
                 (Layout.horizontalPadding * 2)
         }

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -224,7 +224,7 @@ enum KeyboardConstants {
         /// are simply `keyAspectRatio == 1.0`, so this only converts a
         /// desired cell size into the outer keyboard width (cells + gaps +
         /// paddings). Used by the App Store screenshot mode to reproduce the
-        /// MessagEase marketing look at the full reference key height.
+        /// square marketing look at the full reference key height.
         static func squareKeyboardWidth(cellSize: CGFloat, columns: Int) -> CGFloat {
             (cellSize * CGFloat(columns)) +
                 (Layout.gridHorizontalSpacing * CGFloat(columns - 1)) +

--- a/wurstfingerKeyboard/Settings/KeyboardLayoutMetrics.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardLayoutMetrics.swift
@@ -1,0 +1,151 @@
+//
+//  KeyboardLayoutMetrics.swift
+//  Wurstfinger
+//
+//  Single source of truth for the keyboard's rendered geometry.
+//
+//  The persisted settings are a *wish* (keyboard width in points + key aspect
+//  ratio); this type resolves them into the *result* for a concrete render
+//  context (container width, current screen height). The resolution is a pure
+//  function: fit-clamps may shrink the result, but the wish is never written
+//  back to the store — moving to a bigger device restores the wish.
+//
+
+import CoreGraphics
+import Foundation
+
+/// Resolved keyboard geometry derived from the persisted wish
+/// (`keyboardWidthPoints`, `keyAspectRatio`) and the render context.
+///
+/// All consumers — the SwiftUI grid, `KeyView` fonts, gesture classification,
+/// and the controller's height constraint — read from the same instance, so
+/// width, row height, and total height cannot desynchronize by construction.
+struct KeyboardLayoutMetrics: Equatable {
+    /// Resolved outer keyboard width in points, including the keyboard's own
+    /// horizontal paddings (`Layout.horizontalPadding` on each side).
+    let keyboardWidth: CGFloat
+    /// Width of a single 1×1 grid cell.
+    let cellWidth: CGFloat
+    /// Height of a single 1×1 grid cell. Exactly `cellWidth / aspectRatio`.
+    let cellHeight: CGFloat
+    /// Grid columns the width was resolved against.
+    let columns: Int
+    /// Grid rows the height was resolved against.
+    let rows: Int
+
+    /// Height of a single grid row (identical to the cell height; rows are
+    /// sized from the cells, not the other way around).
+    var rowHeight: CGFloat {
+        cellHeight
+    }
+
+    /// Cell aspect ratio (width/height) as actually rendered. Feeds gesture
+    /// classification so swipe geometry always matches the visible keys.
+    var cellAspectRatio: CGFloat {
+        cellHeight > 0 ? cellWidth / cellHeight : 1
+    }
+
+    /// Font/hint scale factor for `KeyView`, relative to the reference key
+    /// height at which the font size constants are defined (54 pt).
+    var fontScale: CGFloat {
+        cellHeight / KeyboardConstants.KeyDimensions.height
+    }
+
+    /// Total keyboard height: rows plus the constant inter-row spacing and
+    /// vertical paddings. This is both the SwiftUI content height and the
+    /// controller's height-constraint value — identical by construction.
+    var totalHeight: CGFloat {
+        cellHeight * CGFloat(rows) + Self.verticalChrome(rows: rows)
+    }
+
+    /// Maximum share of the *screen* height the keyboard may occupy. The
+    /// extension's own window is only keyboard-sized, so the height guard
+    /// must be evaluated against screen bounds, never window bounds.
+    static let maxScreenHeightFraction: CGFloat = 0.70
+
+    /// Reference metrics at the iPhone default wish (270 pt, square cells)
+    /// with no fit-clamp engaged. For tests and previews that need a valid
+    /// geometry without a render context.
+    static let reference = resolve(
+        wishWidth: 270,
+        aspectRatio: 1.0,
+        columns: 4,
+        availableWidth: 270,
+        screenHeight: 0
+    )
+
+    /// Resolves the persisted wish into concrete metrics for a render context.
+    ///
+    /// - Parameters:
+    ///   - wishWidth: Persisted keyboard width wish in points (device- and
+    ///     orientation-independent).
+    ///   - aspectRatio: Persisted cell aspect ratio (width/height).
+    ///   - columns: Columns of the active arrangement.
+    ///   - rows: Rows of the keyboard (letters + space row).
+    ///   - availableWidth: Actual container width (view width capped by the
+    ///     hosting window). The keyboard's own 12 pt horizontal paddings are
+    ///     part of `wishWidth`, so they double as the minimal side margin.
+    ///   - screenHeight: Screen height in the *current* orientation for the
+    ///     height guard. Pass `0` to skip the guard (unknown context).
+    static func resolve(
+        wishWidth: CGFloat,
+        aspectRatio: CGFloat,
+        columns: Int,
+        rows: Int = KeyboardConstants.KeyDimensions.totalRows,
+        availableWidth: CGFloat,
+        screenHeight: CGFloat
+    ) -> KeyboardLayoutMetrics {
+        let columns = max(columns, 1)
+        let rows = max(rows, 1)
+        // Harden against corrupt stored values: a zero/non-finite aspect
+        // ratio must not propagate NaN into the render tree.
+        let aspect = (aspectRatio.isFinite && aspectRatio > 0) ? aspectRatio : 1.0
+        let wish = (wishWidth.isFinite && wishWidth > 0) ? wishWidth : 270
+
+        // Width fit-clamp: the wish may exceed the hosting container
+        // (smaller device, Slide Over pane). Render smaller, never persist.
+        var width = availableWidth > 0 ? min(wish, availableWidth) : wish
+
+        let horizontalChrome = Self.horizontalChrome(columns: columns)
+        var cellWidth = max((width - horizontalChrome) / CGFloat(columns), 1)
+        var cellHeight = cellWidth / aspect
+
+        // Height guard: keep the keyboard within a fixed share of the screen
+        // (current orientation). Scale the cells proportionally — spacing and
+        // paddings are constants — so the aspect ratio is preserved exactly.
+        let verticalChrome = Self.verticalChrome(rows: rows)
+        if screenHeight > 0 {
+            let maxHeight = screenHeight * Self.maxScreenHeightFraction
+            let contentHeight = cellHeight * CGFloat(rows) + verticalChrome
+            if contentHeight > maxHeight {
+                let scale = max(maxHeight - verticalChrome, 0) / (cellHeight * CGFloat(rows))
+                cellWidth *= scale
+                cellHeight *= scale
+                width = cellWidth * CGFloat(columns) + horizontalChrome
+            }
+        }
+
+        return KeyboardLayoutMetrics(
+            keyboardWidth: width,
+            cellWidth: cellWidth,
+            cellHeight: cellHeight,
+            columns: columns,
+            rows: rows
+        )
+    }
+
+    /// Constant horizontal space around/between the cells: outer paddings
+    /// plus inter-column gaps. Never scaled.
+    static func horizontalChrome(columns: Int) -> CGFloat {
+        KeyboardConstants.Layout.horizontalPadding * 2 +
+            KeyboardConstants.Layout.gridHorizontalSpacing * CGFloat(max(columns, 1) - 1)
+    }
+
+    /// Constant vertical space around/between the rows: top/bottom paddings
+    /// plus inter-row gaps. Never scaled.
+    static func verticalChrome(rows: Int) -> CGFloat {
+        KeyboardConstants.Layout.verticalPaddingTop +
+            KeyboardConstants.Layout.verticalPaddingBottom +
+            KeyboardConstants.Layout.gridVerticalSpacing * CGFloat(max(rows, 1) - 1)
+    }
+}

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -22,7 +22,12 @@ enum SettingsKey: String {
     case hapticEnabled
     case utilityColumnLeading
     case keyAspectRatio
+    /// Legacy fraction-of-screen-width size. Read once to migrate into
+    /// `keyboardWidthPoints`; the stored value is kept for downgrade safety
+    /// but no longer consulted afterwards.
     case keyboardScale
+    /// Keyboard width wish in points (density- and orientation-independent).
+    case keyboardWidthPoints
     case keyboardHorizontalPosition
     case numpadStyle
     case selectedLanguageId
@@ -162,15 +167,19 @@ final class LayoutSettings: ObservableObject {
         }
     }
 
-    /// Keyboard scale relative to screen width. Range: 0.25 to 1.0
-    @Published var keyboardScale: Double {
+    /// Keyboard width wish in points. Range: 90 to 600.
+    ///
+    /// This is the *wish*: what the user asked for, independent of device
+    /// and orientation. The rendered *result* may be smaller (fit-clamped by
+    /// `KeyboardLayoutMetrics.resolve`), but the clamp is never written back.
+    @Published var keyboardWidth: Double {
         didSet {
-            let clamped = Self.clampScale(keyboardScale)
-            if clamped != keyboardScale {
-                keyboardScale = clamped
+            let clamped = Self.clampWidth(keyboardWidth)
+            if clamped != keyboardWidth {
+                keyboardWidth = clamped
                 return
             }
-            persistIfNeeded(clamped, forKey: .keyboardScale)
+            persistIfNeeded(clamped, forKey: .keyboardWidthPoints)
         }
     }
 
@@ -196,9 +205,7 @@ final class LayoutSettings: ObservableObject {
             ?? DeviceLayoutUtils.defaultKeyAspectRatio
         keyAspectRatio = Self.clampAspectRatio(savedRatio)
 
-        let savedScale = defaults.object(forKey: SettingsKey.keyboardScale.rawValue) as? Double
-            ?? DeviceLayoutUtils.defaultKeyboardScale
-        keyboardScale = Self.clampScale(savedScale)
+        keyboardWidth = Self.loadWishWidth(from: defaults, shouldPersist: shouldPersist)
 
         let savedPosition = defaults.object(forKey: SettingsKey.keyboardHorizontalPosition.rawValue) as? Double
             ?? DeviceLayoutUtils.defaultKeyboardPosition
@@ -215,15 +222,66 @@ final class LayoutSettings: ObservableObject {
         let newRatio = Self.clampAspectRatio(savedRatio)
         if keyAspectRatio != newRatio { keyAspectRatio = newRatio }
 
-        let savedScale = defaults.object(forKey: SettingsKey.keyboardScale.rawValue) as? Double
-            ?? DeviceLayoutUtils.defaultKeyboardScale
-        let newScale = Self.clampScale(savedScale)
-        if keyboardScale != newScale { keyboardScale = newScale }
+        let newWidth = Self.loadWishWidth(from: defaults, shouldPersist: shouldPersist)
+        if keyboardWidth != newWidth { keyboardWidth = newWidth }
 
         let savedPosition = defaults.object(forKey: SettingsKey.keyboardHorizontalPosition.rawValue) as? Double
             ?? DeviceLayoutUtils.defaultKeyboardPosition
         let newPosition = Self.clampPosition(savedPosition)
         if keyboardHorizontalPosition != newPosition { keyboardHorizontalPosition = newPosition }
+    }
+
+    // MARK: - Layout Metrics
+
+    /// Resolves the persisted wish (width + aspect ratio) into concrete
+    /// metrics for a render context. Pure: fit-clamps shrink the result but
+    /// never write back to the store.
+    func resolveMetrics(columns: Int, availableWidth: CGFloat, screenHeight: CGFloat) -> KeyboardLayoutMetrics {
+        KeyboardLayoutMetrics.resolve(
+            wishWidth: keyboardWidth,
+            aspectRatio: keyAspectRatio,
+            columns: columns,
+            availableWidth: availableWidth,
+            screenHeight: screenHeight
+        )
+    }
+
+    // MARK: - Migration
+
+    /// Performs the one-time legacy `keyboardScale` → `keyboardWidthPoints`
+    /// migration without constructing a settings instance. The host app calls
+    /// this at launch **before** registering defaults (a registered width
+    /// would make the key appear present and mask a pending migration); the
+    /// extension migrates in `init`/`reload`.
+    static func migrateLegacyScaleIfNeeded(in defaults: UserDefaults) {
+        _ = loadWishWidth(from: defaults, shouldPersist: true)
+    }
+
+    /// Loads the wish width, migrating a legacy `keyboardScale` exactly once.
+    ///
+    /// - A stored `keyboardWidthPoints` always wins (clamped on load).
+    /// - Otherwise a user-persisted legacy scale (fraction of screen width)
+    ///   is converted against the orientation-stable shortest screen side —
+    ///   on iPhone this preserves the rendered width existing users see —
+    ///   and persisted once. The legacy key stays in the store for downgrade
+    ///   safety; it is simply no longer read afterwards.
+    /// - With neither present, the device-class default applies and is NOT
+    ///   persisted (fallback only, like the other layout defaults).
+    private static func loadWishWidth(from defaults: UserDefaults, shouldPersist: Bool) -> Double {
+        if let stored = defaults.object(forKey: SettingsKey.keyboardWidthPoints.rawValue) as? Double {
+            return clampWidth(stored)
+        }
+        if let legacyScale = defaults.object(forKey: SettingsKey.keyboardScale.rawValue) as? Double {
+            let bounds = DeviceLayoutUtils.screenBounds
+            let shortestSide = min(bounds.width, bounds.height)
+            let clampedScale = min(1.0, max(0.25, legacyScale))
+            let width = clampWidth(clampedScale * shortestSide)
+            if shouldPersist {
+                defaults.set(width, forKey: SettingsKey.keyboardWidthPoints.rawValue)
+            }
+            return width
+        }
+        return DeviceLayoutUtils.defaultKeyboardWidth
     }
 
     // MARK: - Private Helpers
@@ -233,9 +291,10 @@ final class LayoutSettings: ObservableObject {
         min(1.62, max(1.0, value))
     }
 
-    /// Scale range: 0.25 (iPad minimum) to 1.0 (full width)
-    private static func clampScale(_ value: Double) -> Double {
-        min(1.0, max(0.25, value))
+    /// Wish-width range in points: 90 (below the old 0.25×iPhone-mini
+    /// minimum) to 600 (beyond any full iPhone width, room for iPad tuning).
+    private static func clampWidth(_ value: Double) -> Double {
+        min(600, max(90, value))
     }
 
     /// Position range: 0.0 (left) to 1.0 (right)

--- a/wurstfingerTests/KeyboardLayoutMetricsTests.swift
+++ b/wurstfingerTests/KeyboardLayoutMetricsTests.swift
@@ -1,0 +1,202 @@
+//
+//  KeyboardLayoutMetricsTests.swift
+//  wurstfingerTests
+//
+//  Tests for the point-anchored layout metrics resolver: aspect-ratio
+//  exactness, the total-height formula, orientation invariance, and the
+//  width/height fit-clamps (which must shrink proportionally and never
+//  persist anything).
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct KeyboardLayoutMetricsTests {
+    private let hChrome = KeyboardLayoutMetrics.horizontalChrome(columns: 4)
+    private let vChrome = KeyboardLayoutMetrics.verticalChrome(rows: 4)
+
+    // MARK: - Aspect exactness
+
+    @Test(arguments: [
+        (wish: CGFloat(270), aspect: CGFloat(1.0)),
+        (wish: CGFloat(270), aspect: CGFloat(1.3)),
+        (wish: CGFloat(270), aspect: CGFloat(1.62)),
+        (wish: CGFloat(120), aspect: CGFloat(1.0)),
+        (wish: CGFloat(390), aspect: CGFloat(1.5)),
+    ])
+    func cellAspectRatioMatchesSettingExactly(config: (wish: CGFloat, aspect: CGFloat)) {
+        let metrics = KeyboardLayoutMetrics.resolve(
+            wishWidth: config.wish,
+            aspectRatio: config.aspect,
+            columns: 4,
+            availableWidth: 1000,
+            screenHeight: 2000
+        )
+        #expect(abs(metrics.cellWidth / metrics.cellHeight - config.aspect) < 0.0001)
+        #expect(abs(metrics.cellAspectRatio - config.aspect) < 0.0001)
+    }
+
+    @Test func cellWidthDividesUsableWidthAcrossColumns() {
+        let metrics = KeyboardLayoutMetrics.resolve(
+            wishWidth: 270,
+            aspectRatio: 1.0,
+            columns: 4,
+            availableWidth: 1000,
+            screenHeight: 2000
+        )
+        #expect(metrics.keyboardWidth == 270)
+        #expect(abs(metrics.cellWidth - (270 - hChrome) / 4) < 0.0001)
+    }
+
+    // MARK: - Total height formula
+
+    @Test func totalHeightIsRowsPlusConstantChrome() {
+        let metrics = KeyboardLayoutMetrics.resolve(
+            wishWidth: 300,
+            aspectRatio: 1.2,
+            columns: 4,
+            availableWidth: 1000,
+            screenHeight: 2000
+        )
+        let expected = metrics.cellHeight * 4 + vChrome
+        #expect(abs(metrics.totalHeight - expected) < 0.0001)
+        // The chrome (spacing + paddings) is constant, never scaled:
+        // 3 × 5 pt inter-row gaps + 4 pt top + 10 pt bottom.
+        #expect(vChrome == CGFloat(5 * 3 + 4 + 10))
+    }
+
+    @Test func totalHeightMatchesRenderedGridContent() {
+        // Height-constraint ≡ content-height: the grid renders rows·rowHeight
+        // plus (rows−1)·spacing; adding the vertical paddings must give
+        // exactly totalHeight (the old formula scaled the paddings, M7).
+        let metrics = KeyboardLayoutMetrics.resolve(
+            wishWidth: 270,
+            aspectRatio: 1.0,
+            columns: 4,
+            availableWidth: 1000,
+            screenHeight: 2000
+        )
+        let gridContent = metrics.rowHeight * 4 +
+            KeyboardConstants.Layout.gridVerticalSpacing * 3
+        let content = gridContent +
+            KeyboardConstants.Layout.verticalPaddingTop +
+            KeyboardConstants.Layout.verticalPaddingBottom
+        #expect(abs(metrics.totalHeight - content) < 0.0001)
+    }
+
+    // MARK: - Orientation invariance
+
+    @Test func sameWishResolvesIdenticallyInPortraitAndLandscape() {
+        // Same wish, no clamp engaged in either orientation: the rendered
+        // keyboard must be identical (H1: the old screen-relative default
+        // halved the keyboard in landscape).
+        let portrait = KeyboardLayoutMetrics.resolve(
+            wishWidth: 270,
+            aspectRatio: 1.0,
+            columns: 4,
+            availableWidth: 393,
+            screenHeight: 852
+        )
+        let landscape = KeyboardLayoutMetrics.resolve(
+            wishWidth: 270,
+            aspectRatio: 1.0,
+            columns: 4,
+            availableWidth: 852,
+            screenHeight: 393
+        )
+        #expect(portrait == landscape)
+    }
+
+    // MARK: - Width fit-clamp
+
+    @Test func wishWiderThanContainerClampsToContainerPreservingAspect() {
+        let clamped = KeyboardLayoutMetrics.resolve(
+            wishWidth: 600,
+            aspectRatio: 1.3,
+            columns: 4,
+            availableWidth: 375,
+            screenHeight: 2000
+        )
+        #expect(clamped.keyboardWidth == 375)
+        #expect(abs(clamped.cellWidth - (375 - hChrome) / 4) < 0.0001)
+        #expect(abs(clamped.cellAspectRatio - 1.3) < 0.0001)
+    }
+
+    @Test func wishNarrowerThanContainerIsNotClamped() {
+        let metrics = KeyboardLayoutMetrics.resolve(
+            wishWidth: 340,
+            aspectRatio: 1.0,
+            columns: 4,
+            availableWidth: 375,
+            screenHeight: 2000
+        )
+        #expect(metrics.keyboardWidth == 340)
+    }
+
+    // MARK: - Height fit-clamp
+
+    @Test func heightGuardShrinksProportionallyAndPreservesAspect() {
+        // Landscape iPhone: screen height 393 → cap 275.1 pt. A big square
+        // wish overflows and must be scaled down, aspect preserved exactly.
+        let metrics = KeyboardLayoutMetrics.resolve(
+            wishWidth: 392,
+            aspectRatio: 1.0,
+            columns: 4,
+            availableWidth: 852,
+            screenHeight: 393
+        )
+        let maxHeight = 393 * KeyboardLayoutMetrics.maxScreenHeightFraction
+        #expect(abs(metrics.totalHeight - maxHeight) < 0.0001)
+        #expect(abs(metrics.cellAspectRatio - 1.0) < 0.0001)
+        // The width shrinks consistently with the cells (chrome constant).
+        let expectedWidth = metrics.cellWidth * 4 + hChrome
+        #expect(abs(metrics.keyboardWidth - expectedWidth) < 0.0001)
+        #expect(metrics.keyboardWidth < 392)
+    }
+
+    @Test func heightGuardIsSkippedWhenScreenHeightUnknown() {
+        let metrics = KeyboardLayoutMetrics.resolve(
+            wishWidth: 392,
+            aspectRatio: 1.0,
+            columns: 4,
+            availableWidth: 852,
+            screenHeight: 0
+        )
+        #expect(metrics.keyboardWidth == 392)
+    }
+
+    // MARK: - Clamps never persist
+
+    @Test func resolvingClampedMetricsNeverWritesBackToTheStore() {
+        let defaults = InMemoryUserDefaults()
+        let settings = LayoutSettings(defaults: defaults, shouldPersist: true)
+        settings.keyboardWidth = 600
+        #expect(defaults.object(forKey: SettingsKey.keyboardWidthPoints.rawValue) as? Double == 600)
+
+        let metrics = settings.resolveMetrics(columns: 4, availableWidth: 375, screenHeight: 812)
+        #expect(metrics.keyboardWidth == 375)
+
+        // The wish stays untouched: a bigger device restores the full width.
+        #expect(defaults.object(forKey: SettingsKey.keyboardWidthPoints.rawValue) as? Double == 600)
+        #expect(settings.keyboardWidth == 600)
+    }
+
+    // MARK: - Hardening
+
+    @Test func degenerateInputsProduceFiniteMetrics() {
+        let metrics = KeyboardLayoutMetrics.resolve(
+            wishWidth: .nan,
+            aspectRatio: 0,
+            columns: 0,
+            rows: 0,
+            availableWidth: -1,
+            screenHeight: .infinity
+        )
+        #expect(metrics.keyboardWidth.isFinite)
+        #expect(metrics.cellWidth > 0)
+        #expect(metrics.cellHeight > 0)
+        #expect(metrics.totalHeight.isFinite)
+    }
+}

--- a/wurstfingerTests/KeyboardSettingsTests.swift
+++ b/wurstfingerTests/KeyboardSettingsTests.swift
@@ -179,8 +179,9 @@ struct LayoutSettingsTests {
         let settings = LayoutSettings(defaults: defaults, shouldPersist: false)
 
         #expect(settings.utilityColumnLeading == false)
-        // Note: keyAspectRatio, keyboardScale, keyboardHorizontalPosition
-        // have device-dependent defaults
+        // The width default is a device-class constant, deliberately not
+        // derived from (orientation-dependent) screen bounds.
+        #expect(settings.keyboardWidth == DeviceLayoutUtils.defaultKeyboardWidth)
     }
 
     @Test func initLoadsPersistedValues() {
@@ -188,14 +189,14 @@ struct LayoutSettingsTests {
 
         defaults.set(true, forKey: SettingsKey.utilityColumnLeading.rawValue)
         defaults.set(1.3, forKey: SettingsKey.keyAspectRatio.rawValue)
-        defaults.set(0.8, forKey: SettingsKey.keyboardScale.rawValue)
+        defaults.set(300.0, forKey: SettingsKey.keyboardWidthPoints.rawValue)
         defaults.set(0.25, forKey: SettingsKey.keyboardHorizontalPosition.rawValue)
 
         let settings = LayoutSettings(defaults: defaults, shouldPersist: false)
 
         #expect(settings.utilityColumnLeading == true)
         #expect(abs(settings.keyAspectRatio - 1.3) < 0.01)
-        #expect(abs(settings.keyboardScale - 0.8) < 0.01)
+        #expect(abs(settings.keyboardWidth - 300.0) < 0.01)
         #expect(abs(settings.keyboardHorizontalPosition - 0.25) < 0.01)
     }
 
@@ -212,15 +213,24 @@ struct LayoutSettingsTests {
         #expect(settings.keyAspectRatio == 1.0)
     }
 
-    @Test func scaleClampedToValidRange() {
+    @Test func widthClampedToValidRange() {
         let defaults = createTestDefaults()
         let settings = LayoutSettings(defaults: defaults, shouldPersist: false)
 
-        settings.keyboardScale = 1.5 // above max (1.0)
-        #expect(settings.keyboardScale == 1.0)
+        settings.keyboardWidth = 10000 // above max (600)
+        #expect(settings.keyboardWidth == 600)
 
-        settings.keyboardScale = 0.1 // below min (0.25)
-        #expect(settings.keyboardScale == 0.25)
+        settings.keyboardWidth = 10 // below min (90)
+        #expect(settings.keyboardWidth == 90)
+    }
+
+    @Test func widthClampedOnLoad() {
+        let defaults = createTestDefaults()
+        defaults.set(10000.0, forKey: SettingsKey.keyboardWidthPoints.rawValue)
+
+        let settings = LayoutSettings(defaults: defaults, shouldPersist: false)
+
+        #expect(settings.keyboardWidth == 600)
     }
 
     @Test func positionClampedToValidRange() {
@@ -266,6 +276,90 @@ struct LayoutSettingsTests {
     }
 }
 
+// MARK: - Legacy Scale Migration Tests
+
+struct LayoutSettingsMigrationTests {
+    private var shortestScreenSide: Double {
+        Double(min(DeviceLayoutUtils.screenBounds.width, DeviceLayoutUtils.screenBounds.height))
+    }
+
+    @Test func legacyScaleMigratesToWidthAndPersistsOnce() {
+        let defaults = InMemoryUserDefaults()
+        defaults.set(0.5, forKey: SettingsKey.keyboardScale.rawValue)
+
+        let settings = LayoutSettings(defaults: defaults, shouldPersist: true)
+
+        // Converted against the orientation-stable shortest screen side, so
+        // the rendered portrait width existing users see is preserved.
+        let expected = 0.5 * shortestScreenSide
+        #expect(abs(settings.keyboardWidth - expected) < 0.01)
+        let persisted = defaults.object(forKey: SettingsKey.keyboardWidthPoints.rawValue) as? Double
+        #expect(persisted != nil)
+        #expect(abs((persisted ?? 0) - expected) < 0.01)
+        // Downgrade safety: the legacy key stays in the store.
+        #expect(defaults.object(forKey: SettingsKey.keyboardScale.rawValue) as? Double == 0.5)
+    }
+
+    @Test func migrationIsIdempotentOnSecondLoad() {
+        let defaults = InMemoryUserDefaults()
+        defaults.set(0.5, forKey: SettingsKey.keyboardScale.rawValue)
+
+        let first = LayoutSettings(defaults: defaults, shouldPersist: true)
+        let migratedWidth = first.keyboardWidth
+
+        // A later legacy-scale change must be ignored: the persisted width
+        // is now the single source of truth.
+        defaults.set(0.9, forKey: SettingsKey.keyboardScale.rawValue)
+        let second = LayoutSettings(defaults: defaults, shouldPersist: true)
+
+        #expect(second.keyboardWidth == migratedWidth)
+    }
+
+    @Test func freshInstallUsesDeviceDefaultWithoutPersisting() {
+        let defaults = InMemoryUserDefaults()
+
+        let settings = LayoutSettings(defaults: defaults, shouldPersist: true)
+
+        #expect(settings.keyboardWidth == DeviceLayoutUtils.defaultKeyboardWidth)
+        // The default is a fallback, never written (consistent with the
+        // registered-defaults behavior of the other layout settings).
+        #expect(defaults.object(forKey: SettingsKey.keyboardWidthPoints.rawValue) == nil)
+    }
+
+    @Test func existingWidthWinsOverLegacyScale() {
+        let defaults = InMemoryUserDefaults()
+        defaults.set(0.5, forKey: SettingsKey.keyboardScale.rawValue)
+        defaults.set(333.0, forKey: SettingsKey.keyboardWidthPoints.rawValue)
+
+        let settings = LayoutSettings(defaults: defaults, shouldPersist: true)
+
+        #expect(settings.keyboardWidth == 333.0)
+    }
+
+    @Test func nonPersistingInstanceMigratesWithoutWriting() {
+        let defaults = InMemoryUserDefaults()
+        defaults.set(0.5, forKey: SettingsKey.keyboardScale.rawValue)
+
+        let settings = LayoutSettings(defaults: defaults, shouldPersist: false)
+
+        let expected = 0.5 * shortestScreenSide
+        #expect(abs(settings.keyboardWidth - expected) < 0.01)
+        #expect(defaults.object(forKey: SettingsKey.keyboardWidthPoints.rawValue) == nil)
+    }
+
+    @Test func standaloneMigrationHelperPersistsTheWidth() {
+        let defaults = InMemoryUserDefaults()
+        defaults.set(0.5, forKey: SettingsKey.keyboardScale.rawValue)
+
+        // The host app runs this at launch before registering defaults.
+        LayoutSettings.migrateLegacyScaleIfNeeded(in: defaults)
+
+        let persisted = defaults.object(forKey: SettingsKey.keyboardWidthPoints.rawValue) as? Double
+        #expect(persisted != nil)
+        #expect(abs((persisted ?? 0) - 0.5 * shortestScreenSide) < 0.01)
+    }
+}
+
 // MARK: - SettingsKey Tests
 
 struct SettingsKeyTests {
@@ -275,6 +369,7 @@ struct SettingsKeyTests {
         #expect(SettingsKey.utilityColumnLeading.rawValue == "utilityColumnLeading")
         #expect(SettingsKey.keyAspectRatio.rawValue == "keyAspectRatio")
         #expect(SettingsKey.keyboardScale.rawValue == "keyboardScale")
+        #expect(SettingsKey.keyboardWidthPoints.rawValue == "keyboardWidthPoints")
         #expect(SettingsKey.numpadStyle.rawValue == "numpadStyle")
     }
 }

--- a/wurstfingerTests/OrientationLayoutTests.swift
+++ b/wurstfingerTests/OrientationLayoutTests.swift
@@ -114,6 +114,26 @@ struct OrientationLayoutTests {
         _ = cancellable
     }
 
+    @Test("Landscape metrics never exceed the portrait width cap")
+    func landscapeMetricsRespectWidthCap() {
+        // PR #223 semantics under the point-anchored model: even a maximal
+        // width wish must not blow the keyboard up to the full landscape
+        // width — the resolved metrics stay within the window-derived cap
+        // (bounded by the screen's shortest side).
+        let viewModel = KeyboardViewModel(
+            userDefaults: InMemoryUserDefaults(), shouldPersistSettings: false
+        )
+        viewModel.keyboardWidth = 600
+
+        // Landscape: the view spans the long side, the window caps at the
+        // screen's shortest side.
+        let longSide = max(DeviceLayoutUtils.screenBounds.width, DeviceLayoutUtils.screenBounds.height)
+        viewModel.updateViewWidth(longSide)
+        viewModel.updateWindowBounds(CGRect(x: 0, y: 0, width: longSide, height: 300))
+
+        #expect(viewModel.layoutMetrics.keyboardWidth <= screenShortestSide)
+    }
+
     @Test("Degenerate window bounds are ignored")
     func degenerateWindowBoundsIgnored() {
         let viewModel = KeyboardViewModel(userDefaults: InMemoryUserDefaults(), shouldPersistSettings: false)

--- a/wurstfingerTests/SettingsReloadObserverTests.swift
+++ b/wurstfingerTests/SettingsReloadObserverTests.swift
@@ -6,7 +6,7 @@
 //  UserDefaults.didChangeNotification — but only when it persists settings.
 //  Non-persisting view models (previews, showcases, App Store screenshots)
 //  are configured programmatically; an observer reloading from the store
-//  would revert forced values (e.g. the full-size screenshot scale) as soon
+//  would revert forced values (e.g. the forced screenshot geometry) as soon
 //  as any same-process defaults write lands.
 //
 
@@ -36,25 +36,25 @@ struct SettingsReloadObserverTests {
     @Test("Persisting view model reloads settings on didChange (control)")
     func persistingViewModelReloadsOnDidChange() {
         let defaults = InMemoryUserDefaults()
-        defaults.set(0.5, forKey: SettingsKey.keyboardScale.rawValue)
+        defaults.set(250.0, forKey: SettingsKey.keyboardWidthPoints.rawValue)
         let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: true)
-        #expect(vm.keyboardScale == 0.5)
+        #expect(vm.keyboardWidth == 250.0)
 
-        defaults.set(0.8, forKey: SettingsKey.keyboardScale.rawValue)
+        defaults.set(320.0, forKey: SettingsKey.keyboardWidthPoints.rawValue)
         postDidChange(for: defaults)
-        drainRunLoop(until: { vm.keyboardScale == 0.8 })
+        drainRunLoop(until: { vm.keyboardWidth == 320.0 })
 
-        #expect(vm.keyboardScale == 0.8)
+        #expect(vm.keyboardWidth == 320.0)
     }
 
     @Test("Non-persisting view model keeps forced values across didChange")
     func nonPersistingViewModelIgnoresDidChange() {
         let defaults = InMemoryUserDefaults()
-        defaults.set(0.5, forKey: SettingsKey.keyboardScale.rawValue)
+        defaults.set(250.0, forKey: SettingsKey.keyboardWidthPoints.rawValue)
         let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
 
-        // Screenshot/showcase views force a full-size keyboard…
-        vm.keyboardScale = 1.0
+        // Screenshot/showcase views force a specific keyboard geometry…
+        vm.keyboardWidth = 363.0
         // …then a same-process defaults write lands (e.g. selecting the
         // screenshot language) and the change notification fires.
         defaults.set("en_US", forKey: SettingsKey.selectedLanguageId.rawValue)
@@ -63,7 +63,7 @@ struct SettingsReloadObserverTests {
         // nothing changed — a fixed short drain could false-pass under load.
         drainRunLoop(deadline: 0.1)
 
-        // The forced scale must survive; a reload would revert it to 0.5.
-        #expect(vm.keyboardScale == 1.0)
+        // The forced width must survive; a reload would revert it to 250.
+        #expect(vm.keyboardWidth == 363.0)
     }
 }

--- a/wurstfingerTests/SquareKeyboardWidthTests.swift
+++ b/wurstfingerTests/SquareKeyboardWidthTests.swift
@@ -2,10 +2,11 @@
 //  SquareKeyboardWidthTests.swift
 //  wurstfingerTests
 //
-//  Verifies that `Calculations.squareKeyboardWidth` produces exactly square
-//  grid cells when fed through the real portrait arrangement and the same
-//  frame math `KeyboardGridLayout` uses at render time. Guards the App Store
-//  screenshot geometry (keys must be 1:1, the square marketing look).
+//  Verifies the App Store screenshot geometry: resolving the point-anchored
+//  metrics at `Calculations.squareKeyboardWidth` with aspect ratio 1.0 must
+//  produce exactly square grid cells of the requested size, fed through the
+//  real portrait arrangement and the same frame math `KeyboardGridLayout`
+//  uses at render time (keys must be 1:1, the square marketing look).
 //
 
 import CoreGraphics
@@ -14,34 +15,36 @@ import Testing
 @testable import WurstfingerApp
 
 struct SquareKeyboardWidthTests {
-    @Test(arguments: [
-        (aspectRatio: CGFloat(1.0), scale: CGFloat(1.0)),
-        (aspectRatio: CGFloat(1.0), scale: CGFloat(0.6)),
-        (aspectRatio: CGFloat(1.5), scale: CGFloat(1.0)),
-    ])
-    func unitCellsAreSquareAtSquareKeyboardWidth(
-        config: (aspectRatio: CGFloat, scale: CGFloat)
-    ) throws {
+    @Test(arguments: [CGFloat(81), CGFloat(54), CGFloat(40)])
+    func unitCellsAreSquareAtSquareKeyboardWidth(cellSize: CGFloat) throws {
         let arrangement = try #require(StandardArrangements.grid3x3[.portrait])
-        let rowHeight = KeyboardConstants.Calculations.keyHeight(
-            aspectRatio: config.aspectRatio
-        ) * config.scale
+
+        // Wish exactly the width the screenshot mode forces; no fit-clamp
+        // engaged (generous container/screen), so the wish is the result.
+        let outerWidth = KeyboardConstants.Calculations.squareKeyboardWidth(
+            cellSize: cellSize,
+            columns: arrangement.columns
+        )
+        let metrics = KeyboardLayoutMetrics.resolve(
+            wishWidth: outerWidth,
+            aspectRatio: 1.0,
+            columns: arrangement.columns,
+            availableWidth: 10000,
+            screenHeight: 10000
+        )
+        #expect(abs(metrics.cellWidth - cellSize) < 0.001)
+        #expect(abs(metrics.cellHeight - cellSize) < 0.001)
 
         // The root view applies the horizontal padding inside the width frame,
         // so the grid itself receives the width minus both paddings.
-        let outerWidth = KeyboardConstants.Calculations.squareKeyboardWidth(
-            aspectRatio: config.aspectRatio,
-            scale: config.scale,
-            columns: arrangement.columns
-        )
-        let gridWidth = outerWidth - 2 * KeyboardConstants.Layout.horizontalPadding
+        let gridWidth = metrics.keyboardWidth - 2 * KeyboardConstants.Layout.horizontalPadding
 
         let cells = GridLayoutSolver.solve(arrangement)
         let frames = KeyboardGridLayout.cellFrames(
             cells: cells,
             columns: arrangement.columns,
             bounds: CGRect(x: 0, y: 0, width: gridWidth, height: .greatestFiniteMagnitude),
-            rowHeight: rowHeight,
+            rowHeight: metrics.rowHeight,
             horizontalSpacing: KeyboardConstants.Layout.gridHorizontalSpacing,
             verticalSpacing: KeyboardConstants.Layout.gridVerticalSpacing
         )
@@ -66,7 +69,7 @@ struct SquareKeyboardWidthTests {
                 abs(visibleWidth - visibleHeight) < 0.001,
                 "cell \(cell.keyId): \(visibleWidth) x \(visibleHeight)"
             )
-            #expect(abs(visibleHeight - rowHeight) < 0.001)
+            #expect(abs(visibleHeight - cellSize) < 0.001)
         }
         #expect(checked > 0, "no single-span cells were checked for \(config)")
     }

--- a/wurstfingerTests/SquareKeyboardWidthTests.swift
+++ b/wurstfingerTests/SquareKeyboardWidthTests.swift
@@ -71,6 +71,6 @@ struct SquareKeyboardWidthTests {
             )
             #expect(abs(visibleHeight - cellSize) < 0.001)
         }
-        #expect(checked > 0, "no single-span cells were checked for \(config)")
+        #expect(checked > 0, "no single-span cells were checked for cellSize \(cellSize)")
     }
 }


### PR DESCRIPTION
Structural fix for findings **H1, H3, M7, M8** of the full codebase review 2026-07-07 (`docs/code-review-develop-2026-07-07.md`).

> **Stacked on #229** (`fix/screenshot-key-aspect`) — builds on its scale/aspect injection pattern. Retarget to `develop` after #229 merges.

## The model: wish vs. result

**Persisted (the wish — device- and orientation-independent):**
- `keyboardWidthPoints` (new key): keyboard width in **points**, clamped 90…600. Points are the density-independent unit — Display Zoom then follows user intent automatically, and pixel density appears nowhere in the model.
- `keyAspectRatio` (existing key, existing 1.0…1.62 clamp): now the *true* cell aspect invariant.

**Derived — `KeyboardLayoutMetrics`, resolved in exactly one place:**
- `cellWidth = (resolvedWidth − 2·12 pt padding − (columns−1)·5 pt gap) / columns`
- `cellHeight = cellWidth / keyAspectRatio` — exact by construction (previously the rendered aspect drifted 1.03–1.16:1 across devices)
- `totalHeight = rows·cellHeight + (rows−1)·5 + 4 + 10` — spacing/paddings are constants, never scaled
- `fontScale = cellHeight / 54` for KeyView fonts/hints; gesture classification consumes `cellWidth/cellHeight` from the same struct

**Fit-clamp (result may be smaller than the wish, never persisted back):**
- Width: `min(wish, container width capped by the window)` — the #223 portrait-width-cap semantics are preserved (test added).
- Height: if `totalHeight > 0.70 × screen height` (current orientation — deliberately *screen* bounds; the extension's window is only keyboard-high, see #219/#223), the whole metrics block scales down proportionally, aspect preserved exactly.
- The clamp is applied at resolve time per render context; moving to a bigger device restores the wish.

## What it fixes
- **H1** — the default was `270 / UIScreen.main.bounds.width`, recomputed per `@AppStorage` reader: a fresh install opened in landscape got a half-size keyboard, and rotation desynced width vs. row height. Defaults are now device-class constants (iPhone 270 pt, iPad 320 pt provisional) with no screen-bounds involvement.
- **M7** — the height constraint scaled the 29 pt of fixed paddings/spacing that the content kept constant (overflow `29·(1−scale)`). Constraint height is now `metrics.totalHeight` — identical to the content by construction; the stale `scaleEffect` comment is gone.
- **M8/H3** — all raw `@AppStorage` scale/aspect reads in the view layer are gone; the root view resolves the metrics once and injects them (extending #229's injection). Screenshot/preview surfaces force values on their non-persisting view models and `shouldPersistSettings: false` now fully controls rendering.

## Migration (one-time, idempotent)
- `keyboardWidthPoints` absent + user-persisted `keyboardScale` present → `width = clamp(oldScale × shortest screen side)`, persisted once (preserves the rendered portrait width for existing users). The legacy key stays in the store for downgrade safety.
- Neither present → device-class default, **not** persisted (fallback/registered only, as before).
- Runs in the shared `LayoutSettings` load path (extension) and explicitly at host-app launch *before* `register(defaults:)` (a registered width would mask a pending migration).

## Host app
- The size slider shows **percent of the device default** (35–145 %, 100 % = 270 pt on iPhone) and writes points; old extremes stay reachable (35 % ≈ the old 0.25×screen minimum, 145 % ≈ full iPhone width). The `scale ≥ 1.0` position-disable special case had no meaning under the new model and was removed.
- `InteractiveKeyboardPreview` now feeds its real container width into the shared render path (`overrideWidth` via GeometryReader — also resolves M9 in passing) and derives its height from the same metrics, deleting the drifted duplicate formula.
- `squareKeyboardWidth` reduces to a cell-size→outer-width conversion; the screenshot mode forces aspect 1.0 + that width, and `SquareKeyboardWidthTests` keep the square-cells property pinned through the real grid math.

## Tests
New `KeyboardLayoutMetricsTests` (aspect exactness, height formula ≡ grid content, **orientation invariance**, width/height clamps proportional + aspect-preserving, clamps never persist, NaN hardening) and `LayoutSettingsMigrationTests` (migrate-once, idempotent, width-wins, fresh-install-not-persisted, non-persisting instances don't write). Adapted: `KeyboardSettingsTests`, `SettingsReloadObserverTests`, `SquareKeyboardWidthTests`; `OrientationLayoutTests` gain a #223-semantics test (landscape metrics ≤ portrait width cap). Full `WurstfingerTests` suite green; SwiftFormat + SwiftLint `--strict` clean.

## Known conflicts
Expected conflicts with unmerged **#235** in `InteractiveKeyboardPreview`/host settings views — unavoidable, this refactor owns those layout formulas now; changes there were kept minimal.

---
_Recreated from PR #239, which auto-closed when its stacked base branch (#229) was deleted on merge. Rebased onto current develop; conflicts resolved (KeyView aspect ratio + long-press, ExpertSettings key-height indicator rewired to the new width-based metrics, square-cell test parametrization)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard sizing now uses width-based settings, enabling more precise control of keyboard layout and preview dimensions.
  * Updated screenshot and preview layouts to better support square, App Store-style keyboard presentations.

* **Bug Fixes**
  * Improved keyboard height updates during layout changes, including rotation.
  * Preserved forced layout settings more reliably across refreshes and settings changes.

* **Tests**
  * Added and updated coverage for keyboard geometry, width clamping, migration behavior, and preview sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->