### PR TITLE
Speed up health log (JSONL) and dedupe screenshot/host-app code

### DIFF
--- a/scripts/generate-appstore-screenshots.sh
+++ b/scripts/generate-appstore-screenshots.sh
@@ -129,8 +129,12 @@ for target in "${TARGETS[@]}"; do
     # Order screenshots by the manifest's human-readable names (which embed
     # the screenshot number). The exported UUID filenames alone would sort
     # randomly. `manifest_names_to_files` emits sorted `name<TAB>file` lines;
-    # we take the exported file column.
-    mapfile -t ORDERED_EXPORTS < <(manifest_names_to_files "$TEMP_SCREENSHOTS/manifest.json" | cut -f2)
+    # we take the exported file column. Use a while-read loop rather than
+    # `mapfile`, which is a bash 4+ builtin absent from macOS's stock bash 3.2.
+    ORDERED_EXPORTS=()
+    while IFS= read -r line; do
+        ORDERED_EXPORTS+=("$line")
+    done < <(manifest_names_to_files "$TEMP_SCREENSHOTS/manifest.json" | cut -f2)
     if [ "${#ORDERED_EXPORTS[@]}" -eq 0 ]; then
         echo -e "${RED}❌ manifest.json contained no attachments${NC}"
         exit 1

--- a/scripts/generate-appstore-screenshots.sh
+++ b/scripts/generate-appstore-screenshots.sh
@@ -18,19 +18,15 @@
 
 set -e
 
-# Colors for output
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-RED='\033[0;31m'
-NC='\033[0m' # No Color
+# Change to project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/simulator-capture.sh
+source "$SCRIPT_DIR/lib/simulator-capture.sh"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
 
 echo -e "${BLUE}📱 Wurstfinger App Store Screenshot Generator${NC}"
 echo ""
-
-# Change to project root
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-cd "$PROJECT_ROOT"
 
 # Configuration
 SCHEME="Wurstfinger"
@@ -54,19 +50,13 @@ for target in "${TARGETS[@]}"; do
 done
 echo ""
 
