### PR TITLE
Improve layout metrics (landscape cap) and gesture long-press handling

### DIFF
--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -288,6 +288,7 @@ final class KeyboardViewModel: ObservableObject {
     func layoutMetrics(forContainerWidth width: CGFloat) -> KeyboardLayoutMetrics {
         layoutSettings.resolveMetrics(
             columns: currentArrangement?.columns ?? 4,
+            rows: currentArrangement?.rows.count ?? KeyboardConstants.KeyDimensions.totalRows,
             availableWidth: width > 0 ? min(width, keyboardWidthCap) : keyboardWidthCap,
             screenHeight: DeviceLayoutUtils.screenBounds.height
         )

--- a/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
@@ -100,8 +100,7 @@ struct KeyGestureRecognizer: ViewModifier {
     var onLongPress: (() -> Bool)?
 
     @State private var sequence = KeyGestureSequence()
-    @State private var pendingLongPress: DispatchWorkItem?
-    @State private var longPressConsumedTouch = false
+    @State private var longPress = LongPressScheduler()
     @Binding var isActive: Bool
 
     /// True while a touch sequence is in flight. Unlike `@State`, SwiftUI
@@ -121,19 +120,19 @@ struct KeyGestureRecognizer: ViewModifier {
                         if sequence.handleChanged(translation: value.translation) {
                             onTouchDown()
                             scheduleLongPress()
-                        } else if pendingLongPress != nil,
+                        } else if longPress.isScheduled,
                                   sequence.maxDisplacement > KeyboardConstants.LongPress.movementTolerance {
-                            cancelPendingLongPress()
+                            longPress.cancel()
                         }
                         isActive = true
                     }
                     .onEnded { value in
-                        cancelPendingLongPress()
-                        if longPressConsumedTouch {
+                        longPress.cancel()
+                        if longPress.consumedTouch {
                             // The long press already dispatched its action;
                             // discard the touch instead of classifying it, so
                             // releasing doesn't produce a second key event.
-                            longPressConsumedTouch = false
+                            longPress.clearConsumed()
                             sequence.handleCancelled()
                             isActive = false
                             return
@@ -152,8 +151,8 @@ struct KeyGestureRecognizer: ViewModifier {
                 // cancelled the touches. Discard the partial gesture without
                 // classifying it.
                 guard !inFlight, sequence.isTracking else { return }
-                cancelPendingLongPress()
-                longPressConsumedTouch = false
+                longPress.cancel()
+                longPress.clearConsumed()
                 sequence.handleCancelled()
                 isActive = false
             }
@@ -161,30 +160,16 @@ struct KeyGestureRecognizer: ViewModifier {
 
     // MARK: - Long Press
 
+    /// Arms the shared scheduler with this recognizer's fire guard. The guard
+    /// reads live `@State` (`sequence`) at fire time through the property
+    /// wrapper — identical to the previous `fireLongPress()` semantics.
     private func scheduleLongPress() {
         guard onLongPress != nil else { return }
-        cancelPendingLongPress()
-        let workItem = DispatchWorkItem { fireLongPress() }
-        pendingLongPress = workItem
-        DispatchQueue.main.asyncAfter(
-            deadline: .now() + KeyboardConstants.LongPress.duration,
-            execute: workItem
-        )
-    }
-
-    private func cancelPendingLongPress() {
-        pendingLongPress?.cancel()
-        pendingLongPress = nil
-    }
-
-    private func fireLongPress() {
-        pendingLongPress = nil
-        // The touch may have ended or been cancelled between scheduling and
-        // firing; a stale fire must not dispatch anything.
-        guard sequence.isTracking,
-              sequence.maxDisplacement <= KeyboardConstants.LongPress.movementTolerance,
-              onLongPress?() == true else { return }
-        longPressConsumedTouch = true
+        longPress.schedule {
+            sequence.isTracking
+                && sequence.maxDisplacement <= KeyboardConstants.LongPress.movementTolerance
+                && onLongPress?() == true
+        }
     }
 
     /// Guarantees the touch-down origin `(0,0)` is the first sample.

--- a/wurstfingerKeyboard/Runtime/Gesture/LongPressScheduler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/LongPressScheduler.swift
@@ -1,0 +1,64 @@
+//
+//  LongPressScheduler.swift
+//  Wurstfinger
+//
+//  Shared long-press timer + touch-consumption bookkeeping extracted from
+//  KeyGestureRecognizer and SlideGestureHandler. Only the DispatchWorkItem
+//  lifecycle and the consumed-touch flag are shared; each recognizer keeps
+//  its own distinct fire-guard predicate (passed as the `fire` closure).
+//
+
+import Foundation
+
+/// Owns the long-press `DispatchWorkItem` lifecycle and the consumed-touch
+/// flag for a gesture recognizer.
+///
+/// A reference type so it can live in `@State` and mutate in place across
+/// SwiftUI body re-evaluations (the same reason the recognizers previously
+/// held two `@State` values directly). The recognizer supplies its fire guard
+/// as the `fire` closure, evaluated at fire time exactly as the old
+/// `fireLongPress()` read live `@State` — so extracting this changes no
+/// timing or staleness behavior.
+final class LongPressScheduler {
+    private var pending: DispatchWorkItem?
+
+    /// True once a fired long press dispatched an action and thereby consumed
+    /// the touch, so the release must not also produce a tap or slide end.
+    private(set) var consumedTouch = false
+
+    /// Whether a long-press timer is currently armed.
+    var isScheduled: Bool {
+        pending != nil
+    }
+
+    /// Arms the long-press timer, cancelling any previously armed one. `fire`
+    /// is the recognizer's guard predicate, evaluated when the timer fires;
+    /// returning `true` marks the touch consumed.
+    func schedule(
+        after delay: TimeInterval = KeyboardConstants.LongPress.duration,
+        fire: @escaping () -> Bool
+    ) {
+        cancel()
+        let item = DispatchWorkItem { [weak self] in self?.runFire(fire) }
+        pending = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
+    }
+
+    /// Cancels any armed timer without touching `consumedTouch`.
+    func cancel() {
+        pending?.cancel()
+        pending = nil
+    }
+
+    /// Evaluates the fire guard synchronously and records touch consumption.
+    /// Not private so it can be unit-tested without a real 0.7 s timer.
+    func runFire(_ fire: () -> Bool) {
+        pending = nil
+        if fire() { consumedTouch = true }
+    }
+
+    /// Clears the consumed-touch flag before the next touch sequence.
+    func clearConsumed() {
+        consumedTouch = false
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -81,11 +81,23 @@ struct SlideGestureState {
         // latch the slide even though the peak committed the up-swipe long
         // ago. Once the upward peak crossed the up-swipe threshold, the
         // gesture belongs to `handleEnded`'s vertical classification and must
-        // never latch.
+        // never latch — *unless* the finger then makes a clearly dominant
+        // horizontal move.
+        //
+        // Re-arm (finding #11): the committed up-peak latch never decayed, so
+        // an incidental up-flick followed by a genuine sideways drag stayed
+        // stuck as an up-swipe and the cursor never moved. Re-allow latching
+        // only when the current horizontal travel is both large in absolute
+        // terms (≥ the 30 pt up-swipe threshold) and strongly horizontal
+        // (> 2× the vertical). Return-leg drift (~10 pt sideways) stays well
+        // below the 30 pt floor, so this does not re-introduce the return-up
+        // mis-latch the peak guard was added to fix.
+        let dominantHorizontalSlide = abs(currentX) >= swipeUpThreshold
+            && abs(currentX) > abs(translation.height) * 2
         if !isSliding,
-           -upwardPeakY < swipeUpThreshold,
            abs(currentX) >= activationThreshold,
-           abs(currentX) > abs(translation.height) {
+           abs(currentX) > abs(translation.height),
+           -upwardPeakY < swipeUpThreshold || dominantHorizontalSlide {
             isSliding = true
             // Anchor at the threshold crossing (not the full translation) so
             // the travel beyond the threshold is reported on the same tick
@@ -175,8 +187,7 @@ struct SlideGestureHandler: ViewModifier {
     @Binding var isActive: Bool
 
     @State private var state = SlideGestureState()
-    @State private var pendingLongPress: DispatchWorkItem?
-    @State private var longPressConsumedTouch = false
+    @State private var longPress = LongPressScheduler()
 
     /// True while a touch sequence is in flight. Unlike `@State`, SwiftUI
     /// guarantees `@GestureState` is reset when the system cancels the
@@ -195,7 +206,7 @@ struct SlideGestureHandler: ViewModifier {
                         // A fired long press owns the rest of this touch:
                         // don't feed the state machine, or the movement would
                         // start a cursor slide after the digit was typed.
-                        if longPressConsumedTouch {
+                        if longPress.consumedTouch {
                             isActive = true
                             return
                         }
@@ -206,10 +217,10 @@ struct SlideGestureHandler: ViewModifier {
                         if update.isTouchDown {
                             onTouchDown()
                             scheduleLongPress()
-                        } else if pendingLongPress != nil,
+                        } else if longPress.isScheduled,
                                   state.isSliding
                                   || state.maxDisplacement > KeyboardConstants.LongPress.movementTolerance {
-                            cancelPendingLongPress()
+                            longPress.cancel()
                         }
                         for phase in update.phases {
                             onSlide(phase)
@@ -217,11 +228,11 @@ struct SlideGestureHandler: ViewModifier {
                         isActive = true
                     }
                     .onEnded { value in
-                        cancelPendingLongPress()
-                        if longPressConsumedTouch {
+                        longPress.cancel()
+                        if longPress.consumedTouch {
                             // Reset silently: no phase is reported, so the
                             // release produces neither a tap nor a slide end.
-                            longPressConsumedTouch = false
+                            longPress.clearConsumed()
                             _ = state.handleCancelled()
                             isActive = false
                             return
@@ -240,8 +251,8 @@ struct SlideGestureHandler: ViewModifier {
                 // if the sequence stops while a drag is still marked as in
                 // flight, the system cancelled the touches.
                 guard !inFlight else { return }
-                cancelPendingLongPress()
-                longPressConsumedTouch = false
+                longPress.cancel()
+                longPress.clearConsumed()
                 if let phase = state.handleCancelled() {
                     onSlide(phase)
                 }
@@ -251,30 +262,20 @@ struct SlideGestureHandler: ViewModifier {
 
     // MARK: - Long Press
 
+    /// Arms the shared scheduler with this handler's fire guard. The guard
+    /// reads live `@State` (`state`) at fire time through the property wrapper
+    /// — identical to the previous `fireLongPress()` semantics. The
+    /// `!state.isSliding` axis is preserved: it is the one guard that
+    /// legitimately differs from `KeyGestureRecognizer` (which has no sliding
+    /// concept).
     private func scheduleLongPress() {
         guard onLongPress != nil else { return }
-        cancelPendingLongPress()
-        let workItem = DispatchWorkItem { fireLongPress() }
-        pendingLongPress = workItem
-        DispatchQueue.main.asyncAfter(
-            deadline: .now() + KeyboardConstants.LongPress.duration,
-            execute: workItem
-        )
-    }
-
-    private func cancelPendingLongPress() {
-        pendingLongPress?.cancel()
-        pendingLongPress = nil
-    }
-
-    private func fireLongPress() {
-        pendingLongPress = nil
-        // The touch may have ended, slid, or been cancelled between
-        // scheduling and firing; a stale fire must not dispatch anything.
-        guard state.dragStarted, !state.isSliding,
-              state.maxDisplacement <= KeyboardConstants.LongPress.movementTolerance,
-              onLongPress?() == true else { return }
-        longPressConsumedTouch = true
+        longPress.schedule {
+            state.dragStarted
+                && !state.isSliding
+                && state.maxDisplacement <= KeyboardConstants.LongPress.movementTolerance
+                && onLongPress?() == true
+        }
     }
 
     private var activationThreshold: CGFloat {

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -40,8 +40,10 @@ struct KeyView: View {
     /// Resolved layout metrics injected by `KeyboardGridView` (same reasoning
     /// as there: an `@AppStorage` read desynchronizes from the width path
     /// when the view model is configured programmatically). Feeds the gesture
-    /// classification geometry and the font scaling.
-    var metrics: KeyboardLayoutMetrics = .reference
+    /// classification geometry and the font scaling. No default: every caller
+    /// must pass the resolved metrics explicitly so a `.reference` fallback can
+    /// never silently mask a wiring gap (production sites already do).
+    var metrics: KeyboardLayoutMetrics
 
     /// Short language label (e.g. "DE") shown on the switch key, and whether to
     /// show it. Driven by the active keyboard locale via `KeyboardViewModel`

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -226,9 +226,11 @@ enum KeyboardConstants {
         /// paddings). Used by the App Store screenshot mode to reproduce the
         /// square marketing look at the full reference key height.
         static func squareKeyboardWidth(cellSize: CGFloat, columns: Int) -> CGFloat {
+            // Cells plus the constant horizontal chrome (paddings + column
+            // gaps). Shares `horizontalChrome` with the metrics resolver so the
+            // two can never diverge if the per-side padding model changes.
             (cellSize * CGFloat(columns)) +
-                (Layout.gridHorizontalSpacing * CGFloat(columns - 1)) +
-                (Layout.horizontalPadding * 2)
+                KeyboardLayoutMetrics.horizontalChrome(columns: columns)
         }
     }
 }

--- a/wurstfingerKeyboard/Settings/KeyboardLayoutMetrics.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardLayoutMetrics.swift
@@ -58,10 +58,20 @@ struct KeyboardLayoutMetrics: Equatable {
         cellHeight * CGFloat(rows) + Self.verticalChrome(rows: rows)
     }
 
-    /// Maximum share of the *screen* height the keyboard may occupy. The
-    /// extension's own window is only keyboard-sized, so the height guard
-    /// must be evaluated against screen bounds, never window bounds.
+    /// Absolute floor for the height cap, as a share of the *screen* height:
+    /// the keyboard may always occupy at least this fraction regardless of the
+    /// reserved band below. The extension's own window is only keyboard-sized,
+    /// so the height guard must be evaluated against screen bounds, never
+    /// window bounds.
     static let maxScreenHeightFraction: CGFloat = 0.70
+
+    /// Fixed band of screen height reserved for the host document above the
+    /// keyboard (Option C). On tall screens this lets the keyboard grow to
+    /// `screenHeight - minReservedScreenHeight` — larger than the 0.70 floor —
+    /// so a large wish stays orientation-invariant instead of being shrunk in
+    /// landscape purely because the screen got shorter. On the shortest
+    /// landscapes the 0.70 floor governs (see `resolve`).
+    static let minReservedScreenHeight: CGFloat = 120
 
     /// Reference metrics at the iPhone default wish (270 pt, square cells)
     /// with no fit-clamp engaged. For tests and previews that need a valid
@@ -110,12 +120,26 @@ struct KeyboardLayoutMetrics: Equatable {
         var cellWidth = max((width - horizontalChrome) / CGFloat(columns), 1)
         var cellHeight = cellWidth / aspect
 
-        // Height guard: keep the keyboard within a fixed share of the screen
-        // (current orientation). Scale the cells proportionally — spacing and
-        // paddings are constants — so the aspect ratio is preserved exactly.
+        // Height guard (Option C — clamp only on genuine overflow): the cap is
+        // whichever is *more* generous of a fixed reserved band
+        // (`screenHeight - minReservedScreenHeight`) or the 0.70 floor. Taking
+        // the max keeps invariance for every wish that fits within
+        // `screenHeight - reserve`, and only shrinks on true landscape
+        // overflow. When it does shrink, the cells scale proportionally —
+        // spacing and paddings are constants — so the aspect ratio is
+        // preserved exactly.
+        //
+        // Shortest-landscape caveat: on the shortest landscapes the reserved
+        // band drops below the 0.70 floor (screenHeight ≲ 400 ⇒
+        // screenHeight - 120 < 0.70·screenHeight), so the floor governs and
+        // the very largest wishes still clamp there — Option C cannot make
+        // them invariant without letting the keyboard exceed the screen.
         let verticalChrome = Self.verticalChrome(rows: rows)
         if screenHeight > 0 {
-            let maxHeight = screenHeight * Self.maxScreenHeightFraction
+            let maxHeight = max(
+                screenHeight - Self.minReservedScreenHeight,
+                screenHeight * Self.maxScreenHeightFraction
+            )
             let contentHeight = cellHeight * CGFloat(rows) + verticalChrome
             if contentHeight > maxHeight {
                 let scale = max(maxHeight - verticalChrome, 0) / (cellHeight * CGFloat(rows))

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -236,11 +236,17 @@ final class LayoutSettings: ObservableObject {
     /// Resolves the persisted wish (width + aspect ratio) into concrete
     /// metrics for a render context. Pure: fit-clamps shrink the result but
     /// never write back to the store.
-    func resolveMetrics(columns: Int, availableWidth: CGFloat, screenHeight: CGFloat) -> KeyboardLayoutMetrics {
+    func resolveMetrics(
+        columns: Int,
+        rows: Int = KeyboardConstants.KeyDimensions.totalRows,
+        availableWidth: CGFloat,
+        screenHeight: CGFloat
+    ) -> KeyboardLayoutMetrics {
         KeyboardLayoutMetrics.resolve(
             wishWidth: keyboardWidth,
             aspectRatio: keyAspectRatio,
             columns: columns,
+            rows: rows,
             availableWidth: availableWidth,
             screenHeight: screenHeight
         )

--- a/wurstfingerTests/KeyboardGridRenderingTests.swift
+++ b/wurstfingerTests/KeyboardGridRenderingTests.swift
@@ -155,7 +155,7 @@ struct KeyViewStyleTests {
             style: .primary,
             tapCycleActions: nil
         )
-        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {})
+        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {}, metrics: .reference)
         #expect(view.primaryLabel == "midLeft")
     }
 
@@ -174,7 +174,7 @@ struct KeyViewStyleTests {
             style: .primary,
             tapCycleActions: nil
         )
-        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {})
+        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {}, metrics: .reference)
         #expect(view.primaryLabel == "d")
     }
 
@@ -193,7 +193,7 @@ struct KeyViewStyleTests {
             style: .utility,
             tapCycleActions: nil
         )
-        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {})
+        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {}, metrics: .reference)
         #expect(view.accessibilityLabel == "Löschen")
     }
 }

--- a/wurstfingerTests/KeyboardLayoutMetricsTests.swift
+++ b/wurstfingerTests/KeyboardLayoutMetricsTests.swift
@@ -109,6 +109,68 @@ struct KeyboardLayoutMetricsTests {
         #expect(portrait == landscape)
     }
 
+    @Test func sameLargeWishResolvesIdenticallyInPortraitAndLandscapeWithinSliderRange() {
+        // Large square wish on a screen tall enough that Option C's reserved
+        // band engages (screenHeight 450 → cap 330, above the 0.70 floor 315).
+        // Under the old flat 0.70 cap the landscape (screenHeight 450) clamped
+        // this 330 pt wish while portrait did not, so the keyboard shrank in
+        // landscape only. Option C reserves a fixed band instead, so the wish
+        // now fits in both orientations and the rendered keyboard is identical.
+        //
+        // Caveat: on the shortest-landscape iPhones (screenHeight ≈ 393) the
+        // reserved band drops below the 0.70 floor, so the very largest wishes
+        // still clamp there — see `heightGuardShrinksProportionallyAndPreservesAspect`.
+        let portrait = KeyboardLayoutMetrics.resolve(
+            wishWidth: 330,
+            aspectRatio: 1.0,
+            columns: 4,
+            availableWidth: 450,
+            screenHeight: 900
+        )
+        let landscape = KeyboardLayoutMetrics.resolve(
+            wishWidth: 330,
+            aspectRatio: 1.0,
+            columns: 4,
+            availableWidth: 900,
+            screenHeight: 450
+        )
+        #expect(portrait == landscape)
+        #expect(abs(portrait.cellHeight - landscape.cellHeight) < 0.0001)
+        #expect(abs(portrait.cellWidth - landscape.cellWidth) < 0.0001)
+    }
+
+    // MARK: - Explicit row count
+
+    @Test func resolveRespectsExplicitRowCountInTotalHeight() {
+        // The resolver must size the height from the row count it is given
+        // (the VM threads the arrangement's own row count through), not a
+        // pinned global constant. A 5-row arrangement produces a 5-row height.
+        let metrics = KeyboardLayoutMetrics.resolve(
+            wishWidth: 270,
+            aspectRatio: 1.0,
+            columns: 4,
+            rows: 5,
+            availableWidth: 1000,
+            screenHeight: 2000
+        )
+        #expect(metrics.rows == 5)
+        let expected = metrics.cellHeight * 5 + KeyboardLayoutMetrics.verticalChrome(rows: 5)
+        #expect(abs(metrics.totalHeight - expected) < 0.0001)
+    }
+
+    // MARK: - squareKeyboardWidth shares horizontalChrome
+
+    @Test(arguments: [3, 4, 5])
+    func squareKeyboardWidthEqualsCellsPlusHorizontalChrome(columns: Int) {
+        let cellSize: CGFloat = 60
+        let expected = cellSize * CGFloat(columns) +
+            KeyboardLayoutMetrics.horizontalChrome(columns: columns)
+        #expect(
+            KeyboardConstants.Calculations.squareKeyboardWidth(cellSize: cellSize, columns: columns)
+                == expected
+        )
+    }
+
     // MARK: - Width fit-clamp
 
     @Test func wishWiderThanContainerClampsToContainerPreservingAspect() {
@@ -138,8 +200,10 @@ struct KeyboardLayoutMetricsTests {
     // MARK: - Height fit-clamp
 
     @Test func heightGuardShrinksProportionallyAndPreservesAspect() {
-        // Landscape iPhone: screen height 393 → cap 275.1 pt. A big square
-        // wish overflows and must be scaled down, aspect preserved exactly.
+        // Shortest-landscape iPhone (screen height 393): the reserved band
+        // (393 − 120 = 273) drops below the 0.70 floor (275.1), so the floor
+        // governs the cap here (Option C). A big square wish still overflows
+        // and must be scaled down, aspect preserved exactly.
         let metrics = KeyboardLayoutMetrics.resolve(
             wishWidth: 392,
             aspectRatio: 1.0,
@@ -147,7 +211,12 @@ struct KeyboardLayoutMetricsTests {
             availableWidth: 852,
             screenHeight: 393
         )
-        let maxHeight = 393 * KeyboardLayoutMetrics.maxScreenHeightFraction
+        // Track the Option C cap directly so the expectation follows whatever
+        // reserve/fraction ships (here it resolves to 393·0.70 = 275.1).
+        let maxHeight = max(
+            393 - KeyboardLayoutMetrics.minReservedScreenHeight,
+            393 * KeyboardLayoutMetrics.maxScreenHeightFraction
+        )
         #expect(abs(metrics.totalHeight - maxHeight) < 0.0001)
         #expect(abs(metrics.cellAspectRatio - 1.0) < 0.0001)
         // The width shrinks consistently with the cells (chrome constant).

--- a/wurstfingerTests/LongPressSchedulerTests.swift
+++ b/wurstfingerTests/LongPressSchedulerTests.swift
@@ -1,0 +1,60 @@
+//
+//  LongPressSchedulerTests.swift
+//  WurstfingerTests
+//
+//  Tests for the shared LongPressScheduler extracted from KeyGestureRecognizer
+//  and SlideGestureHandler: the synchronous fire/consume core plus the
+//  DispatchWorkItem timer wiring. `runFire` is synchronous so the guard path
+//  is testable without a real 0.7 s timer.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+@Suite(.serialized)
+struct LongPressSchedulerTests {
+    @Test func runFireWithPassingGuardConsumesTouch() {
+        let scheduler = LongPressScheduler()
+        scheduler.runFire { true }
+        #expect(scheduler.consumedTouch)
+        #expect(!scheduler.isScheduled)
+    }
+
+    @Test func runFireWithFailingGuardDoesNotConsume() {
+        let scheduler = LongPressScheduler()
+        scheduler.runFire { false }
+        #expect(!scheduler.consumedTouch)
+    }
+
+    @Test func clearConsumedResetsFlag() {
+        let scheduler = LongPressScheduler()
+        scheduler.runFire { true }
+        #expect(scheduler.consumedTouch)
+        scheduler.clearConsumed()
+        #expect(!scheduler.consumedTouch)
+    }
+
+    @Test func scheduleSetsIsScheduledAndCancelClearsIt() {
+        let scheduler = LongPressScheduler()
+        // Long delay so the timer never fires during the test — assert only on
+        // the synchronous `isScheduled` bookkeeping.
+        scheduler.schedule(after: 5) { true }
+        #expect(scheduler.isScheduled)
+        scheduler.cancel()
+        #expect(!scheduler.isScheduled)
+    }
+
+    @Test func scheduledWorkItemFiresGuardAndConsumes() async {
+        await confirmation { confirmed in
+            let scheduler = LongPressScheduler()
+            scheduler.schedule(after: 0.02) {
+                confirmed()
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(200))
+            #expect(scheduler.consumedTouch)
+            #expect(!scheduler.isScheduled)
+        }
+    }
+}

--- a/wurstfingerTests/SlideGestureStateTests.swift
+++ b/wurstfingerTests/SlideGestureStateTests.swift
@@ -267,6 +267,50 @@ struct SlideGestureStateTests {
         #expect(phase == .tap)
     }
 
+    // MARK: - Up-swipe latch re-arm (finding #11)
+
+    @Test func incidentalUpFlickThenDominantHorizontalDragReArmsSlide() {
+        var state = SlideGestureState()
+        // An incidental up-flick commits the up-swipe peak (-35, beyond the
+        // 30 pt threshold) without latching a slide. Previously the peak guard
+        // never decayed, so a subsequent clearly-horizontal drag stayed stuck
+        // as an up-swipe and the cursor never moved. The dominant-horizontal
+        // re-arm now latches the slide.
+        let flick = state.handleChanged(
+            translation: CGSize(width: 2, height: -35), activationThreshold: threshold
+        )
+        #expect(flick.phases.isEmpty)
+        let latch = state.handleChanged(
+            translation: CGSize(width: 100, height: -20), activationThreshold: threshold
+        )
+        #expect(latch.phases.first == .began)
+        let phase = state.handleEnded(
+            translation: CGSize(width: 100, height: -20), activationThreshold: threshold
+        )
+        #expect(phase == .ended)
+    }
+
+    @Test func smallHorizontalDriftAfterUpPeakStillDoesNotReArm() {
+        var state = SlideGestureState()
+        // Regression fence for the re-arm: return-leg drift (|x| ≈ 10, below
+        // the 30 pt re-arm floor) must NOT latch — this is the same shape as
+        // `returnUpSwipeWithDriftAtLiftOffStaysAReturnUpSwipe`, asserting the
+        // re-arm threshold does not loosen it into a slide.
+        let samples: [CGSize] = [
+            CGSize(width: 6, height: -45),
+            CGSize(width: 9, height: -15),
+            CGSize(width: 10, height: -6),
+        ]
+        for sample in samples {
+            let update = state.handleChanged(translation: sample, activationThreshold: threshold)
+            #expect(update.phases.isEmpty)
+        }
+        let phase = state.handleEnded(
+            translation: CGSize(width: 10, height: -6), activationThreshold: threshold
+        )
+        #expect(phase == .swipeUp(isReturn: true))
+    }
+
     // MARK: - Touch cancellation (Bug 1)
 
     @Test func cancellationMidSlideReportsCancelled() {


### PR DESCRIPTION
Addresses the layout-metrics and gesture findings from the 2026-07-22 review (findings #7, #12, #11, plus nitpicks). Test-driven; all unit tests green.

## Findings fixed
- **#7 — Landscape 70%-height cap broke orientation-size invariance (regression vs 1.3.1 / PR #197).** Implemented the reviewer's "cap only on genuine overflow" option: a fixed document band (`minReservedScreenHeight`, currently **120pt**) is reserved, with the old 0.70 fraction kept as an absolute floor. Portrait key sizes now stay invariant across orientations wherever the keyboard actually fits.
  - ⚠️ **Product note / your call:** on short landscape screens (e.g. a 393pt-tall iPhone), the very largest slider sizes still shrink — because you genuinely cannot fit ~330pt-square keys *and* keep the document visible. `minReservedScreenHeight` is the knob: lower it to shrink less (keyboard eats more of the screen), raise it to keep more document visible. 120pt is a starting point; happy to retune.
- **#12 — `KeyView.metrics` regained a silent `.reference` default.** Removed; metrics (which feed gesture classification, not just rendering) are always injected explicitly now.
- **#11 — Up-swipe latch blocked cursor slide after incidental upward drift.** A dominant horizontal drag now re-arms the slide (conservative thresholds: |x| ≥ 30 and |x| > 2·|y|). Return-leg drift stays below the floor (regression-guarded).
- **Nitpicks:** extracted a shared `LongPressScheduler` used by both `KeyGestureRecognizer` and `SlideGestureHandler` (behavior-preserving — each keeps its own fire guard, including SlideGestureHandler's `!isSliding` axis); threaded the arrangement's row count through metrics resolution; routed `squareKeyboardWidth` through `KeyboardLayoutMetrics.horizontalChrome`.

## Tests
New `LongPressSchedulerTests`; new invariance + re-arm + row-count + chrome tests; the existing `heightGuardShrinksProportionallyAndPreservesAspect` updated in lockstep. Full suite passes.

## Verification still recommended (on device)
- **#11 re-arm thresholds want feel-tuning** — try an up-flick then a sideways drag; confirm the cursor moves and labels don't unexpectedly toggle.
- **#7** — check key sizes across orientations at a few slider sizes on a real phone, and confirm the `minReservedScreenHeight` value feels right.
