### PR TITLE
Add Cut-All Circular Gesture on the Clipboard Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+- Cut-all circular gesture on the clipboard key — circling it cuts the text around the cursor, off by default and gated behind a new Gestures setting (#260)
+
+### Fixed
+
+- Case-insensitive String Catalog key collision that broke symbol generation on Xcode 26 (#260)
+
 ## v1.3.1 — 2026-07-04
 
 ### Added

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -17939,139 +17939,139 @@
         }
       }
     },
-    "Circle the 123 key to cut the text around the cursor. Swipe down on the same key to paste it back.": {
+    "Circle the 123 key to cut the text around the cursor. Swipe down on the same key to paste it back. Both gestures stay on the key after it switches the keyboard to numbers.": {
       "extractionState": "manual",
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "ارسم دائرة على مفتاح 123 لقص النص حول المؤشر. اسحب لأسفل على المفتاح نفسه للصقه مرة أخرى."
+            "value": "ارسم دائرة على مفتاح 123 لقص النص حول المؤشر. اسحب لأسفل على المفتاح نفسه للصقه مرة أخرى. تبقى الإيماءتان على المفتاح بعد أن يبدّل لوحة المفاتيح إلى الأرقام."
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kreise die 123-Taste ein, um den Text um den Cursor auszuschneiden. Streiche auf derselben Taste nach unten, um ihn wieder einzufügen."
+            "value": "Kreise die 123-Taste ein, um den Text um den Cursor auszuschneiden. Streiche auf derselben Taste nach unten, um ihn wieder einzufügen. Beide Gesten bleiben auf der Taste, auch nachdem sie die Tastatur auf Zahlen umgestellt hat."
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Κάντε κυκλική κίνηση στο πλήκτρο 123 για αποκοπή του κειμένου γύρω από τον δρομέα. Σύρετε προς τα κάτω στο ίδιο πλήκτρο για να το επικολλήσετε ξανά."
+            "value": "Κάντε κυκλική κίνηση στο πλήκτρο 123 για αποκοπή του κειμένου γύρω από τον δρομέα. Σύρετε προς τα κάτω στο ίδιο πλήκτρο για να το επικολλήσετε ξανά. Και οι δύο κινήσεις παραμένουν στο πλήκτρο αφού αυτό αλλάξει το πληκτρολόγιο σε αριθμούς."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Traza un círculo en la tecla 123 para cortar el texto alrededor del cursor. Desliza hacia abajo en la misma tecla para volver a pegarlo."
+            "value": "Traza un círculo en la tecla 123 para cortar el texto alrededor del cursor. Desliza hacia abajo en la misma tecla para volver a pegarlo. Ambos gestos siguen en la tecla después de que cambie el teclado a números."
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "روی کلید 123 دایره بکشید تا متن اطراف مکان‌نما بریده شود. برای چسباندن دوباره، روی همان کلید به پایین بکشید."
+            "value": "روی کلید 123 دایره بکشید تا متن اطراف مکان‌نما بریده شود. برای چسباندن دوباره، روی همان کلید به پایین بکشید. هر دو حرکت پس از آنکه کلید صفحه‌کلید را به اعداد تغییر دهد، روی همان کلید باقی می‌مانند."
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Piirrä ympyrä 123-näppäimeen, niin kohdistimen ympärillä oleva teksti leikataan. Liu’uta samaa näppäintä alaspäin liittääksesi sen takaisin."
+            "value": "Piirrä ympyrä 123-näppäimeen, niin kohdistimen ympärillä oleva teksti leikataan. Liu’uta samaa näppäintä alaspäin liittääksesi sen takaisin. Molemmat eleet säilyvät näppäimellä sen jälkeen, kun se on vaihtanut näppäimistön numeroihin."
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Umikot sa 123 key para gupitin ang teksto sa paligid ng cursor. Mag-swipe pababa sa parehong key para i-paste ito ulit."
+            "value": "Umikot sa 123 key para gupitin ang teksto sa paligid ng cursor. Mag-swipe pababa sa parehong key para i-paste ito ulit. Nananatili ang dalawang galaw sa key kahit matapos nitong palitan ang keyboard sa mga numero."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tracez un cercle sur la touche 123 pour couper le texte autour du curseur. Balayez vers le bas sur la même touche pour le recoller."
+            "value": "Tracez un cercle sur la touche 123 pour couper le texte autour du curseur. Balayez vers le bas sur la même touche pour le recoller. Les deux gestes restent sur la touche après qu’elle a basculé le clavier sur les chiffres."
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "שרטטו מעגל על מקש 123 כדי לגזור את הטקסט סביב הסמן. החליקו מטה על אותו מקש כדי להדביק אותו בחזרה."
+            "value": "שרטטו מעגל על מקש 123 כדי לגזור את הטקסט סביב הסמן. החליקו מטה על אותו מקש כדי להדביק אותו בחזרה. שתי המחוות נשארות על המקש גם אחרי שהוא מחליף את המקלדת למספרים."
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "कर्सर के आसपास का टेक्स्ट काटने के लिए 123 कुंजी पर गोला बनाएँ। उसे वापस चिपकाने के लिए उसी कुंजी पर नीचे स्वाइप करें।"
+            "value": "कर्सर के आसपास का टेक्स्ट काटने के लिए 123 कुंजी पर गोला बनाएँ। उसे वापस चिपकाने के लिए उसी कुंजी पर नीचे स्वाइप करें। कुंजी द्वारा कीबोर्ड को अंकों पर बदलने के बाद भी दोनों हावभाव उसी कुंजी पर बने रहते हैं।"
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Napravi kružni pokret po tipki 123 za izrezivanje teksta oko pokazivača. Povuci prema dolje po istoj tipki da ga zalijepiš natrag."
+            "value": "Napravi kružni pokret po tipki 123 za izrezivanje teksta oko pokazivača. Povuci prema dolje po istoj tipki da ga zalijepiš natrag. Obje geste ostaju na tipki i nakon što ona prebaci tipkovnicu na brojke."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Traccia un cerchio sul tasto 123 per tagliare il testo attorno al cursore. Scorri verso il basso sullo stesso tasto per incollarlo di nuovo."
+            "value": "Traccia un cerchio sul tasto 123 per tagliare il testo attorno al cursore. Scorri verso il basso sullo stesso tasto per incollarlo di nuovo. Entrambi i gesti restano sul tasto anche dopo che ha portato la tastiera ai numeri."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "123キーで円を描くと、カーソル周辺のテキストを切り取ります。同じキーを下にスワイプすると貼り付け直せます。"
+            "value": "123キーで円を描くと、カーソル周辺のテキストを切り取ります。同じキーを下にスワイプすると貼り付け直せます。 このキーがキーボードを数字に切り替えたあとも、両方のジェスチャーはそのまま使えます。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "123 키에서 원을 그리면 커서 주변 텍스트를 잘라냅니다. 같은 키를 아래로 쓸어내리면 다시 붙여넣습니다."
+            "value": "123 키에서 원을 그리면 커서 주변 텍스트를 잘라냅니다. 같은 키를 아래로 쓸어내리면 다시 붙여넣습니다. 이 키가 키보드를 숫자로 전환한 뒤에도 두 제스처는 그대로 유지됩니다."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Zakreśl kółko na klawiszu 123, aby wyciąć tekst wokół kursora. Przesuń w dół na tym samym klawiszu, aby wkleić go z powrotem."
+            "value": "Zakreśl kółko na klawiszu 123, aby wyciąć tekst wokół kursora. Przesuń w dół na tym samym klawiszu, aby wkleić go z powrotem. Oba gesty pozostają na klawiszu także po przełączeniu klawiatury na cyfry."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Trace um círculo na tecla 123 para cortar o texto à volta do cursor. Deslize para baixo na mesma tecla para o colar de novo."
+            "value": "Trace um círculo na tecla 123 para cortar o texto à volta do cursor. Deslize para baixo na mesma tecla para o colar de novo. Ambos os gestos permanecem na tecla depois de esta mudar o teclado para números."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Обведите клавишу 123, чтобы вырезать текст вокруг курсора. Свайп вниз по той же клавише вернёт его."
+            "value": "Обведите клавишу 123, чтобы вырезать текст вокруг курсора. Свайп вниз по той же клавише вернёт его. Оба жеста остаются на клавише и после переключения на цифры."
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rita en cirkel på 123-tangenten för att klippa ut texten runt markören. Svep nedåt på samma tangent för att klistra in den igen."
+            "value": "Rita en cirkel på 123-tangenten för att klippa ut texten runt markören. Svep nedåt på samma tangent för att klistra in den igen. Båda gesterna finns kvar på tangenten även efter att den växlat tangentbordet till siffror."
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "วนนิ้วบนปุ่ม 123 เพื่อตัดข้อความรอบเคอร์เซอร์ ปัดลงบนปุ่มเดียวกันเพื่อวางกลับ"
+            "value": "วนนิ้วบนปุ่ม 123 เพื่อตัดข้อความรอบเคอร์เซอร์ ปัดลงบนปุ่มเดียวกันเพื่อวางกลับ ทั้งสองท่าทางยังคงอยู่บนปุ่มนี้แม้หลังจากที่ปุ่มสลับแป้นพิมพ์เป็นตัวเลขแล้ว"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Обведіть клавішу 123, щоб вирізати текст навколо курсора. Проведіть вниз по тій самій клавіші, щоб вставити його назад."
+            "value": "Обведіть клавішу 123, щоб вирізати текст навколо курсора. Проведіть вниз по тій самій клавіші, щоб вставити його назад. Обидва жести залишаються на клавіші й після перемикання на цифри."
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "کرسر کے ارد گرد متن کاٹنے کے لیے 123 کلید پر دائرہ بنائیں۔ اسے واپس چسپاں کرنے کے لیے اسی کلید پر نیچے سوائپ کریں۔"
+            "value": "کرسر کے ارد گرد متن کاٹنے کے لیے 123 کلید پر دائرہ بنائیں۔ اسے واپس چسپاں کرنے کے لیے اسی کلید پر نیچے سوائپ کریں۔ کلید کے کی بورڈ کو ہندسوں پر بدلنے کے بعد بھی دونوں اشارے اسی کلید پر برقرار رہتے ہیں۔"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Vẽ vòng tròn trên phím 123 để cắt văn bản quanh con trỏ. Vuốt xuống trên cùng phím đó để dán lại."
+            "value": "Vẽ vòng tròn trên phím 123 để cắt văn bản quanh con trỏ. Vuốt xuống trên cùng phím đó để dán lại. Cả hai cử chỉ vẫn nằm trên phím sau khi phím chuyển bàn phím sang số."
           }
         }
       }

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -17664,6 +17664,554 @@
         }
       },
       "comment": "Footer on the language selection screen"
