### PR TITLE
Theme Editor + User Themes (M3)

### DIFF
--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -352,6 +352,66 @@
             "state": "translated",
             "value": "%@ Kopya"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخة من %@"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ αντίγραφο"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کپی"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ कॉपी"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@のコピー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 복사본"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ cópia"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ สำเนา"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (копія)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کی کاپی"
+          }
         }
       }
     },
@@ -429,6 +489,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ Kopya %lld"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخة %2$lld من %1$@"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ αντίγραφο %lld"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کپی %lld"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ कॉपी %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@のコピー %lld"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 복사본 %lld"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ cópia %lld"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ สำเนา %lld"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (копія %lld)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کی کاپی %lld"
           }
         }
       }
@@ -2440,6 +2560,66 @@
             "state": "translated",
             "value": "Kulay ng border"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لون الحد"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Χρώμα περιγράμματος"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رنگ حاشیه"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बॉर्डर का रंग"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "枠線の色"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테두리 색상"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cor do contorno"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สีเส้นขอบ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Колір рамки"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بارڈر کا رنگ"
+          }
         }
       }
     },
@@ -2518,6 +2698,66 @@
             "state": "translated",
             "value": "Lapad ng border"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عرض الحد"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πάχος περιγράμματος"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ضخامت حاشیه"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बॉर्डर की चौड़ाई"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "枠線の太さ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테두리 두께"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Espessura do contorno"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ความหนาเส้นขอบ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Товщина рамки"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بارڈر کی چوڑائی"
+          }
         }
       }
     },
@@ -2595,6 +2835,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kanselahin"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إلغاء"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Άκυρο"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لغو"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रद्द करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ยกเลิก"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скасувати"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "منسوخ کریں"
           }
         }
       }
@@ -4190,6 +4490,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Radius ng sulok"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نصف قطر الزوايا"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Στρογγύλεμα γωνιών"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شعاع گوشه"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कॉर्नर रेडियस"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "角の丸み"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모서리 둥글기"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raio dos cantos"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ความโค้งมุม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Радіус заокруглення"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کونے کی گولائی"
           }
         }
       }
@@ -5924,6 +6284,66 @@
             "state": "translated",
             "value": "Tanggalin ang tema"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف السمة"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διαγραφή θέματος"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف پوسته"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "थीम हटाएँ"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テーマを削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테마 삭제"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar tema"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลบธีม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити тему"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تھیم حذف کریں"
+          }
         }
       }
     },
@@ -6001,6 +6421,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tanggalin ang temang ito?"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "هل تريد حذف هذه السمة؟"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διαγραφή αυτού του θέματος;"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "این پوسته حذف شود؟"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "यह थीम हटाएँ?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このテーマを削除しますか？"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 테마를 삭제하시겠습니까?"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar este tema?"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ลบธีมนี้หรือไม่"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалити цю тему?"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کیا یہ تھیم حذف کریں؟"
           }
         }
       }
@@ -7046,6 +7526,66 @@
             "state": "translated",
             "value": "I-duplicate"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تكرار"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διπλότυπο"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تکثیر"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "डुप्लिकेट करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복제"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplicar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ทำสำเนา"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дублювати"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کاپی بنائیں"
+          }
         }
       }
     },
@@ -7124,6 +7664,66 @@
             "state": "translated",
             "value": "I-edit"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحرير"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επεξεργασία"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ویرایش"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "एडिट करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編集"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แก้ไข"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Редагувати"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ترمیم"
+          }
         }
       }
     },
@@ -7201,6 +7801,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "I-edit ang tema"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحرير السمة"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επεξεργασία θέματος"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ویرایش پوسته"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "थीम एडिट करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テーマを編集"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테마 편집"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar tema"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แก้ไขธีม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Редагувати тему"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تھیم میں ترمیم"
           }
         }
       }
@@ -8107,6 +8767,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Label ng function"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التسمية الوظيفية"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ετικέτα λειτουργίας"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برچسب کلید کاربردی"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "फ़ंक्शन लेबल"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "機能キーの文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기능 키 글자"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiqueta de função"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ป้ายกำกับฟังก์ชัน"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Службовий підпис"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فنکشن لیبل"
           }
         }
       }
@@ -9703,6 +10423,66 @@
             "state": "translated",
             "value": "Titik ng hint"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرف التلميح"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Γράμμα υπόδειξης"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرف راهنما"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हिंट अक्षर"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヒントの文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "힌트 글자"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letra de indicação"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวอักษรคำใบ้"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Літера-підказка"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہنٹ حرف"
+          }
         }
       }
     },
@@ -9780,6 +10560,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Simbolo ng hint"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رمز التلميح"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σύμβολο υπόδειξης"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نماد راهنما"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हिंट सिंबल"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヒントの記号"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "힌트 기호"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Símbolo de indicação"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สัญลักษณ์คำใบ้"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Символ-підказка"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہنٹ علامت"
           }
         }
       }
@@ -10549,6 +11389,66 @@
             "state": "translated",
             "value": "Key"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المفتاح"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πλήκτρο"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلید"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कुंजी"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tecla"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่ม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавіша"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی"
+          }
         }
       }
     },
@@ -10626,6 +11526,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Key (pinindot)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "المفتاح (مضغوط)"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πλήκτρο (πατημένο)"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلید (فشرده)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कुंजी (दबी हुई)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キー（押下時）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키(누른 상태)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tecla (premida)"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปุ่ม (ขณะกด)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавіша (натиснута)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی (دبی ہوئی)"
           }
         }
       }
