### PR TITLE
Restore Å on the Finnish layout

### DIFF
--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
@@ -133,7 +133,7 @@ enum LanguageDefinitions {
                 ["t", "e", "s"],
             ],
             directionalOverrides: [
-                GridSlot.topLeft: [.swipeDown: "ä", .swipeDownRight: "v"],
+                GridSlot.topLeft: [.swipeUp: "å", .swipeDown: "ä", .swipeDownRight: "v"],
                 GridSlot.topCenter: [.swipeDown: "l"],
                 GridSlot.topRight: [.swipeDownLeft: "x"],
                 GridSlot.midLeft: [.swipeDown: "ö", .swipeRight: "k"],

--- a/wurstfingerTests/LanguageDefinitionTests.swift
+++ b/wurstfingerTests/LanguageDefinitionTests.swift
@@ -101,13 +101,42 @@ struct GermanLayoutTests {
         let letterRows = arrangement.rows.map { row in
             row.compactMap { main.keys[$0.keyId]?.bindings[.tap]?.action }
                 .compactMap { action -> String? in
-                    if case let .commitText(text) = action { return text }
+                    if case let .commitText(text) = action {
+                        return text
+                    }
                     return nil
                 }
         }
         #expect(letterRows[0] == ["a", "n", "i"])
         #expect(letterRows[1] == ["h", "d", "r"])
         #expect(letterRows[2] == ["t", "e", "s"])
+    }
+}
+
+// MARK: - Finnish Layout Tests
+
+struct FinnishLayoutTests {
+    static let finnish = LanguageDefinitions.finnish.makeDefinition()
+
+    /// The three Finnish vowels follow the MessagEase Nordic arrangement:
+    /// Å and Ä share the a-key (swipe up / down), Ö sits directly below on
+    /// the h-key (swipe down). See issue #262.
+    @Test func nordicVowels() throws {
+        let main = try #require(Self.finnish.modes[ModeNames.main])
+        #expect(main.keys[GridSlot.topLeft]?.bindings[.swipeUp]?.action == .commitText("å"))
+        #expect(main.keys[GridSlot.topLeft]?.bindings[.swipeDown]?.action == .commitText("ä"))
+        #expect(main.keys[GridSlot.midLeft]?.bindings[.swipeDown]?.action == .commitText("ö"))
+    }
+
+    @Test func shiftedNordicVowels() throws {
+        let shifted = try #require(Self.finnish.modes[ModeNames.shifted])
+        #expect(shifted.keys[GridSlot.topLeft]?.bindings[.swipeUp]?.action == .commitText("Å"))
+        #expect(shifted.keys[GridSlot.topLeft]?.bindings[.swipeDown]?.action == .commitText("Ä"))
+        #expect(shifted.keys[GridSlot.midLeft]?.bindings[.swipeDown]?.action == .commitText("Ö"))
+    }
+
+    @Test func localeIsFinnish() {
+        #expect(Self.finnish.localeIdentifier == "fi_FI")
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #262. The Finnish (`fi_FI`) layout had no `Å` binding, so a swipe-up on the a-key produced nothing — the character was effectively unreachable.

- Add `Å` at `topLeft.swipeUp` (on the a-key, above `Ä`).
- `Ä` (`topLeft.swipeDown`) and `Ö` (`midLeft.swipeDown`) were already at their intended positions and are **unchanged**.

## Intended mapping

I checked the Finnish vowel placement against the MessagEase Nordic vowel arrangement, where `Å`/`Ä` share the a-key (swipe up / down) and `Ö` sits directly below on the h-key (swipe down). This is the same convention the existing **Estonian** layout in `LanguageDefinitions.swift` already follows (`topLeft.swipeUp: "å"`, `topLeft.swipeDown: "ä"`).

Against that reference, the current `Ä`/`Ö` positions were already correct; the only defect was the missing `Å`, which this PR restores. No existing Finnish characters are moved or lost.

## Tests

Added `FinnishLayoutTests` pinning the three vowel bindings in both `main` and `shifted` modes, plus the locale. Verified locally:

- `WurstfingerTests/FinnishLayoutTests` — pass
- `WurstfingerTests/LanguageDefinitionValidationTests` — pass (all layouts still validate)