+    },
+    "Cut All by Circling": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قص الكل بحركة دائرية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles ausschneiden per Kreis"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αποκοπή όλων με κυκλική κίνηση"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar todo con un círculo"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برش همه با حرکت دایره‌ای"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leikkaa kaikki ympyröimällä"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gupitin lahat sa pamamagitan ng pag-ikot"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout couper en traçant un cercle"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גזירת הכול בתנועה מעגלית"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "गोला बनाकर सब कुछ काटें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izreži sve kružnim pokretom"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taglia tutto con un cerchio"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "円を描いてすべて切り取り"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "원을 그려 전체 잘라내기"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wytnij wszystko kółkiem"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar tudo com um círculo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вырезать всё круговым жестом"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klipp ut allt med en cirkel"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัดทั้งหมดด้วยการวนนิ้ว"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вирізати все круговим жестом"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دائرہ بنا کر سب کاٹیں"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cắt tất cả bằng vòng tròn"
+          }
+        }
+      }
+    },
+    "Cutting to the clipboard requires Full Access": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتطلب القص إلى الحافظة الوصول الكامل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausschneiden in die Zwischenablage erfordert Vollzugriff"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Η αποκοπή στο πρόχειρο απαιτεί πλήρη πρόσβαση"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar al portapapeles requiere acceso completo"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برش به کلیپ‌بورد به دسترسی کامل نیاز دارد"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leikkaaminen leikepöydälle vaatii täyden käyttöoikeuden"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kailangan ng Full Access para gupitin papunta sa clipboard"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couper vers le presse-papiers nécessite l'accès complet"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גזירה ללוח דורשת גישה מלאה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "क्लिपबोर्ड में काटने के लिए पूर्ण एक्सेस ज़रूरी है"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izrezivanje u međuspremnik zahtijeva puni pristup"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il taglio negli appunti richiede l'accesso completo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリップボードへの切り取りにはフルアクセスが必要です"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클립보드로 잘라내려면 전체 접근이 필요합니다"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wycinanie do schowka wymaga pełnego dostępu"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar para a área de transferência requer acesso total"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вырезание в буфер обмена требует полного доступа"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Att klippa ut till urklipp kräver fullständig åtkomst"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การตัดไปยังคลิปบอร์ดต้องใช้การเข้าถึงเต็มรูปแบบ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вирізання в буфер обміну потребує повного доступу"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلپ بورڈ میں کاٹنے کے لیے مکمل رسائی درکار ہے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cắt vào bảng nhớ tạm yêu cầu Truy cập đầy đủ"
+          }
+        }
+      }
+    },
+    "Circle the 123 key to cut the text around the cursor. Swipe down on the same key to paste it back.": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ارسم دائرة على مفتاح 123 لقص النص حول المؤشر. اسحب لأسفل على المفتاح نفسه للصقه مرة أخرى."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kreise die 123-Taste ein, um den Text um den Cursor auszuschneiden. Streiche auf derselben Taste nach unten, um ihn wieder einzufügen."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κάντε κυκλική κίνηση στο πλήκτρο 123 για αποκοπή του κειμένου γύρω από τον δρομέα. Σύρετε προς τα κάτω στο ίδιο πλήκτρο για να το επικολλήσετε ξανά."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traza un círculo en la tecla 123 para cortar el texto alrededor del cursor. Desliza hacia abajo en la misma tecla para volver a pegarlo."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "روی کلید 123 دایره بکشید تا متن اطراف مکان‌نما بریده شود. برای چسباندن دوباره، روی همان کلید به پایین بکشید."
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piirrä ympyrä 123-näppäimeen, niin kohdistimen ympärillä oleva teksti leikataan. Liu’uta samaa näppäintä alaspäin liittääksesi sen takaisin."
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Umikot sa 123 key para gupitin ang teksto sa paligid ng cursor. Mag-swipe pababa sa parehong key para i-paste ito ulit."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tracez un cercle sur la touche 123 pour couper le texte autour du curseur. Balayez vers le bas sur la même touche pour le recoller."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שרטטו מעגל על מקש 123 כדי לגזור את הטקסט סביב הסמן. החליקו מטה על אותו מקש כדי להדביק אותו בחזרה."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कर्सर के आसपास का टेक्स्ट काटने के लिए 123 कुंजी पर गोला बनाएँ। उसे वापस चिपकाने के लिए उसी कुंजी पर नीचे स्वाइप करें।"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Napravi kružni pokret po tipki 123 za izrezivanje teksta oko pokazivača. Povuci prema dolje po istoj tipki da ga zalijepiš natrag."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Traccia un cerchio sul tasto 123 per tagliare il testo attorno al cursore. Scorri verso il basso sullo stesso tasto per incollarlo di nuovo."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "123キーで円を描くと、カーソル周辺のテキストを切り取ります。同じキーを下にスワイプすると貼り付け直せます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "123 키에서 원을 그리면 커서 주변 텍스트를 잘라냅니다. 같은 키를 아래로 쓸어내리면 다시 붙여넣습니다."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zakreśl kółko na klawiszu 123, aby wyciąć tekst wokół kursora. Przesuń w dół na tym samym klawiszu, aby wkleić go z powrotem."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trace um círculo na tecla 123 para cortar o texto à volta do cursor. Deslize para baixo na mesma tecla para o colar de novo."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обведите клавишу 123, чтобы вырезать текст вокруг курсора. Свайп вниз по той же клавише вернёт его."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rita en cirkel på 123-tangenten för att klippa ut texten runt markören. Svep nedåt på samma tangent för att klistra in den igen."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วนนิ้วบนปุ่ม 123 เพื่อตัดข้อความรอบเคอร์เซอร์ ปัดลงบนปุ่มเดียวกันเพื่อวางกลับ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обведіть клавішу 123, щоб вирізати текст навколо курсора. Проведіть вниз по тій самій клавіші, щоб вставити його назад."
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کرسر کے ارد گرد متن کاٹنے کے لیے 123 کلید پر دائرہ بنائیں۔ اسے واپس چسپاں کرنے کے لیے اسی کلید پر نیچے سوائپ کریں۔"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vẽ vòng tròn trên phím 123 để cắt văn bản quanh con trỏ. Vuốt xuống trên cùng phím đó để dán lại."
+          }
+        }
+      }
+    },
+    "Gestures": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الإيماءات"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesten"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Χειρονομίες"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestos"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اشاره‌ها"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eleet"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga Galaw"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestes"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מחוות"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "जेस्चर"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geste"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesti"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ジェスチャ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제스처"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesty"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Жесты"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gester"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ท่าทาง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Жести"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اشارے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cử chỉ"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -5659,7 +5659,7 @@
       },
       "comment": "About row / title: legal imprint / impressum"
     },