-# Get device UDID
-get_device_udid() {
-    local device_name="$1"
-    xcrun simctl list devices available | grep "$device_name" | head -n 1 | grep -oE '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}' || true
-}
-
 # Ensure cleanup runs on any exit (normal, error, or signal)
 CURRENT_UDID=""
 cleanup() {
     echo ""
     echo -e "${BLUE}🧹 Cleaning up...${NC}"
     if [ -n "$CURRENT_UDID" ]; then
-        xcrun simctl status_bar "$CURRENT_UDID" clear 2>/dev/null || true
+        sim_status_bar_clear "$CURRENT_UDID"
         xcrun simctl shutdown "$CURRENT_UDID" 2>/dev/null || true
     fi
     rm -rf "$DERIVED_DATA"
@@ -84,7 +74,7 @@ for target in "${TARGETS[@]}"; do
 
     echo -e "${BLUE}🔄 Capturing $SIZE_PREFIX screenshots on $DEVICE_NAME${NC}"
 
-    UDID=$(get_device_udid "$DEVICE_NAME")
+    UDID=$(sim_udid_for_name "$DEVICE_NAME")
     if [ -z "$UDID" ]; then
         echo -e "${RED}❌ Device not found: $DEVICE_NAME${NC}"
         echo "Available devices:"
@@ -96,28 +86,20 @@ for target in "${TARGETS[@]}"; do
 
     # Boot simulator
     echo "  Booting simulator..."
-    xcrun simctl boot "$UDID" 2>/dev/null || true
-    xcrun simctl bootstatus "$UDID" -b 2>/dev/null || true
+    sim_boot_and_wait "$UDID"
 
     # Override status bar to get consistent screenshots (Apple's standard 9:41)
     echo "  Setting consistent status bar..."
-    xcrun simctl status_bar "$UDID" override --time "9:41" --batteryState charged --batteryLevel 100
+    sim_status_bar_941 "$UDID"
 
     # Run screenshot tests
     echo "  Running screenshot tests..."
-    rm -rf "$DERIVED_DATA"
-
-    set +e
-    xcodebuild test \
-        -scheme "$SCHEME" \
-        -destination "platform=iOS Simulator,id=$UDID" \
-        -only-testing:"$TEST_TARGET" \
-        -derivedDataPath "$DERIVED_DATA" \
-        CODE_SIGNING_ALLOWED=NO \
-        2>&1 | if command -v xcpretty >/dev/null; then xcpretty --color; else cat; fi
-    # $? after a pipe is the formatter's exit code (always 0); we need xcodebuild's.
-    TEST_RESULT=${PIPESTATUS[0]}
-    set -e
+    TEST_RESULT=0
+    run_screenshot_tests \
+        "$SCHEME" \
+        "platform=iOS Simulator,id=$UDID" \
+        "$TEST_TARGET" \
+        "$DERIVED_DATA" || TEST_RESULT=$?
 
     if [ "$TEST_RESULT" -ne 0 ]; then
         # These screenshots ship to the App Store (deliver uploads with
@@ -129,15 +111,13 @@ for target in "${TARGETS[@]}"; do
     fi
 
     # Find and extract screenshots from xcresult
-    RESULTS_BUNDLE=$(find "$DERIVED_DATA" -name "*.xcresult" -type d | head -n 1)
+    RESULTS_BUNDLE=$(find_xcresult_bundle "$DERIVED_DATA")
     if [ -z "$RESULTS_BUNDLE" ]; then
         echo -e "${RED}❌ No results bundle found${NC}"
         exit 1
     fi
 
-    rm -rf "$TEMP_SCREENSHOTS"
-    mkdir -p "$TEMP_SCREENSHOTS"
-    xcrun xcresulttool export attachments --path "$RESULTS_BUNDLE" --output-path "$TEMP_SCREENSHOTS"
+    export_xcresult_attachments "$RESULTS_BUNDLE" "$TEMP_SCREENSHOTS"
 
     PNG_COUNT=$(find "$TEMP_SCREENSHOTS" -name "*.png" -type f | wc -l | tr -d ' ')
     echo "  Found $PNG_COUNT PNG files"
@@ -146,44 +126,26 @@ for target in "${TARGETS[@]}"; do
         exit 1
     fi
 
-    # xcresulttool exports attachments under opaque UUID filenames; the
-    # attachment name (which embeds the screenshot number, …-keyboard-01-…)
-    # only exists in manifest.json. Sorting the files directly would produce
-    # a random screenshot order, so order by the manifest names instead.
+    # Order screenshots by the manifest's human-readable names (which embed
+    # the screenshot number). The exported UUID filenames alone would sort
+    # randomly. `manifest_names_to_files` emits sorted `name<TAB>file` lines;
+    # we take the exported file column.
+    mapfile -t ORDERED_EXPORTS < <(manifest_names_to_files "$TEMP_SCREENSHOTS/manifest.json" | cut -f2)
+    if [ "${#ORDERED_EXPORTS[@]}" -eq 0 ]; then
+        echo -e "${RED}❌ manifest.json contained no attachments${NC}"
+        exit 1
+    fi
+
     COUNTER=1
-    while IFS= read -r exported; do
+    for exported in "${ORDERED_EXPORTS[@]}"; do
         filename=$(printf "%s_%02d.png" "$SIZE_PREFIX" $COUNTER)
         cp "$TEMP_SCREENSHOTS/$exported" "$PRIMARY_DIR/$filename"
         echo "    ✓ $filename ($exported)"
         COUNTER=$((COUNTER + 1))
-    done < <(python3 - "$TEMP_SCREENSHOTS/manifest.json" <<'PYEOF'
-import json
-import sys
-
-
-def walk(node, out):
-    if isinstance(node, dict):
-        if "exportedFileName" in node and "suggestedHumanReadableName" in node:
-            out.append((node["suggestedHumanReadableName"], node["exportedFileName"]))
-        for value in node.values():
-            walk(value, out)
-    elif isinstance(node, list):
-        for value in node:
-            walk(value, out)
-
-
-attachments = []
-with open(sys.argv[1]) as f:
-    walk(json.load(f), attachments)
-if not attachments:
-    sys.exit("manifest.json contained no attachments")
-for _, exported in sorted(attachments):
-    print(exported)
-PYEOF
-)
+    done
 
     # Shut down before switching to the next device
-    xcrun simctl status_bar "$UDID" clear 2>/dev/null || true
+    sim_status_bar_clear "$UDID"
     xcrun simctl shutdown "$UDID" 2>/dev/null || true
     CURRENT_UDID=""
     echo ""

--- a/scripts/generate-screenshots.sh
+++ b/scripts/generate-screenshots.sh
@@ -7,19 +7,15 @@
 
 set -e
 
-# Colors for output
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-RED='\033[0;31m'
-NC='\033[0m' # No Color
+# Change to project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/simulator-capture.sh
+source "$SCRIPT_DIR/lib/simulator-capture.sh"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
 
 echo -e "${BLUE}🖼️  Wurstfinger Screenshot Generator${NC}"
 echo ""
-
-# Change to project root
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-cd "$PROJECT_ROOT"
 
 # Configuration
 SCHEME="Wurstfinger"
@@ -48,17 +44,7 @@ echo "  Output: $DOCS_DIR"
 echo ""
 
 # Find target simulator UDID by name
-TARGET_UDID=$(xcrun simctl list devices available -j | python3 -c "
-import json, sys
-name = '$DEVICE_NAME'
-devices = json.load(sys.stdin)['devices']
-for runtime_devices in devices.values():
-    for d in runtime_devices:
-        if d.get('name') == name and d.get('isAvailable', True):
-            print(d['udid'])
-            raise SystemExit(0)
-raise SystemExit(1)
-" 2>/dev/null || true)
+TARGET_UDID=$(sim_udid_for_name "$DEVICE_NAME")
 
 # Marker file so we can count only screenshots created by this run
 # (pre-existing .webp files in $DOCS_DIR must not count as success).
@@ -69,7 +55,7 @@ cleanup() {
     echo ""
     echo -e "${BLUE}🧹 Cleaning up...${NC}"
     if [ -n "$TARGET_UDID" ]; then
-        xcrun simctl status_bar "$TARGET_UDID" clear 2>/dev/null || true
+        sim_status_bar_clear "$TARGET_UDID"
     fi
     rm -rf "$DERIVED_DATA"
     rm -f "$RUN_MARKER"
@@ -79,7 +65,7 @@ trap cleanup EXIT
 # Override status bar to get consistent screenshots (Apple's standard 9:41)
 echo -e "${BLUE}⏰ Setting consistent status bar...${NC}"
 if [ -n "$TARGET_UDID" ]; then
-    xcrun simctl status_bar "$TARGET_UDID" override --time "9:41" --batteryState charged --batteryLevel 100
+    sim_status_bar_941 "$TARGET_UDID"
     echo "  Set status bar to 9:41 on $TARGET_UDID ($DEVICE_NAME)"
 else
     echo "  ⚠️  Could not find simulator '$DEVICE_NAME', skipping status bar override"
@@ -94,17 +80,8 @@ echo -e "${BLUE}📱 Simulator status before test:${NC}"
 xcrun simctl list devices booted || echo "No booted devices"
 echo ""
 
-TEST_OUTPUT=$(mktemp)
-set +e
-xcodebuild test \
-  -scheme "$SCHEME" \
-  -destination "$DESTINATION" \
-  -only-testing:"$TEST_TARGET" \
-  -derivedDataPath "$DERIVED_DATA" \
-  CODE_SIGNING_ALLOWED=NO \
-  2>&1 | tee "$TEST_OUTPUT" | if command -v xcpretty >/dev/null; then xcpretty --color; else cat; fi
-TEST_EXIT_CODE=${PIPESTATUS[0]}
-set -e
+TEST_EXIT_CODE=0
+run_screenshot_tests "$SCHEME" "$DESTINATION" "$TEST_TARGET" "$DERIVED_DATA" || TEST_EXIT_CODE=$?
 
 if [ "$TEST_EXIT_CODE" -ne 0 ]; then
   echo -e "${RED}⚠️  UI tests failed (exit code: $TEST_EXIT_CODE), but continuing to check for screenshots...${NC}"
@@ -114,7 +91,7 @@ echo ""
 echo -e "${BLUE}📤 Exporting screenshots...${NC}"
 
 # Find the test results bundle
-RESULTS_BUNDLE=$(find "$DERIVED_DATA" -name "*.xcresult" -type d | head -n 1)
+RESULTS_BUNDLE=$(find_xcresult_bundle "$DERIVED_DATA")
 
 if [ -z "$RESULTS_BUNDLE" ]; then
   echo -e "${RED}❌ Error: Could not find test results bundle${NC}"
@@ -129,23 +106,26 @@ echo -e "${BLUE}🔍 Extracting screenshots with proper names...${NC}"
 
 # Export all attachments
 TEMP_EXPORT="/tmp/screenshot-exports"
-rm -rf "$TEMP_EXPORT"
-xcrun xcresulttool export attachments --path "$RESULTS_BUNDLE" --output-path "$TEMP_EXPORT"
+export_xcresult_attachments "$RESULTS_BUNDLE" "$TEMP_EXPORT"
 
 # Map exported files to proper names based on manifest
 COPIED=0
 if [ -f "$TEMP_EXPORT/manifest.json" ]; then
-    # Parse manifest, crop, and convert to WebP
+    # Parse manifest (via the shared recursive walk), crop, convert to WebP.
+    # The name/file pairs go to a temp file rather than a pipe: the Python
+    # heredoc already occupies stdin, so it reads the pairs from PAIRS_FILE.
+    PAIRS_FILE=$(mktemp)
+    manifest_names_to_files "$TEMP_EXPORT/manifest.json" > "$PAIRS_FILE"
     export TEMP_EXPORT
     export DOCS_DIR
+    export PAIRS_FILE
     python3 << 'EOF'
-import json
 import os
 import re
+
 import numpy as np
 from PIL import Image
 
-manifest_path = os.environ['TEMP_EXPORT'] + '/manifest.json'
 docs_dir = os.environ['DOCS_DIR']
 
 # Screenshots that come from the tab-based app (Home/Test/Settings/Setup) —
@@ -229,43 +209,45 @@ def crop_screenshot(img, base_name):
     return largest_content_block_crop(img)
 
 
-with open(manifest_path, 'r') as f:
-    manifest = json.load(f)
+# Attachment name/file pairs come from `manifest_names_to_files`, written to
+# PAIRS_FILE as tab-separated `suggestedHumanReadableName<TAB>exportedFileName`.
+with open(os.environ['PAIRS_FILE']) as pairs:
+    lines = pairs.read().splitlines()
 
-for test_result in manifest:
-    for attachment in test_result.get('attachments', []):
-        exported_file = attachment['exportedFileName']
-        suggested_name = attachment['suggestedHumanReadableName']
+for line in lines:
+    if not line:
+        continue
+    suggested_name, exported_file = line.split('\t', 1)
 
-        # Skip non-image files (videos, etc.)
-        if not exported_file.lower().endswith(('.png', '.jpg', '.jpeg')):
-            print(f"  ⏭ Skipping non-image: {exported_file}")
-            continue
+    # Skip non-image files (videos, etc.)
+    if not exported_file.lower().endswith(('.png', '.jpg', '.jpeg')):
+        print(f"  ⏭ Skipping non-image: {exported_file}")
+        continue
 
-        # Extract base name (e.g., "keyboard-lower-light" from "keyboard-lower-light_0_UUID.png")
-        base_name = suggested_name.split('_')[0]
+    # Extract base name (e.g., "keyboard-lower-light" from "keyboard-lower-light_0_UUID.png")
+    base_name = suggested_name.split('_')[0]
 
-        src_path = os.path.join(os.environ['TEMP_EXPORT'], exported_file)
-        temp_png = os.path.join(os.environ['TEMP_EXPORT'], f'{base_name}-temp.png')
-        final_webp = os.path.join(docs_dir, f'{base_name}.webp')
+    src_path = os.path.join(os.environ['TEMP_EXPORT'], exported_file)
+    final_webp = os.path.join(docs_dir, f'{base_name}.webp')
 
-        if os.path.exists(src_path):
-            img = Image.open(src_path)
+    if os.path.exists(src_path):
+        img = Image.open(src_path)
 
-            # Convert to RGB if necessary
-            if img.mode in ('RGBA', 'LA', 'P'):
-                background = Image.new('RGB', img.size, (255, 255, 255))
-                if img.mode == 'P':
-                    img = img.convert('RGBA')
-                background.paste(img, mask=img.split()[-1] if img.mode == 'RGBA' else None)
-                img = background
+        # Convert to RGB if necessary
+        if img.mode in ('RGBA', 'LA', 'P'):
+            background = Image.new('RGB', img.size, (255, 255, 255))
+            if img.mode == 'P':
+                img = img.convert('RGBA')
+            background.paste(img, mask=img.split()[-1] if img.mode == 'RGBA' else None)
+            img = background
 
-            img = crop_screenshot(img, base_name)
+        img = crop_screenshot(img, base_name)
 
-            # Save as WebP with good quality
-            img.save(final_webp, 'WEBP', quality=85)
-            print(f"  ✓ Created {base_name}.webp ({img.width}x{img.height})")
+        # Save as WebP with good quality
+        img.save(final_webp, 'WEBP', quality=85)
+        print(f"  ✓ Created {base_name}.webp ({img.width}x{img.height})")
 EOF
+    rm -f "$PAIRS_FILE"
 
     # Count only files created (or overwritten) by this run
     COPIED=$(find "$DOCS_DIR" -maxdepth 1 -name "*.webp" -type f -newer "$RUN_MARKER" | wc -l | tr -d ' ')

--- a/scripts/lib/simulator-capture.sh
+++ b/scripts/lib/simulator-capture.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# simulator-capture.sh
+# Shared simulator screenshot-capture pipeline, sourced by
+# generate-appstore-screenshots.sh and generate-screenshots.sh.
+#
+# Provides the common simctl/xcodebuild/xcresulttool steps plus the single
+# manifest parser both generators use. Callers keep their own error/exit
+# semantics (the App Store generator refuses partial sets and fails hard; the
+# docs generator warns and continues to salvage whatever rendered).
+#
+# Usage:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/lib/simulator-capture.sh"
+
+# Colors for output (consumed by the sourcing generator scripts).
+# shellcheck disable=SC2034
+GREEN='\033[0;32m'
+# shellcheck disable=SC2034
+BLUE='\033[0;34m'
+# shellcheck disable=SC2034
+RED='\033[0;31m'
+# shellcheck disable=SC2034
+NC='\033[0m' # No Color
+
+# Resolves a simulator UDID by exact device name (available devices only).
+# Prints the UDID, or nothing if no matching available device exists.
+sim_udid_for_name() {
+    local name="$1"
+    xcrun simctl list devices available -j | python3 -c "
+import json, sys
+name = sys.argv[1]
+devices = json.load(sys.stdin)['devices']
+for runtime_devices in devices.values():
+    for d in runtime_devices:
+        if d.get('name') == name and d.get('isAvailable', True):
+            print(d['udid'])
+            raise SystemExit(0)
+raise SystemExit(1)
+" "$name" 2>/dev/null || true
+}
+
+# Boots the simulator and blocks until it has finished booting.
+sim_boot_and_wait() {
+    local udid="$1"
+    xcrun simctl boot "$udid" 2>/dev/null || true
+    xcrun simctl bootstatus "$udid" -b 2>/dev/null || true
+}
+
+# Overrides the status bar to Apple's standard 9:41 / full battery so
+# screenshots are deterministic.
+sim_status_bar_941() {
+    xcrun simctl status_bar "$1" override --time "9:41" --batteryState charged --batteryLevel 100
+}
+
+# Clears any status-bar override. Best-effort — never fails the caller.
+sim_status_bar_clear() {
+    xcrun simctl status_bar "$1" clear 2>/dev/null || true
+}
+
+# Runs the screenshot UI test and returns xcodebuild's real exit code.
+# `$?` after the pipe is the formatter's exit code (always 0), so we recover
+# xcodebuild's via PIPESTATUS. Callers decide what a non-zero result means.
+run_screenshot_tests() {
+    local scheme="$1" destination="$2" test_target="$3" derived_data="$4"
+    rm -rf "$derived_data"
+    local result
+    set +e
+    xcodebuild test \
+        -scheme "$scheme" \
+        -destination "$destination" \
+        -only-testing:"$test_target" \
+        -derivedDataPath "$derived_data" \
+        CODE_SIGNING_ALLOWED=NO \
+        2>&1 | if command -v xcpretty >/dev/null; then xcpretty --color; else cat; fi
+    result=${PIPESTATUS[0]}
+    set -e
+    return "$result"
+}
+
+# Prints the first .xcresult bundle under the given derived-data path (empty
+# if none). Callers guard against the empty case with their own message.
+find_xcresult_bundle() {
+    find "$1" -name "*.xcresult" -type d | head -n 1
+}
+
+# Exports all attachments from an .xcresult bundle into a fresh output dir.
+export_xcresult_attachments() {
+    local bundle="$1" out="$2"
+    rm -rf "$out"
+    mkdir -p "$out"
+    xcrun xcresulttool export attachments --path "$bundle" --output-path "$out"
+}
+
+# The single manifest parser both generators share. xcresulttool exports
+# attachments under opaque UUID filenames; the human-readable name (which
+# embeds the screenshot number, e.g. …-keyboard-01-…) only exists in
+# manifest.json. A naive top-level read misses attachments nested at varying
+# depths, so this walks the whole tree. Emits one tab-separated
+# `suggestedHumanReadableName<TAB>exportedFileName` line per attachment,
+# sorted by the human-readable name (i.e. in screenshot order).
+manifest_names_to_files() {
+    python3 - "$1" <<'PYEOF'
+import json
+import sys
+
+
+def walk(node, out):
+    if isinstance(node, dict):
+        if "exportedFileName" in node and "suggestedHumanReadableName" in node:
+            out.append((node["suggestedHumanReadableName"], node["exportedFileName"]))
+        for value in node.values():
+            walk(value, out)
+    elif isinstance(node, list):
+        for value in node:
+            walk(value, out)
+
+
+attachments = []
+with open(sys.argv[1]) as f:
+    walk(json.load(f), attachments)
+for suggested, exported in sorted(attachments):
+    print(f"{suggested}\t{exported}")
+PYEOF
+}

--- a/wurstfinger/InteractiveKeyboardPreview.swift
+++ b/wurstfinger/InteractiveKeyboardPreview.swift
@@ -66,7 +66,7 @@ struct InteractiveKeyboardPreview: View {
         // the frame height always matches the rendered content height.
         let containerWidth = DeviceLayoutUtils.screenBounds.width - 32
         let metrics = previewViewModel.layoutMetrics(forContainerWidth: containerWidth)
-        return min(KeyboardConstants.Preview.maxHeight, max(KeyboardConstants.Preview.minHeight, metrics.totalHeight))
+        return KeyboardConstants.Preview.frameHeight(forContentHeight: metrics.totalHeight)
     }
 
     var body: some View {

--- a/wurstfinger/KeyboardShowcaseView.swift
+++ b/wurstfinger/KeyboardShowcaseView.swift
@@ -81,6 +81,15 @@ struct KeyboardShowcaseView: View {
     private let isDeadZoneTest = ProcessInfo.processInfo.environment["DEAD_ZONE_TEST"] != nil
     private let isTypingTest = ProcessInfo.processInfo.environment["TYPING_TEST"] != nil
 
+    /// Resolves the showcase's language id. A `FORCE_LANGUAGE` override (UI
+    /// tests) wins verbatim — it may name an id not in the registry, so it must
+    /// NOT be routed through the registry-validating helper. Otherwise the
+    /// stored id is resolved via `LanguageSettings.resolvedLanguageId`, which
+    /// falls back to the detected system language when the stored id is stale.
+    static func resolvedShowcaseLanguageId(forceLanguage: String?, storedId: String?) -> String {
+        forceLanguage ?? LanguageSettings.resolvedLanguageId(storedId)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             DataDrivenKeyboardRootView(viewModel: viewModel)
@@ -123,9 +132,10 @@ struct KeyboardShowcaseView: View {
             // stored selection. The forced id is applied to the view model
             // only — the showcase must never persist into the real shared
             // app-group store (`shouldPersistSettings: false`).
-            let languageId = ProcessInfo.processInfo.environment["FORCE_LANGUAGE"]
-                ?? SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue)
-                ?? LanguageSettings.detectSystemLanguage()
+            let languageId = Self.resolvedShowcaseLanguageId(
+                forceLanguage: ProcessInfo.processInfo.environment["FORCE_LANGUAGE"],
+                storedId: SharedDefaults.store.string(forKey: SettingsKey.selectedLanguageId.rawValue)
+            )
             viewModel.loadDefinition(for: languageId)
 
             // Set keyboard mode from environment if specified (for UI tests)

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -209,6 +209,15 @@ enum KeyboardConstants {
         static let minHeight: CGFloat = 100
         /// Maximum height for keyboard preview in settings.
         static let maxHeight: CGFloat = 400
+
+        /// Frame height for the settings preview given the rendered keyboard's
+        /// content height. Applies only the lower bound — there is deliberately
+        /// no upper cap, so the preview grows to match the real keyboard
+        /// exactly (which lays out at its content height with no upper clamp)
+        /// instead of clipping tall content.
+        static func frameHeight(forContentHeight contentHeight: CGFloat) -> CGFloat {
+            max(minHeight, contentHeight)
+        }
     }
 
     // MARK: - Keyboard Calculations

--- a/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
@@ -52,15 +52,30 @@ struct KeyboardHealthLog {
 
     static let fileName = "keyboard-health-log.json"
 
-    /// Shared instance persisting into the app group container.
-    static let shared = KeyboardHealthLog(
-        fileURL: FileManager.default
+    /// Shared instance persisting into the app group container. The
+    /// `containerURL(...)` lookup is out-of-process IPC; it is deferred into a
+    /// provider closure so it runs lazily inside the `ioQueue` on first file
+    /// access, never synchronously on the main thread during the latency-
+    /// critical extension spawn.
+    static let shared = KeyboardHealthLog(fileURLProvider: {
+        FileManager.default
             .containerURL(forSecurityApplicationGroupIdentifier: SharedDefaults.suiteName)?
             .appendingPathComponent(fileName)
-    )
+    })
 
-    private let fileURL: URL?
+    private let fileURLProvider: () -> URL?
     private let maxEntries: Int
+
+    /// Approximate encoded size of one entry, used to size the compaction
+    /// threshold. Only needs to be within an order of magnitude.
+    private static let approxBytesPerEntry = 160
+
+    /// Compaction fires once the file grows past this many bytes, i.e. roughly
+    /// once every `maxEntries` appends — keeping the append hot path O(1)
+    /// amortized while bounding the file to ~`2 * maxEntries` entries on disk.
+    private var trimThresholdBytes: Int {
+        2 * maxEntries * Self.approxBytesPerEntry
+    }
 
     /// Serializes all file access across instances. `record` hops onto it
     /// asynchronously; `entries()`/`clear()` sync through it, so reads always
@@ -75,7 +90,11 @@ struct KeyboardHealthLog {
     #endif
 
     init(fileURL: URL?, maxEntries: Int = KeyboardHealthLog.defaultMaxEntries) {
-        self.fileURL = fileURL
+        self.init(fileURLProvider: { fileURL }, maxEntries: maxEntries)
+    }
+
+    init(fileURLProvider: @escaping () -> URL?, maxEntries: Int = KeyboardHealthLog.defaultMaxEntries) {
+        self.fileURLProvider = fileURLProvider
         self.maxEntries = maxEntries
     }
 
@@ -94,41 +113,83 @@ struct KeyboardHealthLog {
             let message = "[\(label)] used: \(used) MB, available: \(available) MB"
             Self.logger.log("\(message, privacy: .public)")
         #endif
-        Self.ioQueue.async {
-            var all = readEntries()
-            all.append(entry)
-            if all.count > maxEntries {
-                all.removeFirst(all.count - maxEntries)
-            }
-            write(all)
-        }
+        Self.ioQueue.async { appendEntry(entry) }
     }
 
-    /// All recorded entries, oldest first. Empty when the file is missing or
-    /// unreadable (corruption is silently discarded — this is diagnostics,
-    /// it must never take the keyboard down).
+    /// All recorded entries, oldest first, capped at `maxEntries`. Empty when
+    /// the file is missing or unreadable (corruption is silently discarded —
+    /// this is diagnostics, it must never take the keyboard down).
+    ///
+    /// The `suffix(maxEntries)` cap keeps the read bound even when the on-disk
+    /// file has grown past `maxEntries` between physical compactions.
     func entries() -> [Entry] {
-        Self.ioQueue.sync { readEntries() }
+        Self.ioQueue.sync {
+            guard let fileURL = fileURLProvider() else { return [] }
+            return Array(readEntries(fileURL).suffix(maxEntries))
+        }
     }
 
     /// Removes all recorded entries.
     func clear() {
-        guard let fileURL else { return }
         Self.ioQueue.sync {
+            guard let fileURL = fileURLProvider() else { return }
             try? FileManager.default.removeItem(at: fileURL)
         }
     }
 
     // MARK: - Private
 
-    /// Raw read; must only run on `ioQueue`.
-    private func readEntries() -> [Entry] {
-        guard let fileURL, let data = try? Data(contentsOf: fileURL) else { return [] }
-        return (try? JSONDecoder().decode([Entry].self, from: data)) ?? []
+    /// Appends a single entry to the newline-delimited JSON (JSONL) file with
+    /// a `seekToEnd` + `write` — O(1), no full-file read on the hot path.
+    /// Must only run on `ioQueue`.
+    private func appendEntry(_ entry: Entry) {
+        guard let fileURL = fileURLProvider(),
+              let encoded = try? JSONEncoder().encode(entry) else { return }
+        if let handle = try? FileHandle(forWritingTo: fileURL) {
+            defer { try? handle.close() }
+            let end = (try? handle.seekToEnd()) ?? 0
+            var payload = Data()
+            // Separate the new line from a prior line or legacy array bytes.
+            if end > 0 { payload.append(0x0A) }
+            payload.append(encoded)
+            try? handle.write(contentsOf: payload)
+        } else {
+            // First write / file absent.
+            try? encoded.write(to: fileURL, options: .atomic)
+        }
+        compactIfNeeded(fileURL)
     }
 
-    private func write(_ entries: [Entry]) {
-        guard let fileURL, let data = try? JSONEncoder().encode(entries) else { return }
+    /// Physically rewrites the file to the last `maxEntries` entries once it
+    /// grows past `trimThresholdBytes`. Gated on a cheap `stat` (no content
+    /// read), so a full read+rewrite happens only ~once per `maxEntries`
+    /// appends — O(1) amortized per event. Must only run on `ioQueue`.
+    private func compactIfNeeded(_ fileURL: URL) {
+        let size = (try? FileManager.default.attributesOfItem(atPath: fileURL.path))?[.size] as? Int ?? 0
+        guard size > trimThresholdBytes else { return }
+        let kept = Array(readEntries(fileURL).suffix(maxEntries))
+        write(kept, to: fileURL)
+    }
+
+    /// Raw JSONL read; must only run on `ioQueue`. `split(separator:)` omits
+    /// empty subsequences, so leading/double newlines and undecodable legacy
+    /// segments are tolerated (corruption-discard contract preserved).
+    private func readEntries(_ fileURL: URL) -> [Entry] {
+        guard let data = try? Data(contentsOf: fileURL) else { return [] }
+        let decoder = JSONDecoder()
+        return data.split(separator: 0x0A).compactMap { try? decoder.decode(Entry.self, from: Data($0)) }
+    }
+
+    /// Atomically rewrites the whole file as newline-delimited JSON. Only used
+    /// by compaction — never on the append hot path.
+    private func write(_ entries: [Entry], to fileURL: URL) {
+        let encoder = JSONEncoder()
+        var data = Data()
+        for entry in entries {
+            guard let line = try? encoder.encode(entry) else { continue }
+            data.append(line)
+            data.append(0x0A)
+        }
         try? data.write(to: fileURL, options: .atomic)
     }
 

--- a/wurstfingerTests/InteractiveKeyboardPreviewHeightTests.swift
+++ b/wurstfingerTests/InteractiveKeyboardPreviewHeightTests.swift
@@ -1,0 +1,36 @@
+//
+//  InteractiveKeyboardPreviewHeightTests.swift
+//  wurstfingerTests
+//
+//  Tests for the settings preview's frame-height clamp seam.
+//
+
+import CoreGraphics
+import Testing
+@testable import WurstfingerApp
+
+struct InteractiveKeyboardPreviewHeightTests {
+    /// The preview frame applies only the lower bound: tall content is not
+    /// clipped (no upper cap), while content below `minHeight` is floored.
+    @Test func previewFrameHeightNeverClipsTallContent() {
+        #expect(KeyboardConstants.Preview.frameHeight(forContentHeight: 590) == 590)
+        #expect(
+            KeyboardConstants.Preview.frameHeight(forContentHeight: 50)
+                == KeyboardConstants.Preview.minHeight
+        )
+    }
+
+    /// Demonstrates the clip precondition is reachable within shipped ranges:
+    /// tall keys (aspect < 1) on a big screen produce content taller than the
+    /// old 400 pt cap, which the removed upper clamp would have clipped.
+    @Test func realisticLargeSettingProducesContentTallerThan400() {
+        let metrics = KeyboardLayoutMetrics.resolve(
+            wishWidth: 390,
+            aspectRatio: 0.7,
+            columns: 4,
+            availableWidth: 390,
+            screenHeight: 2000
+        )
+        #expect(metrics.totalHeight > KeyboardConstants.Preview.maxHeight)
+    }
+}

--- a/wurstfingerTests/KeyboardHealthLogTests.swift
+++ b/wurstfingerTests/KeyboardHealthLogTests.swift
@@ -98,4 +98,72 @@ struct KeyboardHealthLogTests {
 
         #expect(entries.map(\.label) == ["cold-start"])
     }
+
+    /// Recording a second entry must not rewrite the bytes of the first: the
+    /// hot path is an O(1) append, not a full read-decode-encode-rewrite of a
+    /// JSON array.
+    @Test func recordWritesAppendOnlyDoesNotRewritePriorBytes() throws {
+        let url = makeTestFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let log = KeyboardHealthLog(fileURL: url, maxEntries: 100)
+
+        log.record("first")
+        _ = log.entries() // drain the async append
+        let data1 = try Data(contentsOf: url)
+        log.record("second")
+        _ = log.entries()
+        let data2 = try Data(contentsOf: url)
+
+        #expect(data2.count > data1.count)
+        #expect(data2.prefix(data1.count) == data1)
+        // Not a JSON array: an append-only JSONL file never opens with `[` (0x5B).
+        #expect(data1.first != 0x5B)
+
+        let decoder = JSONDecoder()
+        let perLine = data2.split(separator: 0x0A)
+            .compactMap { try? decoder.decode(KeyboardHealthLog.Entry.self, from: Data($0)) }
+        #expect(perLine.map(\.label) == ["first", "second"])
+    }
+
+    /// The on-disk file is physically compacted once it grows past the
+    /// size threshold, so it never accumulates one line per lifetime event,
+    /// while `entries()` still returns only the last `maxEntries`.
+    @Test func appendOnlyFileIsPhysicallyCompactedWhileEntriesReturnsLastMax() throws {
+        let url = makeTestFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let log = KeyboardHealthLog(fileURL: url, maxEntries: 3)
+
+        for index in 0 ..< 100 {
+            log.record("event-\(index)")
+        }
+        _ = log.entries() // drain
+
+        #expect(log.entries().map(\.label) == ["event-97", "event-98", "event-99"])
+
+        let decoder = JSONDecoder()
+        let perLine = try Data(contentsOf: url).split(separator: 0x0A)
+            .compactMap { try? decoder.decode(KeyboardHealthLog.Entry.self, from: Data($0)) }
+        #expect(perLine.count >= 1)
+        #expect(perLine.count <= 2 * 3 + 2)
+    }
+
+    /// The file URL provider must not be invoked at construction — that is
+    /// what keeps the shared instance's `containerURL(...)` IPC off the
+    /// main/spawn thread. It is resolved lazily on first file access.
+    @Test func fileURLProviderIsNotResolvedAtInit() {
+        var resolveCount = 0
+        let url = makeTestFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let log = KeyboardHealthLog(fileURLProvider: {
+            resolveCount += 1
+            return url
+        })
+
+        #expect(resolveCount == 0)
+
+        log.record("e")
+        _ = log.entries() // ioQueue.sync — any deferred resolution has completed
+
+        #expect(resolveCount >= 1)
+    }
 }

--- a/wurstfingerTests/KeyboardShowcaseLanguageResolutionTests.swift
+++ b/wurstfingerTests/KeyboardShowcaseLanguageResolutionTests.swift
@@ -1,0 +1,41 @@
+//
+//  KeyboardShowcaseLanguageResolutionTests.swift
+//  wurstfingerTests
+//
+//  Tests for the showcase's language-id resolution seam.
+//
+
+import Testing
+@testable import WurstfingerApp
+
+struct KeyboardShowcaseLanguageResolutionTests {
+    /// A `FORCE_LANGUAGE` override wins verbatim over the stored id and the
+    /// system default — UI tests may force an id that is not in the registry,
+    /// so it must not be routed through the registry-validating helper.
+    @Test func forceLanguageOverrideWinsOverStoredAndSystem() {
+        #expect(
+            KeyboardShowcaseView.resolvedShowcaseLanguageId(
+                forceLanguage: "ru_RU",
+                storedId: "de_DE"
+            ) == "ru_RU"
+        )
+    }
+
+    /// Without an override, a stale/unknown stored id resolves to the detected
+    /// system language (registry-validated), not passed through raw; a valid
+    /// stored id passes through; a nil stored id resolves to system default.
+    @Test func staleStoredIdResolvesToSystemLanguageNotPassthrough() {
+        #expect(
+            KeyboardShowcaseView.resolvedShowcaseLanguageId(forceLanguage: nil, storedId: "xx_XX")
+                == LanguageSettings.detectSystemLanguage()
+        )
+        #expect(
+            KeyboardShowcaseView.resolvedShowcaseLanguageId(forceLanguage: nil, storedId: "de_DE")
+                == "de_DE"
+        )
+        #expect(
+            KeyboardShowcaseView.resolvedShowcaseLanguageId(forceLanguage: nil, storedId: nil)
+                == LanguageSettings.detectSystemLanguage()
+        )
+    }
+}


### PR DESCRIPTION
Addresses the performance finding and the cleanup nitpicks from the 2026-07-22 review (finding #10 + host-app / script nitpicks). Test-driven; all unit tests green.

## Findings fixed
- **#10 — Health log did O(n) rewrites at jetsam-critical moments + eager container IPC at spawn.** `KeyboardHealthLog` is now append-only JSONL with a stat-gated, size-triggered compaction (amortized O(1) per event instead of a full ~50KB read-decode-append-encode-rewrite on every record — including inside `didReceiveMemoryWarning`). The app-group container URL is resolved lazily on the IO queue instead of via synchronous IPC in the `shared` static initializer on the extension spawn path.
  - Legacy JSON-array log files are dropped once on upgrade (accepted; the log is bounded diagnostics). `Entry: Identifiable` / UUID kept, so the health view is untouched.

## Nitpicks
- `KeyboardShowcaseView` language resolution now routes through the shared, registry-validating `LanguageSettings.resolvedLanguageId` (a stale stored id resolves to the system language instead of falling through to English); `FORCE_LANGUAGE` still wins verbatim for UI tests.
- The settings keyboard preview grows to the real keyboard height instead of clipping at a fixed 400pt cap (lower-bound-only frame height).
- Extracted `scripts/lib/simulator-capture.sh` so both screenshot generators share one capture pipeline and one manifest parser (the robust recursive walk).

## Tests
New `KeyboardHealthLogTests` cases (append-only bytes, physical compaction bound, lazy-URL-not-resolved-at-init), `KeyboardShowcaseLanguageResolutionTests`, `InteractiveKeyboardPreviewHeightTests`. Existing corruption-tolerance / trim guards stay green. Scripts pass `shellcheck -x` + `bash -n` (not Swift-Testing-able).

## Verification still recommended
- Run both `scripts/generate-*.sh` against a simulator and diff the produced screenshot sets before/after (behavior-preserving refactor).
- On device: confirm the health log still records across foreground/suspend and the settings preview isn't clipped at large sizes.