@@ -10843,6 +11803,66 @@
             "state": "translated",
             "value": "Border ng key"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حد المفتاح"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Περίγραμμα πλήκτρου"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حاشیهٔ کلید"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कुंजी का बॉर्डर"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーの枠線"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키 테두리"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contorno da tecla"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เส้นขอบปุ่ม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Рамка клавіші"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی کا بارڈر"
+          }
         }
       }
     },
@@ -11059,6 +12079,66 @@
             "state": "translated",
             "value": "Background ng keyboard"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خلفية لوحة المفاتيح"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Φόντο πληκτρολογίου"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پس‌زمینهٔ صفحه‌کلید"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कीबोर्ड बैकग्राउंड"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードの背景"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키보드 배경"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fundo do teclado"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พื้นหลังคีย์บอร์ด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тло клавіатури"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کی بورڈ کا پس منظر"
+          }
         }
       }
     },
@@ -11274,6 +12354,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mga Label"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "التسميات"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ετικέτες"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برچسب‌ها"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "लेबल"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ラベル"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "레이블"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiquetas"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ป้ายกำกับ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підписи"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لیبل"
           }
         }
       }
@@ -12319,6 +13459,66 @@
             "state": "translated",
             "value": "Pangunahing titik"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الحرف الرئيسي"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κύριο γράμμα"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرف اصلی"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मुख्य अक्षर"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メインの文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 글자"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letra principal"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวอักษรหลัก"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Основна літера"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مرکزی حرف"
+          }
         }
       }
     },
@@ -12949,6 +14149,66 @@
             "state": "translated",
             "value": "Aking mga tema"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سماتي"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τα θέματά μου"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "پوسته‌های من"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मेरी थीम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マイテーマ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "나의 테마"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os meus temas"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ธีมของฉัน"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мої теми"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "میری تھیمز"
+          }
         }
       }
     },
@@ -13026,6 +14286,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pangalan"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الاسم"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Όνομα"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نام"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नाम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名前"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이름"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ชื่อ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назва"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نام"
           }
         }
       }
@@ -14899,6 +16219,66 @@
             "state": "translated",
             "value": "Prominenteng icon"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أيقونة بارزة"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Έντονο εικονίδιο"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آیکون برجسته"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "प्रमुख आइकन"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目立つアイコン"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "강조 아이콘"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ícone destacado"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไอคอนเด่น"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помітний значок"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نمایاں آئیکن"
+          }
         }
       }
     },
@@ -15252,6 +16632,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "I-save"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حفظ"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αποθήκευση"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ذخیره"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेव करें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "บันทึก"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зберегти"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "محفوظ کریں"
           }
         }
       }
@@ -17539,6 +18979,66 @@
             "state": "translated",
             "value": "Banayad na icon"
           }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أيقونة خافتة"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Διακριτικό εικονίδιο"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آیکون کم‌رنگ"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हल्का आइकन"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控えめなアイコン"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연한 아이콘"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ícone discreto"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไอคอนจาง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приглушений значок"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ہلکا آئیکن"
+          }
         }
       }
     },
@@ -17616,6 +19116,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mga Ibabaw"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الأسطح"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επιφάνειες"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سطوح"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सतहें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーと背景"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키와 배경"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superfícies"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พื้นผิว"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхні"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سطحیں"
           }
         }
       }
@@ -19350,6 +20910,66 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pangalan ng tema"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اسم السمة"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Όνομα θέματος"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نام پوسته"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "थीम का नाम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テーマ名"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테마 이름"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome do tema"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ชื่อธีม"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назва теми"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تھیم کا نام"
           }
         }
       }

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -277,6 +277,162 @@
       },
       "comment": "Languages summary: first language + count of remaining"
     },
+    "%@ Copy": {
+      "comment": "Theme editor: default name for a duplicated theme (base name + Copy)",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopie"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copie"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ копия"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopia"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopia"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopio"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopija"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ עותק"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ bản sao"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopya"
+          }
+        }
+      }
+    },
+    "%@ Copy %lld": {
+      "comment": "Theme editor: duplicated theme name disambiguated with a number",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopie %lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copie %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia %lld"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia %lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ копия %lld"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopia %lld"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopia %lld"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopio %lld"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopija %lld"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ עותק %lld"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ bản sao %lld"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopya %lld"
+          }
+        }
+      }
+    },
     "About": {
       "extractionState": "manual",
       "localizations": {
@@ -2209,6 +2365,240 @@
       },
       "comment": "Toggle title"
     },
+    "Border color": {
+      "comment": "Theme editor: key border color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rahmenfarbe"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couleur de bordure"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color del borde"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colore del bordo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цвет границы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kolor obramowania"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kantfärg"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reunuksen väri"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Boja ruba"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "צבע מסגרת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Màu viền"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kulay ng border"
+          }
+        }
+      }
+    },
+    "Border width": {
+      "comment": "Theme editor: key border width",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rahmenbreite"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Épaisseur de bordure"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ancho del borde"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spessore del bordo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Толщина границы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Szerokość obramowania"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kantbredd"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reunuksen leveys"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Širina ruba"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "רוחב מסגרת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Độ rộng viền"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lapad ng border"
+          }
+        }
+      }
+    },
+    "Cancel": {
+      "comment": "Theme editor: cancel button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuler"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulla"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмена"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anuluj"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avbryt"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Peruuta"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odustani"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ביטול"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hủy"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kanselahin"
+          }
+        }
+      }
+    },
     "Cannot Disable": {
       "extractionState": "manual",
       "localizations": {
@@ -3725,6 +4115,84 @@
         }
       },
       "comment": "ACCESSIBILITY label for the copy gesture (VoiceOver)"
