### PR TITLE
Fix Cut-All Handling of an Active Selection

### DIFF
--- a/wurstfingerKeyboard/Runtime/Pipeline/AdvancedTextMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/AdvancedTextMiddleware.swift
@@ -145,13 +145,22 @@ struct AdvancedTextMiddleware: ActionMiddleware {
     /// with the paste swipe on the same key.
     private func handleCutAll(target: TextInputTarget) {
         guard isCutAllEnabled(), target.hasFullAccess else { return }
+        // With an active selection the context properties describe the text
+        // *around* it, so the selection must be stitched back in for the
+        // pasteboard — and consumed by its own deleteBackward below, because
+        // the proxy deletes a selected range as one unit and the counting
+        // loop would otherwise run past the document.
         let before = target.documentContextBeforeInput ?? ""
+        let selected = target.selectedText ?? ""
         let after = target.documentContextAfterInput ?? ""
-        let all = before + after
+        let all = before + selected + after
         guard !all.isEmpty else { return }
 
         UIPasteboard.general.string = all
 
+        if !selected.isEmpty {
+            target.deleteBackward()
+        }
         // Deletion only runs backwards, so park the cursor past the trailing
         // context first. The offset is in UTF-16 code units (see the protocol).
         if !after.isEmpty {
@@ -161,7 +170,7 @@ struct AdvancedTextMiddleware: ActionMiddleware {
         // leading `after` fuses with the last character of `before` into one
         // grapheme cluster, and deleteBackward removes clusters, so summing the
         // halves separately would delete one character too many.
-        for _ in 0 ..< all.count {
+        for _ in 0 ..< (before + after).count {
             target.deleteBackward()
         }
         onClipboardSuccess()

--- a/wurstfingerTests/AdvancedTextMiddlewareTests.swift
+++ b/wurstfingerTests/AdvancedTextMiddlewareTests.swift
@@ -468,6 +468,43 @@ final class AdvancedTextMiddlewareClipboardTests {
         #expect(target.events == [.adjustCursor(11), .deleteBackward])
     }
 
+    @Test func cutAllIncludesActiveSelectionInPasteboardAndDeletesIt() {
+        let target = MockTextTarget()
+        target.hasFullAccess = true
+        target.documentContextBeforeInput = "abc"
+        target.selectedText = "xyz"
+        target.documentContextAfterInput = "def"
+        let middleware = AdvancedTextFixtures.middleware(target: target)
+
+        middleware.process(AdvancedTextFixtures.context(.cutAll)) { _ in }
+
+        #expect(UIPasteboard.general.string == "abcxyzdef")
+        // The selection is consumed by its own deleteBackward first; only then
+        // is the cursor parked past "def" and the remaining six characters
+        // deleted — otherwise the first backward delete would swallow the
+        // selection and the loop would run three deletes past the document.
+        #expect(
+            target.events == [.deleteBackward, .adjustCursor(3)]
+                + Array(repeating: .deleteBackward, count: 6)
+        )
+        #expect(target.documentContextBeforeInput == "")
+        #expect(target.documentContextAfterInput == "")
+    }
+
+    @Test func cutAllWithWholeTextSelectedActsLikeCut() {
+        let target = MockTextTarget()
+        target.hasFullAccess = true
+        target.documentContextBeforeInput = ""
+        target.selectedText = "everything"
+        target.documentContextAfterInput = ""
+        let middleware = AdvancedTextFixtures.middleware(target: target)
+
+        middleware.process(AdvancedTextFixtures.context(.cutAll)) { _ in }
+
+        #expect(UIPasteboard.general.string == "everything")
+        #expect(target.events == [.deleteBackward])
+    }
+
     @Test func cutAllIsNoopWhenDisabledInSettings() {
         let marker = "untouched-\(UUID().uuidString)"
         UIPasteboard.general.string = marker


### PR DESCRIPTION
## Summary

The cut-all circular gesture (#260) corrupted the document when a selection was active: `documentContextBeforeInput`/`AfterInput` describe the text *around* a selection, so the pasteboard received `before + after` — the selected text was silently dropped. Worse, the first `deleteBackward()` of the counting loop consumed the entire selection as one unit (standard proxy semantics), so the loop then deleted up to `all.count − 1` extra characters past the document. Example: `abc[xyz selected]def` → pasteboard `"abcdef"`, `xyz` unrecoverable — defeating the feature's own cut-not-delete recoverability rationale. With the whole text selected, cut-all did nothing at all (`before + after` empty → early return).

## Fix

`handleCutAll` now stitches the selection back in: the pasteboard gets `before + selected + after`, an active selection is consumed by its own `deleteBackward()` first, and the counting loop runs over `before + after` only.

## Tests

Two new unit tests, both verified red against the previous implementation:

- `cutAllIncludesActiveSelectionInPasteboardAndDeletesIt` — mixed context + selection
- `cutAllWithWholeTextSelectedActsLikeCut` — selection-only document

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected “Cut All” behavior when text is selected, ensuring the complete content is copied and deleted correctly.
  * Prevented unnecessary deletion actions when the entire text is selected.

* **Tests**
  * Added coverage for cut-all operations with partial and full text selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->