### PR TITLE
Test that every String(localized:) key exists in a catalog

### DIFF
--- a/wurstfingerTests/LocalizationCompletenessTests.swift
+++ b/wurstfingerTests/LocalizationCompletenessTests.swift
@@ -132,3 +132,105 @@ struct LocalizationCompletenessTests {
         )
     }
 }
+
+// MARK: - Usage → catalog coverage
+
+/// Source directories whose Swift files are scanned for localizable string usage.
+private let localizedSourceDirs: [String] = ["wurstfinger", "wurstfingerKeyboard"]
+
+/// A `String(localized:)` usage discovered in the source tree.
+private struct LocalizedUsage: Hashable {
+    let key: String
+    let file: String
+    let line: Int
+}
+
+/// Matches `String(localized: "…")` and captures the literal, honouring escaped
+/// characters inside the string so `\"` does not end the match early.
+private let localizedCallRegex: NSRegularExpression = {
+    // The pattern is a compile-time constant, so construction cannot fail.
+    guard let regex = try? NSRegularExpression(pattern: #"String\(localized:\s*"((?:[^"\\]|\\.)*)""#) else {
+        preconditionFailure("Invalid localizedCallRegex pattern")
+    }
+    return regex
+}()
+
+/// Turns a Swift string-literal body back into its runtime value for the escapes
+/// that can legally appear in a catalog key (`\"` and `\\`).
+private func unescapeSwiftLiteral(_ raw: String) -> String {
+    raw.replacingOccurrences(of: "\\\"", with: "\"")
+        .replacingOccurrences(of: "\\\\", with: "\\")
+}
+
+/// Every non-interpolated `String(localized:)` literal used under the product
+/// source directories, with its file and line for actionable failures.
+///
+/// Interpolated calls (`String(localized: "Enable \(name)")`) are skipped on
+/// purpose: Xcode rewrites their catalog key to a format string (`Enable %@`),
+/// so the source literal is not the key to look up.
+private func scanLocalizedUsages() -> [LocalizedUsage] {
+    let root = projectDir()
+    var usages: [LocalizedUsage] = []
+    let fileManager = FileManager.default
+
+    for dir in localizedSourceDirs {
+        let base = root.appendingPathComponent(dir)
+        guard let enumerator = fileManager.enumerator(at: base, includingPropertiesForKeys: nil) else { continue }
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            guard let source = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            for (index, line) in source.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
+                let text = String(line)
+                let range = NSRange(text.startIndex..., in: text)
+                for match in localizedCallRegex.matches(in: text, range: range) {
+                    guard let literalRange = Range(match.range(at: 1), in: text) else { continue }
+                    let literal = String(text[literalRange])
+                    // Skip interpolated calls: Xcode rewrites their key to a format string.
+                    if literal.contains("\\(") {
+                        continue
+                    }
+                    usages.append(
+                        LocalizedUsage(
+                            key: unescapeSwiftLiteral(literal),
+                            file: "\(dir)/\(url.lastPathComponent)",
+                            line: index + 1
+                        )
+                    )
+                }
+            }
+        }
+    }
+    return usages
+}
+
+/// Guards the *other* direction from `LocalizationCompletenessTests`: that every
+/// string the code asks for actually exists in a catalog. The completeness tests
+/// work from the catalog outwards and cannot see a key that was never added, so a
+/// `String(localized: "…")` whose key is missing renders as the raw key in every
+/// language (as happened in #261) without failing any existing test.
+///
+/// Scope: this covers the explicit `String(localized:)` API only. Bare
+/// `LocalizedStringKey` literals passed to a view initializer (e.g.
+/// `SettingsRow(title: "…")`) are not statically detectable without type
+/// information and remain outside this guard.
+struct LocalizationUsageTests {
+    @Test("Every String(localized:) key exists in a catalog")
+    func everyLocalizedKeyExistsInCatalog() throws {
+        var catalogKeys: Set<String> = []
+        for relativePath in localizationCatalogs {
+            try catalogKeys.formUnion(loadCatalog(relativePath).strings.keys)
+        }
+
+        let usages = scanLocalizedUsages()
+        #expect(!usages.isEmpty, "Found no String(localized:) usages to check — has the source layout moved?")
+
+        let missing = usages.filter { !catalogKeys.contains($0.key) }
+        let detail = missing
+            .sorted { ($0.file, $0.line) < ($1.file, $1.line) }
+            .map { "\($0.file):\($0.line)  \"\($0.key)\"" }
+            .joined(separator: "\n")
+        #expect(
+            missing.isEmpty,
+            "\(missing.count) localized string(s) used in code but absent from every catalog:\n\(detail)"
+        )
+    }
+}

