### PR TITLE
Separate Light/Dark Theme Slots (M2b)

### DIFF
--- a/wurstfinger/InteractiveKeyboardPreview.swift
+++ b/wurstfinger/InteractiveKeyboardPreview.swift
@@ -47,17 +47,25 @@ struct InteractiveKeyboardPreview: View {
     @Binding var width: Double
     @Binding var position: Double
 
+    /// Forces the keyboard preview into a specific appearance (so the theme
+    /// gallery can preview the light or dark slot regardless of the device
+    /// setting). `nil` follows the system.
+    var appearanceOverride: ColorScheme?
+
     @StateObject private var previewViewModel = KeyboardViewModel(shouldPersistSettings: false)
     @StateObject private var previewTarget = PreviewTextTarget()
+    @Environment(\.colorScheme) private var systemColorScheme
 
     init(
         aspectRatio: Binding<Double> = .constant(1.0),
         width: Binding<Double> = .constant(DeviceLayoutUtils.defaultKeyboardWidth),
-        position: Binding<Double> = .constant(0.5)
+        position: Binding<Double> = .constant(0.5),
+        appearanceOverride: ColorScheme? = nil
     ) {
         _aspectRatio = aspectRatio
         _width = width
         _position = position
+        self.appearanceOverride = appearanceOverride
     }
 
     private var previewHeight: CGFloat {
@@ -134,6 +142,9 @@ struct InteractiveKeyboardPreview: View {
             }
             .frame(height: previewHeight)
             .clipShape(RoundedRectangle(cornerRadius: 12))
+            // Preview the chosen slot's appearance (light/dark) independent of
+            // the device; the keyboard resolves its theme from this colorScheme.
+            .environment(\.colorScheme, appearanceOverride ?? systemColorScheme)
             .animation(.easeInOut(duration: 0.2), value: aspectRatio)
             .animation(.easeInOut(duration: 0.2), value: width)
             .animation(.easeInOut(duration: 0.2), value: position)

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -4904,6 +4904,66 @@
             "state": "translated",
             "value": "Madilim"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوضع الداكن"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σκοτεινή λειτουργία"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حالت تیره"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डार्क मोड"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダークモード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다크 모드"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escuro"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โหมดมืด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Темний режим"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈارک موڈ"
+          }
         }
       }
     },
@@ -6361,6 +6421,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "I-edit ang hitsura"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المظهر قيد التحرير"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επεξεργασία εμφάνισης"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ظاهر در حال ویرایش"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "दिखावट एडिट करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編集中の外観"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집 중인 외관"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar aspeto"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รูปลักษณ์ที่กำลังแก้ไข"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Редагований вигляд"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زیرِ ترمیم ظاہری شکل"
           }
         }
       }
@@ -10302,6 +10422,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Maliwanag"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوضع الفاتح"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Φωτεινή λειτουργία"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حالت روشن"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लाइट मोड"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライトモード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "라이트 모드"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claro"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โหมดสว่าง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Світлий режим"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لائٹ موڈ"
           }
         }
       }
@@ -17970,6 +18150,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gumamit ng ibang tema sa Dark Mode"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استخدام سمة مختلفة في الوضع الداكن"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Χρήση διαφορετικού θέματος στη σκοτεινή λειτουργία"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استفاده از پوستهٔ متفاوت در حالت تیره"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डार्क मोड में अलग थीम इस्तेमाल करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダークモードでは別のテーマを使う"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다크 모드에서 다른 테마 사용"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar um tema diferente no modo escuro"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ใช้ธีมอื่นในโหมดมืด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Окрема тема для темного режиму"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ڈارک موڈ میں مختلف تھیم استعمال کریں"
           }
         }
       }

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -4829,6 +4829,84 @@
         }
       }
     },
+    "Dark Mode": {
+      "comment": "Theme gallery: segment selecting the dark-appearance theme slot",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dunkel"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sombre"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oscuro"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scuro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмный"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemny"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mörkt"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tumma"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamno"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "כהה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tối"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Madilim"
+          }
+        }
+      }
+    },
     "Dark keys with golden letters": {
       "comment": "Keyboard theme description: dark-gold",
       "extractionState": "manual",
@@ -6208,6 +6286,84 @@
         }
       },
       "comment": "Toggle subtitle explaining the gesture trail"