+    },
+    "Corner radius": {
+      "comment": "Theme editor: key corner radius",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eckenradius"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rayon des coins"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radio de esquina"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raggio degli angoli"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Радиус скругления"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Promień narożnika"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hörnradie"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kulman pyöristys"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radijus kuta"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "רדיוס פינה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bán kính góc"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radius ng sulok"
+          }
+        }
+      }
     },
     "Current: %@:1": {
       "extractionState": "manual",
@@ -5381,6 +5849,162 @@
       },
       "comment": "ACCESSIBILITY label for the delete/backspace key (VoiceOver)"
     },
+    "Delete Theme": {
+      "comment": "Theme editor: delete button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme löschen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer le thème"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar tema"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimina tema"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить тему"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń motyw"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radera tema"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poista teema"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izbriši temu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מחק ערכת נושא"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa chủ đề"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tanggalin ang tema"
+          }
+        }
+      }
+    },
+    "Delete this theme?": {
+      "comment": "Theme editor: delete confirmation title",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Theme löschen?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer ce thème ?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Eliminar este tema?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminare questo tema?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить эту тему?"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usunąć ten motyw?"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radera detta tema?"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poistetaanko tämä teema?"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izbrisati ovu temu?"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "למחוק ערכת נושא זו?"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa chủ đề này?"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tanggalin ang temang ito?"
+          }
+        }
+      }
+    },
     "Disable %@": {
       "extractionState": "manual",
       "localizations": {
@@ -6347,6 +6971,240 @@
       },
       "comment": "Toggle subtitle explaining the gesture trail"
     },
+    "Duplicate": {
+      "comment": "Theme gallery: context menu action to copy a theme",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplizieren"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dupliquer"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplicar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplica"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дублировать"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplikuj"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplicera"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Monista"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dupliciraj"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שכפל"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhân bản"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-duplicate"
+          }
+        }
+      }
+    },
+    "Edit": {
+      "comment": "Theme gallery: context menu action to edit a user theme",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bearbeiten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменить"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edytuj"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redigera"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muokkaa"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uredi"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "עריכה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chỉnh sửa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-edit"
+          }
+        }
+      }
+    },
+    "Edit Theme": {
+      "comment": "Theme editor: navigation title",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme bearbeiten"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifier le thème"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Editar tema"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifica tema"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Редактировать тему"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edytuj motyw"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redigera tema"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muokkaa teemaa"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uredi temu"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "עריכת ערכת נושא"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chỉnh sửa chủ đề"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-edit ang tema"
+          }
+        }
+      }
+    },
     "Editing appearance": {
       "comment": "Theme gallery: accessibility label for the light/dark slot picker",
       "extractionState": "manual",
@@ -7174,6 +8032,84 @@
         }
       },
       "comment": "Settings section header (covers haptic feedback)"
+    },
+    "Function label": {
+      "comment": "Theme editor: function/utility label color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funktionsbeschriftung"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Étiquette de fonction"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiqueta de función"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etichetta funzione"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подпись функции"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etykieta funkcji"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funktionsetikett"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toimintomerkintä"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oznaka funkcije"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תווית פונקציה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhãn chức năng"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Label ng function"
+          }
+        }
+      }
     },
     "General": {
       "extractionState": "manual",
@@ -8692,6 +9628,162 @@
       },
       "comment": "Label visibility subtitle; %@ is a list like 'letters, extra symbols'"
     },
+    "Hint letter": {
+      "comment": "Theme editor: hint letter color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinweis-Buchstabe"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettre d’indice"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letra de sugerencia"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettera suggerimento"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Буква подсказки"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Litera podpowiedzi"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipsbokstav"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vihjekirjain"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slovo natuknice"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אות רמז"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chữ gợi ý"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Titik ng hint"
+          }
+        }
+      }
+    },
+    "Hint symbol": {
+      "comment": "Theme editor: hint symbol color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hinweis-Symbol"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbole d’indice"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Símbolo de sugerencia"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simbolo suggerimento"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Символ подсказки"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol podpowiedzi"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipssymbol"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vihjesymboli"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simbol natuknice"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סמל רמז"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ký hiệu gợi ý"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simbolo ng hint"
+          }
+        }
+      }
+    },
     "Hold a letter key to type its digit": {
       "extractionState": "manual",
       "localizations": {
@@ -9382,6 +10474,162 @@
       },
       "comment": "Link to the GitHub issue tracker (report bugs)"
     },
+    "Key": {
+      "comment": "Theme editor: key fill color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taste"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touche"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tecla"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавиша"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klawisz"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangent"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäin"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipka"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקש"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Key"
+          }
+        }
+      }
+    },
+    "Key (pressed)": {
+      "comment": "Theme editor: pressed key fill color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taste (gedrückt)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Touche (enfoncée)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tecla (pulsada)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tasto (premuto)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Клавиша (нажата)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klawisz (naciśnięty)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangent (nedtryckt)"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäin (painettuna)"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tipka (pritisnuta)"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מקש (לחוץ)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím (đang nhấn)"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Key (pinindot)"
+          }
+        }
+      }
+    },
     "Key Aspect Ratio": {
       "extractionState": "manual",
       "localizations": {
@@ -9519,6 +10767,84 @@
         }
       },
       "comment": "Settings row / title: width-to-height ratio of keys"
+    },
+    "Key border": {
+      "comment": "Theme editor: toggle to show a key border",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastenrahmen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bordure de touche"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borde de tecla"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bordo del tasto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Граница клавиши"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obramowanie klawisza"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangentkant"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäimen reunus"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rub tipke"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מסגרת מקש"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Viền phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Border ng key"
+          }
+        }
+      }
     },
     "Keyboard Size": {
       "extractionState": "manual",
@@ -9658,6 +10984,84 @@
       },
       "comment": "Slider title: overall keyboard size"
     },
