### PR TITLE
Translate the "Type Numbers by Holding" Setting

### DIFF
--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -2761,6 +2761,282 @@
       },
       "comment": "Toggle subtitle"
     },
+    "Type Numbers by Holding": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كتابة الأرقام بالضغط المطوّل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ziffern durch Halten"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αριθμοί με παρατεταμένο πάτημα"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Números manteniendo pulsado"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تایپ اعداد با نگه‌داشتن"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Numerot pitkällä painalluksella"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga numero sa pagpindot nang matagal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiffres par appui long"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ספרות בלחיצה ארוכה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "दबाकर रखने से अंक"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brojke dugim pritiskom"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Numeri tenendo premuto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "長押しで数字を入力"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "길게 눌러 숫자 입력"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cyfry przez przytrzymanie"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Números mantendo premido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ввод цифр удержанием"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siffror med långt tryck"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พิมพ์ตัวเลขด้วยการกดค้าง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введення цифр утриманням"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دبا کر رکھنے سے ہندسے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhập số bằng cách giữ phím"
+          }
+        }
+      },
+      "comment": "Toggle title: type digits by long-pressing letter keys"
+    },
+    "Hold a letter key to type its digit": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط مطوّلاً على حرف لكتابة رقمه"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Halte eine Buchstabentaste, um ihre Ziffer einzugeben"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κρατήστε ένα γράμμα για να πληκτρολογήσετε το ψηφίο του"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantén pulsada una letra para escribir su número"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلید حرف را نگه دارید تا عدد آن تایپ شود"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pidä kirjainta pohjassa saadaksesi sen numeron"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pindutin nang matagal ang letra para sa numero nito"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maintenez une lettre pour saisir son chiffre"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "החזיקו מקש אות כדי להקליד את הספרה שלו"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अक्षर दबाए रखें और उसका अंक टाइप करें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dugo pritisni slovo za njegovu brojku"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tieni premuta una lettera per la sua cifra"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字キーを長押しすると数字を入力できます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문자 키를 길게 누르면 숫자가 입력됩니다"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przytrzymaj literę, aby wpisać jej cyfrę"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantenha premida uma letra para o seu algarismo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удержание буквы вводит её цифру"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Håll in en bokstav för att skriva dess siffra"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กดตัวอักษรค้างไว้เพื่อพิมพ์ตัวเลข"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Утримання літери вводить її цифру"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرف دبائے رکھیں تاکہ اس کا ہندسہ ٹائپ ہو"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giữ phím chữ để nhập số của phím"
+          }
+        }
+      },
+      "comment": "Toggle subtitle explaining the type-numbers-by-holding option"
+    },
     "Cursor Movement": {
       "extractionState": "manual",
       "localizations": {
@@ -17388,280 +17664,6 @@
         }
       },
       "comment": "Footer on the language selection screen"
-    },
-    "Type Numbers by Holding": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "كتابة الأرقام بالضغط المطوّل"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ziffern durch Halten"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αριθμοί με παρατεταμένο πάτημα"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Números manteniendo pulsado"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تایپ اعداد با نگه‌داشتن"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numerot pitkällä painalluksella"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mga numero sa pagpindot nang matagal"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chiffres par appui long"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ספרות בלחיצה ארוכה"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "दबाकर रखने से अंक"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Brojke dugim pritiskom"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Numeri tenendo premuto"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "長押しで数字を入力"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "길게 눌러 숫자 입력"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cyfry przez przytrzymanie"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Números mantendo premido"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ввод цифр удержанием"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Siffror med långt tryck"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "พิมพ์ตัวเลขด้วยการกดค้าง"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Введення цифр утриманням"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "دبا کر رکھنے سے ہندسے"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nhập số bằng cách giữ phím"
-          }
-        }
-      }
-    },
-    "Hold a letter key to type its digit": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اضغط مطوّلاً على حرف لكتابة رقمه"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Halte eine Buchstabentaste, um ihre Ziffer einzugeben"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Κρατήστε ένα γράμμα για να πληκτρολογήσετε το ψηφίο του"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mantén pulsada una letra para escribir su número"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کلید حرف را نگه دارید تا عدد آن تایپ شود"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pidä kirjainta pohjassa saadaksesi sen numeron"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pindutin nang matagal ang letra para sa numero nito"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Maintenez une lettre pour saisir son chiffre"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "החזיקו מקש אות כדי להקליד את הספרה שלו"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "अक्षर दबाए रखें और उसका अंक टाइप करें"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dugo pritisni slovo za njegovu brojku"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tieni premuta una lettera per la sua cifra"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "文字キーを長押しすると数字を入力できます"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "문자 키를 길게 누르면 숫자가 입력됩니다"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przytrzymaj literę, aby wpisać jej cyfrę"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mantenha premida uma letra para o seu algarismo"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Удержание буквы вводит её цифру"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Håll in en bokstav för att skriva dess siffra"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "กดตัวอักษรค้างไว้เพื่อพิมพ์ตัวเลข"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Утримання літери вводить її цифру"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "حرف دبائے رکھیں تاکہ اس کا ہندسہ ٹائپ ہو"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Giữ phím chữ để nhập số của phím"
-          }
-        }
-      }
     }
   },
   "version": "1.0"

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -17388,6 +17388,280 @@
         }
       },
       "comment": "Footer on the language selection screen"