+    },
+    "Editing appearance": {
+      "comment": "Theme gallery: accessibility label for the light/dark slot picker",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erscheinungsbild bearbeiten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier l’apparence"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar apariencia"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica aspetto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Редактирование оформления"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edytuj wygląd"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redigera utseende"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muokkaa ulkoasua"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uredi izgled"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "עריכת מראה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chỉnh sửa giao diện"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-edit ang hitsura"
+          }
+        }
+      }
     },
     "Enable %@": {
       "extractionState": "manual",
@@ -10071,6 +10227,84 @@
         }
       },
       "comment": "Haptic intensity level name"
+    },
+    "Light Mode": {
+      "comment": "Theme gallery: segment selecting the light-appearance theme slot",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hell"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clair"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claro"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiaro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Светлый"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jasny"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ljust"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vaalea"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Svijetlo"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "בהיר"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sáng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maliwanag"
+          }
+        }
+      }
     },
     "Liquid Glass": {
       "extractionState": "manual",
@@ -17661,6 +17895,84 @@
         }
       },
       "comment": "Toggle subtitle: explains double-space to period"
+    },
+    "Use a different theme in Dark Mode": {
+      "comment": "Theme gallery: toggle to assign a separate theme for Dark Mode",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Dunkelmodus anderes Theme verwenden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utiliser un thème différent en mode sombre"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar un tema diferente en modo oscuro"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usa un tema diverso in modalità scura"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Другая тема в тёмном режиме"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Użyj innego motywu w trybie ciemnym"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Använd ett annat tema i mörkt läge"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Käytä eri teemaa tummassa tilassa"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koristi drugu temu u tamnom načinu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "השתמש בערכת נושא שונה במצב כהה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dùng chủ đề khác ở chế độ tối"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gumamit ng ibang tema sa Dark Mode"
+          }
+        }
+      }
     },
     "Utility Keys on Left": {
       "extractionState": "manual",

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -14,6 +14,13 @@ struct StyleSettingsView: View {
     @AppStorage(SettingsKey.selectedThemeDark.rawValue, store: SharedDefaults.store)
     private var selectedThemeDark = BuiltInThemes.classic.id
 
+    @AppStorage(SettingsKey.themeSeparateDarkSlot.rawValue, store: SharedDefaults.store)
+    private var separateDarkSlot = false
+
+    /// Which slot the gallery currently edits and previews. Only meaningful
+    /// while `separateDarkSlot` is on; otherwise selection writes both slots.
+    @State private var editingAppearance: ColorScheme = .light
+
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var previewAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 
@@ -26,14 +33,28 @@ struct StyleSettingsView: View {
     /// Grid columns for the color-palette swatches.
     private let paletteColumns = [GridItem(.adaptive(minimum: 64), spacing: 10)]
 
+    /// The theme id the gallery currently reflects: the dark slot while editing
+    /// dark mode, otherwise the light slot (which both slots share when the
+    /// separate-dark-slot toggle is off).
+    private var activeThemeId: String {
+        separateDarkSlot && editingAppearance == .dark ? selectedThemeDark : selectedThemeLight
+    }
+
     var body: some View {
         VStack(spacing: 20) {
-            // Keyboard Preview
-            InteractiveKeyboardPreview(aspectRatio: $previewAspectRatio, width: $previewWidth, position: $previewPosition)
-                .padding(.horizontal, 16)
+            // Keyboard Preview — forced into the edited appearance so the dark
+            // slot can be previewed on a light device (and vice versa).
+            InteractiveKeyboardPreview(
+                aspectRatio: $previewAspectRatio,
+                width: $previewWidth,
+                position: $previewPosition,
+                appearanceOverride: separateDarkSlot ? editingAppearance : nil
+            )
+            .padding(.horizontal, 16)
 
             ScrollView {
                 VStack(spacing: 24) {
+                    appearanceSection
                     stylesSection
                     palettesSection
                 }
@@ -43,6 +64,31 @@ struct StyleSettingsView: View {
         .padding(.vertical, 20)
         .navigationTitle("Style")
         .navigationBarTitleDisplayMode(.inline)
+    }
+
+    /// Toggle for assigning a separate dark-mode theme, plus the light/dark
+    /// segment that picks which slot the gallery edits.
+    private var appearanceSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Toggle("Use a different theme in Dark Mode", isOn: $separateDarkSlot)
+                .padding(.horizontal, 16)
+                .onChange(of: separateDarkSlot) { _, isOn in
+                    if !isOn {
+                        // Collapse back to one selection.
+                        selectedThemeDark = selectedThemeLight
+                        editingAppearance = .light
+                    }
+                }
+
+            if separateDarkSlot {
+                Picker("Editing appearance", selection: $editingAppearance) {
+                    Label("Light Mode", systemImage: "sun.max").tag(ColorScheme.light)
+                    Label("Dark Mode", systemImage: "moon").tag(ColorScheme.dark)
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal, 16)
+            }
+        }
     }
 
     /// Adaptive/material styles (Classic, Liquid Glass) as descriptive cards.
@@ -56,7 +102,7 @@ struct StyleSettingsView: View {
                 themeOption(theme)
             }
 
-            if selectedThemeLight == BuiltInThemes.liquidGlass.id {
+            if activeThemeId == BuiltInThemes.liquidGlass.id {
                 if #unavailable(iOS 26.0) {
                     Text("Liquid Glass is designed for iOS 26 and later. On earlier versions a simplified translucent style is used.")
                         .font(.caption)
@@ -79,7 +125,7 @@ struct StyleSettingsView: View {
                     Button {
                         select(theme)
                     } label: {
-                        ThemeSwatch(theme: theme, isSelected: selectedThemeLight == theme.id)
+                        ThemeSwatch(theme: theme, isSelected: activeThemeId == theme.id)
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(theme.displayName)
@@ -89,11 +135,19 @@ struct StyleSettingsView: View {
         }
     }
 
-    /// Both appearance slots follow one selection until the gallery gains its
-    /// separate light/dark assignment (milestone M2b).
+    /// Assigns the theme to the slot being edited. With the separate-dark-slot
+    /// toggle off, both slots follow one selection.
     private func select(_ theme: KeyboardThemeDefinition) {
-        selectedThemeLight = theme.id
-        selectedThemeDark = theme.id
+        if separateDarkSlot {
+            if editingAppearance == .dark {
+                selectedThemeDark = theme.id
+            } else {
+                selectedThemeLight = theme.id
+            }
+        } else {
+            selectedThemeLight = theme.id
+            selectedThemeDark = theme.id
+        }
     }
 
     private func themeOption(_ theme: KeyboardThemeDefinition) -> some View {
@@ -115,7 +169,7 @@ struct StyleSettingsView: View {
 
                 Spacer()
 
-                if selectedThemeLight == theme.id {
+                if activeThemeId == theme.id {
                     Image(systemName: "checkmark")
                         .foregroundColor(.accentColor)
                         .fontWeight(.semibold)
@@ -125,7 +179,7 @@ struct StyleSettingsView: View {
             .padding(.vertical, 12)
             .background(
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(selectedThemeLight == theme.id ? Color.accentColor.opacity(0.1) : Color.clear)
+                    .fill(activeThemeId == theme.id ? Color.accentColor.opacity(0.1) : Color.clear)
             )
         }
         .buttonStyle(.plain)

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -40,6 +40,10 @@ enum SettingsKey: String, CaseIterable {
     case keyboardStyle
     case selectedThemeLight
     case selectedThemeDark
+    /// Whether the user assigns a separate theme for dark mode. Settings-UI
+    /// only: the keyboard always resolves per-slot; this just governs whether
+    /// the two slots are edited together or independently.
+    case themeSeparateDarkSlot
     case userThemes
     case keyboardFullAccess
     case cursorMovementStyle


### PR DESCRIPTION
## Summary

Milestone **M2b** of the theme engine: assign a **separate theme for Dark Mode**.

Stacked on #255 (M2a). Part of the theme-engine chain #253 → #255 → this.

## What changed

- **Appearance toggle** — "Use a different theme in Dark Mode" in the Style gallery. Off (default) keeps the previous behavior: one selection writes both slots.
- **Light/Dark segmented control** — when the toggle is on, picks which appearance slot the gallery edits. Selection writes the active slot only; the checkmark/accent-border and swatch selection reflect that slot.
- **Slot-aware preview** — the preview is forced into the edited appearance (`.environment(\.colorScheme, …)`), so the Dark slot can be previewed on a Light device and vice versa.
- **Settings key** — adds `themeSeparateDarkSlot` (settings-UI only; the keyboard already resolves per-slot via the existing `ThemeStore` cascade).
- **Localization** — new toggle, the Hell/Dunkel segments, and the picker accessibility label in all 12 languages. The segment keys are `Light Mode`/`Dark Mode` on purpose, so they don't collide with the existing haptic-strength `Light` → *Leicht* string.

## Verification

- `WurstfingerTests` green, run serially (960 passed), incl. the "every string is fully translated" catalog test.
- SwiftFormat + SwiftLint clean.
- Simulator self-check: toggle reveals the segments (localized **Hell** / **Dunkel**), preview switches appearance independent of the device, and the two slots stay independent (Light = Classic while Dark = Liquid Glass).

## Notes for reviewers

- Base is `feature/theme-engine-m2a`; **retarget to `develop` before squash-merging the chain**.