+    "Keyboard background": {
+      "comment": "Theme editor: board background color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tastatur-Hintergrund"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrière-plan du clavier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fondo del teclado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sfondo della tastiera"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Фон клавиатуры"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tło klawiatury"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tangentbordsbakgrund"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Näppäimistön tausta"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pozadina tipkovnice"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "רקע המקלדת"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nền bàn phím"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Background ng keyboard"
+          }
+        }
+      }
+    },
     "Label Visibility": {
       "extractionState": "manual",
       "localizations": {
@@ -9795,6 +11199,84 @@
         }
       },
       "comment": "Settings row title"
+    },
+    "Labels": {
+      "comment": "Theme editor: section header for label colors",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beschriftungen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Étiquettes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiquetas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etichette"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Надписи"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etykiety"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiketter"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Merkinnät"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oznake"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "תוויות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhãn"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Label"
+          }
+        }
+      }
     },
     "Languages": {
       "extractionState": "manual",
@@ -10762,6 +12244,84 @@
       },
       "comment": "Note shown on pre-iOS-26 devices; 'Liquid Glass' is a style name (keep)"
     },
+    "Main letter": {
+      "comment": "Theme editor: main label color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hauptbuchstabe"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettre principale"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letra principal"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettera principale"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Основная буква"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Główna litera"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Huvudbokstav"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pääkirjain"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Glavno slovo"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אות ראשית"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chữ cái chính"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pangunahing titik"
+          }
+        }
+      }
+    },
     "Max": {
       "extractionState": "manual",
       "localizations": {
@@ -11313,6 +12873,162 @@
         }
       },
       "comment": "Haptic intensity level name"
+    },
+    "My Themes": {
+      "comment": "Theme gallery: section header for user-created themes",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meine Themes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mes thèmes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mis temas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I miei temi"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мои темы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moje motywy"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mina teman"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omat teemat"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moje teme"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ערכות הנושא שלי"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chủ đề của tôi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aking mga tema"
+          }
+        }
+      }
+    },
+    "Name": {
+      "comment": "Theme editor: name field section header",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Имя"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nazwa"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Namn"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nimi"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naziv"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שם"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tên"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pangalan"
+          }
+        }
+      }
     },
     "New line": {
       "extractionState": "manual",
@@ -13108,6 +14824,84 @@
       },
       "comment": "Header above the interactive keyboard preview"
     },
+    "Prominent icon": {
+      "comment": "Theme editor: prominent icon hint color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Betontes Symbol"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icône proéminente"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icono destacado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icona in evidenza"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Заметный значок"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyróżniona ikona"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Framträdande ikon"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korostettu kuvake"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Istaknuta ikona"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סמל בולט"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biểu tượng nổi bật"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prominenteng icon"
+          }
+        }
+      }
+    },
     "Reset": {
       "extractionState": "manual",
       "localizations": {
@@ -13383,6 +15177,84 @@
         }
       },
       "comment": "Slider label: right position"
+    },
+    "Save": {
+      "comment": "Theme editor: save button",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sichern"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salva"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранить"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zapisz"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spara"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tallenna"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spremi"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שמור"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lưu"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I-save"
+          }
+        }
+      }
     },
     "Scale: %@, Position: %@": {
       "extractionState": "manual",
@@ -15592,6 +17464,162 @@
         }
       }
     },
+    "Subtle icon": {
+      "comment": "Theme editor: subtle icon hint color",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dezentes Symbol"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icône discrète"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icono sutil"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icona discreta"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неброский значок"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Subtelna ikona"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diskret ikon"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hillitty kuvake"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suptilna ikona"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סמל עדין"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biểu tượng tinh tế"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Banayad na icon"
+          }
+        }
+      }
+    },
+    "Surfaces": {
+      "comment": "Theme editor: section header for surface fills",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flächen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surfaces"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superficies"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superfici"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхности"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Powierzchnie"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ytor"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pinnat"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Površine"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "משטחים"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bề mặt"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Ibabaw"
+          }
+        }
+      }
+    },
     "Swipe per character, return-swipe per word": {
       "extractionState": "manual",
       "localizations": {
@@ -17247,6 +19275,84 @@
         }
       },
       "comment": "Playful app tagline/slogan"
+    },
+    "Theme name": {
+      "comment": "Theme editor: placeholder for the theme name field",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme-Name"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nom du thème"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre del tema"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nome del tema"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Название темы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nazwa motywu"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temanamn"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teeman nimi"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naziv teme"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שם ערכת הנושא"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tên chủ đề"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pangalan ng tema"
+          }
+        }
+      }
     },
     "Traditional opaque keys": {
       "extractionState": "manual",

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -33,6 +33,12 @@ struct StyleSettingsView: View {
     /// Grid columns for the color-palette swatches.
     private let paletteColumns = [GridItem(.adaptive(minimum: 64), spacing: 10)]
 
+    /// User-created themes, reloaded from the store after every edit.
+    @State private var userThemes: [KeyboardThemeDefinition] = ThemeStore.userThemes()
+
+    /// The theme currently open in the editor sheet.
+    @State private var editingTheme: KeyboardThemeDefinition?
+
     /// The theme id the gallery currently reflects: the dark slot while editing
     /// dark mode, otherwise the light slot (which both slots share when the
     /// separate-dark-slot toggle is off).
@@ -57,6 +63,7 @@ struct StyleSettingsView: View {
                     appearanceSection
                     stylesSection
                     palettesSection
+                    userThemesSection
                 }
                 .padding(.vertical, 8)
             }
@@ -64,6 +71,19 @@ struct StyleSettingsView: View {
         .padding(.vertical, 20)
         .navigationTitle("Style")
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $editingTheme) { theme in
+            ThemeEditorView(
+                theme: theme,
+                onSave: { updated in
+                    ThemeStore.saveUserTheme(updated)
+                    reloadUserThemes()
+                },
+                onDelete: { id in
+                    ThemeStore.deleteUserTheme(id: id)
+                    reloadUserThemes()
+                }
+            )
+        }
     }
 
     /// Toggle for assigning a separate dark-mode theme, plus the light/dark
