### PR TITLE
Shed the SwiftUI hosting graph before suspension

### DIFF
--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import UIKit
 
 final class KeyboardViewController: UIInputViewController {
-    private var hostingController: UIHostingController<AnyView>?
+    private var hostingController: UIHostingController<DataDrivenKeyboardRootView>?
     private lazy var viewModel = KeyboardViewModel()
     private var heightConstraint: NSLayoutConstraint?
     private var documentProxyTarget: DocumentProxyTarget?
@@ -98,6 +98,11 @@ final class KeyboardViewController: UIInputViewController {
         // Reload definition only if language (or numpad style) changed while the
         // keyboard was backgrounded — avoids rebuilding the pipeline every time.
         loadDefinitionIfNeeded()
+        // Rebuild the SwiftUI host if it was torn down before suspension (see
+        // `shedMemoryBeforeSuspension`). Idempotent, so first appearance —
+        // where `viewDidLoad` already built it — is a no-op. Rebuild before the
+        // height constraint and layout pass below so the content exists first.
+        configureHosting()
         // Reopen on the default (letters) layer: a keyboard dismissed on the
         // numeric or shifted layer must not resurface there.
         viewModel.resetToDefaultMode()
@@ -153,9 +158,29 @@ final class KeyboardViewController: UIInputViewController {
     /// per-process-limit` kill, silent system-keyboard fallback. Suspending
     /// small is what makes the next resume survive; a memory warning never
     /// fires on suspension, so this cannot wait for didReceiveMemoryWarning.
+    ///
+    /// Evicting the definition cache alone freed only a few MB: a device-log
+    /// audit (2026-07-22) found the suspended process sitting at ~140 MB with
+    /// the *SwiftUI hosting graph* — not any app data structure — as the bulk
+    /// of the footprint. So the hosting controller is torn down here too and
+    /// rebuilt in `viewWillAppear`. The health-log entry records the footprint
+    /// *after* shedding, so it measures what actually survives to suspension.
     private func shedMemoryBeforeSuspension(_ event: String) {
         KeyboardRegistry.evictAll(except: selectedLanguageId)
+        teardownHosting()
         KeyboardHealthLog.shared.record(event)
+    }
+
+    /// Removes the SwiftUI hosting controller and releases its view graph.
+    /// The view model (and thus all keyboard state) is retained by `self`, so
+    /// a rebuild in `viewWillAppear` restores the same keyboard without
+    /// reloading the definition. No-op if hosting is already gone.
+    private func teardownHosting() {
+        guard let controller = hostingController else { return }
+        controller.willMove(toParent: nil)
+        controller.view.removeFromSuperview()
+        controller.removeFromParent()
+        hostingController = nil
     }
 
     /// The keyboard can be suspended without `viewDidDisappear` ever firing:
@@ -177,7 +202,12 @@ final class KeyboardViewController: UIInputViewController {
             forName: NSNotification.Name.NSExtensionHostWillEnterForeground,
             object: nil,
             queue: .main
-        ) { _ in
+        ) { [weak self] _ in
+            // Foreground return after a host-background suspension does not
+            // fire `viewWillAppear` (the view stayed in the hierarchy), so the
+            // hosting graph torn down in `shedMemoryBeforeSuspension` must be
+            // rebuilt here too — otherwise the keyboard returns blank.
+            self?.configureHosting()
             KeyboardHealthLog.shared.record("hostWillEnterForeground")
         })
     }
@@ -232,9 +262,18 @@ final class KeyboardViewController: UIInputViewController {
         true
     }
 
+    /// Builds the SwiftUI hosting controller and installs it as a child.
+    /// Idempotent: a no-op if hosting already exists, so `viewWillAppear` can
+    /// call it to rebuild after a suspension teardown without double-adding.
+    ///
+    /// The root view is hosted concretely (no `AnyView`) so SwiftUI keeps the
+    /// view's structural identity and does not pay the type-erased
+    /// AttributeGraph overhead — every byte matters under the extension's
+    /// jetsam budget.
     private func configureHosting() {
+        guard hostingController == nil else { return }
         let rootView = DataDrivenKeyboardRootView(viewModel: viewModel)
-        let controller = UIHostingController(rootView: AnyView(rootView))
+        let controller = UIHostingController(rootView: rootView)
         controller.view.translatesAutoresizingMaskIntoConstraints = false
         controller.view.backgroundColor = .clear
 


### PR DESCRIPTION
## Why

A device-log audit on 2026-07-22 (user reported the keyboard repeatedly not starting, showing only the system keyboard) found:

- **No crash** — the old rotation trap stays fixed.
- Wurstfinger is **never the jetsam victim** in any synced `JetsamEvent` (so the kills are silent, matching the 2026-07-07 resume-time `per-process-limit` finding).
- The **suspended** extension footprint has ballooned far past the June ~48 MB baseline: sampled at **164 MB (07-08)** and **142 MB (07-21)**.

A full code audit found **no memory hog and no leak in the app's own code**: caches are bounded/evictable, the pipeline is reassigned per load with `[weak self]` closures (no retain cycle), compose tables are ~60 rules, and nothing renders images/assets. The bulk of the footprint is the **SwiftUI + UIHostingController + AttributeGraph** runtime — exactly the lever predicted in the earlier telemetry work.

The existing `shedMemoryBeforeSuspension` only evicted the definition cache (a few MB) and left the ~100 MB hosting graph fully resident through suspension. So the shedding aimed at the wrong memory.

## What

1. **Tear down the hosting controller before suspension** and rebuild it in `viewWillAppear` — and on `hostWillEnterForeground`, where `viewWillAppear` does not fire (host backgrounded while the keyboard stayed on screen). The retained view model keeps all keyboard state, so the rebuild restores the same keyboard without reloading the definition.
2. **Host the root view concretely** (`DataDrivenKeyboardRootView`) instead of via `AnyView`, restoring SwiftUI structural identity and dropping the type-erased AttributeGraph overhead. `configureHosting()` is now idempotent so the rebuild paths are safe.

## Verification

- ✅ Build succeeds (iPhone 17 Pro sim).
- ✅ SwiftFormat + SwiftLint clean.
- ✅ `TypingTests` (real gesture typing on the concrete root view) pass — confirms the `AnyView` removal renders/types correctly.
- ⏳ **On-device**: the teardown/rebuild lifecycle only runs in the real extension (the simulator has no jetsam and the UI tests use the in-app showcase, not the appex). Verify via **Settings → Expert → Tools → Keyboard Health**: the `viewDidDisappear` / `hostDidEnterBackground` entries should now record a footprint near the baseline instead of ~140 MB, and the keyboard must come back correctly after backgrounding the host and returning.

Draft until on-device health-log confirms the suspended footprint drops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard restoration after the app or host returns from the background.
  * Fixed cases where the keyboard interface could be missing after suspension or memory cleanup.
  * Improved reliability when switching between keyboard modes after reopening.

* **Performance**
  * Reduced memory usage during suspension by releasing keyboard interface resources and rebuilding them when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->