-    "Switch Keyboard": {
+    "Switching Keyboards": {
       "extractionState": "manual",
       "localizations": {
         "de": {

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -43,6 +43,18 @@ struct SettingsView: View {
     @AppStorage(SettingsKey.longPressNumbersEnabled.rawValue, store: SharedDefaults.store)
     private var longPressNumbersEnabled = false
 
+    @AppStorage(SettingsKey.cutAllEnabled.rawValue, store: SharedDefaults.store)
+    private var cutAllEnabled = false
+
+    @AppStorage(SettingsKey.keyboardFullAccess.rawValue, store: SharedDefaults.store)
+    private var hasFullAccess = false
+
+    /// Mirrors `HapticSettingsView`: an unset key means the keyboard has not
+    /// reported its Full Access status yet, which must not read as "denied".
+    private var hasSyncedFullAccess: Bool {
+        SharedDefaults.store.object(forKey: SettingsKey.keyboardFullAccess.rawValue) != nil
+    }
+
     private let licenseURL = URL(string: "https://github.com/cl445/wurstfinger/blob/main/LICENSE")!
 
     @AppStorage(SettingsKey.expertModeEnabled.rawValue, store: SharedDefaults.store)
@@ -61,6 +73,7 @@ struct SettingsView: View {
         NavigationStack {
             Form {
                 generalSection
+                gesturesSection
                 appearanceSection
                 feedbackSection
                 expertSection
@@ -114,6 +127,22 @@ struct SettingsView: View {
             }
         } header: {
             Text("General")
+        }
+    }
+
+    private var gesturesSection: some View {
+        Section {
+            Toggle(isOn: $cutAllEnabled) {
+                SettingsRow(icon: "scissors", color: .red, title: "Cut All by Circling")
+            }
+            .disabled(isFullAccessDenied)
+        } header: {
+            Text("Gestures")
+        } footer: {
+            // The explanation lives here rather than as a row subtitle: a
+            // Toggle caps the height of its label, which clips the text in
+            // languages whose title wraps. A footer is free to wrap.
+            Text(cutAllFooter)
         }
     }
 
@@ -280,6 +309,18 @@ struct SettingsView: View {
         case .discrete:
             return String(localized: "Swipe per character, return-swipe per word")
         }
+    }
+
+    /// Full Access is known to be missing — as opposed to not yet reported,
+    /// which happens before the keyboard has been opened once.
+    private var isFullAccessDenied: Bool {
+        hasSyncedFullAccess && !hasFullAccess
+    }
+
+    private var cutAllFooter: String {
+        isFullAccessDenied
+            ? String(localized: "Cutting to the clipboard requires Full Access")
+            : String(localized: "Circle the 123 key to cut the text around the cursor. Swipe down on the same key to paste it back.")
     }
 
     private var numpadStyleDescription: String {

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -318,9 +318,18 @@ struct SettingsView: View {
     }
 
     private var cutAllFooter: String {
-        isFullAccessDenied
-            ? String(localized: "Cutting to the clipboard requires Full Access")
-            : String(localized: "Circle the 123 key to cut the text around the cursor. Swipe down on the same key to paste it back.")
+        if isFullAccessDenied {
+            return String(localized: "Cutting to the clipboard requires Full Access")
+        }
+        // The key keeps its clipboard gestures in both modes, so the text names
+        // it by the label it carries in the letter mode, where the gesture is
+        // found, and then says it survives the switch. Naming the numeric-mode
+        // label instead is not possible: it is per language (abc, абв, かな).
+        return String(localized: """
+        Circle the 123 key to cut the text around the cursor. \
+        Swipe down on the same key to paste it back. \
+        Both gestures stay on the key after it switches the keyboard to numbers.
+        """)
     }
 
     private var numpadStyleDescription: String {

--- a/wurstfinger/TestAreaView.swift
+++ b/wurstfinger/TestAreaView.swift
@@ -17,7 +17,7 @@ struct TestAreaView: View {
                 VStack(spacing: 20) {
                     // How to switch keyboard
                     VStack(alignment: .leading, spacing: 12) {
-                        Label("Switch Keyboard", systemImage: "info.circle")
+                        Label("Switching Keyboards", systemImage: "info.circle")
                             .font(.headline)
 
                         HStack(spacing: 8) {

--- a/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
+++ b/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
@@ -53,8 +53,20 @@ enum CommonKeys {
         accessibilityLabel: String(localized: "New line")
     )
 
-    /// Clipboard swipe bindings shared between the symbols key and numeric back-to-main key.
-    static let clipboardSwipes: [GestureType: KeyBinding] = [
+    /// Cut-all, bound to both circle directions below.
+    ///
+    /// Circling one key is easier to aim than circling a letter, and the key
+    /// already owns the clipboard, so the gesture reads as "cut, but for
+    /// everything". The direction is deliberately not distinguished: a thumb
+    /// circle rarely comes out the way it was intended, and mapping the two
+    /// directions to different clipboard actions would make a slip destructive.
+    private static let cutAll = KeyBinding(
+        label: "", action: .cutAll, category: .utility,
+        returnAction: nil, accessibilityLabel: String(localized: "Cut all")
+    )
+
+    /// Clipboard bindings shared between the symbols key and numeric back-to-main key.
+    static let clipboardBindings: [GestureType: KeyBinding] = [
         .swipeUp: KeyBinding(
             label: "", action: .copy, category: .utility,
             returnAction: nil, accessibilityLabel: String(localized: "Copy")
@@ -67,12 +79,14 @@ enum CommonKeys {
             label: "", action: .paste, category: .utility,
             returnAction: nil, accessibilityLabel: String(localized: "Paste")
         ),
+        .circularClockwise: cutAll,
+        .circularCounterclockwise: cutAll,
     ]
 
     static let symbols = KeyConfig.utility(
         UtilitySlot.symbols, label: "123", action: .switchMode(ModeNames.numeric),
         swipeMode: .eightWay,
-        swipes: clipboardSwipes
+        swipes: clipboardBindings
     )
 
     static let spacebar = KeyConfig(

--- a/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
+++ b/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
@@ -80,7 +80,7 @@ enum NumericLayouts {
         KeyConfig.utility(
             UtilitySlot.symbols, label: label, action: .switchMode(ModeNames.main),
             swipeMode: .eightWay,
-            swipes: CommonKeys.clipboardSwipes
+            swipes: CommonKeys.clipboardBindings
         )
     }
 

--- a/wurstfingerKeyboard/Definition/Model/KeyAction.swift
+++ b/wurstfingerKeyboard/Definition/Model/KeyAction.swift
@@ -52,6 +52,11 @@ enum KeyAction: Codable, Equatable {
     /// Clipboard
     case copy, paste, cut
 
+    /// Cut everything the document proxy exposes, without a prior selection.
+    /// The proxy offers no way to select text, so this reads the context
+    /// around the cursor instead — see `AdvancedTextMiddleware.handleCutAll`.
+    case cutAll
+
     /// No action (empty slot)
     case none
 }

--- a/wurstfingerKeyboard/Definition/Model/KeyCategory.swift
+++ b/wurstfingerKeyboard/Definition/Model/KeyCategory.swift
@@ -37,7 +37,7 @@ extension KeyAction {
         case .deleteBackward, .deleteForward, .moveCursor,
              .advanceToNextInputMode, .dismissKeyboard, .switchToNextLanguage:
             return .utility
-        case .copy, .paste, .cut: return .utility
+        case .copy, .paste, .cut, .cutAll: return .utility
         case .none: return .utility
         }
     }

--- a/wurstfingerKeyboard/Localizable.xcstrings
+++ b/wurstfingerKeyboard/Localizable.xcstrings
@@ -829,6 +829,143 @@
       },
       "comment": "ACCESSIBILITY label for the cut gesture (VoiceOver)"
     },
+    "Cut all": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles ausschneiden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout couper"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar todo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taglia tutto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вырезать всё"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wytnij wszystko"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klipp ut allt"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leikkaa kaikki"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izreži sve"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גזור הכול"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cắt tất cả"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gupitin lahat"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αποκοπή όλων"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar tudo"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вирізати все"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قص الكل"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برش همه"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سب کاٹیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัดทั้งหมด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सभी काटें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて切り取り"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모두 잘라내기"
+          }
+        }
+      }
+    },
     "Paste": {
       "extractionState": "manual",
       "localizations": {

--- a/wurstfingerKeyboard/Runtime/Pipeline/AdvancedTextMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/AdvancedTextMiddleware.swift
@@ -19,15 +19,18 @@ struct AdvancedTextMiddleware: ActionMiddleware {
     private let targetProvider: () -> TextInputTarget?
     private let localeProvider: () -> Locale
     private let onClipboardSuccess: () -> Void
+    private let isCutAllEnabled: () -> Bool
 
     init(
         target: @escaping () -> TextInputTarget?,
         locale: @escaping () -> Locale,
-        onClipboardSuccess: @escaping () -> Void = {}
+        onClipboardSuccess: @escaping () -> Void = {},
+        isCutAllEnabled: @escaping () -> Bool = { true }
     ) {
         targetProvider = target
         localeProvider = locale
         self.onClipboardSuccess = onClipboardSuccess
+        self.isCutAllEnabled = isCutAllEnabled
     }
 
     func process(_ context: ActionContext, next: (ActionContext) -> Void) {
@@ -141,7 +144,7 @@ struct AdvancedTextMiddleware: ActionMiddleware {
     /// delete: the pasteboard copy makes an accidental circle recoverable
     /// with the paste swipe on the same key.
     private func handleCutAll(target: TextInputTarget) {
-        guard target.hasFullAccess else { return }
+        guard isCutAllEnabled(), target.hasFullAccess else { return }
         let before = target.documentContextBeforeInput ?? ""
         let after = target.documentContextAfterInput ?? ""
         let all = before + after

--- a/wurstfingerKeyboard/Runtime/Pipeline/AdvancedTextMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/AdvancedTextMiddleware.swift
@@ -49,6 +49,8 @@ struct AdvancedTextMiddleware: ActionMiddleware {
             handlePaste(target: target)
         case .cut:
             handleCut(target: target)
+        case .cutAll:
+            handleCutAll(target: target)
         default:
             break
         }
@@ -122,6 +124,44 @@ struct AdvancedTextMiddleware: ActionMiddleware {
             target.deleteBackward()
             onClipboardSuccess()
         }
+    }
+
+    /// Cuts everything the proxy exposes around the cursor: the surrounding
+    /// context goes to the pasteboard and is then deleted.
+    ///
+    /// This is as close to "select all and cut" as an extension can get. The
+    /// proxy has no API to set a selection, so `handleCut` above can only act
+    /// on a selection the user made by hand; here the text is read from the
+    /// two context properties instead. Those reach no further than the current
+    /// paragraph, so in a multi-paragraph field this cuts that paragraph
+    /// rather than the whole document — single-line fields, where the feature
+    /// earns its keep, are unaffected.
+    ///
+    /// Deletion is destructive and unaided by undo, hence cut rather than
+    /// delete: the pasteboard copy makes an accidental circle recoverable
+    /// with the paste swipe on the same key.
+    private func handleCutAll(target: TextInputTarget) {
+        guard target.hasFullAccess else { return }
+        let before = target.documentContextBeforeInput ?? ""
+        let after = target.documentContextAfterInput ?? ""
+        let all = before + after
+        guard !all.isEmpty else { return }
+
+        UIPasteboard.general.string = all
+
+        // Deletion only runs backwards, so park the cursor past the trailing
+        // context first. The offset is in UTF-16 code units (see the protocol).
+        if !after.isEmpty {
+            target.adjustTextPosition(byCharacterOffset: after.utf16.count)
+        }
+        // Counted over the joined string, not the two halves: a combining mark
+        // leading `after` fuses with the last character of `before` into one
+        // grapheme cluster, and deleteBackward removes clusters, so summing the
+        // halves separately would delete one character too many.
+        for _ in 0 ..< all.count {
+            target.deleteBackward()
+        }
+        onClipboardSuccess()
     }
 
     /// Returns `text` capped at `KeyboardConstants.TextInput.maxPasteUTF16Length`

--- a/wurstfingerKeyboard/Runtime/Pipeline/AutoCapitalizationMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/AutoCapitalizationMiddleware.swift
@@ -41,7 +41,7 @@ struct AutoCapitalizationMiddleware: ActionMiddleware {
     static func affectsCapitalization(_ action: KeyAction) -> Bool {
         switch action {
         case .commitText, .space, .newline, .deleteBackward, .deleteForward,
-             .compose, .cycleAccents, .paste, .cut:
+             .compose, .cycleAccents, .paste, .cut, .cutAll:
             true
         case .moveCursor, .switchMode, .capitalizeWord, .advanceToNextInputMode,
              .dismissKeyboard, .copy, .none, .switchToNextLanguage:

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -176,7 +176,14 @@ extension KeyboardViewModel {
         middlewares.append(AdvancedTextMiddleware(
             target: { [weak self] in self?.textInputTarget },
             locale: { [weak self] in self?.pipelineLocale ?? Locale.current },
-            onClipboardSuccess: { [weak self] in self?.feedbackStateChange() }
+            onClipboardSuccess: { [weak self] in self?.feedbackStateChange() },
+            // Read on use, not captured at build time: the pipeline is only
+            // rebuilt on definition or target changes, so a captured value
+            // would keep the old setting until the next reload. Cut-all runs
+            // once per deliberate circle, so the read is off the hot path.
+            isCutAllEnabled: { [weak self] in
+                self?.sharedDefaults.bool(forKey: SettingsKey.cutAllEnabled.rawValue) ?? false
+            }
         ))
 
         // 5. Basic text input (commitText, deleteBackward, space, newline, moveCursor)

--- a/wurstfingerKeyboard/Runtime/Pipeline/TextInputMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/TextInputMiddleware.swift
@@ -50,7 +50,7 @@ struct TextInputMiddleware: ActionMiddleware {
             target.adjustTextPosition(byCharacterOffset: offset)
         case .compose, .cycleAccents, .switchMode, .capitalizeWord,
              .advanceToNextInputMode, .dismissKeyboard, .deleteForward,
-             .copy, .paste, .cut, .none, .switchToNextLanguage:
+             .copy, .paste, .cut, .cutAll, .none, .switchToNextLanguage:
             break
         }
     }

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -44,6 +44,10 @@ enum SettingsKey: String {
     /// Holding a letter key types the digit that key carries on the
     /// numeric layer, without switching modes.
     case longPressNumbersEnabled
+    /// Circling the clipboard key cuts the text around the cursor.
+    /// Opt-in: the action is destructive and unaided by undo, so it stays off
+    /// until asked for rather than surprising anyone who circles the key.
+    case cutAllEnabled
 }
 
 // MARK: - Haptic Settings

--- a/wurstfingerTests/AdvancedTextMiddlewareTests.swift
+++ b/wurstfingerTests/AdvancedTextMiddlewareTests.swift
@@ -24,12 +24,14 @@ private enum AdvancedTextFixtures {
     static func middleware(
         target: MockTextTarget,
         localeId: String = "de_DE",
+        cutAllEnabled: Bool = true,
         onClipboardSuccess: @escaping () -> Void = {}
     ) -> AdvancedTextMiddleware {
         AdvancedTextMiddleware(
             target: { target },
             locale: { Locale(identifier: localeId) },
-            onClipboardSuccess: onClipboardSuccess
+            onClipboardSuccess: onClipboardSuccess,
+            isCutAllEnabled: { cutAllEnabled }
         )
     }
 }
@@ -464,6 +466,40 @@ final class AdvancedTextMiddlewareClipboardTests {
 
         #expect(UIPasteboard.general.string == "👨‍👩‍👧‍👦")
         #expect(target.events == [.adjustCursor(11), .deleteBackward])
+    }
+
+    @Test func cutAllIsNoopWhenDisabledInSettings() {
+        let marker = "untouched-\(UUID().uuidString)"
+        UIPasteboard.general.string = marker
+
+        let target = MockTextTarget()
+        target.hasFullAccess = true
+        target.documentContextBeforeInput = "secret"
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(
+            target: target,
+            cutAllEnabled: false
+        ) { successTicks += 1 }
+
+        middleware.process(AdvancedTextFixtures.context(.cutAll)) { _ in }
+
+        #expect(target.events.isEmpty)
+        #expect(UIPasteboard.general.string == marker) // pasteboard untouched
+        #expect(successTicks == 0, "A guarded no-op must not fire a success tick")
+    }
+
+    /// The switch gates cut-all only — the plain clipboard swipes on the same
+    /// key must keep working when it is off.
+    @Test func disablingCutAllLeavesPlainCutWorking() {
+        let target = MockTextTarget()
+        target.hasFullAccess = true
+        target.selectedText = "picked"
+        let middleware = AdvancedTextFixtures.middleware(target: target, cutAllEnabled: false)
+
+        middleware.process(AdvancedTextFixtures.context(.cut)) { _ in }
+
+        #expect(UIPasteboard.general.string == "picked")
+        #expect(target.events == [.deleteBackward])
     }
 
     @Test func cutAllIsNoopWithoutFullAccess() {

--- a/wurstfingerTests/AdvancedTextMiddlewareTests.swift
+++ b/wurstfingerTests/AdvancedTextMiddlewareTests.swift
@@ -403,6 +403,103 @@ final class AdvancedTextMiddlewareClipboardTests {
         #expect(UIPasteboard.general.string == marker) // pasteboard untouched
         #expect(successTicks == 0, "A guarded no-op must not fire a success tick")
     }
+
+    // MARK: cut-all
+
+    @Test func cutAllCopiesContextOnBothSidesOfCursorAndEmptiesIt() {
+        let target = MockTextTarget()
+        target.hasFullAccess = true
+        target.documentContextBeforeInput = "hallo "
+        target.documentContextAfterInput = "welt"
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(target: target) { successTicks += 1 }
+
+        middleware.process(AdvancedTextFixtures.context(.cutAll)) { _ in }
+
+        #expect(UIPasteboard.general.string == "hallo welt")
+        // Cursor parked past "welt" (4 UTF-16 units), then all 10 characters deleted.
+        #expect(target.events == [.adjustCursor(4)] + Array(repeating: .deleteBackward, count: 10))
+        #expect(target.documentContextBeforeInput == "")
+        #expect(target.documentContextAfterInput == "")
+        #expect(successTicks == 1)
+    }
+
+    @Test func cutAllDoesNotMoveCursorWhenNothingFollowsIt() {
+        let target = MockTextTarget()
+        target.hasFullAccess = true
+        target.documentContextBeforeInput = "hallo"
+        target.documentContextAfterInput = ""
+        let middleware = AdvancedTextFixtures.middleware(target: target)
+
+        middleware.process(AdvancedTextFixtures.context(.cutAll)) { _ in }
+
+        #expect(UIPasteboard.general.string == "hallo")
+        #expect(target.events == Array(repeating: .deleteBackward, count: 5))
+    }
+
+    @Test func cutAllTreatsFusedGraphemeClusterAcrossCursorAsOneCharacter() {
+        let target = MockTextTarget()
+        target.hasFullAccess = true
+        // The cursor sits between a base letter and its combining acute accent,
+        // which join into the single cluster "é" — one deleteBackward, not two.
+        target.documentContextBeforeInput = "e"
+        target.documentContextAfterInput = "\u{0301}"
+        let middleware = AdvancedTextFixtures.middleware(target: target)
+
+        middleware.process(AdvancedTextFixtures.context(.cutAll)) { _ in }
+
+        #expect(UIPasteboard.general.string == "e\u{0301}")
+        #expect(target.events == [.adjustCursor(1), .deleteBackward])
+    }
+
+    @Test func cutAllDeletesMultiUnitEmojiAsOneCharacter() {
+        let target = MockTextTarget()
+        target.hasFullAccess = true
+        target.documentContextBeforeInput = ""
+        // ZWJ family: 11 UTF-16 units, one grapheme cluster.
+        target.documentContextAfterInput = "👨‍👩‍👧‍👦"
+        let middleware = AdvancedTextFixtures.middleware(target: target)
+
+        middleware.process(AdvancedTextFixtures.context(.cutAll)) { _ in }
+
+        #expect(UIPasteboard.general.string == "👨‍👩‍👧‍👦")
+        #expect(target.events == [.adjustCursor(11), .deleteBackward])
+    }
+
+    @Test func cutAllIsNoopWithoutFullAccess() {
+        let marker = "untouched-\(UUID().uuidString)"
+        UIPasteboard.general.string = marker
+
+        let target = MockTextTarget()
+        target.hasFullAccess = false
+        target.documentContextBeforeInput = "secret"
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(target: target) { successTicks += 1 }
+
+        middleware.process(AdvancedTextFixtures.context(.cutAll)) { _ in }
+
+        #expect(target.events.isEmpty)
+        #expect(UIPasteboard.general.string == marker) // pasteboard untouched
+        #expect(successTicks == 0, "A guarded no-op must not fire a success tick")
+    }
+
+    @Test func cutAllIsNoopWhenDocumentIsEmpty() {
+        let marker = "untouched-\(UUID().uuidString)"
+        UIPasteboard.general.string = marker
+
+        let target = MockTextTarget()
+        target.hasFullAccess = true
+        target.documentContextBeforeInput = nil
+        target.documentContextAfterInput = nil
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(target: target) { successTicks += 1 }
+
+        middleware.process(AdvancedTextFixtures.context(.cutAll)) { _ in }
+
+        #expect(target.events.isEmpty)
+        #expect(UIPasteboard.general.string == marker) // pasteboard untouched
+        #expect(successTicks == 0, "A guarded no-op must not fire a success tick")
+    }
 }
 
 // MARK: - Paste size cap

--- a/wurstfingerTests/CircularGesturePipelineTests.swift
+++ b/wurstfingerTests/CircularGesturePipelineTests.swift
@@ -128,3 +128,60 @@ struct CircularGesturePipelineTests {
         #expect(target.events == [.insertText("ẞ")])
     }
 }
+
+// MARK: - Cut-all
+
+/// The clipboard key's circular bindings, asserted on the definition rather
+/// than by circling it end-to-end: dispatching cut-all writes to the
+/// process-wide `UIPasteboard.general`, which would race the serialized
+/// clipboard suite in `AdvancedTextMiddlewareTests`. The cut itself is covered
+/// there; what matters here is that both directions reach it.
+struct CircularCutAllBindingTests {
+    private func symbolsKey(_ vm: KeyboardViewModel) -> KeyConfig? {
+        vm.activeModeFromDefinition?.key(for: UtilitySlot.symbols)
+    }
+
+    /// Both directions are bound explicitly, so neither relies on
+    /// `handleCircular`'s opposite-direction fallback.
+    @Test func symbolsKeyBindsBothCircleDirectionsToCutAll() {
+        let (vm, _) = makeViewModel(languageId: "de_DE")
+
+        guard let key = symbolsKey(vm) else {
+            Issue.record("Expected a symbols key in the main mode")
+            return
+        }
+
+        #expect(key.bindings[.circularClockwise]?.action == .cutAll)
+        #expect(key.bindings[.circularCounterclockwise]?.action == .cutAll)
+    }
+
+    /// The numeric layer's back-to-main key shares the same clipboard bindings.
+    @Test func numericBackKeyBindsBothCircleDirectionsToCutAll() {
+        let (vm, _) = makeViewModel(languageId: "de_DE")
+
+        vm.handleGesture(.tap, keyId: UtilitySlot.symbols, isReturn: false)
+        #expect(vm.activeModeName == ModeNames.numeric)
+
+        guard let key = symbolsKey(vm) else {
+            Issue.record("Expected a back-to-main key in the numeric mode")
+            return
+        }
+
+        #expect(key.bindings[.circularClockwise]?.action == .cutAll)
+        #expect(key.bindings[.circularCounterclockwise]?.action == .cutAll)
+    }
+
+    /// Circling the key must not fall through to its tap action (the mode
+    /// switch). Full access is off, so cut-all no-ops before the pasteboard.
+    @Test func circleOnSymbolsKeyDoesNotSwitchMode() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+        target.hasFullAccess = false
+        target.documentContextBeforeInput = "hallo"
+
+        vm.handleGesture(.circularCounterclockwise, keyId: UtilitySlot.symbols, isReturn: false)
+
+        #expect(vm.activeModeName == ModeNames.main)
+        #expect(target.events.isEmpty)
+        #expect(target.documentContextBeforeInput == "hallo")
+    }
+}


### PR DESCRIPTION
Add Cut-All Circular Gesture on the Clipboard Key

---

Circling the clipboard key (`123`, and the back-to-main key on the numeric layer — they share `clipboardBindings`) puts the text around the cursor on the pasteboard and deletes it. Direction is deliberately not distinguished: a thumb circle rarely comes out the way it was intended, and mapping the two directions to different clipboard actions would make a slip destructive.

### Why cut rather than delete

The deletion is unaided by undo, so the pasteboard copy is what makes an accidental circle recoverable — the paste swipe on the same key brings the text straight back. The settings footer says so explicitly, because that is the part a user needs at the moment it happens.

### Off by default

The action is destructive, so it is opt-in: a new `Gestures` section holds the switch, and nothing changes for anyone who does not go looking for it. Without Full Access the clipboard is unreachable, so the switch disables itself and explains why.

### Known limitation, and I would like your read on it

`UITextDocumentProxy` cannot set a selection, so this reads `documentContextBefore/AfterInput` — which does not reach past the current paragraph. In single-line fields (search bars, form fields, chat composers) it behaves exactly like "select all and cut", which is where the feature earns its keep. In a multi-paragraph document it cuts the current paragraph instead of everything. I chose the name "Cut All" for the gesture's intent rather than its worst case; if you would rather it promise less, I am happy to rename.

### Implementation notes

- The setting is read when the gesture fires rather than captured in `rebuildPipeline`: the pipeline only rebuilds on definition or target changes, so a captured value would keep the old setting until the next reload. Cut-all runs once per deliberate circle, so this never touches the hot path.
- Deletion counts grapheme clusters over the joined string, not the two halves separately — a combining mark leading `after` fuses with the last character of `before` into one cluster, and summing the halves would delete one character too many. Covered by tests with a ZWJ emoji sequence and a fused cluster across the cursor.
- The confirmation tick fires from the middleware's success paths, matching how `copy`/`cut`/`paste` already behave, so a guarded no-op stays silent.
- The explanation lives in the section footer rather than a row subtitle: `Toggle` caps the height of its label, which clipped the text in languages whose title wraps to two lines. A footer wraps freely and needs no per-language length tuning.

### One rename, which I will drop if you disagree

`clipboardSwipes` → `clipboardBindings` in `CommonKeys.swift`. The dictionary held nothing but swipes until this PR put both circle directions into it, and a circle is not a swipe — the name stopped describing its contents in this very commit, which is why the rename travels with it rather than arriving as drive-by cleanup. Three references across two files, nothing public.

I deliberately stopped there: `KeyConfig.utility(swipes:)` now receives circles too, so the parameter has the same problem one level up, but renaming that is your API and a far wider diff — not something to bury here. And if `swipes` is simply your umbrella term for every gesture on a key, then this is a terminology preference rather than a fix, and I am happy to revert it.

### Tests

New tests cover the gesture bindings, the cut itself (both sides of the cursor, cursor-at-end, fused clusters, multi-unit emoji), and the guards: no Full Access, empty document, switch off. One test pins that the switch gates only the circle — the plain cut swipe on the same key keeps working when it is off. Full suite is green; SwiftLint is clean.

### Heads-up: this PR wakes a pre-existing build failure on Xcode 26

Adding strings to `wurstfinger/Localizable.xcstrings` triggers symbol generation, which then trips over two existing keys that differ only in case — `Switch Keyboard` (the setup header) and `Switch keyboard` (the globe key's VoiceOver label):

```
error: This string key would generate the same symbol as “Switch keyboard”.
Please change the key or disable symbol generation for this string.
```

This is not caused by my strings: adding a single empty probe key to the catalog on a clean `develop` reproduces it identically. The collision is simply dormant until any string is touched. Note that `pr-tests.yml` runs on the image default Xcode while `testflight-beta.yml` explicitly selects Xcode 26, so this may pass CI here and surface in the nightly beta instead.

Fixing it means renaming one of the two keys and moving its 22 translations, which touches your accessibility label — that felt like your call and not something to bury in this PR. I can open a separate issue or a small PR for it, whichever you prefer, and rebase this one on top. `STRING_CATALOG_GENERATE_SYMBOLS=NO` works as a local workaround meanwhile.

### One thing I left out on purpose

Cut-all is destructive but currently ticks exactly like a layer switch — `.selectionTick`, the subtlest pulse available, since `HapticFeedbackManager` hardwires it for every `.stateChange`. A notification-style haptic on clipboard success would set it apart, but that is your cross-cutting feedback mechanism, not something this feature should redefine on its way past. Happy to look into it separately if you think it is worth it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional “Cut All by Circling” gesture that copies content around the cursor, then restores it via swipe.
  * Introduced a new Gestures settings section with Full Access gating and localized labels across supported locales.
  * Enabled the gesture on both symbol and numeric keyboard layouts.
* **Bug Fixes**
  * Ensured the gesture is safely disabled when turned off, unavailable, when context is empty, or when Full Access is missing.
  * Addressed a symbol generation issue caused by a case-insensitive string collision (Xcode 26).
* **Documentation**
  * Updated “Switch Keyboard” wording to “Switching Keyboards” in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->