@@ -122,17 +142,42 @@ struct StyleSettingsView: View {
 
             LazyVGrid(columns: paletteColumns, spacing: 10) {
                 ForEach(BuiltInThemes.palettes) { theme in
-                    Button {
-                        select(theme)
-                    } label: {
-                        ThemeSwatch(theme: theme, isSelected: activeThemeId == theme.id)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(theme.displayName)
+                    swatchButton(theme)
                 }
             }
             .padding(.horizontal, 16)
         }
+    }
+
+    /// User-created themes as a swatch grid, with edit/delete in the menu.
+    /// Hidden until the user duplicates their first theme.
+    @ViewBuilder private var userThemesSection: some View {
+        if !userThemes.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("My Themes")
+                    .font(.headline)
+                    .padding(.horizontal, 16)
+
+                LazyVGrid(columns: paletteColumns, spacing: 10) {
+                    ForEach(userThemes) { theme in
+                        swatchButton(theme)
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+        }
+    }
+
+    /// A selectable swatch with the shared theme context menu.
+    private func swatchButton(_ theme: KeyboardThemeDefinition) -> some View {
+        Button {
+            select(theme)
+        } label: {
+            ThemeSwatch(theme: theme, isSelected: activeThemeId == theme.id)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(theme.displayName)
+        .contextMenu { themeMenu(for: theme) }
     }
 
     /// Assigns the theme to the slot being edited. With the separate-dark-slot
@@ -184,6 +229,46 @@ struct StyleSettingsView: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal, 16)
+        .contextMenu { themeMenu(for: theme) }
+    }
+
+    // MARK: - Theme actions
+
+    /// Shared context menu: any theme can be duplicated into an editable copy;
+    /// user themes can also be edited and deleted (built-ins cannot).
+    @ViewBuilder private func themeMenu(for theme: KeyboardThemeDefinition) -> some View {
+        Button {
+            duplicate(theme)
+        } label: {
+            Label("Duplicate", systemImage: "plus.square.on.square")
+        }
+
+        if !theme.isBuiltIn {
+            Button {
+                editingTheme = theme
+            } label: {
+                Label("Edit", systemImage: "pencil")
+            }
+
+            Button(role: .destructive) {
+                ThemeStore.deleteUserTheme(id: theme.id)
+                reloadUserThemes()
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+
+    /// Creates a user-owned copy and opens it in the editor immediately.
+    private func duplicate(_ theme: KeyboardThemeDefinition) {
+        let copy = ThemeStore.duplicate(theme, existing: userThemes)
+        ThemeStore.saveUserTheme(copy)
+        reloadUserThemes()
+        editingTheme = copy
+    }
+
+    private func reloadUserThemes() {
+        userThemes = ThemeStore.userThemes()
     }
 }
 

--- a/wurstfinger/ThemeEditorView.swift
+++ b/wurstfinger/ThemeEditorView.swift
@@ -1,0 +1,255 @@
+//
+//  ThemeEditorView.swift
+//  wurstfinger
+//
+//  Edits a single user theme: name, surface fills, and label colors. Works on
+//  a local copy and calls back on Save/Delete, so the gallery owns
+//  persistence. A live preview renders the working copy through the same
+//  `ResolvedTheme` path as the keyboard.
+//
+
+import SwiftUI
+
+struct ThemeEditorView: View {
+    /// Working copy. Edits stay local until Save.
+    @State private var theme: KeyboardThemeDefinition
+
+    let onSave: (KeyboardThemeDefinition) -> Void
+    let onDelete: (String) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var showDeleteConfirmation = false
+
+    init(
+        theme: KeyboardThemeDefinition,
+        onSave: @escaping (KeyboardThemeDefinition) -> Void,
+        onDelete: @escaping (String) -> Void
+    ) {
+        _theme = State(initialValue: theme)
+        self.onSave = onSave
+        self.onDelete = onDelete
+    }
+
+    private var trimmedName: String {
+        theme.name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    ThemePreviewGrid(theme: theme.resolved())
+                        .frame(maxWidth: .infinity)
+                        .listRowInsets(EdgeInsets())
+                        .listRowBackground(Color.clear)
+                }
+
+                Section("Name") {
+                    TextField("Theme name", text: $theme.name)
+                }
+
+                Section("Surfaces") {
+                    fillRow("Keyboard background", fill: $theme.boardBackground)
+                    fillRow("Key", fill: $theme.keyFill)
+                    fillRow("Key (pressed)", fill: $theme.keyFillActive)
+                    borderRows
+                    cornerRadiusRow
+                }
+
+                Section("Labels") {
+                    colorRow("Main letter", color: $theme.mainLabel)
+                    colorRow("Function label", color: $theme.utilityLabel)
+                    colorRow("Hint letter", color: $theme.hintLetter)
+                    colorRow("Hint symbol", color: $theme.hintSymbol)
+                    colorRow("Prominent icon", color: $theme.hintIconProminent)
+                    colorRow("Subtle icon", color: $theme.hintIconSubtle)
+                }
+
+                Section {
+                    Button(role: .destructive) {
+                        showDeleteConfirmation = true
+                    } label: {
+                        Label("Delete Theme", systemImage: "trash")
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+            }
+            .navigationTitle("Edit Theme")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        onSave(theme)
+                        dismiss()
+                    }
+                    .disabled(trimmedName.isEmpty)
+                }
+            }
+            .confirmationDialog(
+                "Delete this theme?",
+                isPresented: $showDeleteConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Delete Theme", role: .destructive) {
+                    onDelete(theme.id)
+                    dismiss()
+                }
+            }
+        }
+    }
+
+    // MARK: - Rows
+
+    /// A color well for a label color. Reads the resolved color; writing stores
+    /// a fixed hex (a user theme is fully explicit once edited).
+    private func colorRow(_ title: LocalizedStringKey, color: Binding<ThemeColor>) -> some View {
+        ColorPicker(
+            title,
+            selection: Binding(
+                get: { color.wrappedValue.resolvedColor() ?? .gray },
+                set: { color.wrappedValue = .from($0) }
+            ),
+            supportsOpacity: true
+        )
+    }
+
+    /// A color well for a surface fill. The glass material has no single color,
+    /// so it reads as a neutral gray and picking any color converts the fill to
+    /// a solid color.
+    private func fillRow(_ title: LocalizedStringKey, fill: Binding<ThemeFill>) -> some View {
+        ColorPicker(
+            title,
+            selection: Binding(
+                get: {
+                    if case let .color(color) = fill.wrappedValue {
+                        return color.resolvedColor() ?? .gray
+                    }
+                    return .gray
+                },
+                set: { fill.wrappedValue = .color(.from($0)) }
+            ),
+            supportsOpacity: true
+        )
+    }
+
+    @ViewBuilder private var borderRows: some View {
+        Toggle("Key border", isOn: Binding(
+            get: { theme.keyBorder != nil },
+            set: { isOn in
+                theme.keyBorder = isOn ? (theme.keyBorder ?? .fixed(hex: "#00000030")) : nil
+                if isOn, theme.keyBorderWidth == 0 { theme.keyBorderWidth = 0.5 }
+            }
+        ))
+
+        if let border = theme.keyBorder {
+            ColorPicker(
+                "Border color",
+                selection: Binding(
+                    get: { border.resolvedColor() ?? .gray },
+                    set: { theme.keyBorder = .from($0) }
+                ),
+                supportsOpacity: true
+            )
+
+            HStack {
+                Text("Border width")
+                Spacer()
+                Text(theme.keyBorderWidth, format: .number.precision(.fractionLength(1)))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            Slider(value: $theme.keyBorderWidth, in: 0.5 ... 4, step: 0.5)
+        }
+    }
+
+    private var cornerRadiusRow: some View {
+        VStack {
+            HStack {
+                Text("Corner radius")
+                Spacer()
+                Text(theme.cornerRadius, format: .number.precision(.fractionLength(0)))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            Slider(value: $theme.cornerRadius, in: 0 ... 24, step: 1)
+        }
+    }
+}
+
+// MARK: - Preview grid
+
+/// A static, representative slice of the keyboard rendered from a resolved
+/// theme: the board fill behind a small grid of keys, with a pressed key and a
+/// couple of hint glyphs so every editable role is visible at a glance.
+struct ThemePreviewGrid: View {
+    let theme: ResolvedTheme
+
+    private let letters = [["a", "n", "i"], ["h", "d", "r"], ["t", "e", "s"]]
+    /// The center key renders in the pressed fill to preview `keyFillActive`.
+    private let pressed = (row: 1, column: 1)
+
+    var body: some View {
+        VStack(spacing: 6) {
+            ForEach(Array(letters.enumerated()), id: \.offset) { rowIndex, row in
+                HStack(spacing: 6) {
+                    ForEach(Array(row.enumerated()), id: \.offset) { columnIndex, letter in
+                        key(letter, isPressed: rowIndex == pressed.row && columnIndex == pressed.column)
+                    }
+                }
+            }
+        }
+        .padding(10)
+        .background { fill(theme.boardBackground) }
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .padding(.vertical, 4)
+    }
+
+    private func key(_ letter: String, isPressed: Bool) -> some View {
+        ZStack {
+            fill(isPressed ? theme.keyFillActive : theme.keyFill)
+                .clipShape(RoundedRectangle(cornerRadius: theme.cornerRadius))
+                .overlay(
+                    RoundedRectangle(cornerRadius: theme.cornerRadius)
+                        .strokeBorder(theme.keyBorder ?? .clear, lineWidth: theme.keyBorderWidth)
+                )
+
+            Text(verbatim: letter)
+                .font(.system(size: 22, weight: .semibold, design: .rounded))
+                .foregroundStyle(theme.mainLabel)
+
+            // Corner hints preview the hint roles.
+            Text(verbatim: "+")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(theme.hintLetter)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            Text(verbatim: "!")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(theme.hintSymbol)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+        }
+        .frame(width: 52, height: 52)
+    }
+
+    @ViewBuilder private func fill(_ resolved: ResolvedFill) -> some View {
+        switch resolved {
+        case let .color(color): color
+        case .material: Rectangle().fill(.regularMaterial)
+        }
+    }
+}
+
+#Preview {
+    ThemeEditorView(
+        theme: {
+            var copy = BuiltInThemes.darkGold
+            copy.id = "preview-user"
+            copy.name = "My Theme"
+            return copy
+        }(),
+        onSave: { _ in },
+        onDelete: { _ in }
+    )
+}