--- a/wurstfingerTests/LocalizationCompletenessTests.swift
+++ b/wurstfingerTests/LocalizationCompletenessTests.swift
@@ -146,20 +146,48 @@ private struct LocalizedUsage: Hashable {
 }
 
 /// Matches `String(localized: "…")` and captures the literal, honouring escaped
-/// characters inside the string so `\"` does not end the match early.
+/// characters inside the string so `\"` does not end the match early. `\s*` after
+/// the paren and the colon tolerates a call whose arguments wrap onto new lines.
+///
+/// The `(?!"")` after the opening quote skips multiline string literals
+/// (`String(localized: """…""")`): the opening `"""` would otherwise read as an
+/// empty `""` and report a bogus missing key. Reconstructing a multiline literal's
+/// key means replaying Swift's indentation stripping and `\`-continuations, so
+/// those keys stay out of scope here and are covered catalog-side by
+/// `LocalizationCompletenessTests` instead.
 private let localizedCallRegex: NSRegularExpression = {
     // The pattern is a compile-time constant, so construction cannot fail.
-    guard let regex = try? NSRegularExpression(pattern: #"String\(localized:\s*"((?:[^"\\]|\\.)*)""#) else {
+    guard let regex = try? NSRegularExpression(pattern: #"String\(\s*localized:\s*"(?!"")((?:[^"\\]|\\.)*)""#) else {
         preconditionFailure("Invalid localizedCallRegex pattern")
     }
     return regex
 }()
 
-/// Turns a Swift string-literal body back into its runtime value for the escapes
-/// that can legally appear in a catalog key (`\"` and `\\`).
+/// Decodes a Swift single-line string-literal body to its runtime value, so the
+/// key we look up matches the one Xcode derives from the same literal.
+///
+/// A single left-to-right pass, not chained `replacingOccurrences`: the latter
+/// would misread `\\n` (an escaped backslash followed by `n`) as a newline. An
+/// unrecognised escape keeps the character after the backslash, which is what
+/// Swift does for the escapes that do not appear in catalog keys.
 private func unescapeSwiftLiteral(_ raw: String) -> String {
-    raw.replacingOccurrences(of: "\\\"", with: "\"")
-        .replacingOccurrences(of: "\\\\", with: "\\")
+    var result = ""
+    result.reserveCapacity(raw.count)
+    var iterator = raw.makeIterator()
+    while let ch = iterator.next() {
+        guard ch == "\\", let escaped = iterator.next() else {
+            result.append(ch)
+            continue
+        }
+        switch escaped {
+        case "n": result.append("\n")
+        case "t": result.append("\t")
+        case "r": result.append("\r")
+        case "0": result.append("\0")
+        default: result.append(escaped)
+        }
+    }
+    return result
 }
 
 /// Every non-interpolated `String(localized:)` literal used under the product
@@ -167,7 +195,8 @@ private func unescapeSwiftLiteral(_ raw: String) -> String {
 ///
 /// Interpolated calls (`String(localized: "Enable \(name)")`) are skipped on
 /// purpose: Xcode rewrites their catalog key to a format string (`Enable %@`),
-/// so the source literal is not the key to look up.
+/// so the source literal is not the key to look up. Multiline literals
+/// (`String(localized: """…""")`) are likewise skipped — see `localizedCallRegex`.
 private func scanLocalizedUsages() -> [LocalizedUsage] {
     let root = projectDir()
     var usages: [LocalizedUsage] = []
@@ -178,24 +207,26 @@ private func scanLocalizedUsages() -> [LocalizedUsage] {
         guard let enumerator = fileManager.enumerator(at: base, includingPropertiesForKeys: nil) else { continue }
         for case let url as URL in enumerator where url.pathExtension == "swift" {
             guard let source = try? String(contentsOf: url, encoding: .utf8) else { continue }
-            for (index, line) in source.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
-                let text = String(line)
-                let range = NSRange(text.startIndex..., in: text)
-                for match in localizedCallRegex.matches(in: text, range: range) {
-                    guard let literalRange = Range(match.range(at: 1), in: text) else { continue }
-                    let literal = String(text[literalRange])
-                    // Skip interpolated calls: Xcode rewrites their key to a format string.
-                    if literal.contains("\\(") {
-                        continue
-                    }
-                    usages.append(
-                        LocalizedUsage(
-                            key: unescapeSwiftLiteral(literal),
-                            file: "\(dir)/\(url.lastPathComponent)",
-                            line: index + 1
-                        )
-                    )
+            // Scan the whole file rather than line by line: a call whose arguments
+            // wrap (`String(\n    localized: "…"\n)`) keeps its literal intact this
+            // way, and the line number is recovered from the match's offset.
+            let ns = source as NSString
+            let fullRange = NSRange(location: 0, length: ns.length)
+            for match in localizedCallRegex.matches(in: source, range: fullRange) {
+                let literal = ns.substring(with: match.range(at: 1))
+                // Skip interpolated calls: Xcode rewrites their key to a format string.
+                if literal.contains("\\(") {
+                    continue
                 }
+                let line = ns.substring(to: match.range.location)
+                    .reduce(1) { $0 + ($1 == "\n" ? 1 : 0) }
+                usages.append(
+                    LocalizedUsage(
+                        key: unescapeSwiftLiteral(literal),
+                        file: "\(dir)/\(url.lastPathComponent)",
+                        line: line
+                    )
+                )
             }
         }
     }


### PR DESCRIPTION
Closes the test gap flagged in #261.

## The gap

`LocalizationCompletenessTests` works from the catalog *outwards*: for every key **present** in a catalog it checks that all 22 languages are translated, non-empty, and marked `translated`. A string that was never added to the catalog at all is invisible to it — so a `String(localized: "…")` whose key is missing renders as the raw key in every language, and no test fails. That is exactly how #261 shipped English in all 22 languages: the keys arrived with #240 without catalog entries, and #252's localization pass did not pick them up.

## The guard

`LocalizationUsageTests` checks the *other* direction. It scans the product sources (`wurstfinger/`, `wurstfingerKeyboard/`) for `String(localized: "literal")` usages and asserts each key exists in one of the catalogs, failing with `file:line` for any that do not.

- **Interpolated calls are skipped** (`String(localized: "Enable \(name)")`) — Xcode rewrites their catalog key to a format string (`Enable %@`), so the source literal is not the key to look up.
- **Escaped quotes** inside the literal are handled so `\"` does not end the match early.

### Scope / honest limitation

This covers the explicit `String(localized:)` API only. Bare `LocalizedStringKey` literals passed to a view initializer — e.g. `SettingsRow(title: "…")`, the *other* half of the #261 pair — are not statically detectable without type information and remain out of scope. Even so, this guard would have caught #261: its subtitle used `String(localized:)`, so the build would have gone red and forced the fix.

## Verification

- New test **passes** on `develop` (36 extracted `String(localized:)` keys, all present).
- Counter-check: deleting one used key (`Hold a letter key to type its digit`) from the catalog makes it **fail** with the offending `file:line` — then restored.
- Run in isolation: `-only-testing:WurstfingerTests/LocalizationUsageTests` → green on the iPhone 17 Pro simulator.

> **Note on CI lint:** the `lint` job is red on `develop` today for a pre-existing, repo-wide reason (unrelated to this PR) — see #264, which fixes it. This PR adds no new lint violations; its `lint` will go green once #264 lands.
