### PR TITLE
Theme Gallery + 16 Color Palettes (M2a)

### DIFF
--- a/wurstfinger/AppStoreScreenshotView.swift
+++ b/wurstfinger/AppStoreScreenshotView.swift
@@ -15,6 +15,13 @@ struct AppStoreScreenshotView: View {
     @State private var displayText: String = "I love it!"
     @State private var receivedText: String = "How do you like the new keyboard?"
 
+    /// Explicit theme injection for screenshots: FORCE_THEME names a theme id
+    /// ("classic", "liquid-glass", "dark-gold"). Defaults to Classic so
+    /// leftover simulator state can never recolor screenshot output.
+    private let forcedTheme: KeyboardThemeDefinition = ProcessInfo.processInfo
+        .environment["FORCE_THEME"]
+        .flatMap { BuiltInThemes.theme(id: $0) } ?? BuiltInThemes.classic
+
     var body: some View {
         VStack(spacing: 0) {
             // iPhone status bar - at the very top
@@ -29,8 +36,9 @@ struct AppStoreScreenshotView: View {
             // Keyboard at the bottom. Its geometry is fully forced onto the
             // non-persisting view model in configureFromEnvironment (square
             // cells at the full reference key height), so the standard render
-            // path applies with no extra overrides here.
-            DataDrivenKeyboardRootView(viewModel: viewModel)
+            // path applies with no extra overrides here. The forced theme keeps
+            // screenshots deterministic (see forcedTheme).
+            DataDrivenKeyboardRootView(viewModel: viewModel, themeOverride: forcedTheme)
                 .frame(maxWidth: .infinity)
                 // `.contain` promotes the per-key accessibilityIdentifiers into
                 // a queryable container so UI tests can find keys by slot id.

--- a/wurstfinger/KeyboardShowcaseView.swift
+++ b/wurstfinger/KeyboardShowcaseView.swift
@@ -90,9 +90,16 @@ struct KeyboardShowcaseView: View {
         forceLanguage ?? LanguageSettings.resolvedLanguageId(storedId)
     }
 
+    /// Explicit theme injection for screenshots: FORCE_THEME names a theme id
+    /// ("classic", "liquid-glass", "dark-gold"). Defaults to Classic so
+    /// leftover simulator state can never recolor screenshot output.
+    private let forcedTheme: KeyboardThemeDefinition = ProcessInfo.processInfo
+        .environment["FORCE_THEME"]
+        .flatMap { BuiltInThemes.theme(id: $0) } ?? BuiltInThemes.classic
+
     var body: some View {
         VStack(spacing: 0) {
-            DataDrivenKeyboardRootView(viewModel: viewModel)
+            DataDrivenKeyboardRootView(viewModel: viewModel, themeOverride: forcedTheme)
                 .frame(maxWidth: .infinity)
                 .background(Color(.systemBackground))
                 // `.contain` promotes the per-key accessibilityIdentifiers into

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -4555,7 +4555,141 @@
     "Dark Gold": {
       "comment": "Keyboard theme name: dark-gold (proper name, do not translate)",
       "extractionState": "manual",
-      "shouldTranslate": false
+      "shouldTranslate": false,
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ذهبي داكن"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σκούρο χρυσό"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oro oscuro"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "طلایی تیره"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Or sombre"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "זהב כהה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डार्क गोल्ड"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamno zlatno"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oro scuro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダークゴールド"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다크 골드"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemne złoto"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouro escuro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмное золото"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทองเข้ม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темне золото"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈارک گولڈ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vàng sẫm"
+          }
+        }
+      }
     },
     "Dark keys with golden letters": {
       "comment": "Keyboard theme description: dark-gold",
@@ -4631,6 +4765,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Madilim na mga key na may gintong mga titik"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفاتيح داكنة بحروف ذهبية"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σκούρα πλήκτρα με χρυσά γράμματα"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدهای تیره با حروف طلایی"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सुनहरे अक्षरों वाली गहरी कीज़"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暗いキーに金色の文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "어두운 키에 금색 글자"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas escuras com letras douradas"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่มสีเข้มพร้อมตัวอักษรสีทอง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темні клавіші із золотими літерами"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سنہری حروف کے ساتھ گہری کیز"
           }
         }
       }

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -3387,6 +3387,66 @@
             "state": "translated",
             "value": "Mga Tema ng Kulay"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سمات الألوان"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Χρωματικά θέματα"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پوسته‌های رنگی"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रंग थीम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カラーテーマ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "색상 테마"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temas de cor"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ธีมสี"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кольорові теми"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رنگین تھیمز"
+          }
         }
       }
     },
@@ -15054,6 +15114,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mga Estilo"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الأنماط"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Στιλ"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سبک‌ها"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्टाइल"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スタイル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스타일"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilos"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สไตล์"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стилі"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انداز"
           }
         }
       }

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -1,12563 +1,143 @@
 {
   "sourceLanguage": "en",
   "strings": {
-    "Home": {
+    "%@ (default: %@)": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start"
+            "value": "%@ (Standard: %@)"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Accueil"
+            "value": "%@ (par défaut : %@)"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Inicio"
+            "value": "%@ (predeterminado: %@)"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Home"
+            "value": "%@ (predefinita: %@)"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Главная"
+            "value": "%@ (по умолчанию: %@)"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Start"
+            "value": "%@ (domyślny: %@)"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hem"
+            "value": "%@ (standard: %@)"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Etusivu"
+            "value": "%@ (oletus: %@)"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Početna"
+            "value": "%@ (zadano: %@)"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "בית"
+            "value": "%@ (ברירת מחדל: %@)"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Trang chủ"
+            "value": "%@ (mặc định: %@)"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Home"
+            "value": "%@ (default: %@)"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Αρχική"
+            "value": "%@ (προεπιλογή: %@)"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Início"
+            "value": "%@ (predefinição: %@)"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Головна"
+            "value": "%@ (за замовчуванням: %@)"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "الرئيسية"
+            "value": "%@ (افتراضي: %@)"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "خانه"
+            "value": "%@ (پیش‌فرض: %@)"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "ہوم"
+            "value": "%@ (طے شدہ: %@)"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "หน้าแรก"
+            "value": "%@ (ค่าเริ่มต้น: %@)"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "होम"
+            "value": "%@ (डिफ़ॉल्ट: %@)"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ホーム"
+            "value": "%@（デフォルト：%@）"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "홈"
+            "value": "%@ (기본값: %@)"
           }
         }
       },
-      "comment": "Tab bar label for the home/landing screen"
-    },
-    "Setup": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einrichtung"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configuration"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configuración"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configurazione"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Настройка"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Konfiguracja"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Konfigurering"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Käyttöönotto"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Postavljanje"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הגדרה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thiết lập"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Setup"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ρύθμιση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Configuração"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Налаштування"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإعداد"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "راه‌اندازی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سیٹ اپ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตั้งค่า"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सेटअप"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セットアップ"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "설정 방법"
-          }
-        }
-      },
-      "comment": "Tab label and title for the first-run setup wizard"
-    },
-    "Test": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Test"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Test"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prueba"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prova"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Проба"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Test"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testa"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testaa"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Isprobaj"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "בדיקה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thử"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Test"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Δοκιμή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тест"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اختبار"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "آزمایش"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ٹیسٹ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ทดสอบ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "टेस्ट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "テスト"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "테스트"
-          }
-        }
-      },
-      "comment": "Tab label for the try-it-out / test screen"
-    },
-    "Settings": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einstellungen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réglages"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajustes"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impostazioni"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Настройки"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ustawienia"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inställningar"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Asetukset"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Postavke"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הגדרות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cài đặt"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga Setting"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ρυθμίσεις"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Definições"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Налаштування"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإعدادات"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تنظیمات"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ترتیبات"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตั้งค่า"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सेटिंग्स"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "設定"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "설정"
-          }
-        }
-      },
-      "comment": "Tab label and navigation title for settings"
-    },
-    "The Keyboard for Fat Fingers": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Die Tastatur für Wurstfinger"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Le clavier pour les gros doigts"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "El teclado para dedos torpes"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La tastiera per dita grosse"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Клавиатура для толстых пальцев"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klawiatura dla grubych palców"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tangentbordet för tjocka fingrar"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Näppäimistö paksuille sormille"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tipkovnica za debele prste"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "המקלדת לאצבעות עבות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bàn phím cho ngón tay to"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ang Keyboard para sa Malalaking Daliri"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Το πληκτρολόγιο για χοντρά δάχτυλα"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O teclado para dedos gordos"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Клавіатура для товстих пальців"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لوحة المفاتيح لأصحاب الأصابع الكبيرة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "صفحه‌کلید برای انگشتان درشت"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "موٹی انگلیوں کے لیے کی بورڈ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คีย์บอร์ดสำหรับนิ้วอวบ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "मोटी उंगलियों के लिए कीबोर्ड"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "太い指のためのキーボード"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "손가락이 두꺼운 분을 위한 키보드"
-          }
-        }
-      },
-      "comment": "Playful app tagline/slogan"
-    },
-    "Setup Instructions": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anleitung zur Einrichtung"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instructions de configuration"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instrucciones de configuración"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Istruzioni di configurazione"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Инструкция по настройке"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instrukcje konfiguracji"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Konfigureringsanvisningar"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Käyttöönotto-ohjeet"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upute za postavljanje"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הוראות הגדרה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hướng dẫn thiết lập"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga Tagubilin sa Setup"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Οδηγίες ρύθμισης"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Instruções de configuração"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Інструкції з налаштування"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تعليمات الإعداد"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "دستورالعمل راه‌اندازی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سیٹ اپ ہدایات"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "วิธีตั้งค่า"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सेटअप निर्देश"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "セットアップ手順"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "설정 안내"
-          }
-        }
-      },
-      "comment": "Button leading to setup steps"
-    },
-    "Issues": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Issues"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Signaler un problème"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incidencias"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Problemi"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сообщить об ошибке"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zgłoszenia"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ärenden"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ongelmat"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Problemi"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "בעיות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Báo lỗi"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga Issue"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Προβλήματα"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Problemas"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Проблеми"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "المشكلات"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مشکل‌ها"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مسائل"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปัญหา"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "समस्याएँ"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "問題"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "문제 해결"
-          }
-        }
-      },
-      "comment": "Link to the GitHub issue tracker (report bugs)"
-    },
-    "Enable keyboard": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastatur aktivieren"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activer le clavier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activar el teclado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attiva la tastiera"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Включите клавиатуру"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Włącz klawiaturę"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktivera tangentbordet"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ota näppäimistö käyttöön"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Omogući tipkovnicu"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הפעלת המקלדת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bật bàn phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-enable ang keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ενεργοποίηση πληκτρολογίου"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ativar teclado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Увімкнути клавіатуру"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تفعيل لوحة المفاتيح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فعال‌سازی صفحه‌کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ فعال کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เปิดใช้คีย์บอร์ด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड चालू करें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードを有効にする"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 켜기"
-          }
-        }
-      },
-      "comment": "Onboarding step 1 title"
-    },
-    "Open iOS Settings → General → Keyboard → Keyboards and add Wurstfinger.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Öffne iOS Einstellungen → Allgemein → Tastatur → Tastaturen und füge Wurstfinger hinzu."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ouvrez Réglages iOS → Général → Clavier → Claviers et ajoutez Wurstfinger."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abre Ajustes de iOS → General → Teclado → Teclados y añade Wurstfinger."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apri Impostazioni iOS → Generali → Tastiera → Tastiere e aggiungi Wurstfinger."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Откройте «Настройки» iOS → «Основные» → «Клавиатура» → «Клавиатуры» и добавьте Wurstfinger."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otwórz Ustawienia iOS → Ogólne → Klawiatura → Klawiatury i dodaj Wurstfinger."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Öppna Inställningar → Allmänt → Tangentbord → Tangentbord och lägg till Wurstfinger."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avaa iOS-Asetukset → Yleiset → Näppäimistö → Näppäimistöt ja lisää Wurstfinger."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otvori Postavke → Općenito → Tipkovnica → Tipkovnice i dodaj Wurstfinger."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פתח את הגדרות iOS → כללי → מקלדת → מקלדות והוסף את Wurstfinger."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mở Cài đặt iOS → Cài đặt chung → Bàn phím → Bàn phím và thêm Wurstfinger."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buksan ang Mga Setting ng iOS → Pangkalahatan → Keyboard → Mga Keyboard at idagdag ang Wurstfinger."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ανοίξτε Ρυθμίσεις iOS → Γενικά → Πληκτρολόγιο → Πληκτρολόγια και προσθέστε το Wurstfinger."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abra Definições do iOS → Geral → Teclado → Teclados e adicione o Wurstfinger."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відкрийте Параметри iOS → Основні → Клавіатура → Клавіатури та додайте Wurstfinger."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "افتح الإعدادات ← عام ← لوحة المفاتيح ← لوحات المفاتيح وأضِف Wurstfinger."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تنظیمات iOS → عمومی → صفحه‌کلید → صفحه‌کلیدها را باز کنید و Wurstfinger را اضافه کنید."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iOS کی ترتیبات → عمومی → کی بورڈ → کی بورڈز کھولیں اور Wurstfinger شامل کریں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เปิดการตั้งค่า iOS → ทั่วไป → แป้นพิมพ์ → แป้นพิมพ์ แล้วเพิ่ม Wurstfinger"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iOS सेटिंग्स → सामान्य → कीबोर्ड → कीबोर्ड खोलें और Wurstfinger जोड़ें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iOSの「設定」→「一般」→「キーボード」→「キーボード」を開いて、Wurstfingerを追加します。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iOS 설정 → 일반 → 키보드 → 키보드로 이동하여 Wurstfinger를 추가하세요."
-          }
-        }
-      },
-      "comment": "Onboarding step 1 description; the arrow-separated words are iOS Settings menu names — use official localized iOS terms"
-    },
-    "Open Settings": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einstellungen öffnen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ouvrir Réglages"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abrir Ajustes"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apri Impostazioni"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Открыть Настройки"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otwórz Ustawienia"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Öppna Inställningar"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avaa Asetukset"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otvori Postavke"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פתח הגדרות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mở Cài đặt"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buksan ang Mga Setting"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Άνοιγμα Ρυθμίσεων"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abrir Definições"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відкрити Параметри"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فتح الإعدادات"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "باز کردن تنظیمات"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ترتیبات کھولیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เปิดการตั้งค่า"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सेटिंग्स खोलें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "設定を開く"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "설정 열기"
-          }
-        }
-      },
-      "comment": "Button that opens the iOS Settings app"
-    },
-    "Allow full access": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vollzugriff erlauben"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autoriser l'accès complet"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permitir acceso completo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Consenti accesso completo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Разрешите полный доступ"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przyznaj pełny dostęp"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tillåt fullständig åtkomst"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Salli täysi käyttöoikeus"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dopusti puni pristup"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אפשר גישה מלאה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cho phép truy cập đầy đủ"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Payagan ang Full Access"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Να επιτρέπεται η πλήρης πρόσβαση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permitir acesso total"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Дозволити повний доступ"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "السماح بالوصول الكامل"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اجازهٔ دسترسی کامل"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مکمل رسائی کی اجازت دیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อนุญาตการเข้าถึงเต็มรูปแบบ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पूर्ण एक्सेस दें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フルアクセスを許可"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 접근 허용"
-          }
-        }
-      },
-      "comment": "Onboarding step 2 title; refers to the iOS keyboard 'Allow Full Access' toggle"
-    },
-    "Activate \"Allow Full Access\" so cursor control and deletion gestures work.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktiviere \"Vollzugriff erlauben\", damit Cursorsteuerung und Löschgesten funktionieren."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activez « Autoriser l'accès complet » pour que le contrôle du curseur et les gestes de suppression fonctionnent."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activa \"Permitir acceso completo\" para que funcionen el control del cursor y los gestos de borrado."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attiva \"Consenti accesso completo\" affinché il controllo del cursore e i gesti di eliminazione funzionino."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Включите «Разрешить полный доступ», чтобы работали управление курсором и жесты удаления."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Włącz „Przyznaj pełny dostęp”, aby działało sterowanie kursorem i gesty usuwania."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktivera \"Tillåt fullständig åtkomst\" så att markörstyrning och raderingsgester fungerar."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ota käyttöön \"Salli täysi käyttöoikeus\", jotta kohdistimen ohjaus ja poistoeleet toimivat."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uključi „Dopusti puni pristup” kako bi radile geste za upravljanje pokazivačem i brisanje."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הפעל את \"אפשר גישה מלאה\" כדי שמחוות שליטת הסמן והמחיקה יפעלו."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bật \"Cho phép truy cập đầy đủ\" để các cử chỉ điều khiển con trỏ và xóa hoạt động."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-activate ang \"Payagan ang Full Access\" para gumana ang kontrol ng cursor at mga gesture sa pagbura."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ενεργοποιήστε την επιλογή «Να επιτρέπεται η πλήρης πρόσβαση» ώστε να λειτουργούν ο έλεγχος του δρομέα και οι χειρονομίες διαγραφής."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ative \"Permitir acesso total\" para que os gestos de controlo do cursor e de eliminação funcionem."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Увімкніть «Дозволити повний доступ», щоб працювали керування курсором і жести видалення."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فعِّل \"السماح بالوصول الكامل\" حتى تعمل إيماءات التحكم في المؤشر والحذف."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "«اجازهٔ دسترسی کامل» را فعال کنید تا کنترل نشانگر و حرکت‌های حذف کار کنند."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"مکمل رسائی کی اجازت دیں\" فعال کریں تاکہ کرسر کنٹرول اور حذف کرنے کے اشارے کام کریں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เปิดใช้ \"อนุญาตการเข้าถึงเต็มรูปแบบ\" เพื่อให้การควบคุมเคอร์เซอร์และเจสเจอร์ลบข้อความทำงานได้"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"पूर्ण एक्सेस दें\" चालू करें ताकि कर्सर नियंत्रण और डिलीट जेस्चर काम करें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カーソル操作と削除ジェスチャを使えるように「フルアクセスを許可」をオンにしてください。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "커서 제어 및 삭제 제스처가 작동하도록 \"전체 접근 허용\"을 켜세요."
-          }
-        }
-      },
-      "comment": "Onboarding step 2 description; 'Allow Full Access' is the iOS toggle name (localized)"
-    },
-    "Try the keyboard": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastatur ausprobieren"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Essayer le clavier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prueba el teclado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prova la tastiera"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Попробуйте клавиатуру"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wypróbuj klawiaturę"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prova tangentbordet"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kokeile näppäimistöä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Isprobaj tipkovnicu"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "נסה את המקלדת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thử bàn phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Subukan ang keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Δοκιμάστε το πληκτρολόγιο"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Experimentar o teclado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Спробувати клавіатуру"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جرّب لوحة المفاتيح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "امتحان صفحه‌کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ آزمائیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ลองใช้คีย์บอร์ด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड आज़माएँ"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードを試す"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 사용해 보기"
-          }
-        }
-      },
-      "comment": "Onboarding step 3 title"
-    },
-    "Switch to the Test tab and experiment with gestures.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wechsle zum Tab „Test“ und probiere die Gesten aus."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passez à l'onglet Test et expérimentez les gestes."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ve a la pestaña Prueba y experimenta con los gestos."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passa alla scheda Prova e sperimenta con i gesti."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перейдите на вкладку «Проба» и поэкспериментируйте с жестами."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przejdź do karty Test i poeksperymentuj z gestami."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Byt till fliken Testa och experimentera med gester."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Siirry Testaa-välilehdelle ja kokeile eleitä."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prijeđi na karticu Isprobaj i isprobaj geste."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "עבור ללשונית בדיקה והתנסה במחוות."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chuyển sang thẻ Thử và thử nghiệm các cử chỉ."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lumipat sa Test tab at mag-eksperimento sa mga gesture."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Μεταβείτε στην καρτέλα Δοκιμή και πειραματιστείτε με τις χειρονομίες."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mude para o separador Testar e experimente os gestos."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перейдіть на вкладку «Тест» та поекспериментуйте з жестами."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "انتقل إلى علامة تبويب الاختبار وجرّب الإيماءات."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "به زبانهٔ آزمایش بروید و حرکت‌ها را امتحان کنید."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ٹیسٹ ٹیب پر جائیں اور اشاروں کے ساتھ تجربہ کریں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สลับไปที่แท็บทดสอบและลองใช้เจสเจอร์ต่างๆ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "टेस्ट टैब पर जाएँ और जेस्चर के साथ प्रयोग करें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "「テスト」タブに切り替えて、ジェスチャを試してみましょう。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "테스트 탭으로 이동하여 제스처를 사용해 보세요."
-          }
-        }
-      },
-      "comment": "Onboarding step 3 description; 'Test tab' refers to the in-app tab labeled 'Test'"
-    },
-    "General": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allgemein"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Général"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "General"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Generali"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Основные"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ogólne"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Allmänt"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Yleiset"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Općenito"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "כללי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cài đặt chung"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pangkalahatan"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Γενικά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geral"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Основні"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "عام"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "عمومی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "عمومی"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ทั่วไป"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सामान्य"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一般"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "일반"
-          }
-        }
-      },
-      "comment": "Settings section header"
-    },
-    "Utility Keys on Left": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Funktionstasten links"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Touches utilitaires à gauche"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Teclas de función a la izquierda"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tasti funzione a sinistra"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Служебные клавиши слева"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klawisze funkcyjne po lewej"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Funktionstangenter till vänster"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apunäppäimet vasemmalla"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pomoćne tipke lijevo"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מקשי שירות מימין"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phím tiện ích bên trái"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga Utility Key sa Kaliwa"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Πλήκτρα βοηθητικών λειτουργιών στα αριστερά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Teclas utilitárias à esquerda"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Службові клавіші ліворуч"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مفاتيح الأدوات على اليسار"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کلیدهای کاربردی در سمت چپ"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "یوٹیلیٹی کیز بائیں طرف"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปุ่มยูทิลิตีอยู่ด้านซ้าย"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "यूटिलिटी कीज़ बाईं ओर"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ユーティリティキーを左に配置"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기능 키를 왼쪽에 배치"
-          }
-        }
-      },
-      "comment": "Toggle title: place utility column on the left side"
-    },
-    "Places globe, symbols, delete and return on the left": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Platziert Globus, Symbole, Löschen und Zeilenschalter links"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Place le globe, les symboles, la suppression et le retour à gauche"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coloca el globo, los símbolos, borrar e intro a la izquierda"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Posiziona globo, simboli, elimina e a capo a sinistra"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Размещает глобус, символы, удаление и ввод слева"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Umieszcza globus, symbole, usuwanie i enter po lewej stronie"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Placerar jordglob, symboler, radera och retur till vänster"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sijoittaa maapallon, symbolit, poiston ja rivinvaihdon vasemmalle"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Postavlja globus, simbole, brisanje i povratak na lijevu stranu"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ממקם את הגלובוס, הסמלים, המחיקה והשורה החדשה בצד שמאל"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Đặt phím địa cầu, ký hiệu, xóa và xuống dòng ở bên trái"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Inilalagay ang globe, symbols, delete at return sa kaliwa"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Τοποθετεί την υδρόγειο, τα σύμβολα, τη διαγραφή και το return στα αριστερά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coloca o globo, os símbolos, a eliminação e a tecla de retorno à esquerda"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Розміщує глобус, символи, видалення й Enter ліворуч"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يضع مفاتيح الكرة الأرضية والرموز والحذف والإدخال على اليسار"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کلیدهای کره، نمادها، حذف و بازگشت را در سمت چپ قرار می‌دهد"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "گلوب، علامتیں، حذف اور ریٹرن کو بائیں طرف رکھتا ہے"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "วางปุ่มลูกโลก สัญลักษณ์ ลบ และขึ้นบรรทัดใหม่ไว้ทางซ้าย"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ग्लोब, सिंबल, डिलीट और रिटर्न को बाईं ओर रखता है"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "地球儀、記号、削除、改行のキーを左側に配置します"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "지구본, 기호, 삭제, 줄바꿈 키를 왼쪽에 배치합니다"
-          }
-        }
-      },
-      "comment": "Toggle subtitle explaining the utility-keys-on-left option"
-    },
-    "Auto-Capitalize": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-Großschreibung"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Majuscule automatique"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mayúsculas automáticas"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maiuscole automatiche"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Автопрописные"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Autom. wielkie litery"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automatisk versal"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automaattiset isot kirjaimet"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Automatska velika slova"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אותיות רישיות אוטומטיות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tự động viết hoa"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Auto-Capitalize"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αυτόματα κεφαλαία"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maiúsculas automáticas"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Автоматичні великі літери"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الأحرف الكبيرة تلقائيًا"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بزرگ‌نویسی خودکار"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خودکار کیپیٹلائز"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "พิมพ์ตัวใหญ่อัตโนมัติ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ऑटो-कैपिटलाइज़"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "自動大文字化"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "자동 대문자화"
-          }
-        }
-      },
-      "comment": "Toggle title"
-    },
-    "Capitalize after sentence-ending punctuation": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Großschreibung nach satzschließenden Satzzeichen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Met une majuscule après la ponctuation de fin de phrase"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poner en mayúscula tras un signo de puntuación final"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maiuscola dopo la punteggiatura di fine frase"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Заглавная буква после знаков конца предложения"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wielka litera po znaku kończącym zdanie"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stor bokstav efter meningsavslutande skiljetecken"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iso alkukirjain lauseen päättävän välimerkin jälkeen"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Veliko slovo nakon interpunkcije na kraju rečenice"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אות רישית לאחר סימן פיסוק שמסיים משפט"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Viết hoa sau dấu kết thúc câu"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-capitalize pagkatapos ng panapos na bantas"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Κεφαλαίο μετά από σημείο στίξης τέλους πρότασης"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coloca maiúscula após a pontuação de fim de frase"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Велика літера після розділового знака в кінці речення"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "استخدام حرف كبير بعد علامات نهاية الجملة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بزرگ‌نویسی پس از نشانه‌های پایان جمله"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جملہ ختم کرنے والی رموز اوقاف کے بعد بڑا حرف بنائیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "พิมพ์ตัวใหญ่หลังเครื่องหมายจบประโยค"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "वाक्य समाप्त करने वाले विराम चिह्न के बाद बड़ा अक्षर बनाएँ"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "文末の句読点の後に大文字にします"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "문장 끝 문장 부호 뒤에 대문자로 시작합니다"
-          }
-        }
-      },
-      "comment": "Toggle subtitle"
-    },
-    "Double-Space Period": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نقطة بمسافتين"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Punkt durch Doppel-Leerzeichen"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Τελεία με διπλό κενό"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Punto con doble espacio"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نقطه با دو فاصله"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piste kaksoisvälilyönnillä"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tuldok sa dobleng espasyo"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Point par double espace"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "נקודה ברווח כפול"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "डबल-स्पेस से पूर्ण विराम"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Točka dvostrukim razmakom"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Punto con doppio spazio"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ダブルスペースでピリオド"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "더블 스페이스로 마침표"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kropka podwójną spacją"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ponto com espaço duplo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Точка двойным пробелом"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Punkt med dubbla mellanslag"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ใส่จุดด้วยการเว้นวรรคสองครั้ง"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Крапка подвійним пробілом"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ڈبل اسپیس سے وقفہ"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dấu chấm bằng cách nhấn cách hai lần"
-          }
-        }
-      },
-      "comment": "Toggle title: a double space inserts a period"
-    },
-    "Type two spaces to insert a period": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اكتب مسافتين لإدراج نقطة"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zwei Leerzeichen fügen einen Punkt ein"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Δύο κενά εισάγουν μια τελεία"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribe dos espacios para insertar un punto"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برای درج نقطه دو بار فاصله بزنید"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kaksi välilyöntiä lisää pisteen"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mag-type ng dalawang espasyo para maglagay ng tuldok"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deux espaces insèrent un point"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "שני רווחים מוסיפים נקודה"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पूर्ण विराम लगाने के लिए दो बार स्पेस दबाएँ"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dva razmaka umeću točku"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Due spazi inseriscono un punto"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "スペースを2回押すとピリオドを入力"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "스페이스를 두 번 누르면 마침표 입력"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dwie spacje wstawiają kropkę"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dois espaços inserem um ponto"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Два пробела вставляют точку"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Två mellanslag infogar en punkt"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เว้นวรรคสองครั้งเพื่อใส่จุด"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Два пробіли вставляють крапку"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "وقفہ ڈالنے کے لیے دو بار اسپیس دبائیں"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nhấn phím cách hai lần để chèn dấu chấm"
-          }
-        }
-      },
-      "comment": "Toggle subtitle: explains double-space to period"
-    },
-    "Type Numbers by Holding": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "كتابة الأرقام بالضغط المطوّل"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ziffern durch Halten"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αριθμοί με παρατεταμένο πάτημα"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Números manteniendo pulsado"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تایپ اعداد با نگه‌داشتن"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numerot pitkällä painalluksella"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga numero sa pagpindot nang matagal"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chiffres par appui long"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ספרות בלחיצה ארוכה"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "दबाकर रखने से अंक"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Brojke dugim pritiskom"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numeri tenendo premuto"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "長押しで数字を入力"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "길게 눌러 숫자 입력"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cyfry przez przytrzymanie"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Números mantendo premido"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ввод цифр удержанием"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Siffror med långt tryck"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "พิมพ์ตัวเลขด้วยการกดค้าง"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Введення цифр утриманням"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "دبا کر رکھنے سے ہندسے"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nhập số bằng cách giữ phím"
-          }
-        }
-      },
-      "comment": "Toggle title: type digits by long-pressing letter keys"
-    },
-    "Hold a letter key to type its digit": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اضغط مطوّلاً على حرف لكتابة رقمه"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Halte eine Buchstabentaste, um ihre Ziffer einzugeben"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Κρατήστε ένα γράμμα για να πληκτρολογήσετε το ψηφίο του"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mantén pulsada una letra para escribir su número"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کلید حرف را نگه دارید تا عدد آن تایپ شود"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pidä kirjainta pohjassa saadaksesi sen numeron"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pindutin nang matagal ang letra para sa numero nito"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maintenez une lettre pour saisir son chiffre"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "החזיקו מקש אות כדי להקליד את הספרה שלו"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अक्षर दबाए रखें और उसका अंक टाइप करें"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dugo pritisni slovo za njegovu brojku"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tieni premuta una lettera per la sua cifra"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "文字キーを長押しすると数字を入力できます"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "문자 키를 길게 누르면 숫자가 입력됩니다"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przytrzymaj literę, aby wpisać jej cyfrę"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mantenha premida uma letra para o seu algarismo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Удержание буквы вводит её цифру"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Håll in en bokstav för att skriva dess siffra"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กดตัวอักษรค้างไว้เพื่อพิมพ์ตัวเลข"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Утримання літери вводить її цифру"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حرف دبائے رکھیں تاکہ اس کا ہندسہ ٹائپ ہو"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giữ phím chữ để nhập số của phím"
-          }
-        }
-      },
-      "comment": "Toggle subtitle explaining the type-numbers-by-holding option"
-    },
-    "Cursor Movement": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cursorbewegung"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Déplacement du curseur"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Movimiento del cursor"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Movimento del cursore"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перемещение курсора"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ruch kursora"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Markörförflyttning"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kohdistimen liike"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pomicanje pokazivača"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "תנועת הסמן"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Di chuyển con trỏ"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Paggalaw ng Cursor"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Κίνηση δρομέα"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Movimento do cursor"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Переміщення курсора"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حركة المؤشر"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حرکت نشانگر"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کرسر کی حرکت"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การเลื่อนเคอร์เซอร์"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कर्सर मूवमेंट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カーソル移動"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "커서 이동"
-          }
-        }
-      },
-      "comment": "Settings row title"
-    },
-    "Continuous": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fortlaufend"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continu"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continuo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Continuo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Непрерывное"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ciągły"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kontinuerlig"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jatkuva"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kontinuirano"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "רציפה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liên tục"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tuluy-tuloy"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Συνεχής"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contínuo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Безперервно"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مستمرة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پیوسته"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مسلسل"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ต่อเนื่อง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "निरंतर"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "連続"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "연속"
-          }
-        }
-      },
-      "comment": "Picker option for cursor movement style (drag continuously)"
-    },
-    "Step-by-step": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Schrittweise"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pas à pas"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Paso a paso"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passo passo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Пошаговое"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Krok po kroku"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Steg för steg"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Askel kerrallaan"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Korak po korak"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "צעד אחר צעד"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Từng bước"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hakbang-hakbang"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Βήμα προς βήμα"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passo a passo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Покроково"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خطوة بخطوة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "گام‌به‌گام"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قدم بہ قدم"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ทีละขั้น"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "चरण-दर-चरण"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1文字ずつ"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "단계별"
-          }
-        }
-      },
-      "comment": "Picker option for cursor movement style (one character per swipe)"
-    },
-    "Appearance": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Darstellung"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apparence"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aspecto"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aspetto"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Внешний вид"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wygląd"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utseende"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ulkoasu"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Izgled"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מראה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giao diện"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hitsura"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Εμφάνιση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aspeto"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вигляд"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "المظهر"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ظاهر"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ظاہری شکل"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รูปลักษณ์"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "दिखावट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "外観"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "외관"
-          }
-        }
-      },
-      "comment": "Settings section header"
-    },
-    "Customize the look and feel of your keyboard.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passe das Erscheinungsbild deiner Tastatur an."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personnalisez l'apparence de votre clavier."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personaliza el aspecto de tu teclado."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personalizza l'aspetto della tua tastiera."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Настройте внешний вид клавиатуры."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dostosuj wygląd swojej klawiatury."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anpassa tangentbordets utseende och känsla."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mukauta näppäimistösi ulkoasua ja tuntumaa."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prilagodi izgled i dojam svoje tipkovnice."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "התאם אישית את המראה והתחושה של המקלדת."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tùy chỉnh giao diện và cảm nhận của bàn phím."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-customize ang hitsura at pakiramdam ng iyong keyboard."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Προσαρμόστε την εμφάνιση και την αίσθηση του πληκτρολογίου σας."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Personalize o aspeto e o comportamento do seu teclado."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Налаштуйте вигляд і поведінку вашої клавіатури."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خصِّص شكل ومظهر لوحة المفاتيح."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ظاهر و حس صفحه‌کلید خود را سفارشی کنید."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اپنے کی بورڈ کی شکل و صورت کو اپنی مرضی کے مطابق بنائیں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปรับแต่งหน้าตาและสัมผัสของคีย์บอร์ดของคุณ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अपने कीबोर्ड के लुक और फील को कस्टमाइज़ करें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードの見た目や操作感をカスタマイズします。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드의 모양과 느낌을 원하는 대로 설정하세요."
-          }
-        }
-      },
-      "comment": "Settings section footer"
-    },
-    "Style": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stil"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Style"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stile"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Стиль"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Styl"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stil"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tyyli"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stil"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "סגנון"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kiểu"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Στιλ"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Стиль"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "النمط"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سبک"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "انداز"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สไตล์"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "स्टाइल"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "スタイル"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "스타일"
-          }
-        }
-      },
-      "comment": "Settings row / title: visual style"
-    },
-    "Key Aspect Ratio": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seitenverhältnis der Tasten"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proportions des touches"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporción de las teclas"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporzioni dei tasti"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Соотношение сторон клавиш"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporcje klawiszy"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tangenternas proportioner"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Näppäinten kuvasuhde"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Omjer stranica tipki"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "יחס גובה-רוחב של המקשים"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tỷ lệ phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aspect Ratio ng Key"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αναλογία διαστάσεων πλήκτρων"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporção das teclas"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Співвідношення сторін клавіш"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسبة أبعاد المفتاح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسبت ابعاد کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی کا پہلو تناسب"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อัตราส่วนปุ่ม"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "की आस्पेक्ट रेशियो"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーの縦横比"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키 가로세로 비율"
-          }
-        }
-      },
-      "comment": "Settings row / title: width-to-height ratio of keys"
-    },
-    "Size & Position": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Größe & Position"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taille et position"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamaño y posición"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dimensioni e posizione"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Размер и положение"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rozmiar i położenie"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Storlek och position"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Koko ja sijainti"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Veličina i položaj"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גודל ומיקום"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kích cỡ & Vị trí"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sukat at Posisyon"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Μέγεθος και θέση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamanho e posição"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Розмір і положення"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الحجم والموضع"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اندازه و موقعیت"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سائز اور پوزیشن"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขนาดและตำแหน่ง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आकार और स्थिति"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サイズと位置"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "크기 및 위치"
-          }
-        }
-      },
-      "comment": "Settings row / title: keyboard size and position"
-    },
-    "Numpad Style": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ziffernblock-Stil"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Style du pavé numérique"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo del teclado numérico"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stile tastierino numerico"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Стиль цифровой панели"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Styl klawiatury numerycznej"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stil på sifferknappsats"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numeronäppäimistön tyyli"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stil numeričke tipkovnice"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "סגנון לוח המספרים"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kiểu bàn phím số"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo ng Numpad"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Στιλ αριθμητικού πληκτρολογίου"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo do teclado numérico"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Стиль цифрового блоку"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نمط لوحة الأرقام"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سبک صفحهٔ اعداد"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نمپیڈ انداز"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สไตล์แป้นตัวเลข"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "नंबरपैड स्टाइल"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "テンキーのスタイル"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "숫자 패드 스타일"
-          }
-        }
-      },
-      "comment": "Settings row title: number pad layout style"
-    },
-    "Classic (7-8-9)": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klassisch (7-8-9)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Classique (7-8-9)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clásico (7-8-9)"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Classico (7-8-9)"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Классический (7-8-9)"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klasyczny (7-8-9)"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klassisk (7-8-9)"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klassinen (7-8-9)"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klasično (7-8-9)"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "קלאסי (7-8-9)"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cổ điển (7-8-9)"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klasiko (7-8-9)"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Κλασικό (7-8-9)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clássico (7-8-9)"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Класичний (7-8-9)"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "كلاسيكي (7-8-9)"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کلاسیک (۷-۸-۹)"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کلاسک (7-8-9)"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คลาสสิก (7-8-9)"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "क्लासिक (7-8-9)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クラシック（7-8-9）"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "클래식 (7-8-9)"
-          }
-        }
-      },
-      "comment": "Picker option: calculator-style numpad with 7-8-9 on top"
-    },
-    "Phone (1-2-3)": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telefon (1-2-3)"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Téléphone (1-2-3)"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Teléfono (1-2-3)"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telefono (1-2-3)"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Телефонный (1-2-3)"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telefoniczny (1-2-3)"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telefon (1-2-3)"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Puhelin (1-2-3)"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telefon (1-2-3)"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "טלפון (1-2-3)"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Điện thoại (1-2-3)"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telepono (1-2-3)"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Τηλέφωνο (1-2-3)"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Telefone (1-2-3)"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Телефонний (1-2-3)"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الهاتف (1-2-3)"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تلفن (۱-۲-۳)"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فون (1-2-3)"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "โทรศัพท์ (1-2-3)"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "फ़ोन (1-2-3)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "電話（1-2-3）"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전화기 (1-2-3)"
-          }
-        }
-      },
-      "comment": "Picker option: phone-style numpad with 1-2-3 on top"
-    },
-    "Feedback": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retour"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Respuesta"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Отклик"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reakcje"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Återkoppling"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Palaute"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Povratne informacije"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משוב"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phản hồi"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ανάδραση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retorno"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відгук"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الاستجابة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بازخورد"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فیڈ بیک"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตอบสนอง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "फ़ीडबैक"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フィードバック"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "피드백"
-          }
-        }
-      },
-      "comment": "Settings section header (covers haptic feedback)"
-    },
-    "Haptic Feedback": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptisches Feedback"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retour haptique"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Respuesta háptica"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback aptico"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тактильный отклик"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reakcje haptyczne"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taktil återkoppling"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tuntopalaute"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptičke povratne informacije"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משוב מישושי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phản hồi xúc giác"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptic Feedback"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Απτική ανάδραση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retorno tátil"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тактильний відгук"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الاستجابة اللمسية"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بازخورد لمسی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ہیپٹک فیڈ بیک"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตอบสนองแบบสัมผัส"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "हैप्टिक फ़ीडबैक"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "触覚フィードバック"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "햅틱 피드백"
-          }
-        }
-      },
-      "comment": "Row title / toggle: vibration feedback"
-    },
-    "Advanced": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erweitert"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avancé"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avanzado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avanzate"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Дополнительно"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zaawansowane"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avancerat"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lisäasetukset"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Napredno"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מתקדם"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nâng cao"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Advanced"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Για προχωρημένους"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avançado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Додатково"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "متقدم"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پیشرفته"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ایڈوانسڈ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขั้นสูง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "उन्नत"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "詳細"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "고급"
-          }
-        }
-      },
-      "comment": "Settings section header"
-    },
-    "Expert": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Experte"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expert"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Experto"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esperto"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Для экспертов"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ekspert"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expert"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Asiantuntija"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stručno"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מומחה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chuyên gia"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Expert"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ειδικός"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Especialista"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Експертний"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الخبير"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حرفه‌ای"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ماہر"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ผู้เชี่ยวชาญ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "एक्सपर्ट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エキスパート"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전문가"
-          }
-        }
-      },
-      "comment": "Settings row title leading to expert/advanced gesture tuning"
-    },
-    "About": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Über"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "À propos"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Información"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informazioni"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "О приложении"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Informacje"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Om"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tietoja"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O aplikaciji"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אודות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giới thiệu"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tungkol Dito"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Σχετικά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Acerca de"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Про програму"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حول"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "درباره"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بارے میں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เกี่ยวกับ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "परिचय"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "情報"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "정보"
-          }
-        }
-      },
-      "comment": "Settings section header"
-    },
-    "Version": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versión"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versione"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Версия"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wersja"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versio"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Verzija"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גרסה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phiên bản"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bersyon"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Έκδοση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Versão"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Версія"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإصدار"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسخه"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ورژن"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เวอร์ชัน"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "वर्शन"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "バージョン"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "버전"
-          }
-        }
-      },
-      "comment": "About row label (app version)"
-    },
-    "License": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lizenz"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licence"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licencia"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licenza"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Лицензия"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licencja"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licens"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lisenssi"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licenca"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "רישיון"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giấy phép"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lisensya"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Άδεια χρήσης"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licença"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ліцензія"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الترخيص"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مجوز"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لائسنس"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สัญญาอนุญาต"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "लाइसेंस"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ライセンス"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "라이선스"
-          }
-        }
-      },
-      "comment": "About row label (software license)"
-    },
-    "Imprint": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impressum"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mentions légales"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aviso legal"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Note legali"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Выходные данные"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nota prawna"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Utgivningsinformation"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Julkaisutiedot"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Impresum"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פרטים משפטיים"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thông tin pháp lý"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Imprint"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Στοιχεία έκδοσης"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ficha técnica"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вихідні дані"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بيانات الناشر"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اطلاعات ناشر"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "امپرنٹ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ข้อมูลผู้จัดทำ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "इम्प्रिंट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "運営者情報"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제작 정보"
-          }
-        }
-      },
-      "comment": "About row / title: legal imprint / impressum"
-    },
-    "Switching Keyboards": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastatur wechseln"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Changer de clavier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambiar de teclado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambia tastiera"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Переключение клавиатуры"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przełącz klawiaturę"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Byt tangentbord"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vaihda näppäimistöä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Promjena tipkovnice"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "החלף מקלדת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chuyển bàn phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Magpalit ng Keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Εναλλαγή πληκτρολογίου"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mudar de teclado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перемкнути клавіатуру"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تبديل لوحة المفاتيح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تعویض صفحه‌کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ تبدیل کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สลับคีย์บอร์ด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड बदलें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードを切り替える"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 전환"
-          }
-        }
-      },
-      "comment": "Header above instructions on how to switch keyboards"
-    },
-    "Tap the globe icon on your keyboard to switch between installed keyboards": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tippe auf das Globussymbol deiner Tastatur, um zwischen installierten Tastaturen zu wechseln"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Touchez l'icône du globe sur votre clavier pour passer d'un clavier installé à un autre"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toca el icono del globo en tu teclado para cambiar entre los teclados instalados"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tocca l'icona del globo sulla tastiera per passare da una tastiera installata all'altra"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Нажмите значок глобуса на клавиатуре, чтобы переключаться между установленными клавиатурами"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stuknij ikonę globusa na klawiaturze, aby przełączać zainstalowane klawiatury"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tryck på jordglobsikonen på tangentbordet för att växla mellan installerade tangentbord"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vaihda asennettujen näppäimistöjen välillä napauttamalla maapallokuvaketta näppäimistössä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dodirni ikonu globusa na tipkovnici za prebacivanje između instaliranih tipkovnica"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הקש על סמל הגלובוס במקלדת כדי לעבור בין המקלדות המותקנות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chạm biểu tượng địa cầu trên bàn phím để chuyển giữa các bàn phím đã cài"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-tap ang globe icon sa iyong keyboard para magpalit sa pagitan ng mga naka-install na keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Πατήστε το εικονίδιο της υδρογείου στο πληκτρολόγιό σας για εναλλαγή μεταξύ των εγκατεστημένων πληκτρολογίων"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toque no ícone do globo no teclado para alternar entre os teclados instalados"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Торкніться значка глобуса на клавіатурі, щоб перемикатися між встановленими клавіатурами"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اضغط على أيقونة الكرة الأرضية في لوحة المفاتيح للتبديل بين لوحات المفاتيح المثبَّتة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "روی نماد کره در صفحه‌کلید ضربه بزنید تا بین صفحه‌کلیدهای نصب‌شده جابه‌جا شوید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "انسٹال شدہ کی بورڈز کے درمیان تبدیل کرنے کے لیے اپنے کی بورڈ پر گلوب آئیکن پر ٹیپ کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แตะไอคอนลูกโลกบนคีย์บอร์ดเพื่อสลับระหว่างคีย์บอร์ดที่ติดตั้งไว้"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "इंस्टॉल किए गए कीबोर्ड के बीच स्विच करने के लिए अपने कीबोर्ड पर ग्लोब आइकन पर टैप करें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードの地球儀アイコンをタップすると、インストール済みのキーボードを切り替えられます"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드의 지구본 아이콘을 탭하면 설치된 키보드 간에 전환할 수 있습니다"
-          }
-        }
-      },
-      "comment": "Instruction text"
-    },
-    "Test Field": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testfeld"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Champ de test"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Campo de prueba"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Campo di prova"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Поле для пробы"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pole testowe"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testfält"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Testikenttä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Polje za isprobavanje"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "שדה בדיקה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ô thử"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Test Field"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Πεδίο δοκιμής"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Campo de teste"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тестове поле"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حقل الاختبار"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فیلد آزمایش"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ٹیسٹ فیلڈ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ช่องทดสอบ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "टेस्ट फ़ील्ड"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "テスト入力欄"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "테스트 입력란"
-          }
-        }
-      },
-      "comment": "Label above a text field for trying the keyboard"
-    },
-    "Tap here to open keyboard...": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hier tippen, um die Tastatur zu öffnen …"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Touchez ici pour ouvrir le clavier…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toca aquí para abrir el teclado..."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tocca qui per aprire la tastiera..."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Нажмите здесь, чтобы открыть клавиатуру…"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stuknij tutaj, aby otworzyć klawiaturę..."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tryck här för att öppna tangentbordet …"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avaa näppäimistö napauttamalla tähän..."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dodirni ovdje za otvaranje tipkovnice..."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הקש כאן כדי לפתוח את המקלדת..."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chạm vào đây để mở bàn phím..."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-tap dito para buksan ang keyboard..."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Πατήστε εδώ για άνοιγμα πληκτρολογίου..."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toque aqui para abrir o teclado..."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Торкніться тут, щоб відкрити клавіатуру…"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اضغط هنا لفتح لوحة المفاتيح..."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برای باز کردن صفحه‌کلید اینجا ضربه بزنید..."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ کھولنے کے لیے یہاں ٹیپ کریں..."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แตะที่นี่เพื่อเปิดคีย์บอร์ด..."
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड खोलने के लिए यहाँ टैप करें..."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ここをタップしてキーボードを開く…"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "여기를 탭하여 키보드 열기..."
-          }
-        }
-      },
-      "comment": "Placeholder text in the test field"
-    },
-    "Clear": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Löschen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Effacer"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Borrar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancella"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Очистить"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wyczyść"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rensa"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tyhjennä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Očisti"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "נקה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xóa hết"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-clear"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Εκκαθάριση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Limpar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Очистити"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مسح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پاک کردن"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "صاف کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ล้าง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "साफ़ करें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "消去"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "지우기"
-          }
-        }
-      },
-      "comment": "Button: clear the text field"
-    },
-    "Done": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fertig"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aceptar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fine"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Готово"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gotowe"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klar"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valmis"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gotovo"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "סיום"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xong"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tapos na"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Τέλος"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Concluído"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Готово"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تم"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تمام"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ہو گیا"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เสร็จสิ้น"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "हो गया"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完了"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "완료"
-          }
-        }
-      },
-      "comment": "Keyboard toolbar button to dismiss the keyboard / finish editing"
-    },
-    "MessagEase Layout": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase-Layout"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disposition MessagEase"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disposición MessagEase"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Layout MessagEase"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Раскладка MessagEase"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Układ MessagEase"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase-layout"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase-asettelu"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase raspored"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פריסת MessagEase"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bố cục MessagEase"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase Layout"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Διάταξη MessagEase"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esquema MessagEase"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Розкладка MessagEase"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تخطيط MessagEase"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "چیدمان MessagEase"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase لے آؤٹ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เลย์เอาต์ MessagEase"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase लेआउट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEaseレイアウト"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "MessagEase 레이아웃"
-          }
-        }
-      },
-      "comment": "Caption under each language option; 'MessagEase' is a product name (keep)"
-    },
-    "Visual Style": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Visueller Stil"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Style visuel"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo visual"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stile visivo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Визуальный стиль"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Styl wizualny"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Visuell stil"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Visuaalinen tyyli"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vizualni stil"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "סגנון חזותי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kiểu hiển thị"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Visual na Estilo"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Οπτικό στιλ"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estilo visual"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Візуальний стиль"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "النمط المرئي"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سبک ظاهری"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بصری انداز"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สไตล์การแสดงผล"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "विज़ुअल स्टाइल"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "表示スタイル"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "비주얼 스타일"
-          }
-        }
-      },
-      "comment": "Header for keyboard visual style options"
-    },
-    "Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass ist für iOS 26 und neuer ausgelegt. Auf älteren Versionen wird ein vereinfachter durchscheinender Stil verwendet."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass est conçu pour iOS 26 et versions ultérieures. Sur les versions antérieures, un style translucide simplifié est utilisé."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass está diseñado para iOS 26 y posteriores. En versiones anteriores se usa un estilo translúcido simplificado."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass è progettato per iOS 26 e versioni successive. Nelle versioni precedenti viene usato uno stile traslucido semplificato."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass разработан для iOS 26 и новее. В более ранних версиях используется упрощённый полупрозрачный стиль."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass jest zaprojektowany dla iOS 26 i nowszych. W starszych wersjach używany jest uproszczony półprzezroczysty styl."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass är utformat för iOS 26 och senare. På äldre versioner används en förenklad halvgenomskinlig stil."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass on suunniteltu iOS 26:lle ja uudemmille. Vanhemmissa versioissa käytetään yksinkertaistettua läpikuultavaa tyyliä."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass je osmišljen za iOS 26 i novije. Na starijim verzijama koristi se pojednostavljeni poluprozirni stil."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass מיועד ל‑iOS 26 ואילך. בגרסאות קודמות נעשה שימוש בסגנון שקוף למחצה ופשוט יותר."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass được thiết kế cho iOS 26 trở lên. Trên các phiên bản cũ hơn, một kiểu trong mờ đơn giản hóa sẽ được dùng."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ang Liquid Glass ay idinisenyo para sa iOS 26 pataas. Sa mas lumang bersyon, gagamitin ang pinasimpleng translucent na estilo."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Το Liquid Glass απαιτεί iOS 26 ή νεότερη έκδοση. Σε αυτή τη συσκευή θα χρησιμοποιηθεί το κλασικό στιλ."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O Liquid Glass requer o iOS 26 ou posterior. Neste dispositivo será usado o estilo clássico."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass потребує iOS 26 або новішої версії. На цьому пристрої використовуватиметься класичний стиль."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يتطلب Liquid Glass نظام iOS 26 أو أحدث. سيُستخدم النمط الكلاسيكي على هذا الجهاز."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass به iOS 26 یا جدیدتر نیاز دارد. در این دستگاه از سبک کلاسیک استفاده می‌شود."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass کے لیے iOS 26 یا بعد کا ورژن درکار ہے۔ اس ڈیوائس پر کلاسک انداز استعمال ہوگا۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass ต้องใช้ iOS 26 ขึ้นไป อุปกรณ์นี้จะใช้สไตล์คลาสสิกแทน"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass के लिए iOS 26 या बाद का वर्शन ज़रूरी है। इस डिवाइस पर क्लासिक स्टाइल इस्तेमाल होगी।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid GlassにはiOS 26以降が必要です。このデバイスではクラシックスタイルが使用されます。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liquid Glass는 iOS 26 이상이 필요합니다. 이 기기에서는 클래식 스타일이 사용됩니다."
-          }
-        }
-      },
-      "comment": "Note shown on pre-iOS-26 devices; 'Liquid Glass' is a style name (keep)"
-    },
-    "Open the keyboard once to sync Full Access status.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Öffne die Tastatur einmal, um den Status von Vollzugriff zu synchronisieren."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ouvrez le clavier une fois pour synchroniser l'état de l'accès complet."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abre el teclado una vez para sincronizar el estado del acceso completo."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apri la tastiera una volta per sincronizzare lo stato dell'accesso completo."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Откройте клавиатуру один раз, чтобы синхронизировать статус полного доступа."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Otwórz raz klawiaturę, aby zsynchronizować stan pełnego dostępu."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Öppna tangentbordet en gång för att synkronisera status för fullständig åtkomst."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avaa näppäimistö kerran, jotta täyden käyttöoikeuden tila synkronoituu."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jednom otvori tipkovnicu za sinkronizaciju statusa punog pristupa."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "פתח את המקלדת פעם אחת כדי לסנכרן את מצב הגישה המלאה."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mở bàn phím một lần để đồng bộ trạng thái Truy cập đầy đủ."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buksan ang keyboard nang isang beses para i-sync ang status ng Full Access."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ανοίξτε το πληκτρολόγιο μία φορά για συγχρονισμό της κατάστασης πλήρους πρόσβασης."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Abra o teclado uma vez para sincronizar o estado do acesso total."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відкрийте клавіатуру один раз, щоб синхронізувати стан повного доступу."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "افتح لوحة المفاتيح مرة واحدة لمزامنة حالة الوصول الكامل."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "یک‌بار صفحه‌کلید را باز کنید تا وضعیت دسترسی کامل همگام شود."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مکمل رسائی کی حالت سنک کرنے کے لیے کی بورڈ ایک بار کھولیں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เปิดคีย์บอร์ดหนึ่งครั้งเพื่อซิงค์สถานะการเข้าถึงเต็มรูปแบบ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पूर्ण एक्सेस स्थिति सिंक करने के लिए कीबोर्ड एक बार खोलें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フルアクセスの状態を同期するために、キーボードを一度開いてください。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 접근 상태를 동기화하려면 키보드를 한 번 열어 주세요."
-          }
-        }
-      },
-      "comment": "Caption; 'Full Access' is the iOS term"
-    },
-    "Tap Feedback": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tipp-Feedback"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retour au toucher"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Respuesta al tocar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback al tocco"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Отклик при нажатии"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reakcja na stuknięcie"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Återkoppling vid tryck"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Napautuspalaute"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Povratne informacije dodira"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משוב בהקשה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phản hồi khi chạm"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap Feedback"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ανάδραση πατήματος"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retorno ao tocar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відгук на дотик"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "استجابة اللمس"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بازخورد ضربه"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ٹیپ فیڈ بیک"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตอบสนองเมื่อแตะ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "टैप फ़ीडबैक"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タップ時のフィードバック"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "탭 피드백"
-          }
-        }
-      },
-      "comment": "Slider control title: haptic strength when tapping keys"
-    },
-    "Applies when you touch any key.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gilt, wenn du eine beliebige Taste berührst."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "S'applique lorsque vous touchez une touche."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se aplica al tocar cualquier tecla."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si applica quando tocchi un tasto qualsiasi."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Применяется при касании любой клавиши."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Działa przy dotknięciu dowolnego klawisza."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gäller när du rör vid en tangent."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vaikuttaa, kun kosketat mitä tahansa näppäintä."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Primjenjuje se kad dodirneš bilo koju tipku."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "חל בעת נגיעה בכל מקש."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Áp dụng khi bạn chạm vào phím bất kỳ."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nalalapat kapag humawak ka sa anumang key."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ισχύει όταν αγγίζετε οποιοδήποτε πλήκτρο."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplica-se quando toca em qualquer tecla."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Застосовується, коли ви торкаєтеся будь-якої клавіші."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تُطبَّق عند لمس أي مفتاح."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "هنگام لمس هر کلید اعمال می‌شود."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جب آپ کوئی کی چھوتے ہیں تو لاگو ہوتا ہے۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ใช้เมื่อคุณแตะปุ่มใดก็ตาม"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "किसी भी की को छूने पर लागू होता है।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "いずれかのキーに触れたときに適用されます。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "아무 키나 누를 때 적용됩니다."
-          }
-        }
-      },
-      "comment": "Caption under the Tap Feedback slider"
-    },
-    "Drag Feedback": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zieh-Feedback"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retour au glissement"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Respuesta al arrastrar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback al trascinamento"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Отклик при перетягивании"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reakcja na przeciąganie"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Återkoppling vid dragning"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vetopalaute"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Povratne informacije povlačenja"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משוב בגרירה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phản hồi khi kéo"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Drag Feedback"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ανάδραση συρσίματος"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retorno ao arrastar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Відгук на перетягування"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "استجابة السحب"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بازخورد کشیدن"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ڈریگ فیڈ بیک"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตอบสนองเมื่อลาก"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ड्रैग फ़ीडबैक"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ドラッグ時のフィードバック"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "드래그 피드백"
-          }
-        }
-      },
-      "comment": "Slider control title: haptic strength when dragging"
-    },
-    "Applies when you drag the Space or Delete key to move the cursor or delete text.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gilt, wenn du die Leertaste oder Löschtaste ziehst, um den Cursor zu bewegen oder Text zu löschen."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "S'applique lorsque vous faites glisser la touche Espace ou Suppr. pour déplacer le curseur ou supprimer du texte."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Se aplica al arrastrar la tecla Espacio o Borrar para mover el cursor o borrar texto."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Si applica quando trascini il tasto Spazio o Elimina per spostare il cursore o eliminare il testo."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Применяется при перетягивании клавиши пробела или удаления для перемещения курсора или удаления текста."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Działa przy przeciąganiu klawisza spacji lub usuwania w celu przesunięcia kursora lub usunięcia tekstu."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gäller när du drar mellanslags- eller raderingstangenten för att flytta markören eller radera text."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vaikuttaa, kun vedät väli- tai poistonäppäintä siirtääksesi kohdistinta tai poistaaksesi tekstiä."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Primjenjuje se kad povučeš tipku Razmaknica ili Brisanje za pomicanje pokazivača ili brisanje teksta."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "חל בעת גרירת מקש הרווח או המחיקה כדי להזיז את הסמן או למחוק טקסט."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Áp dụng khi bạn kéo phím Cách hoặc Xóa để di chuyển con trỏ hoặc xóa văn bản."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nalalapat kapag ni-drag mo ang Space o Delete key para igalaw ang cursor o magbura ng teksto."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ισχύει όταν σέρνετε το πλήκτρο διαστήματος ή διαγραφής για να μετακινήσετε τον δρομέα ή να διαγράψετε κείμενο."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aplica-se quando arrasta a tecla Espaço ou Eliminar para mover o cursor ou apagar texto."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Застосовується, коли ви перетягуєте клавішу пробілу або видалення, щоб перемістити курсор чи видалити текст."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تُطبَّق عند سحب مفتاح المسافة أو الحذف لتحريك المؤشر أو حذف النص."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "هنگامی که کلید فاصله یا حذف را برای جابه‌جایی نشانگر یا حذف متن می‌کشید اعمال می‌شود."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جب آپ کرسر کو منتقل کرنے یا متن حذف کرنے کے لیے اسپیس یا ڈیلیٹ کی کو ڈریگ کرتے ہیں تو لاگو ہوتا ہے۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ใช้เมื่อคุณลากปุ่มเว้นวรรคหรือปุ่มลบเพื่อเลื่อนเคอร์เซอร์หรือลบข้อความ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कर्सर हिलाने या टेक्स्ट डिलीट करने के लिए स्पेस या डिलीट की को ड्रैग करने पर लागू होता है।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "スペースキーや削除キーをドラッグしてカーソルを移動したり、テキストを削除したりするときに適用されます。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "스페이스 또는 삭제 키를 드래그하여 커서를 이동하거나 텍스트를 삭제할 때 적용됩니다."
-          }
-        }
-      },
-      "comment": "Caption; 'Space' and 'Delete' are key names"
-    },
-    "Off": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aus"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Désactivé"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apagado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Выкл."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wył."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Av"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pois"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Isklj."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "כבוי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tắt"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Off"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ανενεργό"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desligado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вимк."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إيقاف"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خاموش"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بند"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปิด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "बंद"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "オフ"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "끔"
-          }
-        }
-      },
-      "comment": "Slider minimum label (intensity off)"
-    },
-    "Minimal": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimal"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimal"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mínimo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Минимальный"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimalny"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimal"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimaalinen"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimalno"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מינימלי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tối thiểu"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimal"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ελάχιστη"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mínimo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Мінімальний"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الحد الأدنى"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کمینه"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کم سے کم"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "น้อยที่สุด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "न्यूनतम"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最小"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "최소"
-          }
-        }
-      },
-      "comment": "Haptic intensity level name"
-    },
-    "Soft": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sanft"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Doux"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Suave"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Morbido"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Мягкий"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Miękki"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mjuk"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pehmeä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mekano"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "רך"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Êm"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Malambot"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Απαλή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Suave"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "М’який"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خفيف"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ملایم"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نرم"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เบา"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "मृदु"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ソフト"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "약하게"
-          }
-        }
-      },
-      "comment": "Haptic intensity level name"
-    },
-    "Light": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leicht"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Léger"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ligero"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leggero"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Лёгкий"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lekki"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lätt"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kevyt"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lagano"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "קל"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nhẹ"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Magaan"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ελαφριά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ligeiro"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Легкий"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خفيف جدًا"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سبک"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ہلکا"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อ่อน"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "हल्का"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "弱"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "가볍게"
-          }
-        }
-      },
-      "comment": "Haptic intensity level name"
-    },
-    "Medium": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mittel"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Moyen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medio"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medio"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Средний"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Średni"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medel"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keskitaso"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Srednje"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "בינוני"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vừa"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Katamtaman"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Μεσαία"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Médio"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Середній"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "متوسط"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "متوسط"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "درمیانہ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปานกลาง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "मध्यम"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "보통"
-          }
-        }
-      },
-      "comment": "Haptic intensity level name"
-    },
-    "Strong": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stark"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fort"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fuerte"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Forte"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сильный"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Silny"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stark"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Voimakas"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jako"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "חזק"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mạnh"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Malakas"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Δυνατή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Forte"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сильний"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قوي"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قوی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مضبوط"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "แรง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "तीव्र"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "強"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "강하게"
-          }
-        }
-      },
-      "comment": "Haptic intensity level name"
-    },
-    "Max": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Max"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Max"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Máx."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Max"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Макс."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maks."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Max"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maks."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maks."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מרבי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tối đa"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Max"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Μέγιστη"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Máximo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Максимальний"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الحد الأقصى"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بیشینه"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "زیادہ سے زیادہ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สูงสุด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अधिकतम"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最大"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "최대"
-          }
-        }
-      },
-      "comment": "Slider maximum label (maximum intensity)"
-    },
-    "Haptics": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptik"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retour haptique"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Háptica"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aptica"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тактильный отклик"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptyka"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taktil återkoppling"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tuntopalaute"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptika"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משוב מישושי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xúc giác"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptics"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Απτική ανάδραση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tátil"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тактильний відгук"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الاستجابة اللمسية"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لرزش لمسی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ہیپٹکس"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การสั่นตอบสนอง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "हैप्टिक्स"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "触覚フィードバック"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "햅틱"
-          }
-        }
-      },
-      "comment": "Navigation title for haptic settings"
-    },
-    "Reset": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zurücksetzen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réinitialiser"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ripristina"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сбросить"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resetuj"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Återställ"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Palauta"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vrati izvorno"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אפס"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Đặt lại"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-reset"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Επαναφορά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Repor"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Скинути"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إعادة تعيين"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بازنشانی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ری سیٹ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รีเซ็ต"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "रीसेट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リセット"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "재설정"
-          }
-        }
-      },
-      "comment": "Button to reset values to defaults"
-    },
-    "Value": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wert"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valeur"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valor"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valore"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Значение"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wartość"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Värde"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arvo"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vrijednost"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ערך"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giá trị"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Halaga"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Τιμή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Valor"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Значення"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "القيمة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مقدار"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قدر"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ค่า"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "मान"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "値"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "값"
-          }
-        }
-      },
-      "comment": "Label/placeholder for a numeric input field"
-    },
-    "Haptic feedback requires Full Access. Enable it in **Settings › Wurstfinger › Keyboards › Wurstfinger › Allow Full Access**.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptisches Feedback erfordert Vollzugriff. Aktiviere ihn unter **Einstellungen › Wurstfinger › Tastaturen › Wurstfinger › Vollzugriff erlauben**."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Le retour haptique nécessite l'accès complet. Activez-le dans **Réglages › Wurstfinger › Claviers › Wurstfinger › Autoriser l'accès complet**."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La respuesta háptica requiere acceso completo. Actívalo en **Ajustes › Wurstfinger › Teclados › Wurstfinger › Permitir acceso completo**."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Il feedback aptico richiede l'accesso completo. Attivalo in **Impostazioni › Wurstfinger › Tastiere › Wurstfinger › Consenti accesso completo**."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тактильный отклик требует полного доступа. Включите его в **Настройки › Wurstfinger › Клавиатуры › Wurstfinger › Разрешить полный доступ**."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reakcje haptyczne wymagają pełnego dostępu. Włącz go w **Ustawienia › Wurstfinger › Klawiatury › Wurstfinger › Przyznaj pełny dostęp**."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taktil återkoppling kräver fullständig åtkomst. Aktivera den i **Inställningar › Wurstfinger › Tangentbord › Wurstfinger › Tillåt fullständig åtkomst**."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tuntopalaute vaatii täyden käyttöoikeuden. Ota se käyttöön kohdassa **Asetukset › Wurstfinger › Näppäimistöt › Wurstfinger › Salli täysi käyttöoikeus**."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haptičke povratne informacije zahtijevaju puni pristup. Uključi ga u **Postavke › Wurstfinger › Tipkovnice › Wurstfinger › Dopusti puni pristup**."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "משוב מישושי דורש גישה מלאה. הפעל אותה ב-**הגדרות › Wurstfinger › מקלדות › Wurstfinger › אפשר גישה מלאה**."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phản hồi xúc giác yêu cầu Truy cập đầy đủ. Bật trong **Cài đặt › Wurstfinger › Bàn phím › Wurstfinger › Cho phép truy cập đầy đủ**."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kailangan ng haptic feedback ang Full Access. I-enable ito sa **Mga Setting › Wurstfinger › Mga Keyboard › Wurstfinger › Payagan ang Full Access**."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Η απτική ανάδραση απαιτεί πλήρη πρόσβαση. Ενεργοποιήστε την στο **Ρυθμίσεις › Wurstfinger › Πληκτρολόγια › Wurstfinger › Να επιτρέπεται η πλήρης πρόσβαση**."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "O retorno tátil requer acesso total. Ative-o em **Definições › Wurstfinger › Teclados › Wurstfinger › Permitir acesso total**."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тактильний відгук потребує повного доступу. Увімкніть його в **Параметри › Wurstfinger › Клавіатури › Wurstfinger › Дозволити повний доступ**."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تتطلب الاستجابة اللمسية الوصول الكامل. فعِّلها في **الإعدادات › Wurstfinger › لوحات المفاتيح › Wurstfinger › السماح بالوصول الكامل**."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بازخورد لمسی به دسترسی کامل نیاز دارد. آن را در **تنظیمات › Wurstfinger › صفحه‌کلیدها › Wurstfinger › اجازهٔ دسترسی کامل** فعال کنید."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ہیپٹک فیڈ بیک کے لیے مکمل رسائی درکار ہے۔ اسے **ترتیبات › Wurstfinger › کی بورڈز › Wurstfinger › مکمل رسائی کی اجازت دیں** میں فعال کریں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตอบสนองแบบสัมผัสต้องใช้การเข้าถึงเต็มรูปแบบ เปิดใช้งานได้ที่ **การตั้งค่า › Wurstfinger › แป้นพิมพ์ › Wurstfinger › อนุญาตการเข้าถึงเต็มรูปแบบ**"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "हैप्टिक फ़ीडबैक के लिए पूर्ण एक्सेस ज़रूरी है। इसे **सेटिंग्स › Wurstfinger › कीबोर्ड › Wurstfinger › पूर्ण एक्सेस दें** में चालू करें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "触覚フィードバックにはフルアクセスが必要です。**「設定」› Wurstfinger ›「キーボード」› Wurstfinger ›「フルアクセスを許可」**で有効にしてください。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "햅틱 피드백에는 전체 접근이 필요합니다. **설정 › Wurstfinger › 키보드 › Wurstfinger › 전체 접근 허용**에서 켜세요."
-          }
-        }
-      },
-      "comment": "Warning with markdown bold and › separators; the path words inside ** ** are iOS Settings names — localize Settings/Keyboards/Allow Full Access, keep 'Wurstfinger', keep markdown ** and ›"
-    },
-    "Keyboard Size": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastaturgröße"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taille du clavier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamaño del teclado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dimensione della tastiera"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Размер клавиатуры"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rozmiar klawiatury"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tangentbordets storlek"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Näppäimistön koko"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Veličina tipkovnice"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גודל המקלדת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kích thước bàn phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Laki ng Keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Μέγεθος πληκτρολογίου"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamanho do teclado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Розмір клавіатури"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حجم لوحة المفاتيح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اندازه صفحه‌کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ کا سائز"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขนาดคีย์บอร์ด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड का आकार"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードのサイズ"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 크기"
-          }
-        }
-      },
-      "comment": "Slider title: overall keyboard size"
-    },
-    "Size relative to the standard keyboard. It stays the same in every orientation; if it does not fit, it shrinks to the screen.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Größe im Verhältnis zur Standardtastatur. Sie bleibt in jeder Bildschirmausrichtung gleich; passt sie nicht auf den Bildschirm, wird sie auf die Bildschirmbreite verkleinert."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taille par rapport au clavier standard. Elle reste identique dans toutes les orientations ; si le clavier ne tient pas, il est réduit à la largeur de l'écran."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamaño relativo al teclado estándar. Se mantiene igual en todas las orientaciones; si no cabe, se reduce al ancho de la pantalla."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dimensione relativa alla tastiera standard. Resta invariata in ogni orientamento; se non c'è spazio sufficiente, viene ridotta alla larghezza dello schermo."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Размер относительно стандартной клавиатуры. Он одинаков в любой ориентации; если клавиатура не помещается, она уменьшается до ширины экрана."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rozmiar względem klawiatury standardowej. Pozostaje taki sam w każdej orientacji; jeśli klawiatura się nie mieści, jest zmniejszana do szerokości ekranu."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Storlek i förhållande till standardtangentbordet. Den är densamma i alla riktningar; om tangentbordet inte får plats krymps det till skärmens bredd."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Koko suhteessa vakionäppäimistöön. Se pysyy samana kaikissa asennoissa; jos näppäimistö ei mahdu, se kutistetaan näytön leveyteen."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Veličina u odnosu na standardnu tipkovnicu. Ostaje ista u svakoj orijentaciji; ako tipkovnica ne stane, smanjuje se na širinu zaslona."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הגודל ביחס למקלדת הרגילה. הוא נשאר זהה בכל כיוון; אם המקלדת לא נכנסת, היא מוקטנת לרוחב המסך."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kích thước so với bàn phím tiêu chuẩn. Kích thước này giữ nguyên ở mọi hướng màn hình; nếu không vừa, bàn phím sẽ thu nhỏ theo chiều rộng màn hình."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Laki kumpara sa karaniwang keyboard. Nananatili itong pareho sa lahat ng oryentasyon; kung hindi kasya, liliitan ito ayon sa lapad ng screen."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Μέγεθος σε σχέση με το τυπικό πληκτρολόγιο. Παραμένει το ίδιο σε κάθε προσανατολισμό· αν δεν χωράει, σμικρύνεται στο πλάτος της οθόνης."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamanho relativo ao teclado padrão. Mantém-se igual em qualquer orientação; se não couber, é reduzido à largura do ecrã."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Розмір відносно стандартної клавіатури. Він однаковий у будь-якій орієнтації; якщо клавіатура не вміщується, вона зменшується до ширини екрана."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الحجم بالنسبة إلى لوحة المفاتيح القياسية. يبقى كما هو في كل الاتجاهات، وإذا لم تتسع لوحة المفاتيح فسيتم تصغيرها لتناسب عرض الشاشة."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اندازه نسبت به صفحه‌کلید استاندارد. در همه جهت‌ها یکسان می‌ماند؛ اگر جا نشود، به عرض صفحه کوچک می‌شود."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "معیاری کی بورڈ کے مقابلے میں سائز۔ یہ ہر سمت میں یکساں رہتا ہے؛ اگر کی بورڈ نہ سما سکے تو اسے اسکرین کی چوڑائی کے مطابق چھوٹا کر دیا جاتا ہے۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขนาดเทียบกับคีย์บอร์ดมาตรฐาน ขนาดจะเท่าเดิมในทุกการวางแนว หากไม่พอดีจะย่อลงให้เท่าความกว้างของหน้าจอ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "मानक कीबोर्ड की तुलना में आकार। यह हर ओरिएंटेशन में एक जैसा रहता है; अगर यह नहीं समाता, तो इसे स्क्रीन की चौड़ाई तक छोटा कर दिया जाता है।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "標準キーボードを基準としたサイズです。どの画面の向きでも同じ大きさを保ち、収まらない場合は画面幅に合わせて縮小されます。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "표준 키보드를 기준으로 한 크기입니다. 화면 방향이 바뀌어도 그대로 유지되며, 들어가지 않으면 화면 너비에 맞춰 줄어듭니다."
-          }
-        }
-      },
-      "comment": "Caption under the size slider"
-    },
-    "Horizontal Position": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Horizontale Position"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Position horizontale"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Posición horizontal"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Posizione orizzontale"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Положение по горизонтали"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Położenie poziome"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Horisontell position"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vaakasijainti"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vodoravni položaj"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מיקום אופקי"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vị trí ngang"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Horizontal na Posisyon"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Οριζόντια θέση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Posição horizontal"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Горизонтальне положення"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الموضع الأفقي"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "موقعیت افقی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "افقی پوزیشن"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตำแหน่งแนวนอน"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "क्षैतिज स्थिति"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水平方向の位置"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "가로 위치"
-          }
-        }
-      },
-      "comment": "Slider title"
-    },
-    "Left": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Links"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gauche"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Izquierda"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sinistra"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Слева"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lewo"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vänster"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vasen"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lijevo"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "שמאל"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trái"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kaliwa"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αριστερά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esquerda"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ліворуч"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اليسار"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "چپ"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "بائیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ซ้าย"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "बायाँ"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "左"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "왼쪽"
-          }
-        }
-      },
-      "comment": "Slider label: left position"
-    },
-    "Center": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mitte"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Centre"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Centro"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Centro"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "По центру"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Środek"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Centrerad"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keskellä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sredina"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מרכז"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giữa"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gitna"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Κέντρο"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Centro"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "По центру"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الوسط"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "وسط"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "درمیان"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กึ่งกลาง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "केंद्र"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中央"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "가운데"
-          }
-        }
-      },
-      "comment": "Slider label: center position"
-    },
-    "Right": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rechts"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Droite"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Derecha"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Destra"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Справа"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prawo"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Höger"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oikea"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desno"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ימין"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phải"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kanan"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Δεξιά"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Direita"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Праворуч"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اليمين"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "راست"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "دائیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขวา"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "दायाँ"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "右"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "오른쪽"
-          }
-        }
-      },
-      "comment": "Slider label: right position"
-    },
-    "Adjust the horizontal position of the keyboard when it is narrower than the screen.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passe die horizontale Position der Tastatur an, wenn sie schmaler als der Bildschirm ist."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajustez la position horizontale du clavier lorsqu'il est plus étroit que l'écran."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajusta la posición horizontal del teclado cuando es más estrecho que la pantalla."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Regola la posizione orizzontale della tastiera quando è più stretta dello schermo."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Настройте положение клавиатуры по горизонтали, когда она уже экрана."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dostosuj poziome położenie klawiatury, gdy jest węższa niż ekran."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Justera tangentbordets horisontella position när det är smalare än skärmen."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Säädä näppäimistön vaakasijaintia, kun se on näyttöä kapeampi."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prilagodi vodoravni položaj tipkovnice kad je uža od zaslona."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "התאם את המיקום האופקי של המקלדת כאשר היא צרה מהמסך."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Điều chỉnh vị trí ngang của bàn phím khi bàn phím hẹp hơn màn hình."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iayos ang horizontal na posisyon ng keyboard kapag mas makitid ito kaysa sa screen."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Προσαρμόστε την οριζόντια θέση του πληκτρολογίου όταν είναι στενότερο από την οθόνη."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajuste a posição horizontal do teclado quando este for mais estreito do que o ecrã."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Регулюйте горизонтальне положення клавіатури, коли вона вужча за екран."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اضبط الموضع الأفقي للوحة المفاتيح عندما تكون أضيق من الشاشة."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "وقتی صفحه‌کلید از صفحه نمایش باریک‌تر است، موقعیت افقی آن را تنظیم کنید."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جب کی بورڈ اسکرین سے تنگ ہو تو اس کی افقی پوزیشن ایڈجسٹ کریں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปรับตำแหน่งแนวนอนของคีย์บอร์ดเมื่อคีย์บอร์ดแคบกว่าหน้าจอ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "जब कीबोर्ड स्क्रीन से सँकरा हो, तो उसकी क्षैतिज स्थिति समायोजित करें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードが画面より狭いときに、水平方向の位置を調整します。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드가 화면보다 좁을 때 가로 위치를 조정합니다."
-          }
-        }
-      },
-      "comment": "Caption under the position slider"
-    },
-    "Aspect Ratio": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seitenverhältnis"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proportions"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporción"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporzioni"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Соотношение сторон"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporcje"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proportioner"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kuvasuhde"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Omjer stranica"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "יחס גובה-רוחב"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tỷ lệ khung"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aspect Ratio"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αναλογία διαστάσεων"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Proporção"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Співвідношення сторін"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسبة الأبعاد"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسبت ابعاد"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پہلو تناسب"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อัตราส่วน"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आस्पेक्ट रेशियो"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "縦横比"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "가로세로 비율"
-          }
-        }
-      },
-      "comment": "Slider title: key width-to-height ratio"
-    },
-    "Square · Default": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quadratisch · Standard"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Carré · Par défaut"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cuadrado · Por defecto"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quadrato · Predefinito"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Квадрат · По умолчанию"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kwadratowe · Domyślne"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kvadratisk · Standard"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Neliö · Oletus"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kvadratno · Zadano"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מרובע · ברירת מחדל"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vuông · Mặc định"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Parisukat · Default"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Τετράγωνο · Προεπιλογή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quadrado · Predefinição"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Квадратне · За замовчуванням"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مربّع · افتراضي"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مربع · پیش‌فرض"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مربع · طے شدہ"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สี่เหลี่ยมจัตุรัส · ค่าเริ่มต้น"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "वर्ग · डिफ़ॉल्ट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正方形・デフォルト"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "정사각형 · 기본값"
-          }
-        }
-      },
-      "comment": "Slider tick label at ratio 1.0; keep the · middle dot"
-    },
-    "Wide": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Breit"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Large"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ancho"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Largo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Широкие"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Szerokie"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bred"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leveä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Široko"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "רחב"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rộng"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Malapad"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Πλατύ"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Largo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Широке"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "عريض"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پهن"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "چوڑا"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กว้าง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "चौड़ा"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワイド"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "넓게"
-          }
-        }
-      },
-      "comment": "Slider tick label (wider keys)"
-    },
-    "Golden": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Golden"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Doré"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Áureo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aureo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Золотое сечение"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Złote"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gyllene"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kultainen"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zlatni rez"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "זהב"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tỷ lệ vàng"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Golden"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Χρυσή τομή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dourado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Золотий перетин"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ذهبي"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "طلایی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "گولڈن"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "อัตราส่วนทอง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "गोल्डन"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "黄金比"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "황금비"
-          }
-        }
-      },
-      "comment": "Slider tick label at the golden ratio 1.62"
-    },
-    "Adjust the width-to-height ratio of the keys. 1.0 creates square keys (the default), and 1.62 is the golden ratio (widest).": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passe das Verhältnis von Breite zu Höhe der Tasten an. 1,0 erzeugt quadratische Tasten (Standard), 1,62 ist der Goldene Schnitt (am breitesten)."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajustez le rapport largeur/hauteur des touches. 1,0 crée des touches carrées (par défaut) et 1,62 correspond au nombre d'or (le plus large)."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajusta la proporción entre el ancho y el alto de las teclas. 1.0 crea teclas cuadradas (por defecto) y 1.62 es la proporción áurea (las más anchas)."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Regola il rapporto larghezza-altezza dei tasti. 1.0 crea tasti quadrati (l'impostazione predefinita), mentre 1.62 è la sezione aurea (la più larga)."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Настройте соотношение ширины и высоты клавиш. 1.0 создаёт квадратные клавиши (по умолчанию), а 1.62 — золотое сечение (самые широкие)."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dostosuj stosunek szerokości do wysokości klawiszy. 1.0 daje klawisze kwadratowe (domyślnie), a 1.62 to złoty podział (najszersze)."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Justera tangenternas förhållande mellan bredd och höjd. 1,0 ger kvadratiska tangenter (standard) och 1,62 är det gyllene snittet (bredast)."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Säädä näppäinten leveyden ja korkeuden suhdetta. 1,0 tuottaa neliönmuotoiset näppäimet (oletus) ja 1,62 on kultainen leikkaus (levein)."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prilagodi omjer širine i visine tipki. 1.0 stvara kvadratne tipke (zadano), a 1.62 je zlatni rez (najšire)."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "התאם את יחס הרוחב-גובה של המקשים. 1.0 יוצר מקשים מרובעים (ברירת המחדל), ו-1.62 הוא יחס הזהב (הרחב ביותר)."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Điều chỉnh tỷ lệ rộng trên cao của phím. 1.0 tạo phím vuông (mặc định), và 1.62 là tỷ lệ vàng (rộng nhất)."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iayos ang ratio ng lapad-sa-taas ng mga key. Ang 1.0 ay gumagawa ng parisukat na key (ang default), at ang 1.62 ay ang golden ratio (pinakamalapad)."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Προσαρμόστε την αναλογία πλάτους προς ύψος των πλήκτρων. Το 1.0 δημιουργεί τετράγωνα πλήκτρα (η προεπιλογή) και το 1.62 είναι η χρυσή τομή (το πλατύτερο)."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajuste a proporção entre a largura e a altura das teclas. 1.0 cria teclas quadradas (a predefinição) e 1.62 é a proporção áurea (a mais larga)."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Регулюйте співвідношення ширини до висоти клавіш. 1.0 створює квадратні клавіші (за замовчуванням), а 1.62 — це золотий перетин (найширше)."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اضبط نسبة العرض إلى الارتفاع للمفاتيح. تُنشئ القيمة 1.0 مفاتيح مربّعة (الافتراضي)، والقيمة 1.62 هي النسبة الذهبية (الأعرض)."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسبت عرض به ارتفاع کلیدها را تنظیم کنید. ۱٫۰ کلیدهای مربعی می‌سازد (پیش‌فرض) و ۱٫۶۲ نسبت طلایی است (پهن‌ترین)."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کیز کی چوڑائی اور اونچائی کا تناسب ایڈجسٹ کریں۔ 1.0 مربع کیز بناتا ہے (طے شدہ)، اور 1.62 گولڈن تناسب ہے (سب سے چوڑا)۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปรับอัตราส่วนความกว้างต่อความสูงของปุ่ม 1.0 จะได้ปุ่มสี่เหลี่ยมจัตุรัส (ค่าเริ่มต้น) และ 1.62 คืออัตราส่วนทอง (กว้างที่สุด)"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीज़ के चौड़ाई-से-ऊँचाई अनुपात को समायोजित करें। 1.0 वर्गाकार कीज़ बनाता है (डिफ़ॉल्ट), और 1.62 गोल्डन रेशियो है (सबसे चौड़ा)।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーの幅と高さの比率を調整します。1.0で正方形のキー（デフォルト）になり、1.62で黄金比（最も幅広）になります。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키의 너비 대 높이 비율을 조정합니다. 1.0은 정사각형 키(기본값)를, 1.62는 황금비(가장 넓음)를 만듭니다."
-          }
-        }
-      },
-      "comment": "Caption under the aspect ratio slider"
-    },
-    "Preview": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vorschau"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aperçu"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vista previa"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Anteprima"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Предпросмотр"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Podgląd"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Förhandsvisning"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Esikatselu"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pregled"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "תצוגה מקדימה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xem trước"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preview"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Προεπισκόπηση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pré-visualização"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перегляд"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "معاينة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پیش‌نمایش"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پیش منظر"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตัวอย่าง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "प्रीव्यू"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プレビュー"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "미리보기"
-          }
-        }
-      },
-      "comment": "Header above the interactive keyboard preview"
-    },
-    "Type on the keyboard below": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tippe auf der Tastatur unten"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tapez sur le clavier ci-dessous"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escribe con el teclado de abajo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scrivi sulla tastiera qui sotto"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Печатайте на клавиатуре ниже"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pisz na klawiaturze poniżej"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skriv på tangentbordet nedan"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kirjoita alla olevalla näppäimistöllä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tipkaj na tipkovnici ispod"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הקלד במקלדת שלמטה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gõ trên bàn phím bên dưới"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mag-type sa keyboard sa ibaba"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Πληκτρολογήστε στο παρακάτω πληκτρολόγιο"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Escreva no teclado abaixo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Друкуйте на клавіатурі нижче"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اكتب على لوحة المفاتيح أدناه"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "روی صفحه‌کلید زیر تایپ کنید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نیچے کی بورڈ پر ٹائپ کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "พิมพ์บนคีย์บอร์ดด้านล่าง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "नीचे दिए कीबोर्ड पर टाइप करें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "下のキーボードで入力してください"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "아래 키보드로 입력해 보세요"
-          }
-        }
-      },
-      "comment": "Placeholder text in the preview when empty"
-    },
-    "Switch keyboard": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastatur wechseln"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Changer de clavier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambiar de teclado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cambia tastiera"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Переключить клавиатуру"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przełącz klawiaturę"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Byt tangentbord"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vaihda näppäimistöä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Promijeni tipkovnicu"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "החלף מקלדת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chuyển bàn phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Magpalit ng keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Εναλλαγή πληκτρολογίου"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mudar de teclado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Перемкнути клавіатуру"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تبديل لوحة المفاتيح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تعویض صفحه‌کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ تبدیل کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สลับคีย์บอร์ด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड बदलें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードを切り替える"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 전환"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the globe key (VoiceOver)"
-    },
-    "Hide keyboard": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastatur ausblenden"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Masquer le clavier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ocultar teclado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nascondi tastiera"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Скрыть клавиатуру"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ukryj klawiaturę"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dölj tangentbordet"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piilota näppäimistö"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sakrij tipkovnicu"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הסתר מקלדת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ẩn bàn phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Itago ang keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Απόκρυψη πληκτρολογίου"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ocultar teclado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сховати клавіатуру"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إخفاء لوحة المفاتيح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پنهان کردن صفحه‌کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ چھپائیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ซ่อนคีย์บอร์ด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड छिपाएँ"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードを隠す"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 숨기기"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for dismiss-keyboard gesture (VoiceOver)"
-    },
-    "Delete": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Löschen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Supprimer"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Borrar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elimina"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Удалить"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usuń"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Radera"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Poista"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Brisanje"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מחק"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Xóa"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Διαγραφή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eliminar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Видалити"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حذف"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حذف"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حذف کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ลบ"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "डिलीट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "削除"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "삭제"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the delete/backspace key (VoiceOver)"
-    },
-    "Next language": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nächste Sprache"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Langue suivante"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Idioma siguiente"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lingua successiva"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Следующий язык"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Następny język"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nästa språk"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seuraava kieli"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sljedeći jezik"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "השפה הבאה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ngôn ngữ tiếp theo"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Susunod na wika"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Επόμενη γλώσσα"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Próximo idioma"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Наступна мова"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اللغة التالية"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "زبان بعدی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اگلی زبان"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ภาษาถัดไป"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अगली भाषा"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "次の言語"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "다음 언어"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY action name for the switch-to-next-language gesture (VoiceOver)"
-    },
-    "New line": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Neue Zeile"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nouvelle ligne"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nueva línea"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A capo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Новая строка"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nowy wiersz"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ny rad"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uusi rivi"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Novi redak"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "שורה חדשה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dòng mới"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bagong linya"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Νέα γραμμή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nova linha"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Новий рядок"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سطر جديد"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "خط جدید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نئی لائن"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ขึ้นบรรทัดใหม่"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "नई लाइन"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "改行"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "줄바꿈"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the return/newline key (VoiceOver)"
-    },
-    "Copy": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopieren"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copiar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copia"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Копировать"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopiuj"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopiera"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopioi"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopiraj"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "העתק"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sao chép"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kopyahin"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αντιγραφή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copiar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Копіювати"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "نسخ"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کپی"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کاپی کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คัดลอก"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कॉपी"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コピー"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "복사"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the copy gesture (VoiceOver)"
-    },
-    "Cut": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ausschneiden"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couper"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taglia"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вырезать"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wytnij"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klipp ut"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leikkaa"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Izreži"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גזור"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cắt"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gupitin"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αποκοπή"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вирізати"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قص"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برش"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کٹ کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตัด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カット"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "오려두기"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the cut gesture (VoiceOver)"
-    },
-    "Cut all": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alles ausschneiden"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tout couper"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar todo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taglia tutto"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вырезать всё"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wytnij wszystko"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klipp ut allt"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leikkaa kaikki"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Izreži sve"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גזור הכול"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cắt tất cả"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gupitin lahat"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αποκοπή όλων"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar tudo"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вирізати все"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قص الكل"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برش همه"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "سب کاٹیں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตัดทั้งหมด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सभी काटें"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "すべて切り取り"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "모두 잘라내기"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the cut-all gesture (VoiceOver)"
-    },
-    "Paste": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Einsetzen"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Coller"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pegar"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incolla"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вставить"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wklej"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klistra in"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Liitä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zalijepi"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הדבק"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dán"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-paste"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Επικόλληση"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Colar"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вставити"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لصق"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "چسباندن"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پیسٹ کریں"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "วาง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पेस्ट"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ペースト"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "붙여넣기"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the paste gesture (VoiceOver)"
-    },
-    "Space": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leertaste"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Espace"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Espacio"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Spazio"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Пробел"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Spacja"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mellanslag"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Välilyönti"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Razmaknica"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "רווח"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phím cách"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Space"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Διάστημα"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Espaço"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Пробіл"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مسافة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "فاصله"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اسپیس"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เว้นวรรค"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "स्पेस"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "スペース"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "스페이스"
-          }
-        }
-      },
-      "comment": "ACCESSIBILITY label for the space bar (VoiceOver)"
+      "comment": "Languages summary: list of languages + pinned default language"
     },
     "%@ + %lld more": {
       "extractionState": "manual",
@@ -12697,695 +277,695 @@
       },
       "comment": "Languages summary: first language + count of remaining"
     },
-    "%@ (default: %@)": {
+    "About": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (Standard: %@)"
+            "value": "Über"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (par défaut : %@)"
+            "value": "À propos"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (predeterminado: %@)"
+            "value": "Información"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (predefinita: %@)"
+            "value": "Informazioni"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (по умолчанию: %@)"
+            "value": "О приложении"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (domyślny: %@)"
+            "value": "Informacje"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (standard: %@)"
+            "value": "Om"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (oletus: %@)"
+            "value": "Tietoja"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (zadano: %@)"
+            "value": "O aplikaciji"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (ברירת מחדל: %@)"
+            "value": "אודות"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (mặc định: %@)"
+            "value": "Giới thiệu"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (default: %@)"
+            "value": "Tungkol Dito"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (προεπιλογή: %@)"
+            "value": "Σχετικά"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (predefinição: %@)"
+            "value": "Acerca de"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (за замовчуванням: %@)"
+            "value": "Про програму"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (افتراضي: %@)"
+            "value": "حول"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (پیش‌فرض: %@)"
+            "value": "درباره"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (طے شدہ: %@)"
+            "value": "بارے میں"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (ค่าเริ่มต้น: %@)"
+            "value": "เกี่ยวกับ"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (डिफ़ॉल्ट: %@)"
+            "value": "परिचय"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@（デフォルト：%@）"
+            "value": "情報"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ (기본값: %@)"
+            "value": "정보"
           }
         }
       },
-      "comment": "Languages summary: list of languages + pinned default language"
+      "comment": "Settings section header"
     },
-    "Current: %@:1": {
+    "Activate \"Allow Full Access\" so cursor control and deletion gestures work.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aktuell: %@:1"
+            "value": "Aktiviere \"Vollzugriff erlauben\", damit Cursorsteuerung und Löschgesten funktionieren."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Actuel : %@:1"
+            "value": "Activez « Autoriser l'accès complet » pour que le contrôle du curseur et les gestes de suppression fonctionnent."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Actual: %@:1"
+            "value": "Activa \"Permitir acceso completo\" para que funcionen el control del cursor y los gestos de borrado."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Attuale: %@:1"
+            "value": "Attiva \"Consenti accesso completo\" affinché il controllo del cursore e i gesti di eliminazione funzionino."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Текущее: %@:1"
+            "value": "Включите «Разрешить полный доступ», чтобы работали управление курсором и жесты удаления."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Obecnie: %@:1"
+            "value": "Włącz „Przyznaj pełny dostęp”, aby działało sterowanie kursorem i gesty usuwania."
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aktuellt: %@:1"
+            "value": "Aktivera \"Tillåt fullständig åtkomst\" så att markörstyrning och raderingsgester fungerar."
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nykyinen: %@:1"
+            "value": "Ota käyttöön \"Salli täysi käyttöoikeus\", jotta kohdistimen ohjaus ja poistoeleet toimivat."
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Trenutno: %@:1"
+            "value": "Uključi „Dopusti puni pristup” kako bi radile geste za upravljanje pokazivačem i brisanje."
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "נוכחי: %@:1"
+            "value": "הפעל את \"אפשר גישה מלאה\" כדי שמחוות שליטת הסמן והמחיקה יפעלו."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hiện tại: %@:1"
+            "value": "Bật \"Cho phép truy cập đầy đủ\" để các cử chỉ điều khiển con trỏ và xóa hoạt động."
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kasalukuyan: %@:1"
+            "value": "I-activate ang \"Payagan ang Full Access\" para gumana ang kontrol ng cursor at mga gesture sa pagbura."
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Τρέχον: %@:1"
+            "value": "Ενεργοποιήστε την επιλογή «Να επιτρέπεται η πλήρης πρόσβαση» ώστε να λειτουργούν ο έλεγχος του δρομέα και οι χειρονομίες διαγραφής."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atual: %@:1"
+            "value": "Ative \"Permitir acesso total\" para que os gestos de controlo do cursor e de eliminação funcionem."
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Поточне: %@:1"
+            "value": "Увімкніть «Дозволити повний доступ», щоб працювали керування курсором і жести видалення."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "الحالي: %@:1"
+            "value": "فعِّل \"السماح بالوصول الكامل\" حتى تعمل إيماءات التحكم في المؤشر والحذف."
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "فعلی: %@:۱"
+            "value": "«اجازهٔ دسترسی کامل» را فعال کنید تا کنترل نشانگر و حرکت‌های حذف کار کنند."
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "موجودہ: %@:1"
+            "value": "\"مکمل رسائی کی اجازت دیں\" فعال کریں تاکہ کرسر کنٹرول اور حذف کرنے کے اشارے کام کریں۔"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ปัจจุบัน: %@:1"
+            "value": "เปิดใช้ \"อนุญาตการเข้าถึงเต็มรูปแบบ\" เพื่อให้การควบคุมเคอร์เซอร์และเจสเจอร์ลบข้อความทำงานได้"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "वर्तमान: %@:1"
+            "value": "\"पूर्ण एक्सेस दें\" चालू करें ताकि कर्सर नियंत्रण और डिलीट जेस्चर काम करें।"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "現在：%@:1"
+            "value": "カーソル操作と削除ジェスチャを使えるように「フルアクセスを許可」をオンにしてください。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "현재: %@:1"
+            "value": "커서 제어 및 삭제 제스처가 작동하도록 \"전체 접근 허용\"을 켜세요."
           }
         }
       },
-      "comment": "Key aspect ratio subtitle, e.g. 'Current: 1.00:1'"
+      "comment": "Onboarding step 2 description; 'Allow Full Access' is the iOS toggle name (localized)"
     },
-    "Scale: %@, Position: %@": {
+    "Adjust the horizontal position of the keyboard when it is narrower than the screen.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Größe: %@, Position: %@"
+            "value": "Passe die horizontale Position der Tastatur an, wenn sie schmaler als der Bildschirm ist."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Échelle : %@, position : %@"
+            "value": "Ajustez la position horizontale du clavier lorsqu'il est plus étroit que l'écran."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Escala: %@, posición: %@"
+            "value": "Ajusta la posición horizontal del teclado cuando es más estrecho que la pantalla."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scala: %@, posizione: %@"
+            "value": "Regola la posizione orizzontale della tastiera quando è più stretta dello schermo."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Масштаб: %@, положение: %@"
+            "value": "Настройте положение клавиатуры по горизонтали, когда она уже экрана."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Skala: %@, położenie: %@"
+            "value": "Dostosuj poziome położenie klawiatury, gdy jest węższa niż ekran."
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Skala: %@, position: %@"
+            "value": "Justera tangentbordets horisontella position när det är smalare än skärmen."
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Koko: %@, sijainti: %@"
+            "value": "Säädä näppäimistön vaakasijaintia, kun se on näyttöä kapeampi."
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Veličina: %@, položaj: %@"
+            "value": "Prilagodi vodoravni položaj tipkovnice kad je uža od zaslona."
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "קנה מידה: %@, מיקום: %@"
+            "value": "התאם את המיקום האופקי של המקלדת כאשר היא צרה מהמסך."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tỷ lệ: %@, vị trí: %@"
+            "value": "Điều chỉnh vị trí ngang của bàn phím khi bàn phím hẹp hơn màn hình."
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scale: %@, posisyon: %@"
+            "value": "Iayos ang horizontal na posisyon ng keyboard kapag mas makitid ito kaysa sa screen."
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Κλίμακα: %@, Θέση: %@"
+            "value": "Προσαρμόστε την οριζόντια θέση του πληκτρολογίου όταν είναι στενότερο από την οθόνη."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Escala: %@, Posição: %@"
+            "value": "Ajuste a posição horizontal do teclado quando este for mais estreito do que o ecrã."
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Масштаб: %@, положення: %@"
+            "value": "Регулюйте горизонтальне положення клавіатури, коли вона вужча за екран."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "الحجم: %@، الموضع: %@"
+            "value": "اضبط الموضع الأفقي للوحة المفاتيح عندما تكون أضيق من الشاشة."
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "مقیاس: %@، موقعیت: %@"
+            "value": "وقتی صفحه‌کلید از صفحه نمایش باریک‌تر است، موقعیت افقی آن را تنظیم کنید."
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "اسکیل: %@، پوزیشن: %@"
+            "value": "جب کی بورڈ اسکرین سے تنگ ہو تو اس کی افقی پوزیشن ایڈجسٹ کریں۔"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ขนาด: %@, ตำแหน่ง: %@"
+            "value": "ปรับตำแหน่งแนวนอนของคีย์บอร์ดเมื่อคีย์บอร์ดแคบกว่าหน้าจอ"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "स्केल: %@, स्थिति: %@"
+            "value": "जब कीबोर्ड स्क्रीन से सँकरा हो, तो उसकी क्षैतिज स्थिति समायोजित करें।"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "サイズ：%@、位置：%@"
+            "value": "キーボードが画面より狭いときに、水平方向の位置を調整します。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "크기: %@, 위치: %@"
+            "value": "키보드가 화면보다 좁을 때 가로 위치를 조정합니다."
           }
         }
       },
-      "comment": "Size & Position subtitle, e.g. 'Scale: 100%, Position: Center'"
+      "comment": "Caption under the position slider"
     },
-    "Tap: %@ • Drag: %@": {
+    "Adjust the width-to-height ratio of the keys. 1.0 creates square keys (the default), and 1.62 is the golden ratio (widest).": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tippen: %@ • Ziehen: %@"
+            "value": "Passe das Verhältnis von Breite zu Höhe der Tasten an. 1,0 erzeugt quadratische Tasten (Standard), 1,62 ist der Goldene Schnitt (am breitesten)."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Toucher : %@ • Glisser : %@"
+            "value": "Ajustez le rapport largeur/hauteur des touches. 1,0 crée des touches carrées (par défaut) et 1,62 correspond au nombre d'or (le plus large)."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tocar: %@ • Arrastrar: %@"
+            "value": "Ajusta la proporción entre el ancho y el alto de las teclas. 1.0 crea teclas cuadradas (por defecto) y 1.62 es la proporción áurea (las más anchas)."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tocco: %@ • Trascinamento: %@"
+            "value": "Regola il rapporto larghezza-altezza dei tasti. 1.0 crea tasti quadrati (l'impostazione predefinita), mentre 1.62 è la sezione aurea (la più larga)."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Нажатие: %@ • Перетягивание: %@"
+            "value": "Настройте соотношение ширины и высоты клавиш. 1.0 создаёт квадратные клавиши (по умолчанию), а 1.62 — золотое сечение (самые широкие)."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Stuknięcie: %@ • Przeciąganie: %@"
+            "value": "Dostosuj stosunek szerokości do wysokości klawiszy. 1.0 daje klawisze kwadratowe (domyślnie), a 1.62 to złoty podział (najszersze)."
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tryck: %@ • Dragning: %@"
+            "value": "Justera tangenternas förhållande mellan bredd och höjd. 1,0 ger kvadratiska tangenter (standard) och 1,62 är det gyllene snittet (bredast)."
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Napautus: %@ • Veto: %@"
+            "value": "Säädä näppäinten leveyden ja korkeuden suhdetta. 1,0 tuottaa neliönmuotoiset näppäimet (oletus) ja 1,62 on kultainen leikkaus (levein)."
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dodir: %@ • Povlačenje: %@"
+            "value": "Prilagodi omjer širine i visine tipki. 1.0 stvara kvadratne tipke (zadano), a 1.62 je zlatni rez (najšire)."
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "הקשה: %@ • גרירה: %@"
+            "value": "התאם את יחס הרוחב-גובה של המקשים. 1.0 יוצר מקשים מרובעים (ברירת המחדל), ו-1.62 הוא יחס הזהב (הרחב ביותר)."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chạm: %@ • Kéo: %@"
+            "value": "Điều chỉnh tỷ lệ rộng trên cao của phím. 1.0 tạo phím vuông (mặc định), và 1.62 là tỷ lệ vàng (rộng nhất)."
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tap: %@ • Drag: %@"
+            "value": "Iayos ang ratio ng lapad-sa-taas ng mga key. Ang 1.0 ay gumagawa ng parisukat na key (ang default), at ang 1.62 ay ang golden ratio (pinakamalapad)."
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Πάτημα: %@ • Σύρσιμο: %@"
+            "value": "Προσαρμόστε την αναλογία πλάτους προς ύψος των πλήκτρων. Το 1.0 δημιουργεί τετράγωνα πλήκτρα (η προεπιλογή) και το 1.62 είναι η χρυσή τομή (το πλατύτερο)."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Toque: %@ • Arrastar: %@"
+            "value": "Ajuste a proporção entre a largura e a altura das teclas. 1.0 cria teclas quadradas (a predefinição) e 1.62 é a proporção áurea (a mais larga)."
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Дотик: %@ • Перетягування: %@"
+            "value": "Регулюйте співвідношення ширини до висоти клавіш. 1.0 створює квадратні клавіші (за замовчуванням), а 1.62 — це золотий перетин (найширше)."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "اللمس: %@ • السحب: %@"
+            "value": "اضبط نسبة العرض إلى الارتفاع للمفاتيح. تُنشئ القيمة 1.0 مفاتيح مربّعة (الافتراضي)، والقيمة 1.62 هي النسبة الذهبية (الأعرض)."
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "ضربه: %@ • کشیدن: %@"
+            "value": "نسبت عرض به ارتفاع کلیدها را تنظیم کنید. ۱٫۰ کلیدهای مربعی می‌سازد (پیش‌فرض) و ۱٫۶۲ نسبت طلایی است (پهن‌ترین)."
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "ٹیپ: %@ • ڈریگ: %@"
+            "value": "کیز کی چوڑائی اور اونچائی کا تناسب ایڈجسٹ کریں۔ 1.0 مربع کیز بناتا ہے (طے شدہ)، اور 1.62 گولڈن تناسب ہے (سب سے چوڑا)۔"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "แตะ: %@ • ลาก: %@"
+            "value": "ปรับอัตราส่วนความกว้างต่อความสูงของปุ่ม 1.0 จะได้ปุ่มสี่เหลี่ยมจัตุรัส (ค่าเริ่มต้น) และ 1.62 คืออัตราส่วนทอง (กว้างที่สุด)"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "टैप: %@ • ड्रैग: %@"
+            "value": "कीज़ के चौड़ाई-से-ऊँचाई अनुपात को समायोजित करें। 1.0 वर्गाकार कीज़ बनाता है (डिफ़ॉल्ट), और 1.62 गोल्डन रेशियो है (सबसे चौड़ा)।"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "タップ：%@ • ドラッグ：%@"
+            "value": "キーの幅と高さの比率を調整します。1.0で正方形のキー（デフォルト）になり、1.62で黄金比（最も幅広）になります。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "탭: %@ • 드래그: %@"
+            "value": "키의 너비 대 높이 비율을 조정합니다. 1.0은 정사각형 키(기본값)를, 1.62는 황금비(가장 넓음)를 만듭니다."
           }
         }
       },
-      "comment": "Haptic feedback subtitle, e.g. 'Tap: 50% • Drag: Off'"
+      "comment": "Caption under the aspect ratio slider"
     },
-    "Gesture tuning enabled": {
+    "Advanced": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestenanpassung aktiviert"
+            "value": "Erweitert"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Réglage des gestes activé"
+            "value": "Avancé"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ajuste de gestos activado"
+            "value": "Avanzado"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Regolazione dei gesti attivata"
+            "value": "Avanzate"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Настройка жестов включена"
+            "value": "Дополнительно"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dostrajanie gestów włączone"
+            "value": "Zaawansowane"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestjustering aktiverad"
+            "value": "Avancerat"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Eleiden hienosäätö käytössä"
+            "value": "Lisäasetukset"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Podešavanje gesti uključeno"
+            "value": "Napredno"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "כוונון מחוות מופעל"
+            "value": "מתקדם"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Đã bật tinh chỉnh cử chỉ"
+            "value": "Nâng cao"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Naka-enable ang pag-tune ng gesture"
+            "value": "Advanced"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Η ρύθμιση χειρονομιών είναι ενεργή"
+            "value": "Για προχωρημένους"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ajuste de gestos ativado"
+            "value": "Avançado"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Налаштування жестів увімкнено"
+            "value": "Додатково"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "ضبط الإيماءات مُفعَّل"
+            "value": "متقدم"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "تنظیم حرکت‌ها فعال شد"
+            "value": "پیشرفته"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "اشارہ ٹیوننگ فعال ہے"
+            "value": "ایڈوانسڈ"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "เปิดใช้การปรับแต่งเจสเจอร์"
+            "value": "ขั้นสูง"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "जेस्चर ट्यूनिंग चालू है"
+            "value": "उन्नत"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ジェスチャ調整が有効"
+            "value": "詳細"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "제스처 조정 사용"
+            "value": "고급"
           }
         }
       },
-      "comment": "Expert row subtitle when expert mode is on"
+      "comment": "Settings section header"
     },
     "Advanced gesture settings": {
       "extractionState": "manual",
@@ -13525,419 +1105,1936 @@
       },
       "comment": "Expert row subtitle when expert mode is off"
     },
-    "Drag to move cursor": {
+    "All labels visible": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ziehen bewegt den Cursor"
+            "value": "Alle Beschriftungen sichtbar"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Glisser pour déplacer le curseur"
+            "value": "Toutes les étiquettes visibles"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arrastra para mover el cursor"
+            "value": "Todas las etiquetas visibles"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Trascina per spostare il cursore"
+            "value": "Tutte le etichette visibili"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Перетягивание перемещает курсор"
+            "value": "Все подписи видны"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Przeciągnij, aby przesunąć kursor"
+            "value": "Wszystkie etykiety widoczne"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dra för att flytta markören"
+            "value": "Alla etiketter synliga"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Siirrä kohdistinta vetämällä"
+            "value": "Kaikki merkinnät näkyvissä"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Povuci za pomicanje pokazivača"
+            "value": "Sve oznake vidljive"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "גרירה מזיזה את הסמן"
+            "value": "כל התוויות גלויות"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kéo để di chuyển con trỏ"
+            "value": "Hiển thị tất cả nhãn"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "I-drag para igalaw ang cursor"
+            "value": "Nakikita ang lahat ng label"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Σύρετε για μετακίνηση του δρομέα"
+            "value": "Όλες οι ετικέτες ορατές"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Arrastar para mover o cursor"
+            "value": "Todas as etiquetas visíveis"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Перетягніть, щоб перемістити курсор"
+            "value": "Усі підписи видимі"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "اسحب لتحريك المؤشر"
+            "value": "جميع التسميات ظاهرة"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "برای جابه‌جایی نشانگر بکشید"
+            "value": "همهٔ برچسب‌ها نمایان"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "کرسر منتقل کرنے کے لیے ڈریگ کریں"
+            "value": "تمام لیبل نظر آ رہے ہیں"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ลากเพื่อเลื่อนเคอร์เซอร์"
+            "value": "แสดงป้ายกำกับทั้งหมด"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "कर्सर हिलाने के लिए ड्रैग करें"
+            "value": "सभी लेबल दिखाई दे रहे हैं"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ドラッグしてカーソルを移動"
+            "value": "すべてのラベルを表示"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "드래그하여 커서 이동"
+            "value": "모든 레이블 표시"
           }
         }
       },
-      "comment": "Cursor movement subtitle: continuous style"
+      "comment": "Label visibility subtitle when nothing is hidden"
     },
-    "Swipe per character, return-swipe per word": {
+    "Allow full access": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wischen pro Zeichen, Hin-und-zurück-Wischen pro Wort"
+            "value": "Vollzugriff erlauben"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Balayage par caractère, aller-retour par mot"
+            "value": "Autoriser l'accès complet"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desliza por carácter, desliza y vuelve por palabra"
+            "value": "Permitir acceso completo"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scorri per carattere, scorri e torna per parola"
+            "value": "Consenti accesso completo"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Свайп — символ, свайп с возвратом — слово"
+            "value": "Разрешите полный доступ"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Przesunięcie – znak, przesunięcie z powrotem – słowo"
+            "value": "Przyznaj pełny dostęp"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Svep per tecken, retursvep per ord"
+            "value": "Tillåt fullständig åtkomst"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pyyhkäisy siirtää merkin, paluupyyhkäisy sanan"
+            "value": "Salli täysi käyttöoikeus"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prijelaz po znaku, povratni prijelaz po riječi"
+            "value": "Dopusti puni pristup"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "החלקה לכל תו, החלקה וחזרה לכל מילה"
+            "value": "אפשר גישה מלאה"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vuốt theo ký tự, vuốt và quay lại theo từ"
+            "value": "Cho phép truy cập đầy đủ"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Swipe kada character, return-swipe kada salita"
+            "value": "Payagan ang Full Access"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Σάρωση ανά χαρακτήρα, σάρωση επιστροφής ανά λέξη"
+            "value": "Να επιτρέπεται η πλήρης πρόσβαση"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Deslize por carácter, deslize de retorno por palavra"
+            "value": "Permitir acesso total"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Свайп для символу, зворотний свайп для слова"
+            "value": "Дозволити повний доступ"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "تمرير لكل حرف، وتمرير عائد لكل كلمة"
+            "value": "السماح بالوصول الكامل"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "کشیدن برای هر نویسه، کشیدن‌و‌بازگشت برای هر واژه"
+            "value": "اجازهٔ دسترسی کامل"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "ہر حرف کے لیے سوائپ، ہر لفظ کے لیے ریٹرن سوائپ"
+            "value": "مکمل رسائی کی اجازت دیں"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ปัดทีละตัวอักษร ปัดกลับทีละคำ"
+            "value": "อนุญาตการเข้าถึงเต็มรูปแบบ"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "प्रति अक्षर स्वाइप, प्रति शब्द रिटर्न-स्वाइप"
+            "value": "पूर्ण एक्सेस दें"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "スワイプで1文字ずつ、リターンスワイプで1単語ずつ"
+            "value": "フルアクセスを許可"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "글자 단위 스와이프, 단어 단위 리턴 스와이프"
+            "value": "전체 접근 허용"
           }
         }
       },
-      "comment": "Cursor movement subtitle: discrete style"
+      "comment": "Onboarding step 2 title; refers to the iOS keyboard 'Allow Full Access' toggle"
     },
-    "Phone layout (1-2-3)": {
+    "Appearance": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Telefon-Layout (1-2-3)"
+            "value": "Darstellung"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Disposition téléphone (1-2-3)"
+            "value": "Apparence"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Disposición de teléfono (1-2-3)"
+            "value": "Aspecto"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Layout telefono (1-2-3)"
+            "value": "Aspetto"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Телефонная раскладка (1-2-3)"
+            "value": "Внешний вид"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Układ telefoniczny (1-2-3)"
+            "value": "Wygląd"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Telefonlayout (1-2-3)"
+            "value": "Utseende"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Puhelinasettelu (1-2-3)"
+            "value": "Ulkoasu"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Telefonski raspored (1-2-3)"
+            "value": "Izgled"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "פריסת טלפון (1-2-3)"
+            "value": "מראה"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Bố cục điện thoại (1-2-3)"
+            "value": "Giao diện"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Layout ng telepono (1-2-3)"
+            "value": "Hitsura"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Διάταξη τηλεφώνου (1-2-3)"
+            "value": "Εμφάνιση"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Esquema de telefone (1-2-3)"
+            "value": "Aspeto"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Телефонна розкладка (1-2-3)"
+            "value": "Вигляд"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "تخطيط الهاتف (1-2-3)"
+            "value": "المظهر"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "چیدمان تلفن (۱-۲-۳)"
+            "value": "ظاهر"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "فون لے آؤٹ (1-2-3)"
+            "value": "ظاہری شکل"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "เลย์เอาต์โทรศัพท์ (1-2-3)"
+            "value": "รูปลักษณ์"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "फ़ोन लेआउट (1-2-3)"
+            "value": "दिखावट"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "電話レイアウト（1-2-3）"
+            "value": "外観"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "전화기 레이아웃 (1-2-3)"
+            "value": "외관"
           }
         }
       },
-      "comment": "Numpad style subtitle: phone layout"
+      "comment": "Settings section header"
+    },
+    "Applies when you drag the Space or Delete key to move the cursor or delete text.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gilt, wenn du die Leertaste oder Löschtaste ziehst, um den Cursor zu bewegen oder Text zu löschen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "S'applique lorsque vous faites glisser la touche Espace ou Suppr. pour déplacer le curseur ou supprimer du texte."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se aplica al arrastrar la tecla Espacio o Borrar para mover el cursor o borrar texto."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si applica quando trascini il tasto Spazio o Elimina per spostare il cursore o eliminare il testo."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Применяется при перетягивании клавиши пробела или удаления для перемещения курсора или удаления текста."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Działa przy przeciąganiu klawisza spacji lub usuwania w celu przesunięcia kursora lub usunięcia tekstu."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gäller när du drar mellanslags- eller raderingstangenten för att flytta markören eller radera text."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaikuttaa, kun vedät väli- tai poistonäppäintä siirtääksesi kohdistinta tai poistaaksesi tekstiä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primjenjuje se kad povučeš tipku Razmaknica ili Brisanje za pomicanje pokazivača ili brisanje teksta."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "חל בעת גרירת מקש הרווח או המחיקה כדי להזיז את הסמן או למחוק טקסט."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Áp dụng khi bạn kéo phím Cách hoặc Xóa để di chuyển con trỏ hoặc xóa văn bản."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nalalapat kapag ni-drag mo ang Space o Delete key para igalaw ang cursor o magbura ng teksto."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ισχύει όταν σέρνετε το πλήκτρο διαστήματος ή διαγραφής για να μετακινήσετε τον δρομέα ή να διαγράψετε κείμενο."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplica-se quando arrasta a tecla Espaço ou Eliminar para mover o cursor ou apagar texto."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Застосовується, коли ви перетягуєте клавішу пробілу або видалення, щоб перемістити курсор чи видалити текст."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تُطبَّق عند سحب مفتاح المسافة أو الحذف لتحريك المؤشر أو حذف النص."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هنگامی که کلید فاصله یا حذف را برای جابه‌جایی نشانگر یا حذف متن می‌کشید اعمال می‌شود."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جب آپ کرسر کو منتقل کرنے یا متن حذف کرنے کے لیے اسپیس یا ڈیلیٹ کی کو ڈریگ کرتے ہیں تو لاگو ہوتا ہے۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ใช้เมื่อคุณลากปุ่มเว้นวรรคหรือปุ่มลบเพื่อเลื่อนเคอร์เซอร์หรือลบข้อความ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कर्सर हिलाने या टेक्स्ट डिलीट करने के लिए स्पेस या डिलीट की को ड्रैग करने पर लागू होता है।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スペースキーや削除キーをドラッグしてカーソルを移動したり、テキストを削除したりするときに適用されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스페이스 또는 삭제 키를 드래그하여 커서를 이동하거나 텍스트를 삭제할 때 적용됩니다."
+          }
+        }
+      },
+      "comment": "Caption; 'Space' and 'Delete' are key names"
+    },
+    "Applies when you touch any key.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gilt, wenn du eine beliebige Taste berührst."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "S'applique lorsque vous touchez une touche."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se aplica al tocar cualquier tecla."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si applica quando tocchi un tasto qualsiasi."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Применяется при касании любой клавиши."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Działa przy dotknięciu dowolnego klawisza."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gäller när du rör vid en tangent."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaikuttaa, kun kosketat mitä tahansa näppäintä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Primjenjuje se kad dodirneš bilo koju tipku."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "חל בעת נגיעה בכל מקש."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Áp dụng khi bạn chạm vào phím bất kỳ."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nalalapat kapag humawak ka sa anumang key."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ισχύει όταν αγγίζετε οποιοδήποτε πλήκτρο."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplica-se quando toca em qualquer tecla."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Застосовується, коли ви торкаєтеся будь-якої клавіші."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تُطبَّق عند لمس أي مفتاح."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هنگام لمس هر کلید اعمال می‌شود."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جب آپ کوئی کی چھوتے ہیں تو لاگو ہوتا ہے۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ใช้เมื่อคุณแตะปุ่มใดก็ตาม"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "किसी भी की को छूने पर लागू होता है।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "いずれかのキーに触れたときに適用されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아무 키나 누를 때 적용됩니다."
+          }
+        }
+      },
+      "comment": "Caption under the Tap Feedback slider"
+    },
+    "Aspect Ratio": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenverhältnis"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proportions"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporción"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporzioni"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Соотношение сторон"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporcje"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proportioner"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kuvasuhde"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omjer stranica"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "יחס גובה-רוחב"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tỷ lệ khung"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aspect Ratio"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αναλογία διαστάσεων"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporção"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Співвідношення сторін"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسبة الأبعاد"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسبت ابعاد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پہلو تناسب"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อัตราส่วน"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आस्पेक्ट रेशियो"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "縦横比"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가로세로 비율"
+          }
+        }
+      },
+      "comment": "Slider title: key width-to-height ratio"
+    },
+    "At least one language must be enabled.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mindestens eine Sprache muss aktiviert sein."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Au moins une langue doit être activée."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Al menos un idioma debe estar activado."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Almeno una lingua deve essere attiva."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хотя бы один язык должен быть включён."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Co najmniej jeden język musi być włączony."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minst ett språk måste vara aktiverat."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vähintään yhden kielen on oltava käytössä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Najmanje jedan jezik mora biti omogućen."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "לפחות שפה אחת חייבת להיות מופעלת."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phải bật ít nhất một ngôn ngữ."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kailangang naka-enable ang kahit isang wika."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πρέπει να είναι ενεργοποιημένη τουλάχιστον μία γλώσσα."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "É necessário ativar pelo menos um idioma."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Має бути увімкнена принаймні одна мова."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يجب تفعيل لغة واحدة على الأقل."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دست‌کم یک زبان باید فعال باشد."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کم از کم ایک زبان فعال ہونی چاہیے۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ต้องเปิดใช้อย่างน้อยหนึ่งภาษา"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कम से कम एक भाषा चालू होनी चाहिए।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "少なくとも1つの言語を有効にする必要があります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "언어를 하나 이상 사용해야 합니다."
+          }
+        }
+      },
+      "comment": "Alert message when disabling the last language"
+    },
+    "Auto-Capitalize": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Großschreibung"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Majuscule automatique"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mayúsculas automáticas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maiuscole automatiche"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автопрописные"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autom. wielkie litery"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisk versal"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automaattiset isot kirjaimet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatska velika slova"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אותיות רישיות אוטומטיות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tự động viết hoa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Capitalize"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αυτόματα κεφαλαία"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maiúsculas automáticas"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматичні великі літери"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الأحرف الكبيرة تلقائيًا"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بزرگ‌نویسی خودکار"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خودکار کیپیٹلائز"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พิมพ์ตัวใหญ่อัตโนมัติ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ऑटो-कैपिटलाइज़"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動大文字化"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 대문자화"
+          }
+        }
+      },
+      "comment": "Toggle title"
+    },
+    "Cannot Disable": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deaktivieren nicht möglich"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactivation impossible"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se puede desactivar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile disattivare"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нельзя отключить"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie można wyłączyć"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kan inte avaktiveras"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ei voi poistaa käytöstä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nije moguće onemogućiti"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "לא ניתן להשבית"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể tắt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hindi Maaaring I-disable"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αδυναμία απενεργοποίησης"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não é possível desativar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неможливо вимкнути"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا يمكن التعطيل"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمی‌توان غیرفعال کرد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غیر فعال نہیں کیا جا سکتا"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิดใช้ไม่ได้"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बंद नहीं कर सकते"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効にできません"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 중지할 수 없음"
+          }
+        }
+      },
+      "comment": "Alert title when disabling the last language"
+    },
+    "Capitalize after sentence-ending punctuation": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Großschreibung nach satzschließenden Satzzeichen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Met une majuscule après la ponctuation de fin de phrase"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poner en mayúscula tras un signo de puntuación final"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maiuscola dopo la punteggiatura di fine frase"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заглавная буква после знаков конца предложения"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wielka litera po znaku kończącym zdanie"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stor bokstav efter meningsavslutande skiljetecken"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iso alkukirjain lauseen päättävän välimerkin jälkeen"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veliko slovo nakon interpunkcije na kraju rečenice"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אות רישית לאחר סימן פיסוק שמסיים משפט"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Viết hoa sau dấu kết thúc câu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-capitalize pagkatapos ng panapos na bantas"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κεφαλαίο μετά από σημείο στίξης τέλους πρότασης"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coloca maiúscula após a pontuação de fim de frase"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Велика літера після розділового знака в кінці речення"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استخدام حرف كبير بعد علامات نهاية الجملة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بزرگ‌نویسی پس از نشانه‌های پایان جمله"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "جملہ ختم کرنے والی رموز اوقاف کے بعد بڑا حرف بنائیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พิมพ์ตัวใหญ่หลังเครื่องหมายจบประโยค"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वाक्य समाप्त करने वाले विराम चिह्न के बाद बड़ा अक्षर बनाएँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文末の句読点の後に大文字にします"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문장 끝 문장 부호 뒤에 대문자로 시작합니다"
+          }
+        }
+      },
+      "comment": "Toggle subtitle"
+    },
+    "Center": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mitte"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centre"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centro"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По центру"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Środek"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centrerad"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keskellä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sredina"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מרכז"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giữa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gitna"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κέντρο"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centro"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По центру"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوسط"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وسط"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "درمیان"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กึ่งกลาง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "केंद्र"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가운데"
+          }
+        }
+      },
+      "comment": "Slider label: center position"
+    },
+    "Circle the 123 key to cut the text around the cursor. Swipe down on the same key to paste it back. Both gestures stay on the key after it switches the keyboard to numbers.": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ارسم دائرة على مفتاح 123 لقص النص حول المؤشر. اسحب لأسفل على المفتاح نفسه للصقه مرة أخرى. تبقى الإيماءتان على المفتاح بعد أن يبدّل لوحة المفاتيح إلى الأرقام."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kreise die 123-Taste ein, um den Text um den Cursor auszuschneiden. Streiche auf derselben Taste nach unten, um ihn wieder einzufügen. Beide Gesten bleiben auf der Taste, auch nachdem sie die Tastatur auf Zahlen umgestellt hat."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κάντε κυκλική κίνηση στο πλήκτρο 123 για αποκοπή του κειμένου γύρω από τον δρομέα. Σύρετε προς τα κάτω στο ίδιο πλήκτρο για να το επικολλήσετε ξανά. Και οι δύο κινήσεις παραμένουν στο πλήκτρο αφού αυτό αλλάξει το πληκτρολόγιο σε αριθμούς."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traza un círculo en la tecla 123 para cortar el texto alrededor del cursor. Desliza hacia abajo en la misma tecla para volver a pegarlo. Ambos gestos siguen en la tecla después de que cambie el teclado a números."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روی کلید 123 دایره بکشید تا متن اطراف مکان‌نما بریده شود. برای چسباندن دوباره، روی همان کلید به پایین بکشید. هر دو حرکت پس از آنکه کلید صفحه‌کلید را به اعداد تغییر دهد، روی همان کلید باقی می‌مانند."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piirrä ympyrä 123-näppäimeen, niin kohdistimen ympärillä oleva teksti leikataan. Liu’uta samaa näppäintä alaspäin liittääksesi sen takaisin. Molemmat eleet säilyvät näppäimellä sen jälkeen, kun se on vaihtanut näppäimistön numeroihin."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umikot sa 123 key para gupitin ang teksto sa paligid ng cursor. Mag-swipe pababa sa parehong key para i-paste ito ulit. Nananatili ang dalawang galaw sa key kahit matapos nitong palitan ang keyboard sa mga numero."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tracez un cercle sur la touche 123 pour couper le texte autour du curseur. Balayez vers le bas sur la même touche pour le recoller. Les deux gestes restent sur la touche après qu’elle a basculé le clavier sur les chiffres."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שרטטו מעגל על מקש 123 כדי לגזור את הטקסט סביב הסמן. החליקו מטה על אותו מקש כדי להדביק אותו בחזרה. שתי המחוות נשארות על המקש גם אחרי שהוא מחליף את המקלדת למספרים."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कर्सर के आसपास का टेक्स्ट काटने के लिए 123 कुंजी पर गोला बनाएँ। उसे वापस चिपकाने के लिए उसी कुंजी पर नीचे स्वाइप करें। कुंजी द्वारा कीबोर्ड को अंकों पर बदलने के बाद भी दोनों हावभाव उसी कुंजी पर बने रहते हैं।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Napravi kružni pokret po tipki 123 za izrezivanje teksta oko pokazivača. Povuci prema dolje po istoj tipki da ga zalijepiš natrag. Obje geste ostaju na tipki i nakon što ona prebaci tipkovnicu na brojke."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traccia un cerchio sul tasto 123 per tagliare il testo attorno al cursore. Scorri verso il basso sullo stesso tasto per incollarlo di nuovo. Entrambi i gesti restano sul tasto anche dopo che ha portato la tastiera ai numeri."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "123キーで円を描くと、カーソル周辺のテキストを切り取ります。同じキーを下にスワイプすると貼り付け直せます。 このキーがキーボードを数字に切り替えたあとも、両方のジェスチャーはそのまま使えます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "123 키에서 원을 그리면 커서 주변 텍스트를 잘라냅니다. 같은 키를 아래로 쓸어내리면 다시 붙여넣습니다. 이 키가 키보드를 숫자로 전환한 뒤에도 두 제스처는 그대로 유지됩니다."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zakreśl kółko na klawiszu 123, aby wyciąć tekst wokół kursora. Przesuń w dół na tym samym klawiszu, aby wkleić go z powrotem. Oba gesty pozostają na klawiszu także po przełączeniu klawiatury na cyfry."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trace um círculo na tecla 123 para cortar o texto à volta do cursor. Deslize para baixo na mesma tecla para o colar de novo. Ambos os gestos permanecem na tecla depois de esta mudar o teclado para números."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обведите клавишу 123, чтобы вырезать текст вокруг курсора. Свайп вниз по той же клавише вернёт его. Оба жеста остаются на клавише и после переключения на цифры."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rita en cirkel på 123-tangenten för att klippa ut texten runt markören. Svep nedåt på samma tangent för att klistra in den igen. Båda gesterna finns kvar på tangenten även efter att den växlat tangentbordet till siffror."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วนนิ้วบนปุ่ม 123 เพื่อตัดข้อความรอบเคอร์เซอร์ ปัดลงบนปุ่มเดียวกันเพื่อวางกลับ ทั้งสองท่าทางยังคงอยู่บนปุ่มนี้แม้หลังจากที่ปุ่มสลับแป้นพิมพ์เป็นตัวเลขแล้ว"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обведіть клавішу 123, щоб вирізати текст навколо курсора. Проведіть вниз по тій самій клавіші, щоб вставити його назад. Обидва жести залишаються на клавіші й після перемикання на цифри."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کرسر کے ارد گرد متن کاٹنے کے لیے 123 کلید پر دائرہ بنائیں۔ اسے واپس چسپاں کرنے کے لیے اسی کلید پر نیچے سوائپ کریں۔ کلید کے کی بورڈ کو ہندسوں پر بدلنے کے بعد بھی دونوں اشارے اسی کلید پر برقرار رہتے ہیں۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vẽ vòng tròn trên phím 123 để cắt văn bản quanh con trỏ. Vuốt xuống trên cùng phím đó để dán lại. Cả hai cử chỉ vẫn nằm trên phím sau khi phím chuyển bàn phím sang số."
+          }
+        }
+      }
+    },
+    "Classic": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisch"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classique"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clásico"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classico"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Классический"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasyczny"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisk"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassinen"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasično"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "קלאסי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cổ điển"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasiko"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κλασικό"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clássico"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Класичний"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كلاسيكي"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلاسیک"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلاسک"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คลาสสิก"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्लासिक"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラシック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클래식"
+          }
+        }
+      },
+      "comment": "Keyboard style name"
+    },
+    "Classic (7-8-9)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisch (7-8-9)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classique (7-8-9)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clásico (7-8-9)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classico (7-8-9)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Классический (7-8-9)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasyczny (7-8-9)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisk (7-8-9)"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassinen (7-8-9)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasično (7-8-9)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "קלאסי (7-8-9)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cổ điển (7-8-9)"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasiko (7-8-9)"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κλασικό (7-8-9)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clássico (7-8-9)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Класичний (7-8-9)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كلاسيكي (7-8-9)"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلاسیک (۷-۸-۹)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلاسک (7-8-9)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คลาสสิก (7-8-9)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्लासिक (7-8-9)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラシック（7-8-9）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클래식 (7-8-9)"
+          }
+        }
+      },
+      "comment": "Picker option: calculator-style numpad with 7-8-9 on top"
     },
     "Classic layout (7-8-9)": {
       "extractionState": "manual",
@@ -14077,143 +3174,4777 @@
       },
       "comment": "Numpad style subtitle: classic layout"
     },
-    "All labels visible": {
+    "Clear": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alle Beschriftungen sichtbar"
+            "value": "Löschen"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Toutes les étiquettes visibles"
+            "value": "Effacer"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas las etiquetas visibles"
+            "value": "Borrar"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tutte le etichette visibili"
+            "value": "Cancella"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Все подписи видны"
+            "value": "Очистить"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wszystkie etykiety widoczne"
+            "value": "Wyczyść"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Alla etiketter synliga"
+            "value": "Rensa"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kaikki merkinnät näkyvissä"
+            "value": "Tyhjennä"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sve oznake vidljive"
+            "value": "Očisti"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "כל התוויות גלויות"
+            "value": "נקה"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hiển thị tất cả nhãn"
+            "value": "Xóa hết"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nakikita ang lahat ng label"
+            "value": "I-clear"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Όλες οι ετικέτες ορατές"
+            "value": "Εκκαθάριση"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Todas as etiquetas visíveis"
+            "value": "Limpar"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Усі підписи видимі"
+            "value": "Очистити"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "جميع التسميات ظاهرة"
+            "value": "مسح"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "همهٔ برچسب‌ها نمایان"
+            "value": "پاک کردن"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "تمام لیبل نظر آ رہے ہیں"
+            "value": "صاف کریں"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "แสดงป้ายกำกับทั้งหมด"
+            "value": "ล้าง"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "सभी लेबल दिखाई दे रहे हैं"
+            "value": "साफ़ करें"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "すべてのラベルを表示"
+            "value": "消去"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "모든 레이블 표시"
+            "value": "지우기"
           }
         }
       },
-      "comment": "Label visibility subtitle when nothing is hidden"
+      "comment": "Button: clear the text field"
+    },
+    "Continuous": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fortlaufend"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continu"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Непрерывное"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciągły"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontinuerlig"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jatkuva"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontinuirano"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "רציפה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liên tục"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tuluy-tuloy"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Συνεχής"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contínuo"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Безперервно"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مستمرة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیوسته"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسلسل"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ต่อเนื่อง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "निरंतर"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連続"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연속"
+          }
+        }
+      },
+      "comment": "Picker option for cursor movement style (drag continuously)"
+    },
+    "Copy": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копировать"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiuj"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiera"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopioi"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiraj"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "העתק"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sao chép"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopyahin"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αντιγραφή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копіювати"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کپی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کاپی کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คัดลอก"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कॉपी"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복사"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the copy gesture (VoiceOver)"
+    },
+    "Current: %@:1": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktuell: %@:1"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actuel : %@:1"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actual: %@:1"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attuale: %@:1"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Текущее: %@:1"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obecnie: %@:1"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktuellt: %@:1"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nykyinen: %@:1"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trenutno: %@:1"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "נוכחי: %@:1"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiện tại: %@:1"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kasalukuyan: %@:1"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τρέχον: %@:1"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atual: %@:1"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поточне: %@:1"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الحالي: %@:1"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فعلی: %@:۱"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "موجودہ: %@:1"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปัจจุบัน: %@:1"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वर्तमान: %@:1"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在：%@:1"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재: %@:1"
+          }
+        }
+      },
+      "comment": "Key aspect ratio subtitle, e.g. 'Current: 1.00:1'"
+    },
+    "Cursor Movement": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cursorbewegung"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déplacement du curseur"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Movimiento del cursor"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Movimento del cursore"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемещение курсора"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruch kursora"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markörförflyttning"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kohdistimen liike"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pomicanje pokazivača"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תנועת הסמן"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Di chuyển con trỏ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paggalaw ng Cursor"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κίνηση δρομέα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Movimento do cursor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переміщення курсора"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حركة المؤشر"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرکت نشانگر"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کرسر کی حرکت"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การเลื่อนเคอร์เซอร์"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कर्सर मूवमेंट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カーソル移動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "커서 이동"
+          }
+        }
+      },
+      "comment": "Settings row title"
+    },
+    "Customize the look and feel of your keyboard.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passe das Erscheinungsbild deiner Tastatur an."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personnalisez l'apparence de votre clavier."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personaliza el aspecto de tu teclado."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizza l'aspetto della tua tastiera."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройте внешний вид клавиатуры."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dostosuj wygląd swojej klawiatury."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anpassa tangentbordets utseende och känsla."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mukauta näppäimistösi ulkoasua ja tuntumaa."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prilagodi izgled i dojam svoje tipkovnice."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "התאם אישית את המראה והתחושה של המקלדת."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tùy chỉnh giao diện và cảm nhận của bàn phím."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-customize ang hitsura at pakiramdam ng iyong keyboard."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Προσαρμόστε την εμφάνιση και την αίσθηση του πληκτρολογίου σας."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalize o aspeto e o comportamento do seu teclado."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштуйте вигляд і поведінку вашої клавіатури."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خصِّص شكل ومظهر لوحة المفاتيح."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ظاهر و حس صفحه‌کلید خود را سفارشی کنید."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اپنے کی بورڈ کی شکل و صورت کو اپنی مرضی کے مطابق بنائیں۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปรับแต่งหน้าตาและสัมผัสของคีย์บอร์ดของคุณ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अपने कीबोर्ड के लुक और फील को कस्टमाइज़ करें।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードの見た目や操作感をカスタマイズします。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드의 모양과 느낌을 원하는 대로 설정하세요."
+          }
+        }
+      },
+      "comment": "Settings section footer"
+    },
+    "Cut": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausschneiden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couper"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taglia"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вырезать"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wytnij"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klipp ut"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leikkaa"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izreži"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גזור"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cắt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gupitin"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αποκοπή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вирізати"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قص"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برش"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کٹ کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오려두기"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the cut gesture (VoiceOver)"
+    },
+    "Cut All by Circling": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قص الكل بحركة دائرية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles ausschneiden per Kreis"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αποκοπή όλων με κυκλική κίνηση"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar todo con un círculo"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برش همه با حرکت دایره‌ای"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leikkaa kaikki ympyröimällä"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gupitin lahat sa pamamagitan ng pag-ikot"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout couper en traçant un cercle"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גזירת הכול בתנועה מעגלית"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "गोला बनाकर सब कुछ काटें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izreži sve kružnim pokretom"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taglia tutto con un cerchio"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "円を描いてすべて切り取り"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "원을 그려 전체 잘라내기"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wytnij wszystko kółkiem"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar tudo com um círculo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вырезать всё круговым жестом"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klipp ut allt med en cirkel"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัดทั้งหมดด้วยการวนนิ้ว"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вирізати все круговим жестом"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دائرہ بنا کر سب کاٹیں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cắt tất cả bằng vòng tròn"
+          }
+        }
+      }
+    },
+    "Cut all": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles ausschneiden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout couper"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar todo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taglia tutto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вырезать всё"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wytnij wszystko"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klipp ut allt"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leikkaa kaikki"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izreži sve"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גזור הכול"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cắt tất cả"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gupitin lahat"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αποκοπή όλων"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar tudo"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вирізати все"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قص الكل"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برش همه"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سب کاٹیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัดทั้งหมด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सभी काटें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて切り取り"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모두 잘라내기"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the cut-all gesture (VoiceOver)"
+    },
+    "Cutting to the clipboard requires Full Access": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتطلب القص إلى الحافظة الوصول الكامل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausschneiden in die Zwischenablage erfordert Vollzugriff"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Η αποκοπή στο πρόχειρο απαιτεί πλήρη πρόσβαση"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar al portapapeles requiere acceso completo"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برش به کلیپ‌بورد به دسترسی کامل نیاز دارد"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leikkaaminen leikepöydälle vaatii täyden käyttöoikeuden"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kailangan ng Full Access para gupitin papunta sa clipboard"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couper vers le presse-papiers nécessite l'accès complet"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גזירה ללוח דורשת גישה מלאה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्लिपबोर्ड में काटने के लिए पूर्ण एक्सेस ज़रूरी है"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izrezivanje u međuspremnik zahtijeva puni pristup"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il taglio negli appunti richiede l'accesso completo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリップボードへの切り取りにはフルアクセスが必要です"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클립보드로 잘라내려면 전체 접근이 필요합니다"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wycinanie do schowka wymaga pełnego dostępu"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar para a área de transferência requer acesso total"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вырезание в буфер обмена требует полного доступа"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Att klippa ut till urklipp kräver fullständig åtkomst"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตัดไปยังคลิปบอร์ดต้องใช้การเข้าถึงเต็มรูปแบบ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вирізання в буфер обміну потребує повного доступу"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلپ بورڈ میں کاٹنے کے لیے مکمل رسائی درکار ہے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cắt vào bảng nhớ tạm yêu cầu Truy cập đầy đủ"
+          }
+        }
+      }
+    },
+    "Dark Gold": {
+      "comment": "Keyboard theme name: dark-gold (proper name, do not translate)",
+      "extractionState": "manual",
+      "shouldTranslate": false
+    },
+    "Dark keys with golden letters": {
+      "comment": "Keyboard theme description: dark-gold",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dunkle Tasten mit goldenen Buchstaben"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touches sombres aux lettres dorées"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas oscuras con letras doradas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasti scuri con lettere dorate"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмные клавиши с золотыми буквами"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemne klawisze ze złotymi literami"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mörka tangenter med gyllene bokstäver"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tummat näppäimet ja kultaiset kirjaimet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamne tipke sa zlatnim slovima"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקשים כהים עם אותיות זהובות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím tối với chữ vàng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Madilim na mga key na may gintong mga titik"
+          }
+        }
+      }
+    },
+    "Default": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Par défaut"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predeterminado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predefinita"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domyślny"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oletus"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zadano"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ברירת מחדל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mặc định"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Προεπιλογή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predefinição"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "За замовчуванням"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افتراضي"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیش‌فرض"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "طے شدہ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ค่าเริ่มต้น"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डिफ़ॉल्ट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값"
+          }
+        }
+      },
+      "comment": "Badge on the default startup language"
+    },
+    "Delete": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Löschen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimina"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radera"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brisanje"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מחק"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διαγραφή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลบ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डिलीट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "삭제"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the delete/backspace key (VoiceOver)"
+    },
+    "Disable %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ deaktivieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactiver %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivar %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disattiva %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отключить %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyłącz %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaktivera %@"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista %@ käytöstä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onemogući %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "השבתת %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tắt %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-disable ang %@"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Απενεργοποίηση %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desativar %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вимкнути %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعطيل %@"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غیرفعال کردن %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ غیر فعال کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิดใช้ %@"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ बंद करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@を無効にする"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 사용 안 함"
+          }
+        }
+      },
+      "comment": "Accessibility label: disable a language; %@ is the language name"
+    },
+    "Disabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deaktiviert"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactivé"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desactivado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disattivato"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отключено"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyłączone"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaktiverad"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ei käytössä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onemogućeno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מושבת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã tắt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naka-disable"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Απενεργοποιημένο"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desativado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вимкнено"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مُعطَّل"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غیرفعال"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "غیر فعال"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิดใช้แล้ว"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बंद"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 안 함"
+          }
+        }
+      },
+      "comment": "Accessibility value: language is disabled"
+    },
+    "Done": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fertig"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aceptar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fine"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Готово"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gotowe"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klar"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valmis"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gotovo"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סיום"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xong"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tapos na"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τέλος"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Concluído"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Готово"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تمام"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہو گیا"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เสร็จสิ้น"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हो गया"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "완료"
+          }
+        }
+      },
+      "comment": "Keyboard toolbar button to dismiss the keyboard / finish editing"
+    },
+    "Double-Space Period": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقطة بمسافتين"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punkt durch Doppel-Leerzeichen"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τελεία με διπλό κενό"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punto con doble espacio"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقطه با دو فاصله"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piste kaksoisvälilyönnillä"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tuldok sa dobleng espasyo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Point par double espace"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "נקודה ברווח כפול"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डबल-स्पेस से पूर्ण विराम"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Točka dvostrukim razmakom"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punto con doppio spazio"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダブルスペースでピリオド"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "더블 스페이스로 마침표"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kropka podwójną spacją"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ponto com espaço duplo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Точка двойным пробелом"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punkt med dubbla mellanslag"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ใส่จุดด้วยการเว้นวรรคสองครั้ง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Крапка подвійним пробілом"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈبل اسپیس سے وقفہ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dấu chấm bằng cách nhấn cách hai lần"
+          }
+        }
+      },
+      "comment": "Toggle title: a double space inserts a period"
+    },
+    "Drag Feedback": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zieh-Feedback"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour au glissement"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Respuesta al arrastrar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback al trascinamento"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отклик при перетягивании"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reakcja na przeciąganie"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Återkoppling vid dragning"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vetopalaute"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povratne informacije povlačenja"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משוב בגרירה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phản hồi khi kéo"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Drag Feedback"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ανάδραση συρσίματος"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retorno ao arrastar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відгук на перетягування"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استجابة السحب"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازخورد کشیدن"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈریگ فیڈ بیک"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตอบสนองเมื่อลาก"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ड्रैग फ़ीडबैक"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドラッグ時のフィードバック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "드래그 피드백"
+          }
+        }
+      },
+      "comment": "Slider control title: haptic strength when dragging"
+    },
+    "Drag to move cursor": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ziehen bewegt den Cursor"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Glisser pour déplacer le curseur"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrastra para mover el cursor"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trascina per spostare il cursore"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перетягивание перемещает курсор"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przeciągnij, aby przesunąć kursor"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dra för att flytta markören"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siirrä kohdistinta vetämällä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povuci za pomicanje pokazivača"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גרירה מזיזה את הסמן"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kéo để di chuyển con trỏ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-drag para igalaw ang cursor"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σύρετε για μετακίνηση του δρομέα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrastar para mover o cursor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перетягніть, щоб перемістити курсор"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسحب لتحريك المؤشر"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برای جابه‌جایی نشانگر بکشید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کرسر منتقل کرنے کے لیے ڈریگ کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลากเพื่อเลื่อนเคอร์เซอร์"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कर्सर हिलाने के लिए ड्रैग करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドラッグしてカーソルを移動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "드래그하여 커서 이동"
+          }
+        }
+      },
+      "comment": "Cursor movement subtitle: continuous style"
+    },
+    "Draw the path your finger takes": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يرسم المسار الذي يسلكه إصبعك"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeichnet den Weg deines Fingers nach"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σχεδιάζει τη διαδρομή που ακολουθεί το δάχτυλο"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dibuja el recorrido de tu dedo"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسیری را که انگشت شما طی می‌کند رسم می‌کند"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piirtää sormesi kulkeman reitin"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iguguhit ang dinaanan ng iyong daliri"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trace le chemin parcouru par votre doigt"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מצייר את המסלול שהאצבע עוברת"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आपकी उंगली के रास्ते को दिखाता है"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crta putanju kojom prolazi prst"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disegna il percorso del tuo dito"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "指がなぞった軌跡を描きます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "손가락이 지나간 경로를 그립니다"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rysuje ścieżkę, którą pokonuje palec"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desenha o caminho percorrido pelo dedo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Рисует путь, по которому движется палец"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ritar vägen som fingret tar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วาดเส้นทางที่นิ้วของคุณลากผ่าน"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Малює шлях, яким рухається палець"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آپ کی انگلی جس راستے سے گزرے، اسے کھینچتا ہے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vẽ đường đi của ngón tay bạn"
+          }
+        }
+      },
+      "comment": "Toggle subtitle explaining the gesture trail"
+    },
+    "Enable %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ aktivieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включить %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Włącz %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivera %@"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ota %@ käyttöön"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omogući %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הפעלת %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bật %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-enable ang %@"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ενεργοποίηση %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativar %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увімкнути %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تفعيل %@"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فعال کردن %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ فعال کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดใช้ %@"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ चालू करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@を有効にする"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 사용"
+          }
+        }
+      },
+      "comment": "Accessibility label: enable a language; %@ is the language name"
+    },
+    "Enable keyboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastatur aktivieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer le clavier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar el teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva la tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включите клавиатуру"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Włącz klawiaturę"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivera tangentbordet"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ota näppäimistö käyttöön"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omogući tipkovnicu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הפעלת המקלדת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bật bàn phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-enable ang keyboard"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ενεργοποίηση πληκτρολογίου"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativar teclado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увімкнути клавіатуру"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تفعيل لوحة المفاتيح"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فعال‌سازی صفحه‌کلید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی بورڈ فعال کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดใช้คีย์บอร์ด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड चालू करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードを有効にする"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 켜기"
+          }
+        }
+      },
+      "comment": "Onboarding step 1 title"
+    },
+    "Enabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiviert"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activé"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attivato"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включено"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Włączone"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiverad"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Käytössä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omogućeno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מופעל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã bật"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naka-enable"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ενεργοποιημένο"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увімкнено"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مُفعَّل"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فعال"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فعال"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดใช้แล้ว"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "चालू"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용"
+          }
+        }
+      },
+      "comment": "Accessibility value: language is enabled"
+    },
+    "Expert": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experte"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Experto"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esperto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для экспертов"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ekspert"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expert"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asiantuntija"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stručno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מומחה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyên gia"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expert"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ειδικός"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Especialista"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Експертний"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الخبير"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرفه‌ای"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ماہر"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ผู้เชี่ยวชาญ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एक्सपर्ट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エキスパート"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전문가"
+          }
+        }
+      },
+      "comment": "Settings row title leading to expert/advanced gesture tuning"
+    },
+    "Feedback": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Respuesta"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отклик"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reakcje"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Återkoppling"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Palaute"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povratne informacije"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משוב"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phản hồi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ανάδραση"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retorno"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відгук"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاستجابة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازخورد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فیڈ بیک"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตอบสนอง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "फ़ीडबैक"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィードバック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "피드백"
+          }
+        }
+      },
+      "comment": "Settings section header (covers haptic feedback)"
+    },
+    "General": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allgemein"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Général"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generali"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Основные"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ogólne"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allmänt"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yleiset"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Općenito"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "כללי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt chung"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pangkalahatan"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Γενικά"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geral"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Основні"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عام"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عمومی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عمومی"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทั่วไป"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सामान्य"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일반"
+          }
+        }
+      },
+      "comment": "Settings section header"
+    },
+    "Gesture Trail": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أثر الإيماءة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wischspur"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ίχνος κίνησης"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estela del gesto"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رد اشاره"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eleen jälki"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bakas ng galaw"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tracé du geste"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שובל התנועה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इशारे का निशान"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trag geste"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scia del gesto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ジェスチャの軌跡"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제스처 궤적"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ślad gestu"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rasto do gesto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "След жеста"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestspår"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เส้นทางการปัด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Слід жесту"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اشارے کا نشان"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vệt vuốt"
+          }
+        }
+      },
+      "comment": "Toggle title: draws a fading trail under the finger while it swipes"
+    },
+    "Gesture tuning enabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestenanpassung aktiviert"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglage des gestes activé"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajuste de gestos activado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Regolazione dei gesti attivata"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройка жестов включена"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dostrajanie gestów włączone"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestjustering aktiverad"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eleiden hienosäätö käytössä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podešavanje gesti uključeno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "כוונון מחוות מופעל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã bật tinh chỉnh cử chỉ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naka-enable ang pag-tune ng gesture"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Η ρύθμιση χειρονομιών είναι ενεργή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajuste de gestos ativado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування жестів увімкнено"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ضبط الإيماءات مُفعَّل"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنظیم حرکت‌ها فعال شد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اشارہ ٹیوننگ فعال ہے"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดใช้การปรับแต่งเจสเจอร์"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जेस्चर ट्यूनिंग चालू है"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ジェスチャ調整が有効"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제스처 조정 사용"
+          }
+        }
+      },
+      "comment": "Expert row subtitle when expert mode is on"
+    },
+    "Gestures": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإيماءات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesten"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Χειρονομίες"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestos"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اشاره‌ها"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eleet"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Galaw"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestes"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מחוות"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जेस्चर"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geste"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesti"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ジェスチャ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제스처"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesty"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Жесты"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gester"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ท่าทาง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Жести"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اشارے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cử chỉ"
+          }
+        }
+      }
+    },
+    "Golden": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Golden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doré"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Áureo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aureo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Золотое сечение"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Złote"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gyllene"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kultainen"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zlatni rez"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "זהב"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tỷ lệ vàng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Golden"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Χρυσή τομή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dourado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Золотий перетин"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ذهبي"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "طلایی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گولڈن"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อัตราส่วนทอง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "गोल्डन"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "黄金比"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "황금비"
+          }
+        }
+      },
+      "comment": "Slider tick label at the golden ratio 1.62"
+    },
+    "Haptic Feedback": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptisches Feedback"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour haptique"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Respuesta háptica"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback aptico"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тактильный отклик"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reakcje haptyczne"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taktil återkoppling"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tuntopalaute"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptičke povratne informacije"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משוב מישושי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phản hồi xúc giác"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptic Feedback"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Απτική ανάδραση"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retorno tátil"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тактильний відгук"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاستجابة اللمسية"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازخورد لمسی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہیپٹک فیڈ بیک"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตอบสนองแบบสัมผัส"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हैप्टिक फ़ीडबैक"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "触覚フィードバック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "햅틱 피드백"
+          }
+        }
+      },
+      "comment": "Row title / toggle: vibration feedback"
+    },
+    "Haptic feedback requires Full Access. Enable it in **Settings › Wurstfinger › Keyboards › Wurstfinger › Allow Full Access**.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptisches Feedback erfordert Vollzugriff. Aktiviere ihn unter **Einstellungen › Wurstfinger › Tastaturen › Wurstfinger › Vollzugriff erlauben**."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le retour haptique nécessite l'accès complet. Activez-le dans **Réglages › Wurstfinger › Claviers › Wurstfinger › Autoriser l'accès complet**."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La respuesta háptica requiere acceso completo. Actívalo en **Ajustes › Wurstfinger › Teclados › Wurstfinger › Permitir acceso completo**."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il feedback aptico richiede l'accesso completo. Attivalo in **Impostazioni › Wurstfinger › Tastiere › Wurstfinger › Consenti accesso completo**."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тактильный отклик требует полного доступа. Включите его в **Настройки › Wurstfinger › Клавиатуры › Wurstfinger › Разрешить полный доступ**."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reakcje haptyczne wymagają pełnego dostępu. Włącz go w **Ustawienia › Wurstfinger › Klawiatury › Wurstfinger › Przyznaj pełny dostęp**."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taktil återkoppling kräver fullständig åtkomst. Aktivera den i **Inställningar › Wurstfinger › Tangentbord › Wurstfinger › Tillåt fullständig åtkomst**."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tuntopalaute vaatii täyden käyttöoikeuden. Ota se käyttöön kohdassa **Asetukset › Wurstfinger › Näppäimistöt › Wurstfinger › Salli täysi käyttöoikeus**."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptičke povratne informacije zahtijevaju puni pristup. Uključi ga u **Postavke › Wurstfinger › Tipkovnice › Wurstfinger › Dopusti puni pristup**."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משוב מישושי דורש גישה מלאה. הפעל אותה ב-**הגדרות › Wurstfinger › מקלדות › Wurstfinger › אפשר גישה מלאה**."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phản hồi xúc giác yêu cầu Truy cập đầy đủ. Bật trong **Cài đặt › Wurstfinger › Bàn phím › Wurstfinger › Cho phép truy cập đầy đủ**."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kailangan ng haptic feedback ang Full Access. I-enable ito sa **Mga Setting › Wurstfinger › Mga Keyboard › Wurstfinger › Payagan ang Full Access**."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Η απτική ανάδραση απαιτεί πλήρη πρόσβαση. Ενεργοποιήστε την στο **Ρυθμίσεις › Wurstfinger › Πληκτρολόγια › Wurstfinger › Να επιτρέπεται η πλήρης πρόσβαση**."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O retorno tátil requer acesso total. Ative-o em **Definições › Wurstfinger › Teclados › Wurstfinger › Permitir acesso total**."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тактильний відгук потребує повного доступу. Увімкніть його в **Параметри › Wurstfinger › Клавіатури › Wurstfinger › Дозволити повний доступ**."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تتطلب الاستجابة اللمسية الوصول الكامل. فعِّلها في **الإعدادات › Wurstfinger › لوحات المفاتيح › Wurstfinger › السماح بالوصول الكامل**."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازخورد لمسی به دسترسی کامل نیاز دارد. آن را در **تنظیمات › Wurstfinger › صفحه‌کلیدها › Wurstfinger › اجازهٔ دسترسی کامل** فعال کنید."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہیپٹک فیڈ بیک کے لیے مکمل رسائی درکار ہے۔ اسے **ترتیبات › Wurstfinger › کی بورڈز › Wurstfinger › مکمل رسائی کی اجازت دیں** میں فعال کریں۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตอบสนองแบบสัมผัสต้องใช้การเข้าถึงเต็มรูปแบบ เปิดใช้งานได้ที่ **การตั้งค่า › Wurstfinger › แป้นพิมพ์ › Wurstfinger › อนุญาตการเข้าถึงเต็มรูปแบบ**"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हैप्टिक फ़ीडबैक के लिए पूर्ण एक्सेस ज़रूरी है। इसे **सेटिंग्स › Wurstfinger › कीबोर्ड › Wurstfinger › पूर्ण एक्सेस दें** में चालू करें।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "触覚フィードバックにはフルアクセスが必要です。**「設定」› Wurstfinger ›「キーボード」› Wurstfinger ›「フルアクセスを許可」**で有効にしてください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "햅틱 피드백에는 전체 접근이 필요합니다. **설정 › Wurstfinger › 키보드 › Wurstfinger › 전체 접근 허용**에서 켜세요."
+          }
+        }
+      },
+      "comment": "Warning with markdown bold and › separators; the path words inside ** ** are iOS Settings names — localize Settings/Keyboards/Allow Full Access, keep 'Wurstfinger', keep markdown ** and ›"
+    },
+    "Haptics": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptik"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour haptique"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Háptica"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aptica"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тактильный отклик"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptyka"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taktil återkoppling"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tuntopalaute"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptika"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משוב מישושי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xúc giác"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptics"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Απτική ανάδραση"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tátil"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тактильний відгук"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاستجابة اللمسية"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لرزش لمسی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہیپٹکس"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การสั่นตอบสนอง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हैप्टिक्स"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "触覚フィードバック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "햅틱"
+          }
+        }
+      },
+      "comment": "Navigation title for haptic settings"
+    },
+    "Hide keyboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastatur ausblenden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masquer le clavier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nascondi tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скрыть клавиатуру"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ukryj klawiaturę"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dölj tangentbordet"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piilota näppäimistö"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sakrij tipkovnicu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הסתר מקלדת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ẩn bàn phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Itago ang keyboard"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Απόκρυψη πληκτρολογίου"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar teclado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сховати клавіатуру"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إخفاء لوحة المفاتيح"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پنهان کردن صفحه‌کلید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی بورڈ چھپائیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ซ่อนคีย์บอร์ด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड छिपाएँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードを隠す"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 숨기기"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for dismiss-keyboard gesture (VoiceOver)"
+    },
+    "Hide labels to practice the layout from memory. Numbers and control keys are always visible.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blende Beschriftungen aus, um das Layout aus dem Gedächtnis zu üben. Zahlen und Steuertasten sind immer sichtbar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masquez les étiquettes pour vous exercer à la disposition de mémoire. Les chiffres et les touches de contrôle restent toujours visibles."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oculta las etiquetas para practicar la disposición de memoria. Los números y las teclas de control siempre están visibles."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nascondi le etichette per esercitarti con il layout a memoria. I numeri e i tasti di controllo restano sempre visibili."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скройте подписи, чтобы тренировать раскладку по памяти. Цифры и служебные клавиши всегда видны."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ukryj etykiety, aby ćwiczyć układ z pamięci. Cyfry i klawisze sterujące są zawsze widoczne."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dölj etiketter för att öva på layouten ur minnet. Siffror och kontrolltangenter är alltid synliga."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piilota merkinnät harjoitellaksesi asettelua muistista. Numerot ja ohjausnäppäimet ovat aina näkyvissä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sakrij oznake da vježbaš raspored napamet. Brojevi i upravljačke tipke uvijek su vidljivi."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הסתר תוויות כדי לתרגל את הפריסה מהזיכרון. הספרות ומקשי הבקרה תמיד גלויים."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ẩn nhãn để luyện tập bố cục theo trí nhớ. Số và các phím điều khiển luôn hiển thị."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Itago ang mga label para masanay sa layout mula sa memorya. Laging nakikita ang mga numero at control key."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Απόκρυψη ετικετών για εξάσκηση της διάταξης από μνήμης. Οι αριθμοί και τα πλήκτρα ελέγχου είναι πάντα ορατά."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oculte os rótulos para praticar o layout de memória. Números e teclas de controle estão sempre visíveis."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приховайте підписи, щоб вивчати розкладку напам'ять. Цифри та клавіші керування завжди видимі."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أخفِ التسميات للتدرب على التخطيط من الذاكرة. الأرقام ومفاتيح التحكم مرئية دائمًا."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برچسب‌ها را پنهان کنید تا چیدمان را از حفظ تمرین کنید. اعداد و کلیدهای کنترل همیشه نمایان هستند."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترتیب کو یادداشت سے مشق کرنے کے لیے لیبل چھپائیں۔ نمبر اور کنٹرول کیز ہمیشہ نظر آتی ہیں۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ซ่อนป้ายกำกับเพื่อฝึกเค้าโครงจากความจำ ตัวเลขและปุ่มควบคุมจะแสดงอยู่เสมอ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लेआउट को याद से अभ्यास करने के लिए लेबल छिपाएँ। संख्याएँ और नियंत्रण कुंजियाँ हमेशा दिखती हैं।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レイアウトを記憶で練習するにはラベルを非表示にします。数字と制御キーは常に表示されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "레이아웃을 외워서 연습하려면 라벨을 숨기세요. 숫자와 컨트롤 키는 항상 표시됩니다."
+          }
+        }
+      },
+      "comment": "Label visibility footer"
     },
     "Hiding %@": {
       "extractionState": "manual",
@@ -14353,419 +8084,5249 @@
       },
       "comment": "Label visibility subtitle; %@ is a list like 'letters, extra symbols'"
     },
-    "letters": {
+    "Hold a letter key to type its digit": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط مطوّلاً على حرف لكتابة رقمه"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Buchstaben"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "lettres"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "letras"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "lettere"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "буквы"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "litery"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "bokstäver"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "kirjaimet"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "slova"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "אותיות"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "chữ cái"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "mga letra"
+            "value": "Halte eine Buchstabentaste, um ihre Ziffer einzugeben"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "γράμματα"
+            "value": "Κρατήστε ένα γράμμα για να πληκτρολογήσετε το ψηφίο του"
           }
         },
-        "pt": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "letras"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "літери"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الحروف"
+            "value": "Mantén pulsada una letra para escribir su número"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "حروف"
+            "value": "کلید حرف را نگه دارید تا عدد آن تایپ شود"
           }
         },
-        "ur": {
+        "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "حروف"
+            "value": "Pidä kirjainta pohjassa saadaksesi sen numeron"
           }
         },
-        "th": {
+        "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "ตัวอักษร"
+            "value": "Pindutin nang matagal ang letra para sa numero nito"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maintenez une lettre pour saisir son chiffre"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "החזיקו מקש אות כדי להקליד את הספרה שלו"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "अक्षर"
+            "value": "अक्षर दबाए रखें और उसका अंक टाइप करें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dugo pritisni slovo za njegovu brojku"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tieni premuta una lettera per la sua cifra"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "文字"
+            "value": "文字キーを長押しすると数字を入力できます"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "문자"
+            "value": "문자 키를 길게 누르면 숫자가 입력됩니다"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przytrzymaj literę, aby wpisać jej cyfrę"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantenha premida uma letra para o seu algarismo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удержание буквы вводит её цифру"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Håll in en bokstav för att skriva dess siffra"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กดตัวอักษรค้างไว้เพื่อพิมพ์ตัวเลข"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Утримання літери вводить її цифру"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرف دبائے رکھیں تاکہ اس کا ہندسہ ٹائپ ہو"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giữ phím chữ để nhập số của phím"
           }
         }
       },
-      "comment": "Label visibility list item"
+      "comment": "Toggle subtitle explaining the type-numbers-by-holding option"
     },
-    "standard symbols": {
+    "Home": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Standardsymbole"
+            "value": "Start"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "symboles standard"
+            "value": "Accueil"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "símbolos estándar"
+            "value": "Inicio"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "simboli standard"
+            "value": "Home"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "стандартные символы"
+            "value": "Главная"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "symbole standardowe"
+            "value": "Start"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "standardsymboler"
+            "value": "Hem"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "vakiosymbolit"
+            "value": "Etusivu"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "standardni simboli"
+            "value": "Početna"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "סמלים רגילים"
+            "value": "בית"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "ký hiệu chuẩn"
+            "value": "Trang chủ"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "mga karaniwang simbolo"
+            "value": "Home"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "τυπικά σύμβολα"
+            "value": "Αρχική"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "símbolos padrão"
+            "value": "Início"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "стандартні символи"
+            "value": "Головна"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "الرموز القياسية"
+            "value": "الرئيسية"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "نمادهای استاندارد"
+            "value": "خانه"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "معیاری علامتیں"
+            "value": "ہوم"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "สัญลักษณ์มาตรฐาน"
+            "value": "หน้าแรก"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "मानक सिंबल"
+            "value": "होम"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "標準記号"
+            "value": "ホーム"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "기본 기호"
+            "value": "홈"
           }
         }
       },
-      "comment": "Label visibility list item"
+      "comment": "Tab bar label for the home/landing screen"
     },
-    "extra symbols": {
+    "Horizontal Position": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Zusatzsymbole"
+            "value": "Horizontale Position"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "symboles supplémentaires"
+            "value": "Position horizontale"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "símbolos adicionales"
+            "value": "Posición horizontal"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "simboli extra"
+            "value": "Posizione orizzontale"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "дополнительные символы"
+            "value": "Положение по горизонтали"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "symbole dodatkowe"
+            "value": "Położenie poziome"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "extra symboler"
+            "value": "Horisontell position"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "lisäsymbolit"
+            "value": "Vaakasijainti"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "dodatni simboli"
+            "value": "Vodoravni položaj"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "סמלים נוספים"
+            "value": "מיקום אופקי"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "ký hiệu bổ sung"
+            "value": "Vị trí ngang"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "mga dagdag na simbolo"
+            "value": "Horizontal na Posisyon"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "επιπλέον σύμβολα"
+            "value": "Οριζόντια θέση"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "símbolos extra"
+            "value": "Posição horizontal"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "додаткові символи"
+            "value": "Горизонтальне положення"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "الرموز الإضافية"
+            "value": "الموضع الأفقي"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "نمادهای اضافی"
+            "value": "موقعیت افقی"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "اضافی علامتیں"
+            "value": "افقی پوزیشن"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "สัญลักษณ์เพิ่มเติม"
+            "value": "ตำแหน่งแนวนอน"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "अतिरिक्त सिंबल"
+            "value": "क्षैतिज स्थिति"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "追加記号"
+            "value": "水平方向の位置"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "추가 기호"
+            "value": "가로 위치"
           }
         }
       },
-      "comment": "Label visibility list item"
+      "comment": "Slider title"
+    },
+    "Imprint": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impressum"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mentions légales"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aviso legal"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note legali"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выходные данные"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nota prawna"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utgivningsinformation"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Julkaisutiedot"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impresum"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פרטים משפטיים"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thông tin pháp lý"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imprint"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Στοιχεία έκδοσης"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ficha técnica"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вихідні дані"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بيانات الناشر"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اطلاعات ناشر"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "امپرنٹ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ข้อมูลผู้จัดทำ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इम्प्रिंट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "運営者情報"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제작 정보"
+          }
+        }
+      },
+      "comment": "About row / title: legal imprint / impressum"
+    },
+    "Issues": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Issues"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signaler un problème"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incidencias"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problemi"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сообщить об ошибке"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zgłoszenia"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ärenden"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ongelmat"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problemi"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "בעיות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Báo lỗi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Issue"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Προβλήματα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problemas"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проблеми"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المشكلات"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مشکل‌ها"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسائل"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปัญหา"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "समस्याएँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "問題"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문제 해결"
+          }
+        }
+      },
+      "comment": "Link to the GitHub issue tracker (report bugs)"
+    },
+    "Key Aspect Ratio": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenverhältnis der Tasten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proportions des touches"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporción de las teclas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporzioni dei tasti"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Соотношение сторон клавиш"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporcje klawiszy"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangenternas proportioner"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäinten kuvasuhde"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omjer stranica tipki"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "יחס גובה-רוחב של המקשים"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tỷ lệ phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aspect Ratio ng Key"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αναλογία διαστάσεων πλήκτρων"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proporção das teclas"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Співвідношення сторін клавіш"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسبة أبعاد المفتاح"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسبت ابعاد کلید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی کا پہلو تناسب"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อัตราส่วนปุ่ม"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "की आस्पेक्ट रेशियो"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーの縦横比"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키 가로세로 비율"
+          }
+        }
+      },
+      "comment": "Settings row / title: width-to-height ratio of keys"
+    },
+    "Keyboard Size": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastaturgröße"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taille du clavier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamaño del teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dimensione della tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Размер клавиатуры"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozmiar klawiatury"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangentbordets storlek"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäimistön koko"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veličina tipkovnice"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גודל המקלדת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kích thước bàn phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laki ng Keyboard"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Μέγεθος πληκτρολογίου"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamanho do teclado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Розмір клавіатури"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حجم لوحة المفاتيح"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اندازه صفحه‌کلید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی بورڈ کا سائز"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ขนาดคีย์บอร์ด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड का आकार"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードのサイズ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 크기"
+          }
+        }
+      },
+      "comment": "Slider title: overall keyboard size"
+    },
+    "Label Visibility": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sichtbarkeit der Beschriftungen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visibilité des étiquettes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visibilidad de etiquetas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visibilità delle etichette"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видимость подписей"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Widoczność etykiet"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiketternas synlighet"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Merkintöjen näkyvyys"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vidljivost oznaka"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "נראות תוויות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiển thị nhãn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visibility ng Label"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ορατότητα ετικετών"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visibilidade das etiquetas"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видимість підписів"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ظهور التسميات"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمایان‌بودن برچسب‌ها"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لیبل کی نمائش"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การแสดงป้ายกำกับ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लेबल दृश्यता"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ラベルの表示"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "레이블 표시"
+          }
+        }
+      },
+      "comment": "Settings row title"
+    },
+    "Languages": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langues"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idiomas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lingue"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Языки"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Języki"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Språk"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kielet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jezici"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שפות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ngôn ngữ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Wika"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Γλώσσες"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idiomas"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мови"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اللغات"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زبان‌ها"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زبانیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ภาษา"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "भाषाएँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "언어"
+          }
+        }
+      },
+      "comment": "Settings row title / language selection screen title"
+    },
+    "Left": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Links"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gauche"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izquierda"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sinistra"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Слева"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lewo"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vänster"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vasen"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lijevo"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שמאל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trái"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaliwa"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αριστερά"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esquerda"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ліворуч"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اليسار"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چپ"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بائیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ซ้าย"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बायाँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "왼쪽"
+          }
+        }
+      },
+      "comment": "Slider label: left position"
+    },
+    "License": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lizenz"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licence"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licencia"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licenza"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лицензия"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licencja"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licens"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lisenssi"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licenca"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "רישיון"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giấy phép"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lisensya"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Άδεια χρήσης"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licença"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ліцензія"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الترخيص"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مجوز"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لائسنس"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สัญญาอนุญาต"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लाइसेंस"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライセンス"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "라이선스"
+          }
+        }
+      },
+      "comment": "About row label (software license)"
+    },
+    "Light": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leicht"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Léger"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ligero"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leggero"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лёгкий"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lekki"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lätt"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kevyt"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lagano"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "קל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhẹ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Magaan"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ελαφριά"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ligeiro"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Легкий"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خفيف جدًا"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سبک"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہلکا"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อ่อน"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हल्का"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "弱"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가볍게"
+          }
+        }
+      },
+      "comment": "Haptic intensity level name"
+    },
+    "Liquid Glass": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        }
+      },
+      "comment": "Keyboard style name (Apple design language, not translated)"
+    },
+    "Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass ist für iOS 26 und neuer ausgelegt. Auf älteren Versionen wird ein vereinfachter durchscheinender Stil verwendet."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass est conçu pour iOS 26 et versions ultérieures. Sur les versions antérieures, un style translucide simplifié est utilisé."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass está diseñado para iOS 26 y posteriores. En versiones anteriores se usa un estilo translúcido simplificado."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass è progettato per iOS 26 e versioni successive. Nelle versioni precedenti viene usato uno stile traslucido semplificato."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass разработан для iOS 26 и новее. В более ранних версиях используется упрощённый полупрозрачный стиль."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass jest zaprojektowany dla iOS 26 i nowszych. W starszych wersjach używany jest uproszczony półprzezroczysty styl."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass är utformat för iOS 26 och senare. På äldre versioner används en förenklad halvgenomskinlig stil."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass on suunniteltu iOS 26:lle ja uudemmille. Vanhemmissa versioissa käytetään yksinkertaistettua läpikuultavaa tyyliä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass je osmišljen za iOS 26 i novije. Na starijim verzijama koristi se pojednostavljeni poluprozirni stil."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass מיועד ל‑iOS 26 ואילך. בגרסאות קודמות נעשה שימוש בסגנון שקוף למחצה ופשוט יותר."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass được thiết kế cho iOS 26 trở lên. Trên các phiên bản cũ hơn, một kiểu trong mờ đơn giản hóa sẽ được dùng."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ang Liquid Glass ay idinisenyo para sa iOS 26 pataas. Sa mas lumang bersyon, gagamitin ang pinasimpleng translucent na estilo."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Το Liquid Glass απαιτεί iOS 26 ή νεότερη έκδοση. Σε αυτή τη συσκευή θα χρησιμοποιηθεί το κλασικό στιλ."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Liquid Glass requer o iOS 26 ou posterior. Neste dispositivo será usado o estilo clássico."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass потребує iOS 26 або новішої версії. На цьому пристрої використовуватиметься класичний стиль."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتطلب Liquid Glass نظام iOS 26 أو أحدث. سيُستخدم النمط الكلاسيكي على هذا الجهاز."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass به iOS 26 یا جدیدتر نیاز دارد. در این دستگاه از سبک کلاسیک استفاده می‌شود."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass کے لیے iOS 26 یا بعد کا ورژن درکار ہے۔ اس ڈیوائس پر کلاسک انداز استعمال ہوگا۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass ต้องใช้ iOS 26 ขึ้นไป อุปกรณ์นี้จะใช้สไตล์คลาสสิกแทน"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass के लिए iOS 26 या बाद का वर्शन ज़रूरी है। इस डिवाइस पर क्लासिक स्टाइल इस्तेमाल होगी।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid GlassにはiOS 26以降が必要です。このデバイスではクラシックスタイルが使用されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass는 iOS 26 이상이 필요합니다. 이 기기에서는 클래식 스타일이 사용됩니다."
+          }
+        }
+      },
+      "comment": "Note shown on pre-iOS-26 devices; 'Liquid Glass' is a style name (keep)"
+    },
+    "Max": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Máx."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Макс."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maks."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maks."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maks."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מרבי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tối đa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Μέγιστη"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Máximo"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Максимальний"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الحد الأقصى"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بیشینه"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زیادہ سے زیادہ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สูงสุด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अधिकतम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最大"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최대"
+          }
+        }
+      },
+      "comment": "Slider maximum label (maximum intensity)"
+    },
+    "Medium": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mittel"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moyen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medio"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medio"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Средний"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Średni"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medel"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keskitaso"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Srednje"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "בינוני"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vừa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Katamtaman"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Μεσαία"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Médio"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Середній"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متوسط"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "متوسط"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "درمیانہ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปานกลาง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मध्यम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보통"
+          }
+        }
+      },
+      "comment": "Haptic intensity level name"
+    },
+    "MessagEase Layout": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase-Layout"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disposition MessagEase"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disposición MessagEase"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Layout MessagEase"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Раскладка MessagEase"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Układ MessagEase"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase-layout"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase-asettelu"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase raspored"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פריסת MessagEase"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bố cục MessagEase"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase Layout"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διάταξη MessagEase"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esquema MessagEase"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Розкладка MessagEase"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تخطيط MessagEase"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چیدمان MessagEase"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase لے آؤٹ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เลย์เอาต์ MessagEase"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase लेआउट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEaseレイアウト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MessagEase 레이아웃"
+          }
+        }
+      },
+      "comment": "Caption under each language option; 'MessagEase' is a product name (keep)"
+    },
+    "Minimal": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimal"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mínimo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Минимальный"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimalny"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimal"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimaalinen"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimalno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מינימלי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tối thiểu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimal"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ελάχιστη"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mínimo"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мінімальний"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الحد الأدنى"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کمینه"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کم سے کم"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "น้อยที่สุด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "न्यूनतम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最小"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최소"
+          }
+        }
+      },
+      "comment": "Haptic intensity level name"
+    },
+    "New line": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neue Zeile"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nouvelle ligne"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nueva línea"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A capo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новая строка"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowy wiersz"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ny rad"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uusi rivi"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Novi redak"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שורה חדשה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dòng mới"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bagong linya"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Νέα γραμμή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nova linha"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Новий рядок"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سطر جديد"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خط جدید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نئی لائن"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ขึ้นบรรทัดใหม่"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नई लाइन"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "改行"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "줄바꿈"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the return/newline key (VoiceOver)"
+    },
+    "Next language": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nächste Sprache"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langue suivante"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma siguiente"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lingua successiva"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Следующий язык"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Następny język"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nästa språk"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seuraava kieli"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sljedeći jezik"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "השפה הבאה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ngôn ngữ tiếp theo"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Susunod na wika"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επόμενη γλώσσα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Próximo idioma"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Наступна мова"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اللغة التالية"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زبان بعدی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اگلی زبان"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ภาษาถัดไป"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अगली भाषा"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次の言語"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음 언어"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY action name for the switch-to-next-language gesture (VoiceOver)"
+    },
+    "Numpad Style": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ziffernblock-Stil"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Style du pavé numérique"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilo del teclado numérico"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stile tastierino numerico"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стиль цифровой панели"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Styl klawiatury numerycznej"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stil på sifferknappsats"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Numeronäppäimistön tyyli"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stil numeričke tipkovnice"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סגנון לוח המספרים"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiểu bàn phím số"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilo ng Numpad"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Στιλ αριθμητικού πληκτρολογίου"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilo do teclado numérico"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стиль цифрового блоку"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمط لوحة الأرقام"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سبک صفحهٔ اعداد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمپیڈ انداز"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สไตล์แป้นตัวเลข"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नंबरपैड स्टाइल"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テンキーのスタイル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "숫자 패드 스타일"
+          }
+        }
+      },
+      "comment": "Settings row title: number pad layout style"
+    },
+    "OK": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ОК"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "U redu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אישור"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "موافق"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تأیید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹھیک ہے"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตกลง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ठीक है"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인"
+          }
+        }
+      },
+      "comment": "Alert confirmation button"
+    },
+    "Off": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Désactivé"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apagado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выкл."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wył."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Av"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pois"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isklj."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "כבוי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tắt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ανενεργό"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desligado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вимк."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إيقاف"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خاموش"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بند"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बंद"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "끔"
+          }
+        }
+      },
+      "comment": "Slider minimum label (intensity off)"
+    },
+    "Open Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen öffnen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir Réglages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Ajustes"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri Impostazioni"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть Настройки"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz Ustawienia"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öppna Inställningar"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaa Asetukset"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvori Postavke"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פתח הגדרות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở Cài đặt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buksan ang Mga Setting"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Άνοιγμα Ρυθμίσεων"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Definições"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрити Параметри"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح الإعدادات"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "باز کردن تنظیمات"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترتیبات کھولیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดการตั้งค่า"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटिंग्स खोलें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定を開く"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 열기"
+          }
+        }
+      },
+      "comment": "Button that opens the iOS Settings app"
+    },
+    "Open iOS Settings → General → Keyboard → Keyboards and add Wurstfinger.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffne iOS Einstellungen → Allgemein → Tastatur → Tastaturen und füge Wurstfinger hinzu."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrez Réglages iOS → Général → Clavier → Claviers et ajoutez Wurstfinger."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre Ajustes de iOS → General → Teclado → Teclados y añade Wurstfinger."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri Impostazioni iOS → Generali → Tastiera → Tastiere e aggiungi Wurstfinger."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Откройте «Настройки» iOS → «Основные» → «Клавиатура» → «Клавиатуры» и добавьте Wurstfinger."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz Ustawienia iOS → Ogólne → Klawiatura → Klawiatury i dodaj Wurstfinger."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öppna Inställningar → Allmänt → Tangentbord → Tangentbord och lägg till Wurstfinger."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaa iOS-Asetukset → Yleiset → Näppäimistö → Näppäimistöt ja lisää Wurstfinger."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvori Postavke → Općenito → Tipkovnica → Tipkovnice i dodaj Wurstfinger."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פתח את הגדרות iOS → כללי → מקלדת → מקלדות והוסף את Wurstfinger."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở Cài đặt iOS → Cài đặt chung → Bàn phím → Bàn phím và thêm Wurstfinger."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buksan ang Mga Setting ng iOS → Pangkalahatan → Keyboard → Mga Keyboard at idagdag ang Wurstfinger."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ανοίξτε Ρυθμίσεις iOS → Γενικά → Πληκτρολόγιο → Πληκτρολόγια και προσθέστε το Wurstfinger."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra Definições do iOS → Geral → Teclado → Teclados e adicione o Wurstfinger."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрийте Параметри iOS → Основні → Клавіатура → Клавіатури та додайте Wurstfinger."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افتح الإعدادات ← عام ← لوحة المفاتيح ← لوحات المفاتيح وأضِف Wurstfinger."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنظیمات iOS → عمومی → صفحه‌کلید → صفحه‌کلیدها را باز کنید و Wurstfinger را اضافه کنید."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS کی ترتیبات → عمومی → کی بورڈ → کی بورڈز کھولیں اور Wurstfinger شامل کریں۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดการตั้งค่า iOS → ทั่วไป → แป้นพิมพ์ → แป้นพิมพ์ แล้วเพิ่ม Wurstfinger"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS सेटिंग्स → सामान्य → कीबोर्ड → कीबोर्ड खोलें और Wurstfinger जोड़ें।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOSの「設定」→「一般」→「キーボード」→「キーボード」を開いて、Wurstfingerを追加します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS 설정 → 일반 → 키보드 → 키보드로 이동하여 Wurstfinger를 추가하세요."
+          }
+        }
+      },
+      "comment": "Onboarding step 1 description; the arrow-separated words are iOS Settings menu names — use official localized iOS terms"
+    },
+    "Open the keyboard once to sync Full Access status.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffne die Tastatur einmal, um den Status von Vollzugriff zu synchronisieren."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrez le clavier une fois pour synchroniser l'état de l'accès complet."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre el teclado una vez para sincronizar el estado del acceso completo."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri la tastiera una volta per sincronizzare lo stato dell'accesso completo."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Откройте клавиатуру один раз, чтобы синхронизировать статус полного доступа."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz raz klawiaturę, aby zsynchronizować stan pełnego dostępu."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öppna tangentbordet en gång för att synkronisera status för fullständig åtkomst."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaa näppäimistö kerran, jotta täyden käyttöoikeuden tila synkronoituu."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jednom otvori tipkovnicu za sinkronizaciju statusa punog pristupa."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פתח את המקלדת פעם אחת כדי לסנכרן את מצב הגישה המלאה."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở bàn phím một lần để đồng bộ trạng thái Truy cập đầy đủ."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buksan ang keyboard nang isang beses para i-sync ang status ng Full Access."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ανοίξτε το πληκτρολόγιο μία φορά για συγχρονισμό της κατάστασης πλήρους πρόσβασης."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra o teclado uma vez para sincronizar o estado do acesso total."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрийте клавіатуру один раз, щоб синхронізувати стан повного доступу."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افتح لوحة المفاتيح مرة واحدة لمزامنة حالة الوصول الكامل."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "یک‌بار صفحه‌کلید را باز کنید تا وضعیت دسترسی کامل همگام شود."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مکمل رسائی کی حالت سنک کرنے کے لیے کی بورڈ ایک بار کھولیں۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดคีย์บอร์ดหนึ่งครั้งเพื่อซิงค์สถานะการเข้าถึงเต็มรูปแบบ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पूर्ण एक्सेस स्थिति सिंक करने के लिए कीबोर्ड एक बार खोलें।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フルアクセスの状態を同期するために、キーボードを一度開いてください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 접근 상태를 동기화하려면 키보드를 한 번 열어 주세요."
+          }
+        }
+      },
+      "comment": "Caption; 'Full Access' is the iOS term"
+    },
+    "Paste": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einsetzen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coller"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pegar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incolla"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вставить"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wklej"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klistra in"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liitä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zalijepi"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הדבק"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dán"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-paste"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επικόλληση"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вставити"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لصق"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چسباندن"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیسٹ کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วาง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पेस्ट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペースト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "붙여넣기"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the paste gesture (VoiceOver)"
+    },
+    "Phone (1-2-3)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefon (1-2-3)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Téléphone (1-2-3)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teléfono (1-2-3)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefono (1-2-3)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Телефонный (1-2-3)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefoniczny (1-2-3)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefon (1-2-3)"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puhelin (1-2-3)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefon (1-2-3)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "טלפון (1-2-3)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Điện thoại (1-2-3)"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telepono (1-2-3)"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τηλέφωνο (1-2-3)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefone (1-2-3)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Телефонний (1-2-3)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الهاتف (1-2-3)"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تلفن (۱-۲-۳)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فون (1-2-3)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โทรศัพท์ (1-2-3)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "फ़ोन (1-2-3)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電話（1-2-3）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전화기 (1-2-3)"
+          }
+        }
+      },
+      "comment": "Picker option: phone-style numpad with 1-2-3 on top"
+    },
+    "Phone layout (1-2-3)": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefon-Layout (1-2-3)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disposition téléphone (1-2-3)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disposición de teléfono (1-2-3)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Layout telefono (1-2-3)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Телефонная раскладка (1-2-3)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Układ telefoniczny (1-2-3)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefonlayout (1-2-3)"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Puhelinasettelu (1-2-3)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Telefonski raspored (1-2-3)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פריסת טלפון (1-2-3)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bố cục điện thoại (1-2-3)"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Layout ng telepono (1-2-3)"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διάταξη τηλεφώνου (1-2-3)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esquema de telefone (1-2-3)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Телефонна розкладка (1-2-3)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تخطيط الهاتف (1-2-3)"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چیدمان تلفن (۱-۲-۳)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فون لے آؤٹ (1-2-3)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เลย์เอาต์โทรศัพท์ (1-2-3)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "फ़ोन लेआउट (1-2-3)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電話レイアウト（1-2-3）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전화기 레이아웃 (1-2-3)"
+          }
+        }
+      },
+      "comment": "Numpad style subtitle: phone layout"
+    },
+    "Places globe, symbols, delete and return on the left": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Platziert Globus, Symbole, Löschen und Zeilenschalter links"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Place le globe, les symboles, la suppression et le retour à gauche"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coloca el globo, los símbolos, borrar e intro a la izquierda"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Posiziona globo, simboli, elimina e a capo a sinistra"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Размещает глобус, символы, удаление и ввод слева"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umieszcza globus, symbole, usuwanie i enter po lewej stronie"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Placerar jordglob, symboler, radera och retur till vänster"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sijoittaa maapallon, symbolit, poiston ja rivinvaihdon vasemmalle"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postavlja globus, simbole, brisanje i povratak na lijevu stranu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ממקם את הגלובוס, הסמלים, המחיקה והשורה החדשה בצד שמאל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đặt phím địa cầu, ký hiệu, xóa và xuống dòng ở bên trái"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inilalagay ang globe, symbols, delete at return sa kaliwa"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τοποθετεί την υδρόγειο, τα σύμβολα, τη διαγραφή και το return στα αριστερά"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coloca o globo, os símbolos, a eliminação e a tecla de retorno à esquerda"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Розміщує глобус, символи, видалення й Enter ліворуч"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يضع مفاتيح الكرة الأرضية والرموز والحذف والإدخال على اليسار"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدهای کره، نمادها، حذف و بازگشت را در سمت چپ قرار می‌دهد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گلوب، علامتیں، حذف اور ریٹرن کو بائیں طرف رکھتا ہے"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วางปุ่มลูกโลก สัญลักษณ์ ลบ และขึ้นบรรทัดใหม่ไว้ทางซ้าย"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ग्लोब, सिंबल, डिलीट और रिटर्न को बाईं ओर रखता है"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地球儀、記号、削除、改行のキーを左側に配置します"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지구본, 기호, 삭제, 줄바꿈 키를 왼쪽에 배치합니다"
+          }
+        }
+      },
+      "comment": "Toggle subtitle explaining the utility-keys-on-left option"
+    },
+    "Preview": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorschau"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aperçu"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vista previa"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anteprima"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предпросмотр"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podgląd"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Förhandsvisning"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esikatselu"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pregled"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תצוגה מקדימה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xem trước"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preview"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Προεπισκόπηση"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pré-visualização"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перегляд"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معاينة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیش‌نمایش"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پیش منظر"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวอย่าง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "प्रीव्यू"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プレビュー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "미리보기"
+          }
+        }
+      },
+      "comment": "Header above the interactive keyboard preview"
+    },
+    "Reset": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurücksetzen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinitialiser"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ripristina"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetuj"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Återställ"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Palauta"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vrati izvorno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אפס"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đặt lại"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-reset"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επαναφορά"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скинути"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تعيين"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازنشانی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ری سیٹ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รีเซ็ต"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रीसेट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リセット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "재설정"
+          }
+        }
+      },
+      "comment": "Button to reset values to defaults"
+    },
+    "Right": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechts"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Droite"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Derecha"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destra"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Справа"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prawo"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Höger"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oikea"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ימין"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phải"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kanan"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Δεξιά"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Direita"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Праворуч"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اليمين"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "راست"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دائیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ขวา"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "दायाँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오른쪽"
+          }
+        }
+      },
+      "comment": "Slider label: right position"
+    },
+    "Scale: %@, Position: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Größe: %@, Position: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échelle : %@, position : %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escala: %@, posición: %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scala: %@, posizione: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштаб: %@, положение: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skala: %@, położenie: %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skala: %@, position: %@"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koko: %@, sijainti: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veličina: %@, položaj: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "קנה מידה: %@, מיקום: %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tỷ lệ: %@, vị trí: %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scale: %@, posisyon: %@"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κλίμακα: %@, Θέση: %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escala: %@, Posição: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштаб: %@, положення: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الحجم: %@، الموضع: %@"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مقیاس: %@، موقعیت: %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسکیل: %@، پوزیشن: %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ขนาด: %@, ตำแหน่ง: %@"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्केल: %@, स्थिति: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイズ：%@、位置：%@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "크기: %@, 위치: %@"
+          }
+        }
+      },
+      "comment": "Size & Position subtitle, e.g. 'Scale: 100%, Position: Center'"
+    },
+    "Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réglages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustawienia"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inställningar"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asetukset"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postavke"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הגדרות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Setting"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ρυθμίσεις"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Definições"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإعدادات"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تنظیمات"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترتیبات"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตั้งค่า"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटिंग्स"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정"
+          }
+        }
+      },
+      "comment": "Tab label and navigation title for settings"
+    },
+    "Setup": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einrichtung"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuración"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurazione"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройка"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguracja"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigurering"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Käyttöönotto"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postavljanje"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הגדרה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thiết lập"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Setup"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ρύθμιση"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuração"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإعداد"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "راه‌اندازی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سیٹ اپ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตั้งค่า"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटअप"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セットアップ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 방법"
+          }
+        }
+      },
+      "comment": "Tab label and title for the first-run setup wizard"
+    },
+    "Setup Instructions": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anleitung zur Einrichtung"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instructions de configuration"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instrucciones de configuración"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Istruzioni di configurazione"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Инструкция по настройке"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instrukcje konfiguracji"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigureringsanvisningar"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Käyttöönotto-ohjeet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upute za postavljanje"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הוראות הגדרה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hướng dẫn thiết lập"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Tagubilin sa Setup"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Οδηγίες ρύθμισης"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instruções de configuração"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Інструкції з налаштування"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعليمات الإعداد"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دستورالعمل راه‌اندازی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سیٹ اپ ہدایات"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วิธีตั้งค่า"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटअप निर्देश"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セットアップ手順"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 안내"
+          }
+        }
+      },
+      "comment": "Button leading to setup steps"
+    },
+    "Show Extra Symbols": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zusatzsymbole anzeigen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher les symboles supplémentaires"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar símbolos adicionales"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra simboli extra"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать дополнительные символы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokazuj symbole dodatkowe"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visa extra symboler"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näytä lisäsymbolit"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prikaži dodatne simbole"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הצגת סמלים נוספים"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiện ký hiệu bổ sung"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ipakita ang mga dagdag na simbolo"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Εμφάνιση πρόσθετων συμβόλων"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar símbolos extras"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показувати додаткові символи"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إظهار الرموز الإضافية"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمایش نمادهای اضافی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضافی علامات دکھائیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แสดงสัญลักษณ์เพิ่มเติม"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अतिरिक्त चिह्न दिखाएँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加記号を表示"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "추가 기호 표시"
+          }
+        }
+      },
+      "comment": "Label visibility toggle"
     },
     "Show Letters": {
       "extractionState": "manual",
@@ -15043,557 +13604,2765 @@
       },
       "comment": "Label visibility toggle"
     },
-    "Show Extra Symbols": {
+    "Size & Position": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Zusatzsymbole anzeigen"
+            "value": "Größe & Position"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Afficher les symboles supplémentaires"
+            "value": "Taille et position"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar símbolos adicionales"
+            "value": "Tamaño y posición"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostra simboli extra"
+            "value": "Dimensioni e posizione"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Показывать дополнительные символы"
+            "value": "Размер и положение"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pokazuj symbole dodatkowe"
+            "value": "Rozmiar i położenie"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visa extra symboler"
+            "value": "Storlek och position"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Näytä lisäsymbolit"
+            "value": "Koko ja sijainti"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prikaži dodatne simbole"
+            "value": "Veličina i položaj"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "הצגת סמלים נוספים"
+            "value": "גודל ומיקום"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hiện ký hiệu bổ sung"
+            "value": "Kích cỡ & Vị trí"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ipakita ang mga dagdag na simbolo"
+            "value": "Sukat at Posisyon"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Εμφάνιση πρόσθετων συμβόλων"
+            "value": "Μέγεθος και θέση"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mostrar símbolos extras"
+            "value": "Tamanho e posição"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Показувати додаткові символи"
+            "value": "Розмір і положення"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "إظهار الرموز الإضافية"
+            "value": "الحجم والموضع"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "نمایش نمادهای اضافی"
+            "value": "اندازه و موقعیت"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "اضافی علامات دکھائیں"
+            "value": "سائز اور پوزیشن"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "แสดงสัญลักษณ์เพิ่มเติม"
+            "value": "ขนาดและตำแหน่ง"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "अतिरिक्त चिह्न दिखाएँ"
+            "value": "आकार और स्थिति"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "追加記号を表示"
+            "value": "サイズと位置"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "추가 기호 표시"
+            "value": "크기 및 위치"
           }
         }
       },
-      "comment": "Label visibility toggle"
+      "comment": "Settings row / title: keyboard size and position"
     },
-    "Hide labels to practice the layout from memory. Numbers and control keys are always visible.": {
+    "Size relative to the standard keyboard. It stays the same in every orientation; if it does not fit, it shrinks to the screen.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Blende Beschriftungen aus, um das Layout aus dem Gedächtnis zu üben. Zahlen und Steuertasten sind immer sichtbar."
+            "value": "Größe im Verhältnis zur Standardtastatur. Sie bleibt in jeder Bildschirmausrichtung gleich; passt sie nicht auf den Bildschirm, wird sie auf die Bildschirmbreite verkleinert."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Masquez les étiquettes pour vous exercer à la disposition de mémoire. Les chiffres et les touches de contrôle restent toujours visibles."
+            "value": "Taille par rapport au clavier standard. Elle reste identique dans toutes les orientations ; si le clavier ne tient pas, il est réduit à la largeur de l'écran."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Oculta las etiquetas para practicar la disposición de memoria. Los números y las teclas de control siempre están visibles."
+            "value": "Tamaño relativo al teclado estándar. Se mantiene igual en todas las orientaciones; si no cabe, se reduce al ancho de la pantalla."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nascondi le etichette per esercitarti con il layout a memoria. I numeri e i tasti di controllo restano sempre visibili."
+            "value": "Dimensione relativa alla tastiera standard. Resta invariata in ogni orientamento; se non c'è spazio sufficiente, viene ridotta alla larghezza dello schermo."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Скройте подписи, чтобы тренировать раскладку по памяти. Цифры и служебные клавиши всегда видны."
+            "value": "Размер относительно стандартной клавиатуры. Он одинаков в любой ориентации; если клавиатура не помещается, она уменьшается до ширины экрана."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ukryj etykiety, aby ćwiczyć układ z pamięci. Cyfry i klawisze sterujące są zawsze widoczne."
+            "value": "Rozmiar względem klawiatury standardowej. Pozostaje taki sam w każdej orientacji; jeśli klawiatura się nie mieści, jest zmniejszana do szerokości ekranu."
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dölj etiketter för att öva på layouten ur minnet. Siffror och kontrolltangenter är alltid synliga."
+            "value": "Storlek i förhållande till standardtangentbordet. Den är densamma i alla riktningar; om tangentbordet inte får plats krymps det till skärmens bredd."
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Piilota merkinnät harjoitellaksesi asettelua muistista. Numerot ja ohjausnäppäimet ovat aina näkyvissä."
+            "value": "Koko suhteessa vakionäppäimistöön. Se pysyy samana kaikissa asennoissa; jos näppäimistö ei mahdu, se kutistetaan näytön leveyteen."
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sakrij oznake da vježbaš raspored napamet. Brojevi i upravljačke tipke uvijek su vidljivi."
+            "value": "Veličina u odnosu na standardnu tipkovnicu. Ostaje ista u svakoj orijentaciji; ako tipkovnica ne stane, smanjuje se na širinu zaslona."
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "הסתר תוויות כדי לתרגל את הפריסה מהזיכרון. הספרות ומקשי הבקרה תמיד גלויים."
+            "value": "הגודל ביחס למקלדת הרגילה. הוא נשאר זהה בכל כיוון; אם המקלדת לא נכנסת, היא מוקטנת לרוחב המסך."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ẩn nhãn để luyện tập bố cục theo trí nhớ. Số và các phím điều khiển luôn hiển thị."
+            "value": "Kích thước so với bàn phím tiêu chuẩn. Kích thước này giữ nguyên ở mọi hướng màn hình; nếu không vừa, bàn phím sẽ thu nhỏ theo chiều rộng màn hình."
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Itago ang mga label para masanay sa layout mula sa memorya. Laging nakikita ang mga numero at control key."
+            "value": "Laki kumpara sa karaniwang keyboard. Nananatili itong pareho sa lahat ng oryentasyon; kung hindi kasya, liliitan ito ayon sa lapad ng screen."
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Απόκρυψη ετικετών για εξάσκηση της διάταξης από μνήμης. Οι αριθμοί και τα πλήκτρα ελέγχου είναι πάντα ορατά."
+            "value": "Μέγεθος σε σχέση με το τυπικό πληκτρολόγιο. Παραμένει το ίδιο σε κάθε προσανατολισμό· αν δεν χωράει, σμικρύνεται στο πλάτος της οθόνης."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Oculte os rótulos para praticar o layout de memória. Números e teclas de controle estão sempre visíveis."
+            "value": "Tamanho relativo ao teclado padrão. Mantém-se igual em qualquer orientação; se não couber, é reduzido à largura do ecrã."
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Приховайте підписи, щоб вивчати розкладку напам'ять. Цифри та клавіші керування завжди видимі."
+            "value": "Розмір відносно стандартної клавіатури. Він однаковий у будь-якій орієнтації; якщо клавіатура не вміщується, вона зменшується до ширини екрана."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "أخفِ التسميات للتدرب على التخطيط من الذاكرة. الأرقام ومفاتيح التحكم مرئية دائمًا."
+            "value": "الحجم بالنسبة إلى لوحة المفاتيح القياسية. يبقى كما هو في كل الاتجاهات، وإذا لم تتسع لوحة المفاتيح فسيتم تصغيرها لتناسب عرض الشاشة."
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "برچسب‌ها را پنهان کنید تا چیدمان را از حفظ تمرین کنید. اعداد و کلیدهای کنترل همیشه نمایان هستند."
+            "value": "اندازه نسبت به صفحه‌کلید استاندارد. در همه جهت‌ها یکسان می‌ماند؛ اگر جا نشود، به عرض صفحه کوچک می‌شود."
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "ترتیب کو یادداشت سے مشق کرنے کے لیے لیبل چھپائیں۔ نمبر اور کنٹرول کیز ہمیشہ نظر آتی ہیں۔"
+            "value": "معیاری کی بورڈ کے مقابلے میں سائز۔ یہ ہر سمت میں یکساں رہتا ہے؛ اگر کی بورڈ نہ سما سکے تو اسے اسکرین کی چوڑائی کے مطابق چھوٹا کر دیا جاتا ہے۔"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ซ่อนป้ายกำกับเพื่อฝึกเค้าโครงจากความจำ ตัวเลขและปุ่มควบคุมจะแสดงอยู่เสมอ"
+            "value": "ขนาดเทียบกับคีย์บอร์ดมาตรฐาน ขนาดจะเท่าเดิมในทุกการวางแนว หากไม่พอดีจะย่อลงให้เท่าความกว้างของหน้าจอ"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "लेआउट को याद से अभ्यास करने के लिए लेबल छिपाएँ। संख्याएँ और नियंत्रण कुंजियाँ हमेशा दिखती हैं।"
+            "value": "मानक कीबोर्ड की तुलना में आकार। यह हर ओरिएंटेशन में एक जैसा रहता है; अगर यह नहीं समाता, तो इसे स्क्रीन की चौड़ाई तक छोटा कर दिया जाता है।"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "レイアウトを記憶で練習するにはラベルを非表示にします。数字と制御キーは常に表示されます。"
+            "value": "標準キーボードを基準としたサイズです。どの画面の向きでも同じ大きさを保ち、収まらない場合は画面幅に合わせて縮小されます。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "레이아웃을 외워서 연습하려면 라벨을 숨기세요. 숫자와 컨트롤 키는 항상 표시됩니다."
+            "value": "표준 키보드를 기준으로 한 크기입니다. 화면 방향이 바뀌어도 그대로 유지되며, 들어가지 않으면 화면 너비에 맞춰 줄어듭니다."
           }
         }
       },
-      "comment": "Label visibility footer"
+      "comment": "Caption under the size slider"
     },
-    "Classic": {
+    "Soft": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Klassisch"
+            "value": "Sanft"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Classique"
+            "value": "Doux"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Clásico"
+            "value": "Suave"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Classico"
+            "value": "Morbido"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Классический"
+            "value": "Мягкий"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Klasyczny"
+            "value": "Miękki"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Klassisk"
+            "value": "Mjuk"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Klassinen"
+            "value": "Pehmeä"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Klasično"
+            "value": "Mekano"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "קלאסי"
+            "value": "רך"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Cổ điển"
+            "value": "Êm"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Klasiko"
+            "value": "Malambot"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Κλασικό"
+            "value": "Απαλή"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Clássico"
+            "value": "Suave"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Класичний"
+            "value": "М’який"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "كلاسيكي"
+            "value": "خفيف"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "کلاسیک"
+            "value": "ملایم"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "کلاسک"
+            "value": "نرم"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "คลาสสิก"
+            "value": "เบา"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "क्लासिक"
+            "value": "मृदु"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "クラシック"
+            "value": "ソフト"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "클래식"
+            "value": "약하게"
           }
         }
       },
-      "comment": "Keyboard style name"
+      "comment": "Haptic intensity level name"
     },
-    "Liquid Glass": {
+    "Space": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Leertaste"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Espace"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Espacio"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Spazio"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Пробел"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Spacja"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Mellanslag"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Välilyönti"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Razmaknica"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "רווח"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Phím cách"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Space"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Διάστημα"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Espaço"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "Пробіл"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "مسافة"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "فاصله"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "اسپیس"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "เว้นวรรค"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "स्पेस"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "スペース"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass"
+            "value": "스페이스"
           }
         }
       },
-      "comment": "Keyboard style name (Apple design language, not translated)"
+      "comment": "ACCESSIBILITY label for the space bar (VoiceOver)"
+    },
+    "Square · Default": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quadratisch · Standard"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carré · Par défaut"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuadrado · Por defecto"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quadrato · Predefinito"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Квадрат · По умолчанию"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kwadratowe · Domyślne"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kvadratisk · Standard"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neliö · Oletus"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kvadratno · Zadano"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מרובע · ברירת מחדל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuông · Mặc định"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Parisukat · Default"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τετράγωνο · Προεπιλογή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quadrado · Predefinição"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Квадратне · За замовчуванням"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مربّع · افتراضي"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مربع · پیش‌فرض"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مربع · طے شدہ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สี่เหลี่ยมจัตุรัส · ค่าเริ่มต้น"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "वर्ग · डिफ़ॉल्ट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正方形・デフォルト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정사각형 · 기본값"
+          }
+        }
+      },
+      "comment": "Slider tick label at ratio 1.0; keep the · middle dot"
+    },
+    "Step-by-step": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schrittweise"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas à pas"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paso a paso"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passo passo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пошаговое"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Krok po kroku"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Steg för steg"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Askel kerrallaan"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korak po korak"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "צעד אחר צעד"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Từng bước"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hakbang-hakbang"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Βήμα προς βήμα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passo a passo"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Покроково"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خطوة بخطوة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گام‌به‌گام"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قدم بہ قدم"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทีละขั้น"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "चरण-दर-चरण"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1文字ずつ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "단계별"
+          }
+        }
+      },
+      "comment": "Picker option for cursor movement style (one character per swipe)"
+    },
+    "Strong": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stark"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fort"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fuerte"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forte"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сильный"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Silny"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stark"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voimakas"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jako"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "חזק"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mạnh"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Malakas"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Δυνατή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forte"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сильний"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قوي"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قوی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مضبوط"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แรง"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "तीव्र"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "強"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "강하게"
+          }
+        }
+      },
+      "comment": "Haptic intensity level name"
+    },
+    "Style": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stil"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Style"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stile"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стиль"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Styl"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stil"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tyyli"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stil"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סגנון"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiểu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilo"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Στιλ"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilo"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стиль"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "النمط"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سبک"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انداز"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สไตล์"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्टाइल"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スタイル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스타일"
+          }
+        }
+      },
+      "comment": "Settings row / title: visual style"
+    },
+    "Swipe per character, return-swipe per word": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wischen pro Zeichen, Hin-und-zurück-Wischen pro Wort"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Balayage par caractère, aller-retour par mot"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desliza por carácter, desliza y vuelve por palabra"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scorri per carattere, scorri e torna per parola"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Свайп — символ, свайп с возвратом — слово"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przesunięcie – znak, przesunięcie z powrotem – słowo"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Svep per tecken, retursvep per ord"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pyyhkäisy siirtää merkin, paluupyyhkäisy sanan"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prijelaz po znaku, povratni prijelaz po riječi"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "החלקה לכל תו, החלקה וחזרה לכל מילה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuốt theo ký tự, vuốt và quay lại theo từ"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swipe kada character, return-swipe kada salita"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σάρωση ανά χαρακτήρα, σάρωση επιστροφής ανά λέξη"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deslize por carácter, deslize de retorno por palavra"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Свайп для символу, зворотний свайп для слова"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تمرير لكل حرف، وتمرير عائد لكل كلمة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کشیدن برای هر نویسه، کشیدن‌و‌بازگشت برای هر واژه"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہر حرف کے لیے سوائپ، ہر لفظ کے لیے ریٹرن سوائپ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปัดทีละตัวอักษร ปัดกลับทีละคำ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "प्रति अक्षर स्वाइप, प्रति शब्द रिटर्न-स्वाइप"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スワイプで1文字ずつ、リターンスワイプで1単語ずつ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글자 단위 스와이프, 단어 단위 리턴 스와이프"
+          }
+        }
+      },
+      "comment": "Cursor movement subtitle: discrete style"
+    },
+    "Swipe right on the globe key to switch languages. Tap a language to set it as the default startup language.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wische auf der Globus-Taste nach rechts, um die Sprache zu wechseln. Tippe auf eine Sprache, um sie als Standard-Startsprache festzulegen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Balayez vers la droite sur la touche globe pour changer de langue. Touchez une langue pour la définir comme langue par défaut au démarrage."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desliza hacia la derecha sobre la tecla del globo para cambiar de idioma. Toca un idioma para establecerlo como idioma predeterminado de inicio."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scorri verso destra sul tasto globo per cambiare lingua. Tocca una lingua per impostarla come lingua predefinita all'avvio."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Смахните вправо по клавише глобуса, чтобы переключить язык. Нажмите на язык, чтобы сделать его языком по умолчанию при запуске."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przesuń w prawo po klawiszu globusa, aby przełączyć język. Stuknij język, aby ustawić go jako domyślny język startowy."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Svep åt höger på jordglobstangenten för att byta språk. Tryck på ett språk för att ange det som standardspråk vid start."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaihda kieltä pyyhkäisemällä maapallonäppäintä oikealle. Aseta kieli oletuskieleksi napauttamalla sitä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prijeđi udesno po tipki globusa za promjenu jezika. Dodirni jezik da ga postaviš kao zadani početni jezik."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "החלק ימינה על מקש הגלובוס כדי להחליף שפה. הקש על שפה כדי להגדיר אותה כשפת ברירת המחדל בהפעלה."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuốt sang phải trên phím địa cầu để chuyển ngôn ngữ. Chạm vào một ngôn ngữ để đặt làm ngôn ngữ mặc định khi khởi động."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mag-swipe pakanan sa globe key para magpalit ng wika. I-tap ang isang wika para gawin itong default na panimulang wika."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σαρώστε δεξιά στο πλήκτρο της υδρογείου για εναλλαγή γλωσσών. Πατήστε μια γλώσσα για να την ορίσετε ως προεπιλεγμένη γλώσσα εκκίνησης."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deslize para a direita na tecla do globo para mudar de idioma. Toque num idioma para o definir como idioma de arranque predefinido."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проведіть праворуч по клавіші глобуса, щоб перемкнути мови. Торкніться мови, щоб зробити її мовою запуску за замовчуванням."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مرِّر يمينًا على مفتاح الكرة الأرضية لتبديل اللغات. اضغط على لغة لتعيينها كلغة البدء الافتراضية."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روی کلید کره به راست بکشید تا زبان‌ها را عوض کنید. روی یک زبان ضربه بزنید تا آن را به‌عنوان زبان پیش‌فرض هنگام شروع تنظیم کنید."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زبانیں تبدیل کرنے کے لیے گلوب کی پر دائیں سوائپ کریں۔ کسی زبان کو طے شدہ آغازی زبان مقرر کرنے کے لیے اس پر ٹیپ کریں۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปัดขวาที่ปุ่มลูกโลกเพื่อสลับภาษา แตะภาษาเพื่อตั้งเป็นภาษาเริ่มต้นเมื่อเปิดใช้งาน"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "भाषाएँ बदलने के लिए ग्लोब की पर दाईं ओर स्वाइप करें। किसी भाषा को डिफ़ॉल्ट स्टार्टअप भाषा बनाने के लिए उस पर टैप करें।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地球儀キーを右にスワイプすると言語を切り替えられます。言語をタップすると、起動時のデフォルト言語に設定されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지구본 키를 오른쪽으로 스와이프하여 언어를 전환하세요. 언어를 탭하면 기본 시작 언어로 설정됩니다."
+          }
+        }
+      },
+      "comment": "Footer on the language selection screen"
+    },
+    "Switch keyboard": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastatur wechseln"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changer de clavier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar de teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переключить клавиатуру"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przełącz klawiaturę"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Byt tangentbord"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaihda näppäimistöä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Promijeni tipkovnicu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "החלף מקלדת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyển bàn phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Magpalit ng keyboard"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Εναλλαγή πληκτρολογίου"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mudar de teclado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемкнути клавіатуру"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تبديل لوحة المفاتيح"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعویض صفحه‌کلید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی بورڈ تبدیل کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สลับคีย์บอร์ด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड बदलें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードを切り替える"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 전환"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the globe key (VoiceOver)"
+    },
+    "Switch to the Test tab and experiment with gestures.": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wechsle zum Tab „Test“ und probiere die Gesten aus."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passez à l'onglet Test et expérimentez les gestes."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ve a la pestaña Prueba y experimenta con los gestos."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passa alla scheda Prova e sperimenta con i gesti."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейдите на вкладку «Проба» и поэкспериментируйте с жестами."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przejdź do karty Test i poeksperymentuj z gestami."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Byt till fliken Testa och experimentera med gester."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siirry Testaa-välilehdelle ja kokeile eleitä."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prijeđi na karticu Isprobaj i isprobaj geste."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "עבור ללשונית בדיקה והתנסה במחוות."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyển sang thẻ Thử và thử nghiệm các cử chỉ."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lumipat sa Test tab at mag-eksperimento sa mga gesture."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Μεταβείτε στην καρτέλα Δοκιμή και πειραματιστείτε με τις χειρονομίες."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mude para o separador Testar e experimente os gestos."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейдіть на вкладку «Тест» та поекспериментуйте з жестами."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انتقل إلى علامة تبويب الاختبار وجرّب الإيماءات."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "به زبانهٔ آزمایش بروید و حرکت‌ها را امتحان کنید."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹیسٹ ٹیب پر جائیں اور اشاروں کے ساتھ تجربہ کریں۔"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สลับไปที่แท็บทดสอบและลองใช้เจสเจอร์ต่างๆ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "टेस्ट टैब पर जाएँ और जेस्चर के साथ प्रयोग करें।"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「テスト」タブに切り替えて、ジェスチャを試してみましょう。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테스트 탭으로 이동하여 제스처를 사용해 보세요."
+          }
+        }
+      },
+      "comment": "Onboarding step 3 description; 'Test tab' refers to the in-app tab labeled 'Test'"
+    },
+    "Switching Keyboards": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastatur wechseln"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changer de clavier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar de teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переключение клавиатуры"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przełącz klawiaturę"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Byt tangentbord"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaihda näppäimistöä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Promjena tipkovnice"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "החלף מקלדת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyển bàn phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Magpalit ng Keyboard"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Εναλλαγή πληκτρολογίου"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mudar de teclado"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перемкнути клавіатуру"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تبديل لوحة المفاتيح"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعویض صفحه‌کلید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی بورڈ تبدیل کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สลับคีย์บอร์ด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड बदलें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードを切り替える"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 전환"
+          }
+        }
+      },
+      "comment": "Header above instructions on how to switch keyboards"
+    },
+    "Tap Feedback": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipp-Feedback"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour au toucher"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Respuesta al tocar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback al tocco"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отклик при нажатии"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reakcja na stuknięcie"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Återkoppling vid tryck"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Napautuspalaute"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povratne informacije dodira"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משוב בהקשה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phản hồi khi chạm"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap Feedback"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ανάδραση πατήματος"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retorno ao tocar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відгук на дотик"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استجابة اللمس"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بازخورد ضربه"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹیپ فیڈ بیک"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตอบสนองเมื่อแตะ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "टैप फ़ीडबैक"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タップ時のフィードバック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭 피드백"
+          }
+        }
+      },
+      "comment": "Slider control title: haptic strength when tapping keys"
+    },
+    "Tap here to open keyboard...": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hier tippen, um die Tastatur zu öffnen …"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touchez ici pour ouvrir le clavier…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca aquí para abrir el teclado..."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tocca qui per aprire la tastiera..."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нажмите здесь, чтобы открыть клавиатуру…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stuknij tutaj, aby otworzyć klawiaturę..."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tryck här för att öppna tangentbordet …"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaa näppäimistö napauttamalla tähän..."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodirni ovdje za otvaranje tipkovnice..."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הקש כאן כדי לפתוח את המקלדת..."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chạm vào đây để mở bàn phím..."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-tap dito para buksan ang keyboard..."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πατήστε εδώ για άνοιγμα πληκτρολογίου..."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque aqui para abrir o teclado..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Торкніться тут, щоб відкрити клавіатуру…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط هنا لفتح لوحة المفاتيح..."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برای باز کردن صفحه‌کلید اینجا ضربه بزنید..."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی بورڈ کھولنے کے لیے یہاں ٹیپ کریں..."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แตะที่นี่เพื่อเปิดคีย์บอร์ด..."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड खोलने के लिए यहाँ टैप करें..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ここをタップしてキーボードを開く…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "여기를 탭하여 키보드 열기..."
+          }
+        }
+      },
+      "comment": "Placeholder text in the test field"
+    },
+    "Tap the globe icon on your keyboard to switch between installed keyboards": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tippe auf das Globussymbol deiner Tastatur, um zwischen installierten Tastaturen zu wechseln"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touchez l'icône du globe sur votre clavier pour passer d'un clavier installé à un autre"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toca el icono del globo en tu teclado para cambiar entre los teclados instalados"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tocca l'icona del globo sulla tastiera per passare da una tastiera installata all'altra"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нажмите значок глобуса на клавиатуре, чтобы переключаться между установленными клавиатурами"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stuknij ikonę globusa na klawiaturze, aby przełączać zainstalowane klawiatury"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tryck på jordglobsikonen på tangentbordet för att växla mellan installerade tangentbord"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaihda asennettujen näppäimistöjen välillä napauttamalla maapallokuvaketta näppäimistössä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodirni ikonu globusa na tipkovnici za prebacivanje između instaliranih tipkovnica"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הקש על סמל הגלובוס במקלדת כדי לעבור בין המקלדות המותקנות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chạm biểu tượng địa cầu trên bàn phím để chuyển giữa các bàn phím đã cài"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-tap ang globe icon sa iyong keyboard para magpalit sa pagitan ng mga naka-install na keyboard"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πατήστε το εικονίδιο της υδρογείου στο πληκτρολόγιό σας για εναλλαγή μεταξύ των εγκατεστημένων πληκτρολογίων"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque no ícone do globo no teclado para alternar entre os teclados instalados"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Торкніться значка глобуса на клавіатурі, щоб перемикатися між встановленими клавіатурами"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط على أيقونة الكرة الأرضية في لوحة المفاتيح للتبديل بين لوحات المفاتيح المثبَّتة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روی نماد کره در صفحه‌کلید ضربه بزنید تا بین صفحه‌کلیدهای نصب‌شده جابه‌جا شوید"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "انسٹال شدہ کی بورڈز کے درمیان تبدیل کرنے کے لیے اپنے کی بورڈ پر گلوب آئیکن پر ٹیپ کریں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แตะไอคอนลูกโลกบนคีย์บอร์ดเพื่อสลับระหว่างคีย์บอร์ดที่ติดตั้งไว้"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इंस्टॉल किए गए कीबोर्ड के बीच स्विच करने के लिए अपने कीबोर्ड पर ग्लोब आइकन पर टैप करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードの地球儀アイコンをタップすると、インストール済みのキーボードを切り替えられます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드의 지구본 아이콘을 탭하면 설치된 키보드 간에 전환할 수 있습니다"
+          }
+        }
+      },
+      "comment": "Instruction text"
+    },
+    "Tap: %@ • Drag: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tippen: %@ • Ziehen: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toucher : %@ • Glisser : %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tocar: %@ • Arrastrar: %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tocco: %@ • Trascinamento: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нажатие: %@ • Перетягивание: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stuknięcie: %@ • Przeciąganie: %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tryck: %@ • Dragning: %@"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Napautus: %@ • Veto: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodir: %@ • Povlačenje: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "הקשה: %@ • גרירה: %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chạm: %@ • Kéo: %@"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap: %@ • Drag: %@"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πάτημα: %@ • Σύρσιμο: %@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toque: %@ • Arrastar: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дотик: %@ • Перетягування: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اللمس: %@ • السحب: %@"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ضربه: %@ • کشیدن: %@"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹیپ: %@ • ڈریگ: %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แตะ: %@ • ลาก: %@"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "टैप: %@ • ड्रैग: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タップ：%@ • ドラッグ：%@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭: %@ • 드래그: %@"
+          }
+        }
+      },
+      "comment": "Haptic feedback subtitle, e.g. 'Tap: 50% • Drag: Off'"
+    },
+    "Test": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prueba"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prova"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проба"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testa"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testaa"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isprobaj"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "בדיקה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thử"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Δοκιμή"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тест"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اختبار"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آزمایش"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹیسٹ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทดสอบ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "टेस्ट"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テスト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테스트"
+          }
+        }
+      },
+      "comment": "Tab label for the try-it-out / test screen"
+    },
+    "Test Field": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testfeld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Champ de test"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Campo de prueba"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Campo di prova"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поле для пробы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pole testowe"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testfält"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Testikenttä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polje za isprobavanje"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שדה בדיקה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ô thử"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test Field"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πεδίο δοκιμής"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Campo de teste"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тестове поле"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حقل الاختبار"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فیلد آزمایش"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ٹیسٹ فیلڈ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ช่องทดสอบ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "टेस्ट फ़ील्ड"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テスト入力欄"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테스트 입력란"
+          }
+        }
+      },
+      "comment": "Label above a text field for trying the keyboard"
+    },
+    "The Keyboard for Fat Fingers": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Tastatur für Wurstfinger"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le clavier pour les gros doigts"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El teclado para dedos torpes"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La tastiera per dita grosse"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавиатура для толстых пальцев"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klawiatura dla grubych palców"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangentbordet för tjocka fingrar"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäimistö paksuille sormille"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipkovnica za debele prste"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "המקלדת לאצבעות עבות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bàn phím cho ngón tay to"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ang Keyboard para sa Malalaking Daliri"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Το πληκτρολόγιο για χοντρά δάχτυλα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O teclado para dedos gordos"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавіатура для товстих пальців"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لوحة المفاتيح لأصحاب الأصابع الكبيرة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "صفحه‌کلید برای انگشتان درشت"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "موٹی انگلیوں کے لیے کی بورڈ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คีย์บอร์ดสำหรับนิ้วอวบ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मोटी उंगलियों के लिए कीबोर्ड"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "太い指のためのキーボード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "손가락이 두꺼운 분을 위한 키보드"
+          }
+        }
+      },
+      "comment": "Playful app tagline/slogan"
     },
     "Traditional opaque keys": {
       "extractionState": "manual",
@@ -15871,2347 +16640,1661 @@
       },
       "comment": "Keyboard style description: Liquid Glass"
     },
-    "Disable %@": {
+    "Try the keyboard": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ deaktivieren"
+            "value": "Tastatur ausprobieren"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Désactiver %@"
+            "value": "Essayer le clavier"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desactivar %@"
+            "value": "Prueba el teclado"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Disattiva %@"
+            "value": "Prova la tastiera"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Отключить %@"
+            "value": "Попробуйте клавиатуру"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wyłącz %@"
+            "value": "Wypróbuj klawiaturę"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Avaktivera %@"
+            "value": "Prova tangentbordet"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Poista %@ käytöstä"
+            "value": "Kokeile näppäimistöä"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Onemogući %@"
+            "value": "Isprobaj tipkovnicu"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "השבתת %@"
+            "value": "נסה את המקלדת"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tắt %@"
+            "value": "Thử bàn phím"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "I-disable ang %@"
+            "value": "Subukan ang keyboard"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Απενεργοποίηση %@"
+            "value": "Δοκιμάστε το πληκτρολόγιο"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativar %@"
+            "value": "Experimentar o teclado"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Вимкнути %@"
+            "value": "Спробувати клавіатуру"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "تعطيل %@"
+            "value": "جرّب لوحة المفاتيح"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "غیرفعال کردن %@"
+            "value": "امتحان صفحه‌کلید"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ غیر فعال کریں"
+            "value": "کی بورڈ آزمائیں"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ปิดใช้ %@"
+            "value": "ลองใช้คีย์บอร์ด"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ बंद करें"
+            "value": "कीबोर्ड आज़माएँ"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@を無効にする"
+            "value": "キーボードを試す"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ 사용 안 함"
+            "value": "키보드 사용해 보기"
           }
         }
       },
-      "comment": "Accessibility label: disable a language; %@ is the language name"
+      "comment": "Onboarding step 3 title"
     },
-    "Enable %@": {
+    "Type Numbers by Holding": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كتابة الأرقام بالضغط المطوّل"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ aktivieren"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activer %@"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activar %@"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attiva %@"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Включить %@"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Włącz %@"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktivera %@"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ota %@ käyttöön"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Omogući %@"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הפעלת %@"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bật %@"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-enable ang %@"
+            "value": "Ziffern durch Halten"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ενεργοποίηση %@"
+            "value": "Αριθμοί με παρατεταμένο πάτημα"
           }
         },
-        "pt": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativar %@"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Увімкнути %@"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تفعيل %@"
+            "value": "Números manteniendo pulsado"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "فعال کردن %@"
+            "value": "تایپ اعداد با نگه‌داشتن"
           }
         },
-        "ur": {
+        "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ فعال کریں"
+            "value": "Numerot pitkällä painalluksella"
           }
         },
-        "th": {
+        "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "เปิดใช้ %@"
+            "value": "Mga numero sa pagpindot nang matagal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiffres par appui long"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ספרות בלחיצה ארוכה"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ चालू करें"
+            "value": "दबाकर रखने से अंक"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brojke dugim pritiskom"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Numeri tenendo premuto"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@を有効にする"
+            "value": "長押しで数字を入力"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ 사용"
+            "value": "길게 눌러 숫자 입력"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cyfry przez przytrzymanie"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Números mantendo premido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ввод цифр удержанием"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siffror med långt tryck"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พิมพ์ตัวเลขด้วยการกดค้าง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введення цифр утриманням"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دبا کر رکھنے سے ہندسے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhập số bằng cách giữ phím"
           }
         }
       },
-      "comment": "Accessibility label: enable a language; %@ is the language name"
+      "comment": "Toggle title: type digits by long-pressing letter keys"
     },
-    "Enabled": {
+    "Type on the keyboard below": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aktiviert"
+            "value": "Tippe auf der Tastatur unten"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Activé"
+            "value": "Tapez sur le clavier ci-dessous"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Activado"
+            "value": "Escribe con el teclado de abajo"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Attivato"
+            "value": "Scrivi sulla tastiera qui sotto"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Включено"
+            "value": "Печатайте на клавиатуре ниже"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Włączone"
+            "value": "Pisz na klawiaturze poniżej"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aktiverad"
+            "value": "Skriv på tangentbordet nedan"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Käytössä"
+            "value": "Kirjoita alla olevalla näppäimistöllä"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Omogućeno"
+            "value": "Tipkaj na tipkovnici ispod"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "מופעל"
+            "value": "הקלד במקלדת שלמטה"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Đã bật"
+            "value": "Gõ trên bàn phím bên dưới"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Naka-enable"
+            "value": "Mag-type sa keyboard sa ibaba"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ενεργοποιημένο"
+            "value": "Πληκτρολογήστε στο παρακάτω πληκτρολόγιο"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ativado"
+            "value": "Escreva no teclado abaixo"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Увімкнено"
+            "value": "Друкуйте на клавіатурі нижче"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "مُفعَّل"
+            "value": "اكتب على لوحة المفاتيح أدناه"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "فعال"
+            "value": "روی صفحه‌کلید زیر تایپ کنید"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "فعال"
+            "value": "نیچے کی بورڈ پر ٹائپ کریں"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "เปิดใช้แล้ว"
+            "value": "พิมพ์บนคีย์บอร์ดด้านล่าง"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "चालू"
+            "value": "नीचे दिए कीबोर्ड पर टाइप करें"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "有効"
+            "value": "下のキーボードで入力してください"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사용"
+            "value": "아래 키보드로 입력해 보세요"
           }
         }
       },
-      "comment": "Accessibility value: language is enabled"
+      "comment": "Placeholder text in the preview when empty"
     },
-    "Disabled": {
+    "Type two spaces to insert a period": {
       "extractionState": "manual",
       "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اكتب مسافتين لإدراج نقطة"
+          }
+        },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Deaktiviert"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Désactivé"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desactivado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disattivato"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Отключено"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wyłączone"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Avaktiverad"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ei käytössä"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Onemogućeno"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מושבת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Đã tắt"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Naka-disable"
+            "value": "Zwei Leerzeichen fügen einen Punkt ein"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Απενεργοποιημένο"
+            "value": "Δύο κενά εισάγουν μια τελεία"
           }
         },
-        "pt": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desativado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вимкнено"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مُعطَّل"
+            "value": "Escribe dos espacios para insertar un punto"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "غیرفعال"
+            "value": "برای درج نقطه دو بار فاصله بزنید"
           }
         },
-        "ur": {
+        "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "غیر فعال"
+            "value": "Kaksi välilyöntiä lisää pisteen"
           }
         },
-        "th": {
+        "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "ปิดใช้แล้ว"
+            "value": "Mag-type ng dalawang espasyo para maglagay ng tuldok"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deux espaces insèrent un point"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שני רווחים מוסיפים נקודה"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "बंद"
+            "value": "पूर्ण विराम लगाने के लिए दो बार स्पेस दबाएँ"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dva razmaka umeću točku"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Due spazi inseriscono un punto"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "無効"
+            "value": "スペースを2回押すとピリオドを入力"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사용 안 함"
+            "value": "스페이스를 두 번 누르면 마침표 입력"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dwie spacje wstawiają kropkę"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dois espaços inserem um ponto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Два пробела вставляют точку"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Två mellanslag infogar en punkt"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เว้นวรรคสองครั้งเพื่อใส่จุด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Два пробіли вставляють крапку"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وقفہ ڈالنے کے لیے دو بار اسپیس دبائیں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhấn phím cách hai lần để chèn dấu chấm"
           }
         }
       },
-      "comment": "Accessibility value: language is disabled"
+      "comment": "Toggle subtitle: explains double-space to period"
     },
-    "Languages": {
+    "Utility Keys on Left": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sprachen"
+            "value": "Funktionstasten links"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Langues"
+            "value": "Touches utilitaires à gauche"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Idiomas"
+            "value": "Teclas de función a la izquierda"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Lingue"
+            "value": "Tasti funzione a sinistra"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Языки"
+            "value": "Служебные клавиши слева"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Języki"
+            "value": "Klawisze funkcyjne po lewej"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Språk"
+            "value": "Funktionstangenter till vänster"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kielet"
+            "value": "Apunäppäimet vasemmalla"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Jezici"
+            "value": "Pomoćne tipke lijevo"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "שפות"
+            "value": "מקשי שירות מימין"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ngôn ngữ"
+            "value": "Phím tiện ích bên trái"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mga Wika"
+            "value": "Mga Utility Key sa Kaliwa"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Γλώσσες"
+            "value": "Πλήκτρα βοηθητικών λειτουργιών στα αριστερά"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Idiomas"
+            "value": "Teclas utilitárias à esquerda"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Мови"
+            "value": "Службові клавіші ліворуч"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "اللغات"
+            "value": "مفاتيح الأدوات على اليسار"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "زبان‌ها"
+            "value": "کلیدهای کاربردی در سمت چپ"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "زبانیں"
+            "value": "یوٹیلیٹی کیز بائیں طرف"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ภาษา"
+            "value": "ปุ่มยูทิลิตีอยู่ด้านซ้าย"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "भाषाएँ"
+            "value": "यूटिलिटी कीज़ बाईं ओर"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "言語"
+            "value": "ユーティリティキーを左に配置"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "언어"
+            "value": "기능 키를 왼쪽에 배치"
           }
         }
       },
-      "comment": "Settings row title / language selection screen title"
+      "comment": "Toggle title: place utility column on the left side"
     },
-    "Label Visibility": {
+    "Value": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sichtbarkeit der Beschriftungen"
+            "value": "Wert"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visibilité des étiquettes"
+            "value": "Valeur"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visibilidad de etiquetas"
+            "value": "Valor"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visibilità delle etichette"
+            "value": "Valore"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Видимость подписей"
+            "value": "Значение"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Widoczność etykiet"
+            "value": "Wartość"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Etiketternas synlighet"
+            "value": "Värde"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Merkintöjen näkyvyys"
+            "value": "Arvo"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vidljivost oznaka"
+            "value": "Vrijednost"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "נראות תוויות"
+            "value": "ערך"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hiển thị nhãn"
+            "value": "Giá trị"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visibility ng Label"
+            "value": "Halaga"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ορατότητα ετικετών"
+            "value": "Τιμή"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Visibilidade das etiquetas"
+            "value": "Valor"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Видимість підписів"
+            "value": "Значення"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "ظهور التسميات"
+            "value": "القيمة"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "نمایان‌بودن برچسب‌ها"
+            "value": "مقدار"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "لیبل کی نمائش"
+            "value": "قدر"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "การแสดงป้ายกำกับ"
+            "value": "ค่า"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "लेबल दृश्यता"
+            "value": "मान"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ラベルの表示"
+            "value": "値"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "레이블 표시"
+            "value": "값"
           }
         }
       },
-      "comment": "Settings row title"
+      "comment": "Label/placeholder for a numeric input field"
     },
-    "Default": {
+    "Version": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Standard"
+            "value": "Version"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Par défaut"
+            "value": "Version"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predeterminado"
+            "value": "Versión"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinita"
+            "value": "Versione"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "По умолчанию"
+            "value": "Версия"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Domyślny"
+            "value": "Wersja"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Standard"
+            "value": "Version"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Oletus"
+            "value": "Versio"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Zadano"
+            "value": "Verzija"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "ברירת מחדל"
+            "value": "גרסה"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mặc định"
+            "value": "Phiên bản"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Default"
+            "value": "Bersyon"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Προεπιλογή"
+            "value": "Έκδοση"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinição"
+            "value": "Versão"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "За замовчуванням"
+            "value": "Версія"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "افتراضي"
+            "value": "الإصدار"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "پیش‌فرض"
+            "value": "نسخه"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "طے شدہ"
+            "value": "ورژن"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ค่าเริ่มต้น"
+            "value": "เวอร์ชัน"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "डिफ़ॉल्ट"
+            "value": "वर्शन"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "デフォルト"
+            "value": "バージョン"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "기본값"
+            "value": "버전"
           }
         }
       },
-      "comment": "Badge on the default startup language"
+      "comment": "About row label (app version)"
     },
-    "Cannot Disable": {
+    "Visual Style": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Deaktivieren nicht möglich"
+            "value": "Visueller Stil"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Désactivation impossible"
+            "value": "Style visuel"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se puede desactivar"
+            "value": "Estilo visual"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Impossibile disattivare"
+            "value": "Stile visivo"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Нельзя отключить"
+            "value": "Визуальный стиль"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nie można wyłączyć"
+            "value": "Styl wizualny"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kan inte avaktiveras"
+            "value": "Visuell stil"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ei voi poistaa käytöstä"
+            "value": "Visuaalinen tyyli"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nije moguće onemogućiti"
+            "value": "Vizualni stil"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "לא ניתן להשבית"
+            "value": "סגנון חזותי"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Không thể tắt"
+            "value": "Kiểu hiển thị"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hindi Maaaring I-disable"
+            "value": "Visual na Estilo"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Αδυναμία απενεργοποίησης"
+            "value": "Οπτικό στιλ"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Não é possível desativar"
+            "value": "Estilo visual"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Неможливо вимкнути"
+            "value": "Візуальний стиль"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "لا يمكن التعطيل"
+            "value": "النمط المرئي"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "نمی‌توان غیرفعال کرد"
+            "value": "سبک ظاهری"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "غیر فعال نہیں کیا جا سکتا"
+            "value": "بصری انداز"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ปิดใช้ไม่ได้"
+            "value": "สไตล์การแสดงผล"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "बंद नहीं कर सकते"
+            "value": "विज़ुअल स्टाइल"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "無効にできません"
+            "value": "表示スタイル"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사용 중지할 수 없음"
+            "value": "비주얼 스타일"
           }
         }
       },
-      "comment": "Alert title when disabling the last language"
+      "comment": "Header for keyboard visual style options"
     },
-    "OK": {
+    "Wide": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Breit"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Large"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Ancho"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Largo"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "ОК"
+            "value": "Широкие"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Szerokie"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Bred"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Leveä"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "U redu"
+            "value": "Široko"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "אישור"
+            "value": "רחב"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Rộng"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Malapad"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Πλατύ"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Largo"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "Широке"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "موافق"
+            "value": "عريض"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "تأیید"
+            "value": "پهن"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "ٹھیک ہے"
+            "value": "چوڑا"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ตกลง"
+            "value": "กว้าง"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "ठीक है"
+            "value": "चौड़ा"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "OK"
+            "value": "ワイド"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "확인"
+            "value": "넓게"
           }
         }
       },
-      "comment": "Alert confirmation button"
+      "comment": "Slider tick label (wider keys)"
     },
-    "At least one language must be enabled.": {
+    "extra symbols": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mindestens eine Sprache muss aktiviert sein."
+            "value": "Zusatzsymbole"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Au moins une langue doit être activée."
+            "value": "symboles supplémentaires"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Al menos un idioma debe estar activado."
+            "value": "símbolos adicionales"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Almeno una lingua deve essere attiva."
+            "value": "simboli extra"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Хотя бы один язык должен быть включён."
+            "value": "дополнительные символы"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Co najmniej jeden język musi być włączony."
+            "value": "symbole dodatkowe"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Minst ett språk måste vara aktiverat."
+            "value": "extra symboler"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vähintään yhden kielen on oltava käytössä."
+            "value": "lisäsymbolit"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Najmanje jedan jezik mora biti omogućen."
+            "value": "dodatni simboli"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "לפחות שפה אחת חייבת להיות מופעלת."
+            "value": "סמלים נוספים"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Phải bật ít nhất một ngôn ngữ."
+            "value": "ký hiệu bổ sung"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kailangang naka-enable ang kahit isang wika."
+            "value": "mga dagdag na simbolo"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Πρέπει να είναι ενεργοποιημένη τουλάχιστον μία γλώσσα."
+            "value": "επιπλέον σύμβολα"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "É necessário ativar pelo menos um idioma."
+            "value": "símbolos extra"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Має бути увімкнена принаймні одна мова."
+            "value": "додаткові символи"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "يجب تفعيل لغة واحدة على الأقل."
+            "value": "الرموز الإضافية"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "دست‌کم یک زبان باید فعال باشد."
+            "value": "نمادهای اضافی"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "کم از کم ایک زبان فعال ہونی چاہیے۔"
+            "value": "اضافی علامتیں"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ต้องเปิดใช้อย่างน้อยหนึ่งภาษา"
+            "value": "สัญลักษณ์เพิ่มเติม"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "कम से कम एक भाषा चालू होनी चाहिए।"
+            "value": "अतिरिक्त सिंबल"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "少なくとも1つの言語を有効にする必要があります。"
+            "value": "追加記号"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "언어를 하나 이상 사용해야 합니다."
+            "value": "추가 기호"
           }
         }
       },
-      "comment": "Alert message when disabling the last language"
+      "comment": "Label visibility list item"
     },
-    "Swipe right on the globe key to switch languages. Tap a language to set it as the default startup language.": {
+    "letters": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wische auf der Globus-Taste nach rechts, um die Sprache zu wechseln. Tippe auf eine Sprache, um sie als Standard-Startsprache festzulegen."
+            "value": "Buchstaben"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Balayez vers la droite sur la touche globe pour changer de langue. Touchez une langue pour la définir comme langue par défaut au démarrage."
+            "value": "lettres"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Desliza hacia la derecha sobre la tecla del globo para cambiar de idioma. Toca un idioma para establecerlo como idioma predeterminado de inicio."
+            "value": "letras"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scorri verso destra sul tasto globo per cambiare lingua. Tocca una lingua per impostarla come lingua predefinita all'avvio."
+            "value": "lettere"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Смахните вправо по клавише глобуса, чтобы переключить язык. Нажмите на язык, чтобы сделать его языком по умолчанию при запуске."
+            "value": "буквы"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Przesuń w prawo po klawiszu globusa, aby przełączyć język. Stuknij język, aby ustawić go jako domyślny język startowy."
+            "value": "litery"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Svep åt höger på jordglobstangenten för att byta språk. Tryck på ett språk för att ange det som standardspråk vid start."
+            "value": "bokstäver"
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vaihda kieltä pyyhkäisemällä maapallonäppäintä oikealle. Aseta kieli oletuskieleksi napauttamalla sitä."
+            "value": "kirjaimet"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Prijeđi udesno po tipki globusa za promjenu jezika. Dodirni jezik da ga postaviš kao zadani početni jezik."
+            "value": "slova"
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "החלק ימינה על מקש הגלובוס כדי להחליף שפה. הקש על שפה כדי להגדיר אותה כשפת ברירת המחדל בהפעלה."
+            "value": "אותיות"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vuốt sang phải trên phím địa cầu để chuyển ngôn ngữ. Chạm vào một ngôn ngữ để đặt làm ngôn ngữ mặc định khi khởi động."
+            "value": "chữ cái"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Mag-swipe pakanan sa globe key para magpalit ng wika. I-tap ang isang wika para gawin itong default na panimulang wika."
+            "value": "mga letra"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Σαρώστε δεξιά στο πλήκτρο της υδρογείου για εναλλαγή γλωσσών. Πατήστε μια γλώσσα για να την ορίσετε ως προεπιλεγμένη γλώσσα εκκίνησης."
+            "value": "γράμματα"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Deslize para a direita na tecla do globo para mudar de idioma. Toque num idioma para o definir como idioma de arranque predefinido."
+            "value": "letras"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Проведіть праворуч по клавіші глобуса, щоб перемкнути мови. Торкніться мови, щоб зробити її мовою запуску за замовчуванням."
+            "value": "літери"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "مرِّر يمينًا على مفتاح الكرة الأرضية لتبديل اللغات. اضغط على لغة لتعيينها كلغة البدء الافتراضية."
+            "value": "الحروف"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "روی کلید کره به راست بکشید تا زبان‌ها را عوض کنید. روی یک زبان ضربه بزنید تا آن را به‌عنوان زبان پیش‌فرض هنگام شروع تنظیم کنید."
+            "value": "حروف"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "زبانیں تبدیل کرنے کے لیے گلوب کی پر دائیں سوائپ کریں۔ کسی زبان کو طے شدہ آغازی زبان مقرر کرنے کے لیے اس پر ٹیپ کریں۔"
+            "value": "حروف"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ปัดขวาที่ปุ่มลูกโลกเพื่อสลับภาษา แตะภาษาเพื่อตั้งเป็นภาษาเริ่มต้นเมื่อเปิดใช้งาน"
+            "value": "ตัวอักษร"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "भाषाएँ बदलने के लिए ग्लोब की पर दाईं ओर स्वाइप करें। किसी भाषा को डिफ़ॉल्ट स्टार्टअप भाषा बनाने के लिए उस पर टैप करें।"
+            "value": "अक्षर"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "地球儀キーを右にスワイプすると言語を切り替えられます。言語をタップすると、起動時のデフォルト言語に設定されます。"
+            "value": "文字"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "지구본 키를 오른쪽으로 스와이프하여 언어를 전환하세요. 언어를 탭하면 기본 시작 언어로 설정됩니다."
+            "value": "문자"
           }
         }
       },
-      "comment": "Footer on the language selection screen"
+      "comment": "Label visibility list item"
     },
-    "Gesture Trail": {
+    "standard symbols": {
       "extractionState": "manual",
       "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "أثر الإيماءة"
-          }
-        },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wischspur"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ίχνος κίνησης"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Estela del gesto"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "رد اشاره"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eleen jälki"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bakas ng galaw"
+            "value": "Standardsymbole"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tracé du geste"
+            "value": "symboles standard"
           }
         },
-        "he": {
+        "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "שובל התנועה"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "इशारे का निशान"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trag geste"
+            "value": "símbolos estándar"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scia del gesto"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ジェスチャの軌跡"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제스처 궤적"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ślad gestu"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rasto do gesto"
+            "value": "simboli standard"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "След жеста"
+            "value": "стандартные символы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "symbole standardowe"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gestspår"
+            "value": "standardsymboler"
           }
         },
-        "th": {
+        "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "เส้นทางการปัด"
+            "value": "vakiosymbolit"
           }
         },
-        "uk": {
+        "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Слід жесту"
+            "value": "standardni simboli"
           }
         },
-        "ur": {
+        "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "اشارے کا نشان"
+            "value": "סמלים רגילים"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vệt vuốt"
+            "value": "ký hiệu chuẩn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mga karaniwang simbolo"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "τυπικά σύμβολα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "símbolos padrão"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "стандартні символи"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الرموز القياسية"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمادهای استاندارد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "معیاری علامتیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สัญลักษณ์มาตรฐาน"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मानक सिंबल"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標準記号"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 기호"
           }
         }
       },
-      "comment": "Toggle title: draws a fading trail under the finger while it swipes"
-    },
-    "Draw the path your finger takes": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يرسم المسار الذي يسلكه إصبعك"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zeichnet den Weg deines Fingers nach"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Σχεδιάζει τη διαδρομή που ακολουθεί το δάχτυλο"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dibuja el recorrido de tu dedo"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مسیری را که انگشت شما طی می‌کند رسم می‌کند"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piirtää sormesi kulkeman reitin"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iguguhit ang dinaanan ng iyong daliri"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trace le chemin parcouru par votre doigt"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מצייר את המסלול שהאצבע עוברת"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "आपकी उंगली के रास्ते को दिखाता है"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Crta putanju kojom prolazi prst"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disegna il percorso del tuo dito"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "指がなぞった軌跡を描きます"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "손가락이 지나간 경로를 그립니다"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rysuje ścieżkę, którą pokonuje palec"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Desenha o caminho percorrido pelo dedo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Рисует путь, по которому движется палец"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ritar vägen som fingret tar"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "วาดเส้นทางที่นิ้วของคุณลากผ่าน"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Малює шлях, яким рухається палець"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "آپ کی انگلی جس راستے سے گزرے، اسے کھینچتا ہے"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vẽ đường đi của ngón tay bạn"
-          }
-        }
-      },
-      "comment": "Toggle subtitle explaining the gesture trail"
-    },
-    "Cut All by Circling": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "قص الكل بحركة دائرية"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Alles ausschneiden per Kreis"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αποκοπή όλων με κυκλική κίνηση"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar todo con un círculo"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برش همه با حرکت دایره‌ای"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leikkaa kaikki ympyröimällä"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gupitin lahat sa pamamagitan ng pag-ikot"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tout couper en traçant un cercle"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גזירת הכול בתנועה מעגלית"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "गोला बनाकर सब कुछ काटें"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Izreži sve kružnim pokretom"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Taglia tutto con un cerchio"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "円を描いてすべて切り取り"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "원을 그려 전체 잘라내기"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wytnij wszystko kółkiem"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar tudo com um círculo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вырезать всё круговым жестом"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Klipp ut allt med en cirkel"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ตัดทั้งหมดด้วยการวนนิ้ว"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вирізати все круговим жестом"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "دائرہ بنا کر سب کاٹیں"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cắt tất cả bằng vòng tròn"
-          }
-        }
-      }
-    },
-    "Cutting to the clipboard requires Full Access": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "يتطلب القص إلى الحافظة الوصول الكامل"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ausschneiden in die Zwischenablage erfordert Vollzugriff"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Η αποκοπή στο πρόχειρο απαιτεί πλήρη πρόσβαση"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar al portapapeles requiere acceso completo"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "برش به کلیپ‌بورد به دسترسی کامل نیاز دارد"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Leikkaaminen leikepöydälle vaatii täyden käyttöoikeuden"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kailangan ng Full Access para gupitin papunta sa clipboard"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couper vers le presse-papiers nécessite l'accès complet"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "גזירה ללוח דורשת גישה מלאה"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "क्लिपबोर्ड में काटने के लिए पूर्ण एक्सेस ज़रूरी है"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Izrezivanje u međuspremnik zahtijeva puni pristup"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Il taglio negli appunti richiede l'accesso completo"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クリップボードへの切り取りにはフルアクセスが必要です"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "클립보드로 잘라내려면 전체 접근이 필요합니다"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wycinanie do schowka wymaga pełnego dostępu"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cortar para a área de transferência requer acesso total"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вырезание в буфер обмена требует полного доступа"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Att klippa ut till urklipp kräver fullständig åtkomst"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "การตัดไปยังคลิปบอร์ดต้องใช้การเข้าถึงเต็มรูปแบบ"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вирізання в буфер обміну потребує повного доступу"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کلپ بورڈ میں کاٹنے کے لیے مکمل رسائی درکار ہے"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cắt vào bảng nhớ tạm yêu cầu Truy cập đầy đủ"
-          }
-        }
-      }
-    },
-    "Circle the 123 key to cut the text around the cursor. Swipe down on the same key to paste it back. Both gestures stay on the key after it switches the keyboard to numbers.": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ارسم دائرة على مفتاح 123 لقص النص حول المؤشر. اسحب لأسفل على المفتاح نفسه للصقه مرة أخرى. تبقى الإيماءتان على المفتاح بعد أن يبدّل لوحة المفاتيح إلى الأرقام."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kreise die 123-Taste ein, um den Text um den Cursor auszuschneiden. Streiche auf derselben Taste nach unten, um ihn wieder einzufügen. Beide Gesten bleiben auf der Taste, auch nachdem sie die Tastatur auf Zahlen umgestellt hat."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Κάντε κυκλική κίνηση στο πλήκτρο 123 για αποκοπή του κειμένου γύρω από τον δρομέα. Σύρετε προς τα κάτω στο ίδιο πλήκτρο για να το επικολλήσετε ξανά. Και οι δύο κινήσεις παραμένουν στο πλήκτρο αφού αυτό αλλάξει το πληκτρολόγιο σε αριθμούς."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Traza un círculo en la tecla 123 para cortar el texto alrededor del cursor. Desliza hacia abajo en la misma tecla para volver a pegarlo. Ambos gestos siguen en la tecla después de que cambie el teclado a números."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "روی کلید 123 دایره بکشید تا متن اطراف مکان‌نما بریده شود. برای چسباندن دوباره، روی همان کلید به پایین بکشید. هر دو حرکت پس از آنکه کلید صفحه‌کلید را به اعداد تغییر دهد، روی همان کلید باقی می‌مانند."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Piirrä ympyrä 123-näppäimeen, niin kohdistimen ympärillä oleva teksti leikataan. Liu’uta samaa näppäintä alaspäin liittääksesi sen takaisin. Molemmat eleet säilyvät näppäimellä sen jälkeen, kun se on vaihtanut näppäimistön numeroihin."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Umikot sa 123 key para gupitin ang teksto sa paligid ng cursor. Mag-swipe pababa sa parehong key para i-paste ito ulit. Nananatili ang dalawang galaw sa key kahit matapos nitong palitan ang keyboard sa mga numero."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tracez un cercle sur la touche 123 pour couper le texte autour du curseur. Balayez vers le bas sur la même touche pour le recoller. Les deux gestes restent sur la touche après qu’elle a basculé le clavier sur les chiffres."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "שרטטו מעגל על מקש 123 כדי לגזור את הטקסט סביב הסמן. החליקו מטה על אותו מקש כדי להדביק אותו בחזרה. שתי המחוות נשארות על המקש גם אחרי שהוא מחליף את המקלדת למספרים."
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कर्सर के आसपास का टेक्स्ट काटने के लिए 123 कुंजी पर गोला बनाएँ। उसे वापस चिपकाने के लिए उसी कुंजी पर नीचे स्वाइप करें। कुंजी द्वारा कीबोर्ड को अंकों पर बदलने के बाद भी दोनों हावभाव उसी कुंजी पर बने रहते हैं।"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Napravi kružni pokret po tipki 123 za izrezivanje teksta oko pokazivača. Povuci prema dolje po istoj tipki da ga zalijepiš natrag. Obje geste ostaju na tipki i nakon što ona prebaci tipkovnicu na brojke."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Traccia un cerchio sul tasto 123 per tagliare il testo attorno al cursore. Scorri verso il basso sullo stesso tasto per incollarlo di nuovo. Entrambi i gesti restano sul tasto anche dopo che ha portato la tastiera ai numeri."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "123キーで円を描くと、カーソル周辺のテキストを切り取ります。同じキーを下にスワイプすると貼り付け直せます。 このキーがキーボードを数字に切り替えたあとも、両方のジェスチャーはそのまま使えます。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "123 키에서 원을 그리면 커서 주변 텍스트를 잘라냅니다. 같은 키를 아래로 쓸어내리면 다시 붙여넣습니다. 이 키가 키보드를 숫자로 전환한 뒤에도 두 제스처는 그대로 유지됩니다."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zakreśl kółko na klawiszu 123, aby wyciąć tekst wokół kursora. Przesuń w dół na tym samym klawiszu, aby wkleić go z powrotem. Oba gesty pozostają na klawiszu także po przełączeniu klawiatury na cyfry."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trace um círculo na tecla 123 para cortar o texto à volta do cursor. Deslize para baixo na mesma tecla para o colar de novo. Ambos os gestos permanecem na tecla depois de esta mudar o teclado para números."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Обведите клавишу 123, чтобы вырезать текст вокруг курсора. Свайп вниз по той же клавише вернёт его. Оба жеста остаются на клавише и после переключения на цифры."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rita en cirkel på 123-tangenten för att klippa ut texten runt markören. Svep nedåt på samma tangent för att klistra in den igen. Båda gesterna finns kvar på tangenten även efter att den växlat tangentbordet till siffror."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "วนนิ้วบนปุ่ม 123 เพื่อตัดข้อความรอบเคอร์เซอร์ ปัดลงบนปุ่มเดียวกันเพื่อวางกลับ ทั้งสองท่าทางยังคงอยู่บนปุ่มนี้แม้หลังจากที่ปุ่มสลับแป้นพิมพ์เป็นตัวเลขแล้ว"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Обведіть клавішу 123, щоб вирізати текст навколо курсора. Проведіть вниз по тій самій клавіші, щоб вставити його назад. Обидва жести залишаються на клавіші й після перемикання на цифри."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کرسر کے ارد گرد متن کاٹنے کے لیے 123 کلید پر دائرہ بنائیں۔ اسے واپس چسپاں کرنے کے لیے اسی کلید پر نیچے سوائپ کریں۔ کلید کے کی بورڈ کو ہندسوں پر بدلنے کے بعد بھی دونوں اشارے اسی کلید پر برقرار رہتے ہیں۔"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vẽ vòng tròn trên phím 123 để cắt văn bản quanh con trỏ. Vuốt xuống trên cùng phím đó để dán lại. Cả hai cử chỉ vẫn nằm trên phím sau khi phím chuyển bàn phím sang số."
-          }
-        }
-      }
-    },
-    "Gestures": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "الإيماءات"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gesten"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Χειρονομίες"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gestos"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اشاره‌ها"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Eleet"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga Galaw"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gestes"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "מחוות"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "जेस्चर"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geste"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gesti"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ジェスチャ"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제스처"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gesty"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gestos"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Жесты"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gester"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ท่าทาง"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Жести"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اشارے"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cử chỉ"
-          }
-        }
-      }
+      "comment": "Label visibility list item"
     }
   },
   "version": "1.0"

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -3312,6 +3312,84 @@
       },
       "comment": "Button: clear the text field"
     },
+    "Color Themes": {
+      "comment": "Theme gallery: section header for fixed-color palettes",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farb-Themes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thèmes de couleur"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temas de color"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temi di colore"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цветовые темы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Motywy kolorów"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Färgteman"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Väriteemat"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teme boja"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ערכות צבע"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chủ đề màu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Tema ng Kulay"
+          }
+        }
+      }
+    },
     "Continuous": {
       "extractionState": "manual",
       "localizations": {
@@ -14901,6 +14979,84 @@
         }
       },
       "comment": "Settings row / title: visual style"
+    },
+    "Styles": {
+      "comment": "Theme gallery: section header for adaptive/material styles",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stile"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Styles"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilos"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stili"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стили"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Style"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stilar"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tyylit"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stilovi"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סגנונות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiểu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Estilo"
+          }
+        }
+      }
     },
     "Swipe per character, return-swipe per word": {
       "extractionState": "manual",

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -34,8 +34,8 @@ struct SettingsView: View {
     @AppStorage(SettingsKey.cursorMovementStyle.rawValue, store: SharedDefaults.store)
     private var cursorMovementStyleRaw = CursorMovementStyle.continuous.rawValue
 
-    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
-    private var keyboardStyleRaw = KeyboardStyle.classic.rawValue
+    @AppStorage(SettingsKey.selectedThemeLight.rawValue, store: SharedDefaults.store)
+    private var selectedThemeLight = BuiltInThemes.classic.id
 
     @AppStorage(SettingsKey.autoCapitalizeEnabled.rawValue, store: SharedDefaults.store)
     private var autoCapitalizeEnabled = false
@@ -307,8 +307,8 @@ struct SettingsView: View {
     }
 
     private var keyboardStyleDescription: String {
-        let style = KeyboardStyle(rawValue: keyboardStyleRaw) ?? .classic
-        return style.displayName
+        let theme = ThemeStore.theme(id: selectedThemeLight) ?? BuiltInThemes.classic
+        return theme.displayName
     }
 
     private var labelVisibilityDescription: String {

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -23,6 +23,9 @@ struct StyleSettingsView: View {
     @AppStorage(SettingsKey.keyboardHorizontalPosition.rawValue, store: SharedDefaults.store)
     private var previewPosition = DeviceLayoutUtils.defaultKeyboardPosition
 
+    /// Grid columns for the color-palette swatches.
+    private let paletteColumns = [GridItem(.adaptive(minimum: 64), spacing: 10)]
+
     var body: some View {
         VStack(spacing: 20) {
             // Keyboard Preview
@@ -31,25 +34,8 @@ struct StyleSettingsView: View {
 
             ScrollView {
                 VStack(spacing: 24) {
-                    // Theme Selection
-                    VStack(alignment: .leading, spacing: 16) {
-                        Text("Visual Style")
-                            .font(.headline)
-                            .padding(.horizontal, 16)
-
-                        ForEach(BuiltInThemes.all) { theme in
-                            themeOption(theme)
-                        }
-
-                        if selectedThemeLight == BuiltInThemes.liquidGlass.id {
-                            if #unavailable(iOS 26.0) {
-                                Text("Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.")
-                                    .font(.caption)
-                                    .foregroundColor(.orange)
-                                    .padding(.horizontal, 16)
-                            }
-                        }
-                    }
+                    stylesSection
+                    palettesSection
                 }
                 .padding(.vertical, 8)
             }
@@ -59,12 +45,60 @@ struct StyleSettingsView: View {
         .navigationBarTitleDisplayMode(.inline)
     }
 
+    /// Adaptive/material styles (Classic, Liquid Glass) as descriptive cards.
+    private var stylesSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Styles")
+                .font(.headline)
+                .padding(.horizontal, 16)
+
+            ForEach(BuiltInThemes.styles) { theme in
+                themeOption(theme)
+            }
+
+            if selectedThemeLight == BuiltInThemes.liquidGlass.id {
+                if #unavailable(iOS 26.0) {
+                    Text("Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                        .padding(.horizontal, 16)
+                }
+            }
+        }
+    }
+
+    /// Fixed-color palettes as a swatch grid.
+    private var palettesSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Color Themes")
+                .font(.headline)
+                .padding(.horizontal, 16)
+
+            LazyVGrid(columns: paletteColumns, spacing: 10) {
+                ForEach(BuiltInThemes.palettes) { theme in
+                    Button {
+                        select(theme)
+                    } label: {
+                        ThemeSwatch(theme: theme, isSelected: selectedThemeLight == theme.id)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(theme.displayName)
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+    }
+
+    /// Both appearance slots follow one selection until the gallery gains its
+    /// separate light/dark assignment (milestone M2b).
+    private func select(_ theme: KeyboardThemeDefinition) {
+        selectedThemeLight = theme.id
+        selectedThemeDark = theme.id
+    }
+
     private func themeOption(_ theme: KeyboardThemeDefinition) -> some View {
         Button {
-            // Both appearance slots follow one selection until the gallery
-            // gains its separate light/dark assignment (milestone M2).
-            selectedThemeLight = theme.id
-            selectedThemeDark = theme.id
+            select(theme)
         } label: {
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
@@ -96,6 +130,48 @@ struct StyleSettingsView: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal, 16)
+    }
+}
+
+/// Miniature key rendering a palette: key fill, main letter, hint dot. Draws
+/// from the theme's own resolved colors, so it always matches the keyboard.
+private struct ThemeSwatch: View {
+    let theme: KeyboardThemeDefinition
+    let isSelected: Bool
+
+    var body: some View {
+        let resolved = theme.resolved()
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(keyColor(resolved.keyFill))
+
+            Text(verbatim: "a")
+                .font(.system(size: 20, weight: .semibold, design: .rounded))
+                .foregroundStyle(resolved.mainLabel)
+
+            Circle()
+                .fill(resolved.hintLetter)
+                .frame(width: 5, height: 5)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+                .padding(6)
+        }
+        .frame(height: 48)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(
+                    isSelected ? Color.accentColor : Color.primary.opacity(0.12),
+                    lineWidth: isSelected ? 2.5 : 0.5
+                )
+        )
+    }
+
+    /// The swatch fill color. Palettes are always color fills; the material
+    /// fallback is only a safety net (styles aren't shown as swatches).
+    private func keyColor(_ fill: ResolvedFill) -> Color {
+        if case let .color(color) = fill {
+            return color
+        }
+        return Color(.secondarySystemBackground)
     }
 }
 

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -40,6 +40,15 @@ struct StyleSettingsView: View {
                         ForEach(BuiltInThemes.all) { theme in
                             themeOption(theme)
                         }
+
+                        if selectedThemeLight == BuiltInThemes.liquidGlass.id {
+                            if #unavailable(iOS 26.0) {
+                                Text("Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.")
+                                    .font(.caption)
+                                    .foregroundColor(.orange)
+                                    .padding(.horizontal, 16)
+                            }
+                        }
                     }
                 }
                 .padding(.vertical, 8)

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -2,14 +2,17 @@
 //  StyleSettingsView.swift
 //  wurstfinger
 //
-//  Visual style settings for the keyboard appearance
+//  Theme selection for the keyboard appearance.
 //
 
 import SwiftUI
 
 struct StyleSettingsView: View {
-    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
-    private var keyboardStyleRaw = KeyboardStyle.classic.rawValue
+    @AppStorage(SettingsKey.selectedThemeLight.rawValue, store: SharedDefaults.store)
+    private var selectedThemeLight = BuiltInThemes.classic.id
+
+    @AppStorage(SettingsKey.selectedThemeDark.rawValue, store: SharedDefaults.store)
+    private var selectedThemeDark = BuiltInThemes.classic.id
 
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var previewAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
@@ -28,23 +31,14 @@ struct StyleSettingsView: View {
 
             ScrollView {
                 VStack(spacing: 24) {
-                    // Style Selection
+                    // Theme Selection
                     VStack(alignment: .leading, spacing: 16) {
                         Text("Visual Style")
                             .font(.headline)
                             .padding(.horizontal, 16)
 
-                        ForEach(KeyboardStyle.allCases, id: \.self) { style in
-                            styleOption(style)
-                        }
-
-                        if keyboardStyleRaw == KeyboardStyle.liquidGlass.rawValue {
-                            if #unavailable(iOS 26.0) {
-                                Text("Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.")
-                                    .font(.caption)
-                                    .foregroundColor(.orange)
-                                    .padding(.horizontal, 16)
-                            }
+                        ForEach(BuiltInThemes.all) { theme in
+                            themeOption(theme)
                         }
                     }
                 }
@@ -56,24 +50,29 @@ struct StyleSettingsView: View {
         .navigationBarTitleDisplayMode(.inline)
     }
 
-    private func styleOption(_ style: KeyboardStyle) -> some View {
+    private func themeOption(_ theme: KeyboardThemeDefinition) -> some View {
         Button {
-            keyboardStyleRaw = style.rawValue
+            // Both appearance slots follow one selection until the gallery
+            // gains its separate light/dark assignment (milestone M2).
+            selectedThemeLight = theme.id
+            selectedThemeDark = theme.id
         } label: {
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(style.displayName)
+                    Text(theme.displayName)
                         .font(.body)
                         .foregroundColor(.primary)
 
-                    Text(style.description)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                    if let description = theme.displayDescription {
+                        Text(description)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
                 }
 
                 Spacer()
 
-                if keyboardStyleRaw == style.rawValue {
+                if selectedThemeLight == theme.id {
                     Image(systemName: "checkmark")
                         .foregroundColor(.accentColor)
                         .fontWeight(.semibold)
@@ -83,31 +82,11 @@ struct StyleSettingsView: View {
             .padding(.vertical, 12)
             .background(
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(keyboardStyleRaw == style.rawValue ? Color.accentColor.opacity(0.1) : Color.clear)
+                    .fill(selectedThemeLight == theme.id ? Color.accentColor.opacity(0.1) : Color.clear)
             )
         }
         .buttonStyle(.plain)
         .padding(.horizontal, 16)
-    }
-}
-
-extension KeyboardStyle {
-    /// User-facing style name. Lives in the host app target: the extension's
-    /// own catalog carries only the strings the keyboard itself displays, so a
-    /// settings-only name must not be looked up from extension code.
-    var displayName: String {
-        switch self {
-        case .classic: String(localized: "Classic")
-        case .liquidGlass: String(localized: "Liquid Glass")
-        }
-    }
-
-    /// One-line explanation shown under the style name.
-    var description: String {
-        switch self {
-        case .classic: String(localized: "Traditional opaque keys")
-        case .liquidGlass: String(localized: "Transparent glass effect (iOS 26+)")
-        }
     }
 }
 

--- a/wurstfinger/wurstfingerApp.swift
+++ b/wurstfinger/wurstfingerApp.swift
@@ -36,6 +36,7 @@ struct wurstfingerApp: App {
             SettingsKey.keyboardHorizontalPosition.rawValue: DeviceLayoutUtils.defaultKeyboardPosition
         ]
         SharedDefaults.store.register(defaults: defaults)
+        ThemeStore.migrateIfNeeded()
 
         // Determine screenshot mode from launch arguments
         let args = ProcessInfo.processInfo.arguments

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -403,12 +403,15 @@ final class KeyboardViewController: UIInputViewController {
     /// Installs the system-keyboard backdrop behind the SwiftUI content.
     ///
     /// A `.keyboard`-style input view renders the real system-keyboard backdrop
-    /// (blur + adaptive tint). It sits behind the SwiftUI content as a genuine
-    /// rendered surface, so themes with a transparent board (Liquid Glass) show
-    /// through to a background that matches the system keyboard, and — because a
-    /// keyboard extension only delivers touches over rendered pixels — the
-    /// inter-key gaps stay tappable without the near-invisible board fill that
-    /// used to be needed (#198).
+    /// (blur + adaptive tint) behind the SwiftUI content, so a theme with a
+    /// near-transparent board (Liquid Glass) shows through to a background that
+    /// matches the system keyboard row. This is purely the *look*: touch
+    /// delivery for the inter-key gaps comes from the SwiftUI board fill,
+    /// because a keyboard extension delivers touches over SwiftUI-rendered
+    /// pixels, not over this UIKit backdrop behind them (see
+    /// `DataDrivenKeyboardRootView.keyboardBackground` + #198). It is left
+    /// interactive only so it never swallows a stray touch itself; the SwiftUI
+    /// content above always wins the hit-test.
     ///
     /// Installed once and kept across hosting teardowns: the suspension shedding
     /// releases only the SwiftUI view graph, so rebuilding hosting must not
@@ -417,11 +420,6 @@ final class KeyboardViewController: UIInputViewController {
         guard backdropView == nil else { return }
         let backdrop = UIInputView(frame: .zero, inputViewStyle: .keyboard)
         backdrop.translatesAutoresizingMaskIntoConstraints = false
-        // Interactive on purpose: a keyboard extension only delivers touches
-        // over an interactive, rendered surface. Left non-interactive, the
-        // gaps between keys go dead again (#198). The SwiftUI key cells sit
-        // above this and win the hit-test wherever they tile, so the backdrop
-        // only ever receives touches that fall outside every key.
         view.addSubview(backdrop)
         NSLayoutConstraint.activate([
             backdrop.topAnchor.constraint(equalTo: view.topAnchor),

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -51,6 +51,10 @@ final class KeyboardViewController: UIInputViewController {
         // Set background immediately to avoid flash
         view.backgroundColor = .clear
 
+        // Migrate the legacy style selection to the theme assignment before
+        // the root view reads it. Idempotent; the host app runs it too.
+        ThemeStore.migrateIfNeeded()
+
         // Wire up the data-driven pipeline
         let target = DocumentProxyTarget(controller: self)
         documentProxyTarget = target

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -18,6 +18,9 @@ final class KeyboardViewController: UIInputViewController {
     /// Render-server snapshot standing in for the torn-down hosting view
     /// while the host app is backgrounded (see `installSuspensionPlaceholder`).
     private var suspensionPlaceholder: UIView?
+    /// System-keyboard backdrop behind the SwiftUI content
+    /// (see `installBackdropIfNeeded`). Outlives hosting teardowns.
+    private var backdropView: UIInputView?
 
     /// The language selected in the host app, normalised to an id that is
     /// guaranteed to exist in the registry (falling back to the system language,
@@ -370,6 +373,8 @@ final class KeyboardViewController: UIInputViewController {
     /// jetsam budget.
     private func configureHosting() {
         guard hostingController == nil else { return }
+        installBackdropIfNeeded()
+
         let rootView = DataDrivenKeyboardRootView(viewModel: viewModel)
         let controller = UIHostingController(rootView: rootView)
         controller.view.translatesAutoresizingMaskIntoConstraints = false
@@ -393,5 +398,37 @@ final class KeyboardViewController: UIInputViewController {
         // can slip in between.
         suspensionPlaceholder?.removeFromSuperview()
         suspensionPlaceholder = nil
+    }
+
+    /// Installs the system-keyboard backdrop behind the SwiftUI content.
+    ///
+    /// A `.keyboard`-style input view renders the real system-keyboard backdrop
+    /// (blur + adaptive tint). It sits behind the SwiftUI content as a genuine
+    /// rendered surface, so themes with a transparent board (Liquid Glass) show
+    /// through to a background that matches the system keyboard, and — because a
+    /// keyboard extension only delivers touches over rendered pixels — the
+    /// inter-key gaps stay tappable without the near-invisible board fill that
+    /// used to be needed (#198).
+    ///
+    /// Installed once and kept across hosting teardowns: the suspension shedding
+    /// releases only the SwiftUI view graph, so rebuilding hosting must not
+    /// stack a second input view behind the keys on every resume.
+    private func installBackdropIfNeeded() {
+        guard backdropView == nil else { return }
+        let backdrop = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        backdrop.translatesAutoresizingMaskIntoConstraints = false
+        // Interactive on purpose: a keyboard extension only delivers touches
+        // over an interactive, rendered surface. Left non-interactive, the
+        // gaps between keys go dead again (#198). The SwiftUI key cells sit
+        // above this and win the hit-test wherever they tile, so the backdrop
+        // only ever receives touches that fall outside every key.
+        view.addSubview(backdrop)
+        NSLayoutConstraint.activate([
+            backdrop.topAnchor.constraint(equalTo: view.topAnchor),
+            backdrop.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            backdrop.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            backdrop.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        backdropView = backdrop
     }
 }

--- a/wurstfingerKeyboard/Localizable.xcstrings
+++ b/wurstfingerKeyboard/Localizable.xcstrings
@@ -1380,6 +1380,828 @@
         }
       },
       "comment": "ACCESSIBILITY label for the space bar (VoiceOver)"
+    },
+    "Classic": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كلاسيكي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisch"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κλασικό"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clásico"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلاسیک"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassinen"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasiko"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classique"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "קלאסי"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्लासिक"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasično"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Classico"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラシック"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클래식"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klasyczny"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clássico"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Классический"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klassisk"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คลาสสิก"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Класичний"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلاسک"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cổ điển"
+          }
+        }
+      }
+    },
+    "Dark Gold": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ذهبي داكن"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σκούρο χρυσό"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oro oscuro"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "طلایی تیره"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Or sombre"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "זהב כהה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डार्क गोल्ड"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamno zlatno"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oro scuro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダークゴールド"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다크 골드"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemne złoto"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouro escuro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмное золото"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Gold"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทองเข้ม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темне золото"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈارک گولڈ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vàng sẫm"
+          }
+        }
+      }
+    },
+    "Dark keys with golden letters": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفاتيح داكنة بحروف ذهبية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dunkle Tasten mit goldenen Buchstaben"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σκούρα πλήκτρα με χρυσά γράμματα"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas oscuras con letras doradas"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدهای تیره با حروف طلایی"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tummat näppäimet ja kultaiset kirjaimet"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Madilim na mga key na may gintong mga titik"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touches sombres aux lettres dorées"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקשים כהים עם אותיות זהובות"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सुनहरे अक्षरों वाली गहरी कीज़"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamne tipke sa zlatnim slovima"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasti scuri con lettere dorate"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暗いキーに金色の文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "어두운 키에 금색 글자"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemne klawisze ze złotymi literami"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas escuras com letras douradas"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмные клавиши с золотыми буквами"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mörka tangenter med gyllene bokstäver"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่มสีเข้มพร้อมตัวอักษรสีทอง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темні клавіші із золотими літерами"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سنہری حروف کے ساتھ گہری کیز"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím tối với chữ vàng"
+          }
+        }
+      }
+    },
+    "Liquid Glass": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass"
+          }
+        }
+      }
+    },
+    "Traditional opaque keys": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مفاتيح تقليدية مُعتِمة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traditionelle deckende Tasten"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Παραδοσιακά αδιαφανή πλήκτρα"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas opacas tradicionales"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلیدهای مات سنتی"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Perinteiset läpinäkymättömät näppäimet"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tradisyonal na opaque na mga key"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touches opaques traditionnelles"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקשים אטומים מסורתיים"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पारंपरिक अपारदर्शी कीज़"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tradicionalne neprozirne tipke"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasti opachi tradizionali"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "従来の不透明なキー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기존의 불투명한 키"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tradycyjne nieprzezroczyste klawisze"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teclas opacas tradicionais"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Традиционные непрозрачные клавиши"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traditionella ogenomskinliga tangenter"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่มทึบแบบดั้งเดิม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Традиційні непрозорі клавіші"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روایتی غیر شفاف کیز"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím đục truyền thống"
+          }
+        }
+      }
+    },
+    "Transparent glass effect (iOS 26+)": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تأثير زجاجي شفاف (iOS 26 وأحدث)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transparenter Glaseffekt (iOS 26+)"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διαφανές γυάλινο εφέ (iOS 26+)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Efecto de cristal transparente (iOS 26+)"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افکت شیشه‌ای شفاف (iOS 26+)"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läpinäkyvä lasiefekti (iOS 26+)"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transparent na glass effect (iOS 26+)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effet de verre transparent (iOS 26+)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אפקט זכוכית שקופה (iOS 26+)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पारदर्शी ग्लास इफ़ेक्ट (iOS 26+)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Efekt prozirnog stakla (iOS 26+)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effetto vetro trasparente (iOS 26+)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透明なガラス効果（iOS 26以降）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "투명한 유리 효과 (iOS 26 이상)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Efekt przezroczystego szkła (iOS 26+)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Efeito de vidro transparente (iOS 26+)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эффект прозрачного стекла (iOS 26+)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genomskinlig glaseffekt (iOS 26+)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เอฟเฟกต์กระจกโปร่งใส (iOS 26 ขึ้นไป)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Прозорий скляний ефект (iOS 26+)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شفاف گلاس ایفیکٹ (iOS 26+)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiệu ứng kính trong suốt (iOS 26+)"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
@@ -51,32 +51,76 @@ enum BuiltInThemes {
         hintIconSubtle: .semantic(.secondary, opacity: 0.45)
     )
 
-    /// Fixed dark-slate/gold palette. Identical in light and dark mode by
-    /// design. Hint roles carry their prominence as alpha (0.9/0.7/0.5/0.45
-    /// of white), mirroring Classic's opacity hierarchy.
-    static let darkGold = KeyboardThemeDefinition(
-        id: "dark-gold",
-        name: "Dark Gold",
-        boardBackground: .color(.fixed(hex: "#252A34")),
-        keyFill: .color(.fixed(hex: "#333A48")),
-        keyFillActive: .color(.fixed(hex: "#4A5468")),
-        keyBorder: .fixed(hex: "#FFFFFF1F"),
-        keyBorderWidth: 0.5,
-        cornerRadius: Double(KeyboardConstants.KeyDimensions.cornerRadius),
-        mainLabel: .fixed(hex: "#D1AA05"),
-        utilityLabel: .fixed(hex: "#FFFFFF"),
-        hintLetter: .fixed(hex: "#FFFFFFE6"),
-        hintSymbol: .fixed(hex: "#FFFFFFB3"),
-        hintIconProminent: .fixed(hex: "#FFFFFF80"),
-        hintIconSubtle: .fixed(hex: "#FFFFFF73")
+    /// The two adaptive/material styles, shown as cards in the gallery.
+    static let styles: [KeyboardThemeDefinition] = [classic, liquidGlass]
+
+    // MARK: - Color palettes
+
+    /// The 16 fixed-color palettes ported from MessagEase, shown as swatches in
+    /// the gallery. Each is derived from four channels (key/main/hint/pressed)
+    /// via `paletteTheme`; the order matches the original app.
+    static let palettes: [KeyboardThemeDefinition] = [
+        paletteTheme(id: "black-yellow", name: "Black & Yellow", key: 0x000000, main: 0xFFF828, hint: 0xFFFFFF, pressed: 0x1E1E1E),
+        paletteTheme(id: "black-red", name: "Black & Red", key: 0x000000, main: 0xFA3838, hint: 0xFFA459, pressed: 0x1E1E1E),
+        paletteTheme(id: "terracotta", name: "Terracotta", key: 0x8A5042, main: 0x000000, hint: 0x1F2A4F, pressed: 0xC87460),
+        paletteTheme(id: "black-violet", name: "Black & Violet", key: 0x000000, main: 0xCC66FF, hint: 0xFF578A, pressed: 0x1E1E1E),
+        paletteTheme(id: "jade", name: "Jade", key: 0x009C7D, main: 0xFF0000, hint: 0xFFEE00, pressed: 0x1EE2B5),
+        paletteTheme(id: "cornflower", name: "Cornflower", key: 0x5599EE, main: 0x6611AA, hint: 0x6611DD, pressed: 0x7BDDFF),
+        paletteTheme(id: "turquoise", name: "Turquoise", key: 0x00C8CC, main: 0x4D2D78, hint: 0xFFFF00, pressed: 0x1EFFFF),
+        paletteTheme(id: "mustard", name: "Mustard", key: 0xE1CF04, main: 0x265100, hint: 0x186EAA, pressed: 0xFFFF22),
+        paletteTheme(id: "grape", name: "Grape", key: 0x8822CC, main: 0x68FF32, hint: 0x55DCDC, pressed: 0xC540FF),
+        paletteTheme(id: "scarlet", name: "Scarlet", key: 0xEE3A3A, main: 0xFFD900, hint: 0x6E0000, pressed: 0xFF5858),
+        paletteTheme(id: "olive", name: "Olive", key: 0x4A4400, main: 0x75C012, hint: 0xEBEB33, pressed: 0x6B621E),
+        paletteTheme(id: "rust", name: "Rust", key: 0x8A2E00, main: 0xFF5A51, hint: 0xFFEE00, pressed: 0xC84C1E),
+        darkGold,
+        paletteTheme(id: "forest", name: "Forest", key: 0x265C00, main: 0xFFB947, hint: 0x16FF00, pressed: 0x44851E),
+        paletteTheme(id: "midnight-blue", name: "Midnight Blue", key: 0x1D2F80, main: 0x06CDF5, hint: 0xFFEE00, pressed: 0x3B4DB9),
+        paletteTheme(id: "espresso", name: "Espresso", key: 0x261001, main: 0xF1F506, hint: 0xFF1E00, pressed: 0x442E1F),
+    ]
+
+    /// The default gold palette (MessagEase theme 12). Kept as a named constant
+    /// because its id is referenced by the legacy-style migration and its name
+    /// is localized (unlike the other palettes, which use their proper name).
+    static let darkGold = paletteTheme(
+        id: "dark-gold", name: "Dark Gold",
+        key: 0x333A48, main: 0xD1AA05, hint: 0xFFFFFF, pressed: 0x4A5468
     )
 
-    static let all: [KeyboardThemeDefinition] = [classic, liquidGlass, darkGold]
+    static let all: [KeyboardThemeDefinition] = styles + palettes
 
     static let ids: Set<String> = Set(all.map(\.id))
 
     static func theme(id: String) -> KeyboardThemeDefinition? {
         all.first { $0.id == id }
+    }
+
+    /// Builds a fixed-color palette theme from four MessagEase channels
+    /// (see THEME_ENGINE_CONCEPT.md §3): the board is a darkened key color, the
+    /// border is light or dark depending on the key's luminance, and the hint
+    /// roles carry their prominence as alpha over the single hint color.
+    private static func paletteTheme(
+        id: String, name: String, key: UInt32, main: UInt32, hint: UInt32, pressed: UInt32
+    ) -> KeyboardThemeDefinition {
+        func fixed(_ rgb: UInt32, alpha: Double = 1) -> ThemeColor {
+            .fixed(hex: HexColor.string(from: .init(rgb: rgb, alpha: alpha)))
+        }
+        let keyIsLight = HexColor.luminance(of: key) > 0.5
+        return KeyboardThemeDefinition(
+            id: id,
+            name: name,
+            boardBackground: .color(fixed(HexColor.scaled(key, by: 0.725))),
+            keyFill: .color(fixed(key)),
+            keyFillActive: .color(fixed(pressed)),
+            keyBorder: keyIsLight ? fixed(0x000000, alpha: 0.18) : fixed(0xFFFFFF, alpha: 0.12),
+            keyBorderWidth: 0.5,
+            cornerRadius: Double(KeyboardConstants.KeyDimensions.cornerRadius),
+            mainLabel: fixed(main),
+            utilityLabel: fixed(hint),
+            hintLetter: fixed(hint, alpha: 0.9),
+            hintSymbol: fixed(hint, alpha: 0.7),
+            hintIconProminent: fixed(hint, alpha: 0.5),
+            hintIconSubtle: fixed(hint, alpha: 0.45)
+        )
     }
 }
 

--- a/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
@@ -33,7 +33,11 @@ enum BuiltInThemes {
     static let liquidGlass = KeyboardThemeDefinition(
         id: "liquid-glass",
         name: "Liquid Glass",
-        boardBackground: .color(.semantic(.systemBackground, opacity: 0.02)),
+        // A faint neutral board: it reads as clear over the
+        // `UIInputView(.keyboard)` backdrop (so the keyboard matches the system
+        // row) while staying just opaque enough to keep the inter-key gaps
+        // tappable (see `keyboardBackground` / `minimumBoardOpacity`, #198).
+        boardBackground: .color(.semantic(.gray, opacity: 0.02)),
         keyFill: .material,
         keyFillActive: .material,
         keyBorder: .semantic(.primary, opacity: 0.1),

--- a/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
@@ -1,0 +1,100 @@
+//
+//  BuiltInThemes.swift
+//  Wurstfinger
+//
+//  The compiled-in themes. Their ids are API — persisted selections and
+//  future export codes reference them — and must never change.
+//
+
+import Foundation
+
+enum BuiltInThemes {
+    /// System-color theme matching the pre-engine "classic" style.
+    static let classic = KeyboardThemeDefinition(
+        id: "classic",
+        name: "Classic",
+        boardBackground: .color(.semantic(.systemBackground)),
+        keyFill: .color(.semantic(.secondarySystemBackground)),
+        keyFillActive: .color(.semantic(.tertiarySystemFill)),
+        keyBorder: nil,
+        keyBorderWidth: 0,
+        cornerRadius: Double(KeyboardConstants.KeyDimensions.cornerRadius),
+        mainLabel: .semantic(.primary),
+        utilityLabel: .semantic(.primary),
+        hintLetter: .semantic(.primary, opacity: 0.65),
+        hintSymbol: .semantic(.secondary, opacity: 0.55),
+        hintIconProminent: .semantic(.primary, opacity: 0.5),
+        hintIconSubtle: .semantic(.secondary, opacity: 0.45)
+    )
+
+    /// Bar-material theme matching the pre-engine "liquidGlass" style. The
+    /// board is a near-invisible color fill, not a material — that is the
+    /// touch fix from #198 (see DataDrivenKeyboardRootView).
+    static let liquidGlass = KeyboardThemeDefinition(
+        id: "liquid-glass",
+        name: "Liquid Glass",
+        boardBackground: .color(.semantic(.systemBackground, opacity: 0.02)),
+        keyFill: .material,
+        keyFillActive: .material,
+        keyBorder: .semantic(.primary, opacity: 0.1),
+        keyBorderWidth: 0.5,
+        cornerRadius: Double(KeyboardConstants.KeyDimensions.cornerRadius),
+        mainLabel: .semantic(.primary),
+        utilityLabel: .semantic(.primary),
+        hintLetter: .semantic(.primary, opacity: 0.65),
+        hintSymbol: .semantic(.secondary, opacity: 0.55),
+        hintIconProminent: .semantic(.primary, opacity: 0.5),
+        hintIconSubtle: .semantic(.secondary, opacity: 0.45)
+    )
+
+    /// Fixed dark-slate/gold palette. Identical in light and dark mode by
+    /// design. Hint roles carry their prominence as alpha (0.9/0.7/0.5/0.45
+    /// of white), mirroring Classic's opacity hierarchy.
+    static let darkGold = KeyboardThemeDefinition(
+        id: "dark-gold",
+        name: "Dark Gold",
+        boardBackground: .color(.fixed(hex: "#252A34")),
+        keyFill: .color(.fixed(hex: "#333A48")),
+        keyFillActive: .color(.fixed(hex: "#4A5468")),
+        keyBorder: .fixed(hex: "#FFFFFF1F"),
+        keyBorderWidth: 0.5,
+        cornerRadius: Double(KeyboardConstants.KeyDimensions.cornerRadius),
+        mainLabel: .fixed(hex: "#D1AA05"),
+        utilityLabel: .fixed(hex: "#FFFFFF"),
+        hintLetter: .fixed(hex: "#FFFFFFE6"),
+        hintSymbol: .fixed(hex: "#FFFFFFB3"),
+        hintIconProminent: .fixed(hex: "#FFFFFF80"),
+        hintIconSubtle: .fixed(hex: "#FFFFFF73")
+    )
+
+    static let all: [KeyboardThemeDefinition] = [classic, liquidGlass, darkGold]
+
+    static let ids: Set<String> = Set(all.map(\.id))
+
+    static func theme(id: String) -> KeyboardThemeDefinition? {
+        all.first { $0.id == id }
+    }
+}
+
+extension KeyboardThemeDefinition {
+    /// Localized display name for built-ins; user themes show their stored
+    /// name verbatim.
+    var displayName: String {
+        switch id {
+        case BuiltInThemes.classic.id: String(localized: "Classic")
+        case BuiltInThemes.liquidGlass.id: String(localized: "Liquid Glass")
+        case BuiltInThemes.darkGold.id: String(localized: "Dark Gold")
+        default: name
+        }
+    }
+
+    /// Short description shown in the theme list (built-ins only).
+    var displayDescription: String? {
+        switch id {
+        case BuiltInThemes.classic.id: String(localized: "Traditional opaque keys")
+        case BuiltInThemes.liquidGlass.id: String(localized: "Transparent glass effect (iOS 26+)")
+        case BuiltInThemes.darkGold.id: String(localized: "Dark keys with golden letters")
+        default: nil
+        }
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Theme/HexColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/HexColor.swift
@@ -57,13 +57,16 @@ enum HexColor {
         )
     }
 
-    /// Formats as `#RRGGBB`, appending the alpha byte (`#RRGGBBAA`) only
-    /// when it is below 1.
+    /// Formats as `#RRGGBB`, appending the alpha byte (`#RRGGBBAA`) only when
+    /// it is not fully opaque. The opacity check is made on the rounded byte,
+    /// not the raw value: an alpha like 0.999 rounds to 0xFF, and emitting
+    /// `#RRGGBBFF` would re-parse to 1.0 anyway — so it is formatted as the
+    /// opaque `#RRGGBB`, keeping the round-trip idempotent.
     static func string(from components: Components) -> String {
-        if components.alpha >= 1 {
+        let alphaByte = UInt32((min(max(components.alpha, 0), 1) * 255).rounded())
+        if alphaByte >= 255 {
             return String(format: "#%06X", components.rgb)
         }
-        let alphaByte = UInt32((min(max(components.alpha, 0), 1) * 255).rounded())
         return String(format: "#%06X%02X", components.rgb, alphaByte)
     }
 
@@ -82,24 +85,5 @@ enum HexColor {
         }
         let rgb = (byte(red) << 16) | (byte(green) << 8) | byte(blue)
         return string(from: Components(rgb: rgb, alpha: Double(alpha)))
-    }
-
-    /// Relative luminance (0...1), sufficient for light/dark decisions.
-    static func luminance(of rgb: UInt32) -> Double {
-        let red = Double((rgb >> 16) & 0xFF) / 255
-        let green = Double((rgb >> 8) & 0xFF) / 255
-        let blue = Double(rgb & 0xFF) / 255
-        return 0.2126 * red + 0.7152 * green + 0.0722 * blue
-    }
-
-    /// Multiplies each RGB channel by `factor`, clamping to 0...255.
-    static func scaled(_ rgb: UInt32, by factor: Double) -> UInt32 {
-        func scale(_ channel: UInt32) -> UInt32 {
-            UInt32(min(max(Double(channel) * factor, 0), 255))
-        }
-        let red = scale((rgb >> 16) & 0xFF)
-        let green = scale((rgb >> 8) & 0xFF)
-        let blue = scale(rgb & 0xFF)
-        return (red << 16) | (green << 8) | blue
     }
 }

--- a/wurstfingerKeyboard/Runtime/Theme/HexColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/HexColor.swift
@@ -1,0 +1,105 @@
+//
+//  HexColor.swift
+//  Wurstfinger
+//
+//  Parsing and formatting of hex color strings, the storage format for
+//  fixed theme colors.
+//
+
+import SwiftUI
+import UIKit
+
+/// Parses and formats `#RRGGBB` / `#RRGGBBAA` strings.
+enum HexColor {
+    /// A parsed hex color: packed RGB plus separate alpha (0...1).
+    struct Components: Equatable {
+        var rgb: UInt32
+        var alpha: Double
+    }
+
+    /// Parses `#RRGGBB` or `#RRGGBBAA` (case-insensitive, `#` optional).
+    static func parse(_ string: String) -> Components? {
+        var hex = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        if hex.hasPrefix("#") {
+            hex.removeFirst()
+        }
+        switch hex.count {
+        case 6:
+            guard let value = UInt32(hex, radix: 16) else { return nil }
+            return Components(rgb: value, alpha: 1)
+        case 8:
+            guard let value = UInt64(hex, radix: 16) else { return nil }
+            return Components(rgb: UInt32(value >> 8), alpha: Double(value & 0xFF) / 255)
+        default:
+            return nil
+        }
+    }
+
+    static func color(from string: String) -> Color? {
+        parse(string).map(color(from:))
+    }
+
+    static func color(from components: Components) -> Color {
+        Color(
+            red: Double((components.rgb >> 16) & 0xFF) / 255,
+            green: Double((components.rgb >> 8) & 0xFF) / 255,
+            blue: Double(components.rgb & 0xFF) / 255,
+            opacity: components.alpha
+        )
+    }
+
+    static func uiColor(from components: Components) -> UIColor {
+        UIColor(
+            red: Double((components.rgb >> 16) & 0xFF) / 255,
+            green: Double((components.rgb >> 8) & 0xFF) / 255,
+            blue: Double(components.rgb & 0xFF) / 255,
+            alpha: components.alpha
+        )
+    }
+
+    /// Formats as `#RRGGBB`, appending the alpha byte (`#RRGGBBAA`) only
+    /// when it is below 1.
+    static func string(from components: Components) -> String {
+        if components.alpha >= 1 {
+            return String(format: "#%06X", components.rgb)
+        }
+        let alphaByte = UInt32((min(max(components.alpha, 0), 1) * 255).rounded())
+        return String(format: "#%06X%02X", components.rgb, alphaByte)
+    }
+
+    /// Formats a runtime color, or nil when its components cannot be
+    /// resolved into RGB (e.g. pattern-based colors).
+    static func string(from color: Color) -> String? {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        guard UIColor(color).getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+            return nil
+        }
+        func byte(_ value: CGFloat) -> UInt32 {
+            UInt32((min(max(value, 0), 1) * 255).rounded())
+        }
+        let rgb = (byte(red) << 16) | (byte(green) << 8) | byte(blue)
+        return string(from: Components(rgb: rgb, alpha: Double(alpha)))
+    }
+
+    /// Relative luminance (0...1), sufficient for light/dark decisions.
+    static func luminance(of rgb: UInt32) -> Double {
+        let red = Double((rgb >> 16) & 0xFF) / 255
+        let green = Double((rgb >> 8) & 0xFF) / 255
+        let blue = Double(rgb & 0xFF) / 255
+        return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+    }
+
+    /// Multiplies each RGB channel by `factor`, clamping to 0...255.
+    static func scaled(_ rgb: UInt32, by factor: Double) -> UInt32 {
+        func scale(_ channel: UInt32) -> UInt32 {
+            UInt32(min(max(Double(channel) * factor, 0), 255))
+        }
+        let red = scale((rgb >> 16) & 0xFF)
+        let green = scale((rgb >> 8) & 0xFF)
+        let blue = scale(rgb & 0xFF)
+        return (red << 16) | (green << 8) | blue
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Theme/HexColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/HexColor.swift
@@ -86,4 +86,25 @@ enum HexColor {
         let rgb = (byte(red) << 16) | (byte(green) << 8) | byte(blue)
         return string(from: Components(rgb: rgb, alpha: Double(alpha)))
     }
+
+    /// Relative luminance (0...1) of a packed RGB value. Used to pick a light
+    /// or dark key border for a palette based on its key color.
+    static func luminance(of rgb: UInt32) -> Double {
+        let red = Double((rgb >> 16) & 0xFF) / 255
+        let green = Double((rgb >> 8) & 0xFF) / 255
+        let blue = Double(rgb & 0xFF) / 255
+        return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+    }
+
+    /// Multiplies each RGB channel by `factor`, rounding and clamping to
+    /// 0...255. Used to derive a palette's board color from its key color.
+    static func scaled(_ rgb: UInt32, by factor: Double) -> UInt32 {
+        func scale(_ channel: UInt32) -> UInt32 {
+            UInt32(min(max((Double(channel) * factor).rounded(), 0), 255))
+        }
+        let red = scale((rgb >> 16) & 0xFF)
+        let green = scale((rgb >> 8) & 0xFF)
+        let blue = scale(rgb & 0xFF)
+        return (red << 16) | (green << 8) | blue
+    }
 }

--- a/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
@@ -1,0 +1,77 @@
+//
+//  KeyboardThemeDefinition.swift
+//  Wurstfinger
+//
+//  The persisted description of a keyboard theme. A theme is data, not a
+//  code path: built-ins (Classic, Liquid Glass, Dark Gold) and user themes
+//  all render through the same resolver.
+//
+
+import Foundation
+
+struct KeyboardThemeDefinition: Identifiable, Equatable {
+    /// Built-ins use stable string ids ("classic", …); user themes use UUID
+    /// strings. Whether a theme is built-in is derived from the id — it is
+    /// never trusted from persisted data.
+    var id: String
+    var name: String
+
+    // Surfaces
+    /// Fill behind the whole keyboard; shows through the gaps between keys.
+    var boardBackground: ThemeFill
+    var keyFill: ThemeFill
+    /// Key fill while pressed.
+    var keyFillActive: ThemeFill
+    /// nil = no border overlay at all (Classic).
+    var keyBorder: ThemeColor?
+    var keyBorderWidth: Double
+    var cornerRadius: Double
+
+    // Labels
+    var mainLabel: ThemeColor
+    var utilityLabel: ThemeColor
+    var hintLetter: ThemeColor
+    var hintSymbol: ThemeColor
+    /// Globe/dismiss icon hints and the language label.
+    var hintIconProminent: ThemeColor
+    /// Copy/cut/paste icon hints.
+    var hintIconSubtle: ThemeColor
+}
+
+/// Tolerant, stable persistence: explicit keys, and every field except
+/// id/name falls back to its Classic value, so themes written by newer app
+/// versions (with additional fields) still decode.
+extension KeyboardThemeDefinition: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case id, name
+        case boardBackground, keyFill, keyFillActive
+        case keyBorder, keyBorderWidth, cornerRadius
+        case mainLabel, utilityLabel
+        case hintLetter, hintSymbol, hintIconProminent, hintIconSubtle
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let fallback = BuiltInThemes.classic
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        boardBackground = try container.decodeIfPresent(ThemeFill.self, forKey: .boardBackground)
+            ?? fallback.boardBackground
+        keyFill = try container.decodeIfPresent(ThemeFill.self, forKey: .keyFill) ?? fallback.keyFill
+        keyFillActive = try container.decodeIfPresent(ThemeFill.self, forKey: .keyFillActive)
+            ?? fallback.keyFillActive
+        keyBorder = try container.decodeIfPresent(ThemeColor.self, forKey: .keyBorder)
+        keyBorderWidth = try container.decodeIfPresent(Double.self, forKey: .keyBorderWidth)
+            ?? fallback.keyBorderWidth
+        cornerRadius = try container.decodeIfPresent(Double.self, forKey: .cornerRadius) ?? fallback.cornerRadius
+        mainLabel = try container.decodeIfPresent(ThemeColor.self, forKey: .mainLabel) ?? fallback.mainLabel
+        utilityLabel = try container.decodeIfPresent(ThemeColor.self, forKey: .utilityLabel)
+            ?? fallback.utilityLabel
+        hintLetter = try container.decodeIfPresent(ThemeColor.self, forKey: .hintLetter) ?? fallback.hintLetter
+        hintSymbol = try container.decodeIfPresent(ThemeColor.self, forKey: .hintSymbol) ?? fallback.hintSymbol
+        hintIconProminent = try container.decodeIfPresent(ThemeColor.self, forKey: .hintIconProminent)
+            ?? fallback.hintIconProminent
+        hintIconSubtle = try container.decodeIfPresent(ThemeColor.self, forKey: .hintIconSubtle)
+            ?? fallback.hintIconSubtle
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeDefinition.swift
@@ -39,8 +39,9 @@ struct KeyboardThemeDefinition: Identifiable, Equatable {
 }
 
 /// Tolerant, stable persistence: explicit keys, and every field except
-/// id/name falls back to its Classic value, so themes written by newer app
-/// versions (with additional fields) still decode.
+/// id/name and the optional `keyBorder` falls back to its Classic value, so
+/// themes written by newer app versions (with additional fields) still decode.
+/// `keyBorder` is optional — an absent key means "no border", matching Classic.
 extension KeyboardThemeDefinition: Codable {
     private enum CodingKeys: String, CodingKey {
         case id, name

--- a/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeEnvironment.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/KeyboardThemeEnvironment.swift
@@ -1,0 +1,13 @@
+//
+//  KeyboardThemeEnvironment.swift
+//  Wurstfinger
+//
+//  Environment plumbing for the resolved theme.
+//
+
+import SwiftUI
+
+extension EnvironmentValues {
+    /// The resolved theme, injected once by `DataDrivenKeyboardRootView`.
+    @Entry var keyboardTheme: ResolvedTheme = BuiltInThemes.classic.resolved()
+}

--- a/wurstfingerKeyboard/Runtime/Theme/ResolvedTheme.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ResolvedTheme.swift
@@ -30,6 +30,12 @@ struct ResolvedTheme: Equatable {
     let hintSymbol: Color
     let hintIconProminent: Color
     let hintIconSubtle: Color
+
+    /// Whether any key fill is the bar/glass material, so the grid wraps its
+    /// keys in a `GlassEffectContainer` on iOS 26 (shared sampling region).
+    var usesGlassMaterial: Bool {
+        keyFill == .material || keyFillActive == .material
+    }
 }
 
 extension KeyboardThemeDefinition {

--- a/wurstfingerKeyboard/Runtime/Theme/ResolvedTheme.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ResolvedTheme.swift
@@ -1,0 +1,92 @@
+//
+//  ResolvedTheme.swift
+//  Wurstfinger
+//
+//  The flat, render-ready form of a theme. Resolved once per keyboard root,
+//  injected via Environment, and Equatable so SwiftUI can skip re-renders.
+//
+
+import SwiftUI
+
+/// A resolved fill. Deliberately not `AnyShapeStyle` (which is not
+/// Equatable, and whose wrapping shifts how `.bar` samples its backdrop);
+/// the view layer switches on this and applies `.bar` directly.
+enum ResolvedFill: Equatable {
+    case color(Color)
+    case material
+}
+
+struct ResolvedTheme: Equatable {
+    let boardBackground: ResolvedFill
+    let keyFill: ResolvedFill
+    let keyFillActive: ResolvedFill
+    /// nil = no border overlay in the view tree.
+    let keyBorder: Color?
+    let keyBorderWidth: CGFloat
+    let cornerRadius: CGFloat
+    let mainLabel: Color
+    let utilityLabel: Color
+    let hintLetter: Color
+    let hintSymbol: Color
+    let hintIconProminent: Color
+    let hintIconSubtle: Color
+}
+
+extension KeyboardThemeDefinition {
+    /// Minimum board alpha that still receives touches. A keyboard
+    /// extension's input view only delivers touches on rendered surfaces, so
+    /// a fully transparent board would drop taps between keys (#198).
+    static let minimumBoardOpacity = 0.02
+
+    /// Resolves the definition into renderable values. Unparsable hex colors
+    /// fall back to the Classic value of the same role, so a broken user
+    /// theme degrades gracefully instead of rendering invisibly.
+    func resolved() -> ResolvedTheme {
+        let fallback = BuiltInThemes.classic
+        return ResolvedTheme(
+            boardBackground: boardBackground
+                .withMinimumOpacity(Self.minimumBoardOpacity)
+                .resolvedFill(fallback: fallback.boardBackground),
+            keyFill: keyFill.resolvedFill(fallback: fallback.keyFill),
+            keyFillActive: keyFillActive.resolvedFill(fallback: fallback.keyFillActive),
+            keyBorder: keyBorder.flatMap { $0.resolvedColor() },
+            keyBorderWidth: CGFloat(keyBorderWidth),
+            cornerRadius: CGFloat(cornerRadius),
+            mainLabel: mainLabel.resolvedColor(fallback: fallback.mainLabel),
+            utilityLabel: utilityLabel.resolvedColor(fallback: fallback.utilityLabel),
+            hintLetter: hintLetter.resolvedColor(fallback: fallback.hintLetter),
+            hintSymbol: hintSymbol.resolvedColor(fallback: fallback.hintSymbol),
+            hintIconProminent: hintIconProminent.resolvedColor(fallback: fallback.hintIconProminent),
+            hintIconSubtle: hintIconSubtle.resolvedColor(fallback: fallback.hintIconSubtle)
+        )
+    }
+}
+
+extension ThemeColor {
+    /// Resolves, falling back to another theme color (whose own resolution
+    /// is expected to be infallible — built-ins only use valid values).
+    fileprivate func resolvedColor(fallback: ThemeColor) -> Color {
+        resolvedColor() ?? fallback.resolvedColor() ?? .primary
+    }
+}
+
+extension ThemeFill {
+    fileprivate func withMinimumOpacity(_ minimum: Double) -> ThemeFill {
+        switch self {
+        case let .color(color): .color(color.withMinimumOpacity(minimum))
+        case .material: .material
+        }
+    }
+
+    fileprivate func resolvedFill(fallback: ThemeFill) -> ResolvedFill {
+        switch self {
+        case let .color(color):
+            if let resolved = color.resolvedColor() {
+                return .color(resolved)
+            }
+            return fallback.resolvedFill(fallback: .color(.semantic(.secondarySystemBackground)))
+        case .material:
+            return .material
+        }
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
@@ -1,0 +1,174 @@
+//
+//  ThemeColor.swift
+//  Wurstfinger
+//
+//  Color and fill primitives of the theme engine.
+//
+
+import SwiftUI
+import UIKit
+
+// MARK: - Semantic Tokens
+
+/// Semantic system colors a theme can reference. These stay trait-dynamic —
+/// themes built from them (like Classic) follow light/dark and other
+/// appearance traits exactly like the previously hardcoded system colors.
+enum ThemeSemanticToken: String, Codable, CaseIterable {
+    case primary
+    case secondary
+    case systemBackground
+    case secondarySystemBackground
+    case tertiarySystemFill
+
+    var color: Color {
+        switch self {
+        case .primary: .primary
+        case .secondary: .secondary
+        case .systemBackground: Color(.systemBackground)
+        case .secondarySystemBackground: Color(.secondarySystemBackground)
+        case .tertiarySystemFill: Color(.tertiarySystemFill)
+        }
+    }
+}
+
+// MARK: - ThemeColor
+
+/// A theme color: a semantic system color with an opacity, a fixed hex value
+/// (identical in light and dark mode), or an explicit light/dark hex pair.
+enum ThemeColor: Equatable {
+    case semantic(ThemeSemanticToken, opacity: Double)
+    case fixed(hex: String)
+    case adaptive(light: String, dark: String)
+
+    /// Convenience for full-opacity semantic colors (enum cases cannot carry
+    /// default associated values).
+    static func semantic(_ token: ThemeSemanticToken) -> ThemeColor {
+        .semantic(token, opacity: 1)
+    }
+
+    /// Resolves to a renderable color. Semantic and adaptive colors remain
+    /// trait-dynamic, so nothing needs to re-resolve on appearance changes.
+    /// Returns nil when a hex value does not parse.
+    func resolvedColor() -> Color? {
+        switch self {
+        case let .semantic(token, opacity):
+            // Skip the .opacity wrapper at 1 so Classic renders through the
+            // exact same color values as before the theme engine.
+            return opacity >= 1 ? token.color : token.color.opacity(opacity)
+        case let .fixed(hex):
+            return HexColor.color(from: hex)
+        case let .adaptive(light, dark):
+            guard let lightComponents = HexColor.parse(light),
+                  let darkComponents = HexColor.parse(dark) else { return nil }
+            return Color(UIColor { traits in
+                traits.userInterfaceStyle == .dark
+                    ? HexColor.uiColor(from: darkComponents)
+                    : HexColor.uiColor(from: lightComponents)
+            })
+        }
+    }
+
+    /// The same color with its opacity raised to at least `minimum`. Used to
+    /// keep the board fill touchable (a keyboard extension's input view only
+    /// delivers touches on rendered surfaces; see DataDrivenKeyboardRootView).
+    func withMinimumOpacity(_ minimum: Double) -> ThemeColor {
+        switch self {
+        case let .semantic(token, opacity):
+            return .semantic(token, opacity: max(opacity, minimum))
+        case let .fixed(hex):
+            guard let components = HexColor.parse(hex), components.alpha < minimum else { return self }
+            return .fixed(hex: HexColor.string(from: .init(rgb: components.rgb, alpha: minimum)))
+        case let .adaptive(light, dark):
+            let raise = { (hex: String) -> String in
+                guard let components = HexColor.parse(hex), components.alpha < minimum else { return hex }
+                return HexColor.string(from: .init(rgb: components.rgb, alpha: minimum))
+            }
+            return .adaptive(light: raise(light), dark: raise(dark))
+        }
+    }
+}
+
+/// Explicit, stable persisted form: `{"type": "semantic"|"fixed"|"adaptive", …}`.
+/// The encoding is the future export wire format — keep it disciplined.
+extension ThemeColor: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type, token, opacity, hex, light, dark
+    }
+
+    private enum Kind: String, Codable {
+        case semantic, fixed, adaptive
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .type) {
+        case .semantic:
+            let token = try container.decode(ThemeSemanticToken.self, forKey: .token)
+            let opacity = try container.decodeIfPresent(Double.self, forKey: .opacity) ?? 1
+            self = .semantic(token, opacity: opacity)
+        case .fixed:
+            self = try .fixed(hex: container.decode(String.self, forKey: .hex))
+        case .adaptive:
+            self = try .adaptive(
+                light: container.decode(String.self, forKey: .light),
+                dark: container.decode(String.self, forKey: .dark)
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .semantic(token, opacity):
+            try container.encode(Kind.semantic, forKey: .type)
+            try container.encode(token, forKey: .token)
+            try container.encode(opacity, forKey: .opacity)
+        case let .fixed(hex):
+            try container.encode(Kind.fixed, forKey: .type)
+            try container.encode(hex, forKey: .hex)
+        case let .adaptive(light, dark):
+            try container.encode(Kind.adaptive, forKey: .type)
+            try container.encode(light, forKey: .light)
+            try container.encode(dark, forKey: .dark)
+        }
+    }
+}
+
+// MARK: - ThemeFill
+
+/// A fill: either a theme color or the system bar material (Liquid Glass).
+enum ThemeFill: Equatable {
+    case color(ThemeColor)
+    case material
+}
+
+extension ThemeFill: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case type, color
+    }
+
+    private enum Kind: String, Codable {
+        case color, material
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .type) {
+        case .color:
+            self = try .color(container.decode(ThemeColor.self, forKey: .color))
+        case .material:
+            self = .material
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .color(color):
+            try container.encode(Kind.color, forKey: .type)
+            try container.encode(color, forKey: .color)
+        case .material:
+            try container.encode(Kind.material, forKey: .type)
+        }
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
@@ -16,6 +16,7 @@ import UIKit
 enum ThemeSemanticToken: String, Codable, CaseIterable {
     case primary
     case secondary
+    case gray
     case systemBackground
     case secondarySystemBackground
     case tertiarySystemFill
@@ -24,6 +25,7 @@ enum ThemeSemanticToken: String, Codable, CaseIterable {
         switch self {
         case .primary: .primary
         case .secondary: .secondary
+        case .gray: .gray
         case .systemBackground: Color(.systemBackground)
         case .secondarySystemBackground: Color(.secondarySystemBackground)
         case .tertiarySystemFill: Color(.tertiarySystemFill)

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
@@ -56,33 +56,54 @@ enum ThemeStore {
         return userThemes(defaults: defaults).first { $0.id == id }
     }
 
-    /// The theme for the given appearance, applying the fallback cascade:
-    /// assigned slot → other slot → Classic.
-    static func selectedTheme(
+    /// Resolves the theme for the given appearance from two explicit slot ids,
+    /// applying the fallback cascade: assigned slot → other slot → Classic.
+    /// This is the single source of truth for slot selection; both the live
+    /// keyboard (`DataDrivenKeyboardRootView`) and `selectedTheme(for:)` call it
+    /// so the tested path is the rendered path.
+    static func theme(
+        lightId: String,
+        darkId: String,
         for colorScheme: ColorScheme,
         defaults: UserDefaults = SharedDefaults.store
     ) -> KeyboardThemeDefinition {
-        let lightId = defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) ?? BuiltInThemes.classic.id
-        let darkId = defaults.string(forKey: SettingsKey.selectedThemeDark.rawValue) ?? lightId
         let (primary, secondary) = colorScheme == .dark ? (darkId, lightId) : (lightId, darkId)
         return theme(id: primary, defaults: defaults)
             ?? theme(id: secondary, defaults: defaults)
             ?? BuiltInThemes.classic
     }
 
+    /// The theme for the given appearance, reading the slot ids from defaults.
+    /// An unset dark slot follows the light slot (both slots track one
+    /// selection until the gallery adds separate assignment in M2).
+    static func selectedTheme(
+        for colorScheme: ColorScheme,
+        defaults: UserDefaults = SharedDefaults.store
+    ) -> KeyboardThemeDefinition {
+        let lightId = defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) ?? BuiltInThemes.classic.id
+        let darkId = defaults.string(forKey: SettingsKey.selectedThemeDark.rawValue) ?? lightId
+        return theme(lightId: lightId, darkId: darkId, for: colorScheme, defaults: defaults)
+    }
+
     // MARK: - Migration
 
     /// One-time migration from the legacy `keyboardStyle` setting to the
-    /// theme assignment. Idempotent and race-safe: host app and extension may
-    /// both run this concurrently — both derive the same deterministic values
-    /// and only write when the new keys are still absent.
+    /// light/dark theme assignment. Idempotent for sequential runs (host app
+    /// and extension both run it); the derived values are deterministic, so a
+    /// second run is a no-op. A concurrent first run has a narrow theoretical
+    /// TOCTOU window, but it only opens on the very first launch before any
+    /// theme is stored, so it is not reachable in practice.
     static func migrateIfNeeded(defaults: UserDefaults = SharedDefaults.store) {
         guard let legacy = defaults.string(forKey: SettingsKey.keyboardStyle.rawValue) else {
             return
         }
+        // Only seed the slots if no selection exists yet; if another run (or the
+        // user) already set one, leave it and just drop the stale legacy key.
         if defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == nil {
             let id = switch legacy {
             case "liquidGlass": BuiltInThemes.liquidGlass.id
+            // "darkGold" never shipped as a keyboardStyle value; kept so an
+            // unreleased dev build's stored value still migrates sensibly.
             case "darkGold": BuiltInThemes.darkGold.id
             default: BuiltInThemes.classic.id
             }

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
@@ -1,0 +1,123 @@
+//
+//  ThemeStore.swift
+//  Wurstfinger
+//
+//  Theme lookup, user-theme persistence, and legacy migration.
+//
+//  Cross-process note: App-Group defaults do NOT deliver live updates between
+//  host app and extension. The extension re-reads on every appearance (its
+//  root view resolves per launch); only same-process observers (previews) are
+//  live via @AppStorage.
+//
+
+import Foundation
+import SwiftUI
+
+enum ThemeStore {
+    // MARK: - Persistence Format
+
+    /// Envelope around persisted user themes. `schemaVersion` starts at 1;
+    /// this format doubles as the future export wire format, so encode with
+    /// sorted keys and decode tolerantly.
+    struct Archive: Equatable {
+        var schemaVersion: Int
+        var themes: [KeyboardThemeDefinition]
+
+        static let currentSchemaVersion = 1
+    }
+
+    /// Decodes the archive from defaults. Lossy on purpose: a corrupt entry
+    /// is skipped instead of destroying all user themes, and entries claiming
+    /// a built-in id are dropped (built-in status is derived, never trusted).
+    static func userThemes(defaults: UserDefaults = SharedDefaults.store) -> [KeyboardThemeDefinition] {
+        guard let data = defaults.data(forKey: SettingsKey.userThemes.rawValue) else {
+            return []
+        }
+        let archive = try? JSONDecoder().decode(Archive.self, from: data)
+        return archive?.themes ?? []
+    }
+
+    static func writeUserThemes(_ themes: [KeyboardThemeDefinition], defaults: UserDefaults = SharedDefaults.store) {
+        let archive = Archive(schemaVersion: Archive.currentSchemaVersion, themes: themes)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        guard let data = try? encoder.encode(archive) else { return }
+        defaults.set(data, forKey: SettingsKey.userThemes.rawValue)
+    }
+
+    // MARK: - Lookup
+
+    /// Built-ins never touch the user-theme blob, so the common case decodes
+    /// nothing on extension launch.
+    static func theme(id: String, defaults: UserDefaults = SharedDefaults.store) -> KeyboardThemeDefinition? {
+        if let builtIn = BuiltInThemes.theme(id: id) {
+            return builtIn
+        }
+        return userThemes(defaults: defaults).first { $0.id == id }
+    }
+
+    /// The theme for the given appearance, applying the fallback cascade:
+    /// assigned slot → other slot → Classic.
+    static func selectedTheme(
+        for colorScheme: ColorScheme,
+        defaults: UserDefaults = SharedDefaults.store
+    ) -> KeyboardThemeDefinition {
+        let lightId = defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) ?? BuiltInThemes.classic.id
+        let darkId = defaults.string(forKey: SettingsKey.selectedThemeDark.rawValue) ?? lightId
+        let (primary, secondary) = colorScheme == .dark ? (darkId, lightId) : (lightId, darkId)
+        return theme(id: primary, defaults: defaults)
+            ?? theme(id: secondary, defaults: defaults)
+            ?? BuiltInThemes.classic
+    }
+
+    // MARK: - Migration
+
+    /// One-time migration from the legacy `keyboardStyle` setting to the
+    /// theme assignment. Idempotent and race-safe: host app and extension may
+    /// both run this concurrently — both derive the same deterministic values
+    /// and only write when the new keys are still absent.
+    static func migrateIfNeeded(defaults: UserDefaults = SharedDefaults.store) {
+        guard let legacy = defaults.string(forKey: SettingsKey.keyboardStyle.rawValue) else {
+            return
+        }
+        if defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == nil {
+            let id = switch legacy {
+            case "liquidGlass": BuiltInThemes.liquidGlass.id
+            case "darkGold": BuiltInThemes.darkGold.id
+            default: BuiltInThemes.classic.id
+            }
+            defaults.set(id, forKey: SettingsKey.selectedThemeLight.rawValue)
+            defaults.set(id, forKey: SettingsKey.selectedThemeDark.rawValue)
+        }
+        defaults.removeObject(forKey: SettingsKey.keyboardStyle.rawValue)
+    }
+}
+
+extension ThemeStore.Archive: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion, themes
+    }
+
+    /// Wrapper that swallows per-element decode failures.
+    private struct FailableTheme: Decodable {
+        let value: KeyboardThemeDefinition?
+
+        init(from decoder: Decoder) {
+            value = try? KeyboardThemeDefinition(from: decoder)
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion)
+            ?? Self.currentSchemaVersion
+        let raw = try container.decodeIfPresent([FailableTheme].self, forKey: .themes) ?? []
+        themes = raw.compactMap(\.value).filter { !BuiltInThemes.ids.contains($0.id) }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(themes, forKey: .themes)
+    }
+}

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -18,14 +18,16 @@ struct DataDrivenKeyboardRootView: View {
     /// When nil, falls back to `viewModel.viewWidth`.
     var overrideWidth: CGFloat?
 
+    /// Explicit theme for showcase/screenshot rendering. When set, the
+    /// stored selection is bypassed entirely — screenshots can never be
+    /// recolored by leftover simulator state.
+    var themeOverride: KeyboardThemeDefinition?
+
     // Single read site for the per-key render settings: one observation per
     // setting for the whole keyboard rather than one per key view. The root
     // re-renders on changes and passes fresh values down. The unstored-value
     // defaults come from `KeyRenderSettings.stock`, so this site and the
     // snapshot type agree on what an untouched installation renders.
-    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
-    private var keyboardStyle: KeyboardStyle = KeyRenderSettings.stock.keyboardStyle
-
     @AppStorage(SettingsKey.hideLetters.rawValue, store: SharedDefaults.store)
     private var hideLetters = KeyRenderSettings.stock.hideLetters
 
@@ -38,14 +40,39 @@ struct DataDrivenKeyboardRootView: View {
     @AppStorage(SettingsKey.longPressNumbersEnabled.rawValue, store: SharedDefaults.store)
     private var longPressNumbersEnabled = KeyRenderSettings.stock.longPressNumbersEnabled
 
+    // The theme selection is observed at the same single site, for the same
+    // reason: the resolved theme is handed down through the environment
+    // instead of being re-read by every key.
+    @AppStorage(SettingsKey.selectedThemeLight.rawValue, store: SharedDefaults.store)
+    private var selectedThemeLight = BuiltInThemes.classic.id
+
+    @AppStorage(SettingsKey.selectedThemeDark.rawValue, store: SharedDefaults.store)
+    private var selectedThemeDark = BuiltInThemes.classic.id
+
+    @Environment(\.colorScheme) private var colorScheme
+
     private var renderSettings: KeyRenderSettings {
         KeyRenderSettings(
-            keyboardStyle: keyboardStyle,
             hideLetters: hideLetters,
             hideStandardSymbols: hideStandardSymbols,
             hideExtraSymbols: hideExtraSymbols,
             longPressNumbersEnabled: longPressNumbersEnabled
         )
+    }
+
+    /// Resolved once here for the whole keyboard; key views read it from the
+    /// environment. Fallback cascade: assigned slot → other slot → Classic.
+    private var resolvedTheme: ResolvedTheme {
+        if let themeOverride {
+            return themeOverride.resolved()
+        }
+        let (primaryId, secondaryId) = colorScheme == .dark
+            ? (selectedThemeDark, selectedThemeLight)
+            : (selectedThemeLight, selectedThemeDark)
+        let definition = ThemeStore.theme(id: primaryId)
+            ?? ThemeStore.theme(id: secondaryId)
+            ?? BuiltInThemes.classic
+        return definition.resolved()
     }
 
     var body: some View {
@@ -58,8 +85,9 @@ struct DataDrivenKeyboardRootView: View {
         let availableSpace = currentWidth - metrics.keyboardWidth
         let horizontalOffset = availableSpace * (viewModel.keyboardHorizontalPosition - 0.5)
 
+        let theme = resolvedTheme
         ZStack {
-            keyboardBackground
+            keyboardBackground(theme.boardBackground)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             if let mode = viewModel.activeModeFromDefinition,
@@ -101,24 +129,29 @@ struct DataDrivenKeyboardRootView: View {
         // directions. A lone hint glyph is direction-agnostic, so RTL text
         // still renders correctly. (Finding #4.)
         .environment(\.layoutDirection, .leftToRight)
+        .environment(\.keyboardTheme, theme)
     }
 
     // MARK: - Background
 
+    /// A keyboard extension's input view only delivers touches that land on
+    /// a rendered surface; fully transparent regions pass through and would
+    /// drop taps in the gaps between keys. The resolver therefore clamps
+    /// color board fills to a near-invisible minimum alpha
+    /// (`KeyboardThemeDefinition.minimumBoardOpacity`), so every theme's
+    /// board is a real touch surface while the keys on top win the hit-test.
+    ///
+    /// Color fills render as a plain `Color`, matching the pre-engine board
+    /// exactly: `Color` and `Rectangle().fill` have different ideal sizes, and
+    /// in the height-free showcase layout that difference would shift the whole
+    /// keyboard. Only the bar material genuinely needs a shape.
     @ViewBuilder
-    private var keyboardBackground: some View {
-        switch keyboardStyle {
-        case .classic:
-            Color(.systemBackground)
-        case .liquidGlass:
-            // A keyboard extension's input view only delivers touches that land
-            // on a rendered surface; fully transparent regions pass through. A
-            // `Color.clear` root would drop taps that fall in the gaps between
-            // keys, so paint a near-invisible fill instead: the whole keyboard
-            // becomes a real surface that receives those touches while the keys
-            // on top still win the hit-test. ~2% over the glass backdrop reads
-            // as clear.
-            Color(.systemBackground).opacity(0.02)
+    private func keyboardBackground(_ fill: ResolvedFill) -> some View {
+        switch fill {
+        case let .color(color):
+            color
+        case .material:
+            Rectangle().fill(.bar)
         }
     }
 }

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -87,7 +87,7 @@ struct DataDrivenKeyboardRootView: View {
 
         let theme = resolvedTheme
         ZStack {
-            keyboardBackground(theme.boardBackground)
+            keyboardBackground(theme)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             if let mode = viewModel.activeModeFromDefinition,
@@ -134,24 +134,34 @@ struct DataDrivenKeyboardRootView: View {
 
     // MARK: - Background
 
-    /// A keyboard extension's input view only delivers touches that land on
-    /// a rendered surface; fully transparent regions pass through and would
-    /// drop taps in the gaps between keys. The resolver therefore clamps
-    /// color board fills to a near-invisible minimum alpha
-    /// (`KeyboardThemeDefinition.minimumBoardOpacity`), so every theme's
-    /// board is a real touch surface while the keys on top win the hit-test.
+    /// Minimum board opacity that still receives touches. A keyboard extension
+    /// only delivers touches over rendered pixels, and UIKit hit-testing
+    /// ignores anything with `alpha <= 0.01`, so a glass theme's board can't be
+    /// fully transparent or the inter-key gaps go dead (#198). This is just
+    /// above that threshold: enough to stay tappable, faint enough that the
+    /// `UIInputView(.keyboard)` backdrop shows through essentially unchanged.
+    private static let glassBoardOpacity = 0.02
+
+    /// The board behind the keys.
     ///
-    /// Color fills render as a plain `Color`, matching the pre-engine board
-    /// exactly: `Color` and `Rectangle().fill` have different ideal sizes, and
-    /// in the height-free showcase layout that difference would shift the whole
-    /// keyboard. Only the bar material genuinely needs a shape.
+    /// Glass themes paint an almost-invisible neutral fill over the
+    /// `UIInputView(.keyboard)` backdrop: the backdrop supplies the system
+    /// keyboard look, while this thin fill keeps the gaps tappable (see
+    /// `glassBoardOpacity`). Color themes paint their board as a plain `Color`
+    /// — matching the pre-engine board exactly, since `Color` and
+    /// `Rectangle().fill` have different ideal sizes and the difference would
+    /// shift the whole keyboard in the height-free showcase layout.
     @ViewBuilder
-    private func keyboardBackground(_ fill: ResolvedFill) -> some View {
-        switch fill {
-        case let .color(color):
-            color
-        case .material:
-            Rectangle().fill(.bar)
+    private func keyboardBackground(_ theme: ResolvedTheme) -> some View {
+        if theme.usesGlassMaterial {
+            Color.gray.opacity(Self.glassBoardOpacity)
+        } else {
+            switch theme.boardBackground {
+            case let .color(color):
+                color
+            case .material:
+                Rectangle().fill(.bar)
+            }
         }
     }
 }

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -49,6 +49,12 @@ struct DataDrivenKeyboardRootView: View {
     @AppStorage(SettingsKey.selectedThemeDark.rawValue, store: SharedDefaults.store)
     private var selectedThemeDark = BuiltInThemes.classic.id
 
+    /// The keyboard follows the system color scheme. A keyboard extension can
+    /// also be asked for a specific appearance via
+    /// `textDocumentProxy.keyboardAppearance`; wiring the slot selection to
+    /// that instead of `colorScheme` is deferred to M2, when the gallery lets
+    /// the light/dark slots actually diverge (today both hold one selection,
+    /// so the distinction is a no-op).
     @Environment(\.colorScheme) private var colorScheme
 
     private var renderSettings: KeyRenderSettings {
@@ -61,18 +67,17 @@ struct DataDrivenKeyboardRootView: View {
     }
 
     /// Resolved once here for the whole keyboard; key views read it from the
-    /// environment. Fallback cascade: assigned slot → other slot → Classic.
+    /// environment. Slot selection uses the shared `ThemeStore` cascade so the
+    /// rendered path is the one the tests exercise.
     private var resolvedTheme: ResolvedTheme {
         if let themeOverride {
             return themeOverride.resolved()
         }
-        let (primaryId, secondaryId) = colorScheme == .dark
-            ? (selectedThemeDark, selectedThemeLight)
-            : (selectedThemeLight, selectedThemeDark)
-        let definition = ThemeStore.theme(id: primaryId)
-            ?? ThemeStore.theme(id: secondaryId)
-            ?? BuiltInThemes.classic
-        return definition.resolved()
+        return ThemeStore.theme(
+            lightId: selectedThemeLight,
+            darkId: selectedThemeDark,
+            for: colorScheme
+        ).resolved()
     }
 
     var body: some View {
@@ -134,34 +139,26 @@ struct DataDrivenKeyboardRootView: View {
 
     // MARK: - Background
 
-    /// Minimum board opacity that still receives touches. A keyboard extension
-    /// only delivers touches over rendered pixels, and UIKit hit-testing
-    /// ignores anything with `alpha <= 0.01`, so a glass theme's board can't be
-    /// fully transparent or the inter-key gaps go dead (#198). This is just
-    /// above that threshold: enough to stay tappable, faint enough that the
-    /// `UIInputView(.keyboard)` backdrop shows through essentially unchanged.
-    private static let glassBoardOpacity = 0.02
-
-    /// The board behind the keys.
+    /// The board behind the keys — always the theme's own resolved
+    /// `boardBackground`. The resolver floors a color board to
+    /// `KeyboardThemeDefinition.minimumBoardOpacity` so it stays a rendered,
+    /// tappable surface: a keyboard extension only delivers touches over
+    /// rendered pixels, and UIKit hit-testing ignores `alpha <= 0.01`, so a
+    /// fully transparent board would drop taps in the inter-key gaps (#198).
+    /// Glass themes therefore declare a faint neutral board that reads as clear
+    /// over the `UIInputView(.keyboard)` backdrop while keeping the gaps live.
     ///
-    /// Glass themes paint an almost-invisible neutral fill over the
-    /// `UIInputView(.keyboard)` backdrop: the backdrop supplies the system
-    /// keyboard look, while this thin fill keeps the gaps tappable (see
-    /// `glassBoardOpacity`). Color themes paint their board as a plain `Color`
-    /// — matching the pre-engine board exactly, since `Color` and
-    /// `Rectangle().fill` have different ideal sizes and the difference would
-    /// shift the whole keyboard in the height-free showcase layout.
+    /// A color fill renders as a plain `Color`, matching the pre-engine board
+    /// exactly: `Color` and `Rectangle().fill` have different ideal sizes, and
+    /// in the height-free showcase layout the difference would shift the whole
+    /// keyboard, so only the (currently unused) material board needs a shape.
     @ViewBuilder
     private func keyboardBackground(_ theme: ResolvedTheme) -> some View {
-        if theme.usesGlassMaterial {
-            Color.gray.opacity(Self.glassBoardOpacity)
-        } else {
-            switch theme.boardBackground {
-            case let .color(color):
-                color
-            case .material:
-                Rectangle().fill(.bar)
-            }
+        switch theme.boardBackground {
+        case let .color(color):
+            color
+        case .material:
+            Rectangle().fill(.bar)
         }
     }
 }

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -273,6 +273,11 @@ struct KeyView: View {
         return false
     }
 
+    /// A subtle neutral tint on the glass, so the keys gain a bit of presence
+    /// and stand out from the backdrop instead of reading as fully clear glass
+    /// — while staying native Liquid Glass that blends with the system row.
+    private static let glassTint = Color.gray.opacity(0.12)
+
     /// The stacked key layers. Native glass wraps the label/hint content with
     /// `glassEffect` (label as content = crisp); every other style keeps the
     /// pre-engine order of a background layer beneath the labels.
@@ -283,7 +288,7 @@ struct KeyView: View {
                 label
                 hintOverlay
             }
-            .glassEffect(.regular, in: RoundedRectangle(cornerRadius: theme.cornerRadius))
+            .glassEffect(.regular.tint(Self.glassTint), in: RoundedRectangle(cornerRadius: theme.cornerRadius))
         } else {
             ZStack {
                 background

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -304,30 +304,25 @@ struct KeyView: View {
         let fill = isActive ? theme.keyFillActive : theme.keyFill
         switch fill {
         case let .color(color):
-            colorBackground(shape, color)
+            filled(shape, with: color)
         case .material:
             // Reached only before iOS 26 (native glass takes the other branch):
             // the bar material with a hairline border, pixel-identical to the
             // pre-engine Liquid Glass rendering.
-            if let border = theme.keyBorder, theme.keyBorderWidth > 0 {
-                shape.fill(.bar)
-                    .overlay(shape.strokeBorder(border, lineWidth: theme.keyBorderWidth))
-            } else {
-                shape.fill(.bar)
-            }
+            filled(shape, with: .bar)
         }
     }
 
-    /// Solid or translucent color fill, with an optional hairline border.
+    /// Fills `shape` and overlays the theme's hairline border when it has one.
+    /// A theme without a border (Classic) gets no overlay in the view tree at
+    /// all, so it renders exactly as before the theme engine.
     @ViewBuilder
-    private func colorBackground(_ shape: RoundedRectangle, _ color: Color) -> some View {
+    private func filled(_ shape: RoundedRectangle, with fill: some ShapeStyle) -> some View {
         if let border = theme.keyBorder, theme.keyBorderWidth > 0 {
-            shape.fill(color)
+            shape.fill(fill)
                 .overlay(shape.strokeBorder(border, lineWidth: theme.keyBorderWidth))
         } else {
-            // No border overlay in the view tree at all — themes without a
-            // border (Classic) render exactly as before the theme engine.
-            shape.fill(color)
+            shape.fill(fill)
         }
     }
 

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -14,8 +14,11 @@ import SwiftUI
 /// The whole keyboard holds one defaults observation per setting, and the
 /// ~100 key views a layer builds hold none: the root re-renders when a
 /// setting changes and hands every key the fresh values.
+///
+/// Colors are not in here: the resolved theme travels through the
+/// `\.keyboardTheme` environment instead, because it also has to reach the
+/// board background that sits outside any key.
 struct KeyRenderSettings: Equatable {
-    var keyboardStyle: KeyboardStyle = .classic
     var hideLetters = false
     var hideStandardSymbols = false
     var hideExtraSymbols = false
@@ -66,6 +69,10 @@ struct KeyView: View {
     /// render stock settings (labels shown, long-press numbers off) instead of
     /// failing the build.
     let settings: KeyRenderSettings
+
+    /// Resolved once in `DataDrivenKeyboardRootView` and injected here — key
+    /// views never resolve theme data themselves.
+    @Environment(\.keyboardTheme) private var theme
 
     /// Resolved layout metrics injected by `KeyboardGridView` (same reasoning
     /// as there: an `@AppStorage` read desynchronizes from the width path
@@ -242,14 +249,6 @@ struct KeyView: View {
         style == .utility
     }
 
-    /// Background fill for the key.
-    static func backgroundColor(for style: KeyStyle, active: Bool = false) -> Color {
-        if active {
-            return Color(.tertiarySystemFill)
-        }
-        return Color(.secondarySystemBackground)
-    }
-
     // MARK: - Gesture Selection
 
     /// Whether this key uses slide gesture handling instead of standard
@@ -269,16 +268,36 @@ struct KeyView: View {
 
     @ViewBuilder
     private var background: some View {
-        let shape = RoundedRectangle(cornerRadius: KeyboardConstants.KeyDimensions.cornerRadius)
-        switch settings.keyboardStyle {
-        case .classic:
-            shape.fill(Self.backgroundColor(for: key.style, active: isActive))
-        case .liquidGlass:
-            shape.fill(.bar)
+        let shape = RoundedRectangle(cornerRadius: theme.cornerRadius)
+        let fill = isActive ? theme.keyFillActive : theme.keyFill
+        if let border = theme.keyBorder, theme.keyBorderWidth > 0 {
+            keyFill(shape, fill)
                 .overlay(
-                    shape.strokeBorder(Color.primary.opacity(0.1), lineWidth: 0.5)
+                    shape.strokeBorder(border, lineWidth: theme.keyBorderWidth)
                 )
+        } else {
+            // No border overlay in the view tree at all — themes without a
+            // border (Classic) render exactly as before the theme engine.
+            keyFill(shape, fill)
         }
+    }
+
+    /// Fills the key shape. The bar material is applied directly rather than
+    /// through `AnyShapeStyle`, because the wrapper changes how the material
+    /// samples its backdrop and would shift Liquid Glass off its baseline.
+    @ViewBuilder
+    private func keyFill(_ shape: RoundedRectangle, _ fill: ResolvedFill) -> some View {
+        switch fill {
+        case let .color(color):
+            shape.fill(color)
+        case .material:
+            shape.fill(.bar)
+        }
+    }
+
+    /// Center label color: utility glyphs may differ from letter keys.
+    private var labelColor: Color {
+        key.style == .utility ? theme.utilityLabel : theme.mainLabel
     }
 
     @ViewBuilder
@@ -294,11 +313,11 @@ struct KeyView: View {
             if let sfName = Self.sfSymbolMap[primaryLabel] {
                 Image(systemName: sfName)
                     .font(font)
-                    .foregroundColor(.primary)
+                    .foregroundColor(labelColor)
             } else {
                 Text(primaryLabel)
                     .font(font)
-                    .foregroundColor(.primary)
+                    .foregroundColor(labelColor)
                     // Multi-character labels ("123") outgrow the cell before
                     // the size cap does; shrink instead of wrapping.
                     .lineLimit(1)
@@ -407,7 +426,7 @@ struct KeyView: View {
                         if showLanguageLabel {
                             Text(languageLabel)
                                 .font(.system(size: scaledHintFontSize * 0.75, weight: .semibold, design: .rounded))
-                                .foregroundStyle(Color.primary.opacity(0.5))
+                                .foregroundStyle(theme.hintIconProminent)
                                 .fixedSize()
                                 .padding(Self.hintEdgePadding(for: gesture, horizontal: hPad, vertical: vPad))
                                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
@@ -441,12 +460,12 @@ struct KeyView: View {
                 // Globe / dismiss: larger, bolder for discoverability
                 Image(systemName: iconName)
                     .font(.system(size: scaledHintFontSize * 0.75, weight: .medium))
-                    .foregroundStyle(Color.primary.opacity(0.5))
+                    .foregroundStyle(theme.hintIconProminent)
             } else {
                 // Copy / paste / cut: smaller, lighter to avoid visual clutter
                 Image(systemName: iconName)
                     .font(.system(size: scaledHintFontSize * 0.6, weight: .regular))
-                    .foregroundStyle(Color.secondary.opacity(0.45))
+                    .foregroundStyle(theme.hintIconSubtle)
             }
         } else {
             // Text hint — letters get higher prominence than symbols
@@ -457,11 +476,7 @@ struct KeyView: View {
                     weight: isLetter ? .medium : .regular,
                     design: .rounded
                 ))
-                .foregroundStyle(
-                    isLetter
-                        ? Color.primary.opacity(0.65)
-                        : Color.secondary.opacity(0.55)
-                )
+                .foregroundStyle(isLetter ? theme.hintLetter : theme.hintSymbol)
                 .minimumScaleFactor(0.6)
                 .lineLimit(1)
         }

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -113,37 +113,33 @@ struct KeyView: View {
 
     @ViewBuilder
     private var keyContent: some View {
-        let base = ZStack {
-            background
-            label
-            hintOverlay
-        }
-        // Inset the drawn key from the touch cell by `visualInset`, so the
-        // visible key keeps its position/size while the cell itself extends into
-        // the inter-key gaps (see KeyboardGridLayout.gapInsets).
-        .padding(visualInset)
-        // Fill the cell frame imposed by KeyboardGridLayout. The layout sizes
-        // rows from the same effective key height, so single-row keys are
-        // unchanged while a spanning key (e.g. landscape return) grows to cover
-        // multiple rows.
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityLabel)
-        .accessibilityIdentifier(key.id)
-        .accessibilityAddTraits(.isButton)
-        .modifier(KeyAccessibilityActions(key: key, onGesture: onGesture))
-        // The whole cell is the touch target. Adjacent cells tile the surface
-        // with no gaps, so a plain rectangle covers it fully.
-        .contentShape(Rectangle())
-        // Pin the key's alignment/padding surface to physical LTR so the
-        // directional hints (`hintAlignments` / `hintEdgePadding`, which use
-        // semantic leading/trailing) always match the physical swipe
-        // directions — even when a host renders this key under an RTL locale
-        // (e.g. KeyboardShowcaseView / AppStoreScreenshotView for localized
-        // screenshots, or SwiftUI previews). Defense-in-depth alongside the
-        // root pin in DataDrivenKeyboardRootView; nested identical pins are
-        // harmless.
-        .environment(\.layoutDirection, .leftToRight)
+        let base = keyLayers
+            // Inset the drawn key from the touch cell by `visualInset`, so the
+            // visible key keeps its position/size while the cell itself extends into
+            // the inter-key gaps (see KeyboardGridLayout.gapInsets).
+            .padding(visualInset)
+            // Fill the cell frame imposed by KeyboardGridLayout. The layout sizes
+            // rows from the same effective key height, so single-row keys are
+            // unchanged while a spanning key (e.g. landscape return) grows to cover
+            // multiple rows.
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityIdentifier(key.id)
+            .accessibilityAddTraits(.isButton)
+            .modifier(KeyAccessibilityActions(key: key, onGesture: onGesture))
+            // The whole cell is the touch target. Adjacent cells tile the surface
+            // with no gaps, so a plain rectangle covers it fully.
+            .contentShape(Rectangle())
+            // Pin the key's alignment/padding surface to physical LTR so the
+            // directional hints (`hintAlignments` / `hintEdgePadding`, which use
+            // semantic leading/trailing) always match the physical swipe
+            // directions — even when a host renders this key under an RTL locale
+            // (e.g. KeyboardShowcaseView / AppStoreScreenshotView for localized
+            // screenshots, or SwiftUI previews). Defense-in-depth alongside the
+            // root pin in DataDrivenKeyboardRootView; nested identical pins are
+            // harmless.
+            .environment(\.layoutDirection, .leftToRight)
 
         if usesSlideGesture {
             base.modifier(SlideGestureHandler(
@@ -266,32 +262,67 @@ struct KeyView: View {
 
     // MARK: - View Construction
 
+    /// Whether this key should render as native Liquid Glass (iOS 26 with a
+    /// material fill). The glass then wraps the label layer directly, so the
+    /// label stays crisp and picks up glass vibrancy — applying it to a
+    /// separate background layer instead blurs the label.
+    private var usesNativeGlass: Bool {
+        if #available(iOS 26.0, *) {
+            return (isActive ? theme.keyFillActive : theme.keyFill) == .material
+        }
+        return false
+    }
+
+    /// The stacked key layers. Native glass wraps the label/hint content with
+    /// `glassEffect` (label as content = crisp); every other style keeps the
+    /// pre-engine order of a background layer beneath the labels.
+    @ViewBuilder
+    private var keyLayers: some View {
+        if usesNativeGlass, #available(iOS 26.0, *) {
+            ZStack {
+                label
+                hintOverlay
+            }
+            .glassEffect(.regular, in: RoundedRectangle(cornerRadius: theme.cornerRadius))
+        } else {
+            ZStack {
+                background
+                label
+                hintOverlay
+            }
+        }
+    }
+
     @ViewBuilder
     private var background: some View {
         let shape = RoundedRectangle(cornerRadius: theme.cornerRadius)
         let fill = isActive ? theme.keyFillActive : theme.keyFill
-        if let border = theme.keyBorder, theme.keyBorderWidth > 0 {
-            keyFill(shape, fill)
-                .overlay(
-                    shape.strokeBorder(border, lineWidth: theme.keyBorderWidth)
-                )
-        } else {
-            // No border overlay in the view tree at all — themes without a
-            // border (Classic) render exactly as before the theme engine.
-            keyFill(shape, fill)
+        switch fill {
+        case let .color(color):
+            colorBackground(shape, color)
+        case .material:
+            // Reached only before iOS 26 (native glass takes the other branch):
+            // the bar material with a hairline border, pixel-identical to the
+            // pre-engine Liquid Glass rendering.
+            if let border = theme.keyBorder, theme.keyBorderWidth > 0 {
+                shape.fill(.bar)
+                    .overlay(shape.strokeBorder(border, lineWidth: theme.keyBorderWidth))
+            } else {
+                shape.fill(.bar)
+            }
         }
     }
 
-    /// Fills the key shape. The bar material is applied directly rather than
-    /// through `AnyShapeStyle`, because the wrapper changes how the material
-    /// samples its backdrop and would shift Liquid Glass off its baseline.
+    /// Solid or translucent color fill, with an optional hairline border.
     @ViewBuilder
-    private func keyFill(_ shape: RoundedRectangle, _ fill: ResolvedFill) -> some View {
-        switch fill {
-        case let .color(color):
+    private func colorBackground(_ shape: RoundedRectangle, _ color: Color) -> some View {
+        if let border = theme.keyBorder, theme.keyBorderWidth > 0 {
             shape.fill(color)
-        case .material:
-            shape.fill(.bar)
+                .overlay(shape.strokeBorder(border, lineWidth: theme.keyBorderWidth))
+        } else {
+            // No border overlay in the view tree at all — themes without a
+            // border (Classic) render exactly as before the theme engine.
+            shape.fill(color)
         }
     }
 

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -35,6 +35,8 @@ struct KeyboardGridView: View {
     /// settings.
     let renderSettings: KeyRenderSettings
 
+    @Environment(\.keyboardTheme) private var theme
+
     /// Resolved layout metrics injected by `DataDrivenKeyboardRootView` from
     /// the view model rather than read via `@AppStorage`: the root view
     /// derives the keyboard *width* from the same metrics, and reading the
@@ -58,15 +60,17 @@ struct KeyboardGridView: View {
     var body: some View {
         let cells = GridLayoutSolver.solve(arrangement)
         let totalRows = cells.map { $0.row + $0.rowSpan }.max() ?? 0
-        KeyboardGridLayout(
-            cells: cells,
-            columns: arrangement.columns,
-            rowHeight: metrics.rowHeight,
-            horizontalSpacing: KeyboardConstants.Layout.gridHorizontalSpacing,
-            verticalSpacing: KeyboardConstants.Layout.gridVerticalSpacing
-        ) {
-            ForEach(Array(cells.enumerated()), id: \.offset) { _, cell in
-                cellContent(for: cell, totalRows: totalRows)
+        glassWrapped {
+            KeyboardGridLayout(
+                cells: cells,
+                columns: arrangement.columns,
+                rowHeight: metrics.rowHeight,
+                horizontalSpacing: KeyboardConstants.Layout.gridHorizontalSpacing,
+                verticalSpacing: KeyboardConstants.Layout.gridVerticalSpacing
+            ) {
+                ForEach(Array(cells.enumerated()), id: \.offset) { _, cell in
+                    cellContent(for: cell, totalRows: totalRows)
+                }
             }
         }
         // Registered here rather than on the root view so it exists wherever a
@@ -79,6 +83,19 @@ struct KeyboardGridView: View {
                 recorder: gestureTrail,
                 headWidth: GestureTrailOverlay.headWidth(for: metrics)
             )
+        }
+    }
+
+    /// Wraps the key grid in a `GlassEffectContainer` when the active theme
+    /// uses the glass material, so all keys share one sampling region on
+    /// iOS 26 (glass cannot sample other glass). Color themes (Classic, Dark
+    /// Gold) and older systems render the grid unwrapped, unchanged.
+    @ViewBuilder
+    private func glassWrapped(@ViewBuilder _ content: () -> some View) -> some View {
+        if theme.usesGlassMaterial, #available(iOS 26.0, *) {
+            GlassEffectContainer { content() }
+        } else {
+            content()
         }
     }
 

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -35,7 +35,12 @@ enum SettingsKey: String, CaseIterable {
     case pinnedLanguageId
     case autoCapitalizeEnabled
     case expertModeEnabled
+    /// Legacy style selection — only read by `ThemeStore.migrateIfNeeded`,
+    /// then removed.
     case keyboardStyle
+    case selectedThemeLight
+    case selectedThemeDark
+    case userThemes
     case keyboardFullAccess
     case cursorMovementStyle
     case hideLetters
@@ -340,12 +345,4 @@ enum NumpadStyle: String, CaseIterable {
 enum CursorMovementStyle: String, CaseIterable {
     case continuous // Joystick-style: drag distance controls cursor position
     case discrete // MessagEase-style: one swipe = one character, return-swipe = one word
-}
-
-// MARK: - Keyboard Style
-
-/// Visual style for the keyboard appearance
-enum KeyboardStyle: String, CaseIterable {
-    case classic // Traditional opaque key backgrounds
-    case liquidGlass // iOS 26+ Liquid Glass effect (renders as a simplified translucent style on older iOS)
 }

--- a/wurstfingerTests/KeyboardGridRenderingTests.swift
+++ b/wurstfingerTests/KeyboardGridRenderingTests.swift
@@ -221,7 +221,7 @@ struct KeyViewStyleTests {
     }
 
     /// The stock snapshot describes what an untouched installation renders:
-    /// nothing hidden, classic style, long-press numbers off. It is what keys
+    /// nothing hidden, long-press numbers off. It is what keys
     /// built without a store render with (tests, previews) *and* what
     /// `DataDrivenKeyboardRootView` seeds its `@AppStorage` wrappers with, so a
     /// silent change here would move both at once.
@@ -234,9 +234,8 @@ struct KeyViewStyleTests {
         #expect(stock.hideStandardSymbols == store.bool(forKey: SettingsKey.hideStandardSymbols.rawValue))
         #expect(stock.hideExtraSymbols == store.bool(forKey: SettingsKey.hideExtraSymbols.rawValue))
         #expect(stock.longPressNumbersEnabled == store.bool(forKey: SettingsKey.longPressNumbersEnabled.rawValue))
-        // No stored style either, so the enum default is what renders.
-        #expect(store.string(forKey: SettingsKey.keyboardStyle.rawValue) == nil)
-        #expect(stock.keyboardStyle == .classic)
+        // Colors are no longer part of the snapshot — they come from the
+        // theme environment. `ThemeResolverTests` covers their defaults.
     }
 
     // MARK: - Label sizing

--- a/wurstfingerTests/LocalizationCompletenessTests.swift
+++ b/wurstfingerTests/LocalizationCompletenessTests.swift
@@ -81,6 +81,11 @@ struct LocalizationCompletenessTests {
         var problems: [String] = []
 
         for (key, entry) in catalog.strings {
+            // Entries marked "shouldTranslate": false stay in the source
+            // language everywhere (e.g. proper names like "Dark Gold").
+            if entry["shouldTranslate"] as? Bool == false {
+                continue
+            }
             let localizations = entry["localizations"] as? [String: Any] ?? [:]
             let present = Set(localizations.keys)
 

--- a/wurstfingerTests/ThemeEngineTests.swift
+++ b/wurstfingerTests/ThemeEngineTests.swift
@@ -42,6 +42,20 @@ struct HexColorTests {
         let string = try #require(HexColor.string(from: HexColor.color(from: original)))
         #expect(HexColor.parse(string) == original)
     }
+
+    @Test func luminanceOrdersLightAndDark() {
+        #expect(HexColor.luminance(of: 0xFFFFFF) > 0.9)
+        #expect(HexColor.luminance(of: 0x000000) < 0.1)
+        // Dark Gold's key color is dark, so it earns a light border.
+        #expect(HexColor.luminance(of: 0x333A48) < 0.5)
+    }
+
+    @Test func scalingRoundsAndClamps() {
+        // Rounds (not truncates): this is exactly Dark Gold's board color.
+        #expect(HexColor.scaled(0x333A48, by: 0.725) == 0x252A34)
+        #expect(HexColor.scaled(0xFFFFFF, by: 2.0) == 0xFFFFFF)
+        #expect(HexColor.scaled(0x000000, by: 0.5) == 0x000000)
+    }
 }
 
 // MARK: - Codable Wire Format
@@ -108,7 +122,42 @@ struct BuiltInThemeTests {
         #expect(BuiltInThemes.classic.id == "classic")
         #expect(BuiltInThemes.liquidGlass.id == "liquid-glass")
         #expect(BuiltInThemes.darkGold.id == "dark-gold")
-        #expect(BuiltInThemes.all.count == 3)
+        #expect(BuiltInThemes.styles.count == 2)
+        #expect(BuiltInThemes.palettes.count == 16)
+        #expect(BuiltInThemes.all.count == 18)
+        // Dark Gold is palette 12 of the original set.
+        #expect(BuiltInThemes.palettes[12].id == "dark-gold")
+    }
+
+    /// Every palette has unique, parsable colors — a resolver fallback to a
+    /// Classic role (nil hex parse) must never happen for a built-in.
+    @Test func palettesHaveUniqueParsableColors() {
+        let ids = BuiltInThemes.palettes.map(\.id)
+        #expect(Set(ids).count == ids.count)
+        for palette in BuiltInThemes.palettes {
+            guard case .color = palette.keyFill else {
+                Issue.record("palette \(palette.id) keyFill is not a color")
+                continue
+            }
+            #expect(palette.mainLabel.resolvedColor() != nil, "palette \(palette.id) mainLabel")
+            #expect(palette.hintLetter.resolvedColor() != nil, "palette \(palette.id) hintLetter")
+        }
+    }
+
+    /// The palette conversion must reproduce the previously hand-written Dark
+    /// Gold definition byte-for-byte, so the on-device-approved look is stable.
+    @Test func darkGoldMatchesReferenceDefinition() {
+        let gold = BuiltInThemes.darkGold
+        #expect(gold.boardBackground == .color(.fixed(hex: "#252A34")))
+        #expect(gold.keyFill == .color(.fixed(hex: "#333A48")))
+        #expect(gold.keyFillActive == .color(.fixed(hex: "#4A5468")))
+        #expect(gold.keyBorder == .fixed(hex: "#FFFFFF1F"))
+        #expect(gold.mainLabel == .fixed(hex: "#D1AA05"))
+        #expect(gold.utilityLabel == .fixed(hex: "#FFFFFF"))
+        #expect(gold.hintLetter == .fixed(hex: "#FFFFFFE6"))
+        #expect(gold.hintSymbol == .fixed(hex: "#FFFFFFB3"))
+        #expect(gold.hintIconProminent == .fixed(hex: "#FFFFFF80"))
+        #expect(gold.hintIconSubtle == .fixed(hex: "#FFFFFF73"))
     }
 
     @Test func classicHasNoBorder() {

--- a/wurstfingerTests/ThemeEngineTests.swift
+++ b/wurstfingerTests/ThemeEngineTests.swift
@@ -42,16 +42,6 @@ struct HexColorTests {
         let string = try #require(HexColor.string(from: HexColor.color(from: original)))
         #expect(HexColor.parse(string) == original)
     }
-
-    @Test func luminanceOrdersLightAndDark() {
-        #expect(HexColor.luminance(of: 0xFFFFFF) > 0.9)
-        #expect(HexColor.luminance(of: 0x000000) < 0.1)
-    }
-
-    @Test func scalingDarkensAndClamps() {
-        #expect(HexColor.scaled(0xFFFFFF, by: 0.5) == 0x7F7F7F)
-        #expect(HexColor.scaled(0xFFFFFF, by: 2.0) == 0xFFFFFF)
-    }
 }
 
 // MARK: - Codable Wire Format

--- a/wurstfingerTests/ThemeEngineTests.swift
+++ b/wurstfingerTests/ThemeEngineTests.swift
@@ -1,0 +1,241 @@
+//
+//  ThemeEngineTests.swift
+//  WurstfingerTests
+//
+//  Covers hex parsing, theme codability (the future export wire format),
+//  built-in stability, resolver fallbacks, and the legacy-style migration.
+//
+
+import SwiftUI
+import Testing
+@testable import WurstfingerApp
+
+// MARK: - HexColor
+
+struct HexColorTests {
+    @Test func parsesSixDigitHex() {
+        #expect(HexColor.parse("#333A48") == .init(rgb: 0x333A48, alpha: 1))
+        #expect(HexColor.parse("d1aa05") == .init(rgb: 0xD1AA05, alpha: 1))
+    }
+
+    @Test func parsesEightDigitHexWithAlpha() throws {
+        let parsed = try #require(HexColor.parse("#FFFFFF80"))
+        #expect(parsed.rgb == 0xFFFFFF)
+        #expect(abs(parsed.alpha - 128.0 / 255.0) < 0.001)
+    }
+
+    @Test func rejectsInvalidHex() {
+        #expect(HexColor.parse("") == nil)
+        #expect(HexColor.parse("#12345") == nil)
+        #expect(HexColor.parse("#1234567") == nil)
+        #expect(HexColor.parse("#GGGGGG") == nil)
+        #expect(HexColor.parse("not a color") == nil)
+    }
+
+    @Test func formatsWithAlphaOnlyWhenBelowOne() {
+        #expect(HexColor.string(from: .init(rgb: 0x333A48, alpha: 1)) == "#333A48")
+        #expect(HexColor.string(from: .init(rgb: 0xFFFFFF, alpha: 0.5)) == "#FFFFFF80")
+    }
+
+    @Test func colorRoundTripsThroughHexString() throws {
+        let original = HexColor.Components(rgb: 0x333A48, alpha: 1)
+        let string = try #require(HexColor.string(from: HexColor.color(from: original)))
+        #expect(HexColor.parse(string) == original)
+    }
+
+    @Test func luminanceOrdersLightAndDark() {
+        #expect(HexColor.luminance(of: 0xFFFFFF) > 0.9)
+        #expect(HexColor.luminance(of: 0x000000) < 0.1)
+    }
+
+    @Test func scalingDarkensAndClamps() {
+        #expect(HexColor.scaled(0xFFFFFF, by: 0.5) == 0x7F7F7F)
+        #expect(HexColor.scaled(0xFFFFFF, by: 2.0) == 0xFFFFFF)
+    }
+}
+
+// MARK: - Codable Wire Format
+
+struct ThemeCodableTests {
+    private func roundTrip(_ definition: KeyboardThemeDefinition) throws -> KeyboardThemeDefinition {
+        let data = try JSONEncoder().encode(definition)
+        return try JSONDecoder().decode(KeyboardThemeDefinition.self, from: data)
+    }
+
+    @Test func builtInsRoundTripLosslessly() throws {
+        for theme in BuiltInThemes.all {
+            #expect(try roundTrip(theme) == theme)
+        }
+    }
+
+    @Test func adaptiveColorRoundTrips() throws {
+        var theme = BuiltInThemes.darkGold
+        theme.id = UUID().uuidString
+        theme.mainLabel = .adaptive(light: "#111111", dark: "#EEEEEE")
+        #expect(try roundTrip(theme) == theme)
+    }
+
+    @Test func missingFieldsDecodeToClassicDefaults() throws {
+        let json = Data(#"{"id": "abc", "name": "Sparse"}"#.utf8)
+        let decoded = try JSONDecoder().decode(KeyboardThemeDefinition.self, from: json)
+        #expect(decoded.keyFill == BuiltInThemes.classic.keyFill)
+        #expect(decoded.cornerRadius == BuiltInThemes.classic.cornerRadius)
+        #expect(decoded.keyBorder == nil)
+    }
+
+    @Test func archiveDecodingIsLossy() throws {
+        // One valid theme, one corrupt entry (id missing), one entry claiming
+        // a built-in id — only the valid one must survive.
+        let json = Data("""
+        {"schemaVersion": 1, "themes": [
+            {"id": "user-1", "name": "Mine"},
+            {"name": "Broken"},
+            {"id": "classic", "name": "Impostor"}
+        ]}
+        """.utf8)
+        let archive = try JSONDecoder().decode(ThemeStore.Archive.self, from: json)
+        #expect(archive.themes.map(\.id) == ["user-1"])
+    }
+
+    @Test func archiveEncodingIsStable() throws {
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-stable"
+        let archive = ThemeStore.Archive(schemaVersion: 1, themes: [theme])
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let first = try encoder.encode(archive)
+        let second = try encoder.encode(archive)
+        #expect(first == second)
+    }
+}
+
+// MARK: - Built-ins
+
+struct BuiltInThemeTests {
+    /// The ids are API: persisted selections and future export codes
+    /// reference them. Changing one silently resets users to Classic.
+    @Test func builtInIdsArePinned() {
+        #expect(BuiltInThemes.classic.id == "classic")
+        #expect(BuiltInThemes.liquidGlass.id == "liquid-glass")
+        #expect(BuiltInThemes.darkGold.id == "dark-gold")
+        #expect(BuiltInThemes.all.count == 3)
+    }
+
+    @Test func classicHasNoBorder() {
+        #expect(BuiltInThemes.classic.resolved().keyBorder == nil)
+    }
+
+    @Test func liquidGlassUsesMaterialKeys() {
+        let resolved = BuiltInThemes.liquidGlass.resolved()
+        #expect(resolved.keyFill == .material)
+        #expect(resolved.keyFillActive == .material)
+    }
+
+    @Test func darkGoldResolvesItsFixedPalette() throws {
+        let resolved = BuiltInThemes.darkGold.resolved()
+        #expect(resolved.mainLabel == HexColor.color(from: "#D1AA05"))
+        #expect(try resolved.keyFill == .color(#require(HexColor.color(from: "#333A48"))))
+    }
+}
+
+// MARK: - Resolver
+
+struct ThemeResolverTests {
+    @Test func unparsableHexFallsBackToClassicRole() {
+        var theme = BuiltInThemes.darkGold
+        theme.mainLabel = .fixed(hex: "garbage")
+        let resolved = theme.resolved()
+        #expect(resolved.mainLabel == BuiltInThemes.classic.resolved().mainLabel)
+    }
+
+    @Test func boardOpacityIsFloored() {
+        // A fully transparent board would drop touches between keys (#198),
+        // so the resolver clamps it to the minimum.
+        let floored = ThemeColor.fixed(hex: "#00000000")
+            .withMinimumOpacity(KeyboardThemeDefinition.minimumBoardOpacity)
+        guard case let .fixed(hex) = floored else {
+            Issue.record("expected fixed color, got \(floored)")
+            return
+        }
+        let components = HexColor.parse(hex)
+        #expect((components?.alpha ?? 0) >= KeyboardThemeDefinition.minimumBoardOpacity - 0.001)
+    }
+
+    @Test func boardOpacityFloorKeepsOpaqueColors() {
+        let untouched = ThemeColor.fixed(hex: "#252A34")
+            .withMinimumOpacity(KeyboardThemeDefinition.minimumBoardOpacity)
+        #expect(untouched == .fixed(hex: "#252A34"))
+    }
+
+    @Test func semanticOpacityIsFlooredToo() {
+        let floored = ThemeColor.semantic(.systemBackground, opacity: 0)
+            .withMinimumOpacity(0.02)
+        #expect(floored == .semantic(.systemBackground, opacity: 0.02))
+    }
+}
+
+// MARK: - Migration
+
+struct ThemeMigrationTests {
+    private func isolatedDefaults() throws -> UserDefaults {
+        let name = "theme-migration-tests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: name))
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
+    @Test func migratesLegacyStyles() throws {
+        let cases: [(legacy: String, expected: String)] = [
+            ("classic", "classic"),
+            ("liquidGlass", "liquid-glass"),
+            ("darkGold", "dark-gold"),
+            ("unknown-junk", "classic"),
+        ]
+        for testCase in cases {
+            let defaults = try isolatedDefaults()
+            defaults.set(testCase.legacy, forKey: SettingsKey.keyboardStyle.rawValue)
+            ThemeStore.migrateIfNeeded(defaults: defaults)
+            #expect(defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == testCase.expected)
+            #expect(defaults.string(forKey: SettingsKey.selectedThemeDark.rawValue) == testCase.expected)
+            #expect(defaults.string(forKey: SettingsKey.keyboardStyle.rawValue) == nil)
+        }
+    }
+
+    @Test func migrationIsIdempotent() throws {
+        let defaults = try isolatedDefaults()
+        defaults.set("liquidGlass", forKey: SettingsKey.keyboardStyle.rawValue)
+        ThemeStore.migrateIfNeeded(defaults: defaults)
+        // A second run (or a racing second process after the first finished)
+        // must not change anything — even if the user re-selected meanwhile.
+        defaults.set("classic", forKey: SettingsKey.selectedThemeLight.rawValue)
+        ThemeStore.migrateIfNeeded(defaults: defaults)
+        #expect(defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == "classic")
+    }
+
+    @Test func migrationWithoutLegacyKeyWritesNothing() throws {
+        let defaults = try isolatedDefaults()
+        ThemeStore.migrateIfNeeded(defaults: defaults)
+        #expect(defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == nil)
+    }
+
+    @Test func selectionFallsBackThroughCascade() throws {
+        let defaults = try isolatedDefaults()
+        // Dark slot points at a nonexistent theme → falls back to the light
+        // slot, then Classic.
+        defaults.set("dark-gold", forKey: SettingsKey.selectedThemeLight.rawValue)
+        defaults.set("deleted-user-theme", forKey: SettingsKey.selectedThemeDark.rawValue)
+        #expect(ThemeStore.selectedTheme(for: .dark, defaults: defaults).id == "dark-gold")
+        defaults.set("also-gone", forKey: SettingsKey.selectedThemeLight.rawValue)
+        #expect(ThemeStore.selectedTheme(for: .dark, defaults: defaults).id == "classic")
+    }
+
+    @Test func userThemesPersistThroughStore() throws {
+        let defaults = try isolatedDefaults()
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-abc"
+        theme.name = "My Theme"
+        ThemeStore.writeUserThemes([theme], defaults: defaults)
+        #expect(ThemeStore.userThemes(defaults: defaults) == [theme])
+        #expect(ThemeStore.theme(id: "user-abc", defaults: defaults) == theme)
+    }
+}


### PR DESCRIPTION
Second milestone of the theme engine (see `THEME_ENGINE_CONCEPT.md`), **stacked on #253 (M1)**. Makes the engine visible: the Style settings become a gallery, and the 16 color palettes ported from MessagEase ship as built-in themes.

> Base is `feature/theme-engine` (M1). Review/merge #253 first, then retarget this PR to `develop`.

## What's in M2a

**Palettes** (`wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift`)
- `paletteTheme()` converts a palette's four MessagEase channels (key/main/hint/pressed) into the ~12 theme roles: board = darkened key color, border = light/dark by key luminance, hint roles carry prominence as alpha (THEME_ENGINE_CONCEPT §3).
- Built-ins split into `styles` (Classic, Liquid Glass) and `palettes` (16 fixed-color themes, Black & Yellow … Espresso); `all = styles + palettes` (18).
- **Dark Gold is now palette 12**, built through the same converter — a test pins it byte-for-byte to the previous hand-written definition, so the on-device-approved look is unchanged. `HexColor.scaled` rounds (not truncates) so the board resolves to `#252A34` exactly.
- `HexColor.scaled` / `luminance` return (removed as dead code in M1, now have a real user).

**Gallery** (`wurstfinger/StyleSettingsView.swift`)
- Styles as descriptive cards (unchanged), palettes as a swatch grid. `ThemeSwatch` draws from each theme's *resolved* colors — no hex-parsing duplication.
- Tap selects (both slots, until M2b adds separate light/dark assignment). No edit/duplicate affordances (that's M3).

**Localization**: two new section headers (Styles / Color Themes) in 12 languages; palette names are proper names, shown verbatim.

## Verification
- Palette conversion, unique+pinned ids (`all.count == 18`), the Dark Gold byte match, and `scaled`/`luminance` rounding are unit-tested. Full `WurstfingerTests` green (serial).
- Gallery verified in the simulator: all 16 swatches render with correct colors, styles as cards, Dark Gold at palette 12.

## Next
- **M2b**: separate light/dark slots (toggle + segmented control + preview sun/moon switch), stacked on this.