--- a/wurstfingerKeyboard/Localizable.xcstrings
+++ b/wurstfingerKeyboard/Localizable.xcstrings
@@ -2202,6 +2202,280 @@
           }
         }
       }
+    },
+    "%@ Copy": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخة من %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopie"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ αντίγραφο"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کپی"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopio"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopya"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copie"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ עותק"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ कॉपी"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopija"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@のコピー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 복사본"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (kopia)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ cópia"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (копия)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopia"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ สำเนา"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (копія)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کی کاپی"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ bản sao"
+          }
+        }
+      }
+    },
+    "%@ Copy %lld": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخة %2$lld من %1$@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopie %lld"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ αντίγραφο %lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia %lld"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کپی %lld"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopio %lld"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ Kopya %lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copie %lld"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ עותק %lld"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ कॉपी %lld"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopija %lld"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ copia %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@のコピー %lld"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 복사본 %lld"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (kopia %lld)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ cópia %lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (копия %lld)"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ kopia %lld"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ สำเนา %lld"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (копія %lld)"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ کی کاپی %lld"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ bản sao %lld"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/BuiltInThemes.swift
@@ -125,6 +125,12 @@ enum BuiltInThemes {
 }
 
 extension KeyboardThemeDefinition {
+    /// Whether this theme is compiled in. Derived from the id, never trusted
+    /// from persisted data — built-ins are not editable or deletable.
+    var isBuiltIn: Bool {
+        BuiltInThemes.ids.contains(id)
+    }
+
     /// Localized display name for built-ins; user themes show their stored
     /// name verbatim.
     var displayName: String {

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeColor.swift
@@ -70,6 +70,13 @@ enum ThemeColor: Equatable {
         }
     }
 
+    /// Builds a fixed color from a SwiftUI color — the form the editor's color
+    /// wells write. A color with no RGB representation (e.g. a pattern) falls
+    /// back to opaque black rather than dropping the edit.
+    static func from(_ color: Color) -> ThemeColor {
+        .fixed(hex: HexColor.string(from: color) ?? "#000000")
+    }
+
     /// The same color with its opacity raised to at least `minimum`. Used to
     /// keep the board fill touchable (a keyboard extension's input view only
     /// delivers touches on rendered surfaces; see DataDrivenKeyboardRootView).

--- a/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
+++ b/wurstfingerKeyboard/Runtime/Theme/ThemeStore.swift
@@ -85,6 +85,65 @@ enum ThemeStore {
         return theme(lightId: lightId, darkId: darkId, for: colorScheme, defaults: defaults)
     }
 
+    // MARK: - Editing
+
+    /// A user-owned copy of any theme: a fresh UUID id, an un-taken " Copy"
+    /// name, and the source's colors. Built-in status is derived from the id,
+    /// so the copy is automatically editable and deletable.
+    static func duplicate(
+        _ source: KeyboardThemeDefinition,
+        existing: [KeyboardThemeDefinition]
+    ) -> KeyboardThemeDefinition {
+        var copy = source
+        copy.id = UUID().uuidString
+        copy.name = uniqueCopyName(base: source.displayName, existing: existing)
+        return copy
+    }
+
+    /// "<name> Copy", disambiguated with a numeric suffix if that name is
+    /// already taken, so duplicating twice never yields two identical names.
+    private static func uniqueCopyName(base: String, existing: [KeyboardThemeDefinition]) -> String {
+        let taken = Set(existing.map(\.name))
+        let first = String(format: String(localized: "%@ Copy"), base)
+        guard taken.contains(first) else { return first }
+        var index = 2
+        while taken.contains(String(format: String(localized: "%@ Copy %lld"), base, index)) {
+            index += 1
+        }
+        return String(format: String(localized: "%@ Copy %lld"), base, index)
+    }
+
+    /// Replaces the theme with the same id, or appends it. Built-in ids are
+    /// rejected (they can never become user themes).
+    static func upsert(
+        _ theme: KeyboardThemeDefinition,
+        into list: [KeyboardThemeDefinition]
+    ) -> [KeyboardThemeDefinition] {
+        guard !BuiltInThemes.ids.contains(theme.id) else { return list }
+        var list = list
+        if let index = list.firstIndex(where: { $0.id == theme.id }) {
+            list[index] = theme
+        } else {
+            list.append(theme)
+        }
+        return list
+    }
+
+    /// Inserts or updates a user theme in defaults.
+    static func saveUserTheme(_ theme: KeyboardThemeDefinition, defaults: UserDefaults = SharedDefaults.store) {
+        writeUserThemes(upsert(theme, into: userThemes(defaults: defaults)), defaults: defaults)
+    }
+
+    /// Removes a user theme and repoints any slot that selected it back to
+    /// Classic, so a deleted theme never leaves a slot resolving to nothing.
+    static func deleteUserTheme(id: String, defaults: UserDefaults = SharedDefaults.store) {
+        writeUserThemes(userThemes(defaults: defaults).filter { $0.id != id }, defaults: defaults)
+        let slots = [SettingsKey.selectedThemeLight, SettingsKey.selectedThemeDark]
+        for key in slots where defaults.string(forKey: key.rawValue) == id {
+            defaults.set(BuiltInThemes.classic.id, forKey: key.rawValue)
+        }
+    }
+
     // MARK: - Migration
 
     /// One-time migration from the legacy `keyboardStyle` setting to the

--- a/wurstfingerTests/ThemeEngineTests.swift
+++ b/wurstfingerTests/ThemeEngineTests.swift
@@ -278,3 +278,92 @@ struct ThemeMigrationTests {
         #expect(ThemeStore.theme(id: "user-abc", defaults: defaults) == theme)
     }
 }