+    },
+    "Type Numbers by Holding": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كتابة الأرقام بالضغط المطوّل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ziffern durch Halten"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αριθμοί με παρατεταμένο πάτημα"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Números manteniendo pulsado"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تایپ اعداد با نگه‌داشتن"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Numerot pitkällä painalluksella"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga numero sa pagpindot nang matagal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiffres par appui long"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ספרות בלחיצה ארוכה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "दबाकर रखने से अंक"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brojke dugim pritiskom"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Numeri tenendo premuto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "長押しで数字を入力"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "길게 눌러 숫자 입력"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cyfry przez przytrzymanie"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Números mantendo premido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ввод цифр удержанием"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siffror med långt tryck"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พิมพ์ตัวเลขด้วยการกดค้าง"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введення цифр утриманням"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "دبا کر رکھنے سے ہندسے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhập số bằng cách giữ phím"
+          }
+        }
+      }
+    },
+    "Hold a letter key to type its digit": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اضغط مطوّلاً على حرف لكتابة رقمه"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Halte eine Buchstabentaste, um ihre Ziffer einzugeben"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κρατήστε ένα γράμμα για να πληκτρολογήσετε το ψηφίο του"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantén pulsada una letra para escribir su número"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کلید حرف را نگه دارید تا عدد آن تایپ شود"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pidä kirjainta pohjassa saadaksesi sen numeron"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pindutin nang matagal ang letra para sa numero nito"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maintenez une lettre pour saisir son chiffre"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "החזיקו מקש אות כדי להקליד את הספרה שלו"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अक्षर दबाए रखें और उसका अंक टाइप करें"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dugo pritisni slovo za njegovu brojku"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tieni premuta una lettera per la sua cifra"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字キーを長押しすると数字を入力できます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문자 키를 길게 누르면 숫자가 입력됩니다"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przytrzymaj literę, aby wpisać jej cyfrę"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantenha premida uma letra para o seu algarismo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удержание буквы вводит её цифру"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Håll in en bokstav för att skriva dess siffra"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กดตัวอักษรค้างไว้เพื่อพิมพ์ตัวเลข"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Утримання літери вводить її цифру"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حرف دبائے رکھیں تاکہ اس کا ہندسہ ٹائپ ہو"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giữ phím chữ để nhập số của phím"
+          }
+        }
+      }
     }
   },
   "version": "1.0"


### PR DESCRIPTION
Translate the "Type Numbers by Holding" Setting

---

Both strings of the toggle in `SettingsView` — the title `Type Numbers by Holding` and the subtitle `Hold a letter key to type its digit` — are missing from `wurstfinger/Localizable.xcstrings` as keys. Not "translation empty": there is no entry at all, so SwiftUI renders the key itself and the setting stays English in all 22 languages, right next to `Auto-Capitalize`, which translates fine.

They arrived with #240 without catalog entries, and the localization pass in #252 did not pick them up.

### Why the tests did not catch it

`LocalizationCompletenessTests` works from the catalog outwards: it checks that every key **present** in the catalog has all 22 languages. A key that never made it into the catalog does not exist as far as the test is concerned. Worth knowing, since the same gap will swallow the next forgotten string just as quietly — though tightening that is a separate conversation, not this PR.

### On the wording

I followed the neighbouring rows rather than the English source. The subtitle states what the gesture does instead of instructing the reader, matching `Drag to move cursor` two rows down — so Russian reads «Удержание буквы вводит её цифру» rather than an imperative calque. German keeps your `du` form, French keeps `vous`, as in the strings already there.

Please overrule me on the German — you will read it first, and it is your call. One thing I left alone deliberately: the German subtitle truncates at `SettingsRow`'s `lineLimit(1)`, exactly like `Platziert Globus, Symbole, Löschen u…` and `Großschreibung nach satzschließend…` next to it. I could shorten it to fit, but that would make this row the odd one out, and the truncation is a property of the row rather than of my string. Happy to trim it if you prefer.

### Heads-up: this PR wakes a pre-existing build failure on Xcode 26

Touching the catalog triggers symbol generation, which then trips over two existing keys that differ only in case — `Switch Keyboard` (the setup header) and `Switch keyboard` (the globe key's VoiceOver label):

```
error: This string key would generate the same symbol as “Switch keyboard”.
Please change the key or disable symbol generation for this string.
```

This is not caused by my strings: adding a single empty probe key to the catalog on a clean `develop` reproduces it identically. The collision simply lies dormant until any string is touched, so a clean build of `develop` passes today. Note that `pr-tests.yml` runs on the image default Xcode while `testflight-beta.yml` explicitly selects Xcode 26, so this may pass CI here and surface in the nightly beta instead.

Fixing it means renaming one of the two keys and moving its 22 translations, which touches your accessibility label — your call, and not something to bury in a translation PR. Happy to open a separate issue or PR for it. `STRING_CATALOG_GENERATE_SYMBOLS=NO` works as a local workaround meanwhile. (Same note as on #260, which hits the same wall.)