+
+// MARK: - Editing
+
+struct ThemeEditingTests {
+    private func isolatedDefaults() throws -> UserDefaults {
+        let name = "theme-editing-tests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: name))
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
+    @Test func isBuiltInIsDerivedFromId() {
+        #expect(BuiltInThemes.classic.isBuiltIn)
+        #expect(BuiltInThemes.darkGold.isBuiltIn)
+        var user = BuiltInThemes.darkGold
+        user.id = UUID().uuidString
+        #expect(!user.isBuiltIn)
+    }
+
+    @Test func duplicateMakesEditableCopyPreservingColors() {
+        let source = BuiltInThemes.darkGold
+        let copy = ThemeStore.duplicate(source, existing: [])
+        #expect(copy.id != source.id)
+        #expect(!copy.isBuiltIn)
+        // Colors carry over untouched; only identity/name change.
+        #expect(copy.keyFill == source.keyFill)
+        #expect(copy.mainLabel == source.mainLabel)
+        #expect(copy.name != source.displayName)
+        #expect(copy.name.contains(source.displayName))
+    }
+
+    @Test func duplicateNamesStayUnique() {
+        let source = BuiltInThemes.darkGold
+        let first = ThemeStore.duplicate(source, existing: [])
+        let second = ThemeStore.duplicate(source, existing: [first])
+        #expect(first.name != second.name)
+    }
+
+    @Test func upsertAppendsThenReplacesById() {
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-1"
+        var list = ThemeStore.upsert(theme, into: [])
+        #expect(list.count == 1)
+        theme.name = "Renamed"
+        list = ThemeStore.upsert(theme, into: list)
+        #expect(list.count == 1)
+        #expect(list[0].name == "Renamed")
+    }
+
+    @Test func upsertRejectsBuiltInIds() {
+        let list = ThemeStore.upsert(BuiltInThemes.classic, into: [])
+        #expect(list.isEmpty)
+    }
+
+    @Test func deleteRepointsSelectedSlotsToClassic() throws {
+        let defaults = try isolatedDefaults()
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-selected"
+        ThemeStore.saveUserTheme(theme, defaults: defaults)
+        defaults.set(theme.id, forKey: SettingsKey.selectedThemeLight.rawValue)
+        defaults.set(theme.id, forKey: SettingsKey.selectedThemeDark.rawValue)
+
+        ThemeStore.deleteUserTheme(id: theme.id, defaults: defaults)
+        #expect(ThemeStore.userThemes(defaults: defaults).isEmpty)
+        #expect(defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == BuiltInThemes.classic.id)
+        #expect(defaults.string(forKey: SettingsKey.selectedThemeDark.rawValue) == BuiltInThemes.classic.id)
+    }
+
+    @Test func deleteLeavesUnrelatedSelectionUntouched() throws {
+        let defaults = try isolatedDefaults()
+        var theme = BuiltInThemes.darkGold
+        theme.id = "user-doomed"
+        ThemeStore.saveUserTheme(theme, defaults: defaults)
+        defaults.set("dark-gold", forKey: SettingsKey.selectedThemeLight.rawValue)
+
+        ThemeStore.deleteUserTheme(id: theme.id, defaults: defaults)
+        #expect(defaults.string(forKey: SettingsKey.selectedThemeLight.rawValue) == "dark-gold")
+    }
+
+    @Test func colorBridgeProducesRoundTrippableFixedHex() throws {
+        let color = try #require(HexColor.color(from: "#3366CC"))
+        let bridged = ThemeColor.from(color)
+        guard case let .fixed(hex) = bridged else {
+            Issue.record("expected a fixed color, got \(bridged)")
+            return
+        }
+        #expect(HexColor.parse(hex)?.rgb == 0x3366CC)
+    }
+}


### PR DESCRIPTION
## Summary

Milestone **M3** of the theme engine: **edit and create themes**. Any theme can be duplicated into a user-owned copy, then customized and deleted — turning the gallery from a fixed picker into an editor.

Stacked on #256 (M2b). Chain: #253 → #255 → #256 → this.

## What changed

**Gallery (`StyleSettingsView`)**
- New **My Themes** section listing user themes as selectable swatches (shown once the first theme exists).
- **Context menu** on every theme: *Duplicate* (all); *Edit* and *Delete* for user themes. Built-ins stay read-only.
- Duplicating creates the copy, persists it, and opens the editor.

**Editor (`ThemeEditorView`)**
- Edits a working copy: name, surface fills (board / key / pressed key), an optional key border (color + width), corner radius, and the six label colors.
- Color wells write fixed hex via `ThemeColor.from(Color)`; a glass-material fill reads as neutral and converts to a solid color on edit.
- A static `ThemePreviewGrid` renders the working copy through the **same `ResolvedTheme` path as the keyboard**, so edits preview live.
- Save / Cancel; Delete behind a confirmation dialog.

**Model & store**
- `KeyboardThemeDefinition.isBuiltIn` derives editability from the id (never trusted from persisted data).
- `ThemeStore` gains pure `duplicate`/`upsert` helpers plus `saveUserTheme`/`deleteUserTheme`. **Deleting repoints any slot that selected the theme back to Classic**, so a slot never resolves to a missing theme.
- Reuses the M1 persistence layer (`userThemes` archive, tolerant Codable) unchanged.

**Localization** — all editor and menu strings in the 12 supported languages.

## Verification

- `WurstfingerTests` green, run serially (968 passed), incl. 8 new editing tests and the "every string is fully translated" catalog test.
- SwiftFormat + SwiftLint clean.
- Simulator self-check of the full flow: long-press a palette → **Duplicate** → editor opens (localized rows, live Jade preview, center key in pressed fill) → **Save** → appears in **My Themes** → user-theme menu shows Duplicate/Edit/Delete → **Delete** removes it and the section collapses.

## Notes for reviewers

- Base is `feature/theme-engine-m2b`; **retarget down the chain to `develop` before squash-merging.**
- Editing an adaptive (light/dark-pair) or semantic color collapses it to a fixed color — acceptable for a user-customized theme; per-appearance color pairs are out of scope for M3 (candidate for M4).
