### PR TITLE
Bump Version to 1.4.0 and Update Release Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Changelog
 
-## v1.4.0 — 2026-07-22
+## v1.4.0 — 2026-07-23
 
 ### Added
 
-- 12 new keyboard layouts: Arabic, Persian, and Urdu (right-to-left, #244), Thai (#247), Hindi with sequential vowel combining (#248), Greek, Portuguese, and Ukrainian (#243), Japanese Hiragana and Katakana (#249), Korean Hangul with syllable composition (#251)
-- Native digit layers for scripts with their own numerals — Arabic-Indic, Extended Arabic-Indic, Devanagari, and Thai (#241, #268)
+- 11 new keyboard layouts: Arabic, Persian, and Urdu (right-to-left, #244), Thai (#247), Hindi with sequential vowel combining (#248), Greek, Portuguese, and Ukrainian (#243), Japanese Hiragana and Katakana (#249), Korean Hangul with syllable composition (#251)
+- Native digit layers for scripts with their own numerals — Arabic-Indic, Extended Arabic-Indic, Devanagari, and Thai (#244, #247, #248, #268)
 - Optional long-press on a letter key to type its digit (#240)
 - Optional double-space period shortcut (#267)
-- Cut-all circular gesture on the clipboard key — circling it cuts the text around the cursor, off by default and gated behind a new Gestures setting (#260)
+- Cut-all circular gesture on the clipboard key — circling it cuts the text around the cursor, off by default and gated behind a new Gestures setting (#260, active-selection handling in #274)
 - App UI localized into the 10 new keyboard languages (#252, #261)
 - Release-safe keyboard health log for diagnosing extension suspensions (#230, append-only JSONL in #271)
 - Å restored on the Finnish layout (#265)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,36 @@
 # Changelog
 
-## Unreleased
+## v1.4.0 — 2026-07-22
 
 ### Added
 
+- 12 new keyboard layouts: Arabic, Persian, and Urdu (right-to-left, #244), Thai (#247), Hindi with sequential vowel combining (#248), Greek, Portuguese, and Ukrainian (#243), Japanese Hiragana and Katakana (#249), Korean Hangul with syllable composition (#251)
+- Native digit layers for scripts with their own numerals — Arabic-Indic, Extended Arabic-Indic, Devanagari, and Thai (#241, #268)
+- Optional long-press on a letter key to type its digit (#240)
+- Optional double-space period shortcut (#267)
 - Cut-all circular gesture on the clipboard key — circling it cuts the text around the cursor, off by default and gated behind a new Gestures setting (#260)
+- App UI localized into the 10 new keyboard languages (#252, #261)
+- Release-safe keyboard health log for diagnosing extension suspensions (#230, append-only JSONL in #271)
+- Å restored on the Finnish layout (#265)
 
 ### Fixed
 
-- Case-insensitive String Catalog key collision that broke symbol generation on Xcode 26 (#260)
+- Input correctness across the new layouts: Hindi/Urdu letter bindings, Korean tense consonants, Japanese handakuten and sokuon, native digits on the space bar (#268)
+- Sequential composition with an active selection, compose space normalization, and RTL hint mirroring (#269)
+- Keyboard extension memory footprint at suspension — the SwiftUI hosting graph is shed before suspension so the keyboard survives the next resume instead of falling back to the system keyboard (#273)
+- One-shot shift semantics, Spanish auto-capitalization, and caseless Hebrew (#236)
+- Gesture edge cases: return-up hijack, ProMotion buffer sizing, aspect-ratio guard (#234)
+- Utility-left layout now moves only the utility keys (#233)
+- Host app preview wiring, settings copy, and screenshot language persistence (#235)
+- Case-insensitive String Catalog key collision that broke symbol generation on Xcode 26, plus repo-wide lint drift (#264)
+- Stretched App Store screenshots — square keys restored (#229)
+- Release pipeline: Xcode 26 selection, upload error handling, screenshot generation, CI keychain cleanup (#227, #228, #232)
+
+### Changed
+
+- Keyboard size anchored in points via a single layout metrics resolver; landscape rescales only on genuine overflow (#254, #270)
+- Composition pipeline consolidated behind a single combiner strategy (#272)
+- Pipeline, definition-layer, and test-hygiene polish from the full codebase review (#237, #238)
 
 ## v1.3.1 — 2026-07-04
 

--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,7 +1,7 @@
 Version 1.4.0
 
 Neu:
-• 12 neue Tastatursprachen: Arabisch, Persisch, Urdu, Thai, Hindi, Koreanisch, Japanisch (Hiragana & Katakana), Griechisch, Portugiesisch und Ukrainisch
+• 10 neue Tastatursprachen: Arabisch, Persisch, Urdu, Thai, Hindi, Koreanisch, Japanisch (Hiragana & Katakana), Griechisch, Portugiesisch und Ukrainisch
 • Koreanische Silben und japanische Kana werden beim Tippen zusammengesetzt; Arabisch, Persisch und Urdu mit Rechts-nach-links-Layouts
 • Native Ziffern für Arabisch, Persisch, Urdu, Hindi und Thai
 • Die App selbst gibt es jetzt in 10 weiteren Sprachen

--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -14,7 +14,7 @@ Neu:
 
 Zuverlässigkeit:
 • Die Tastatur gibt im Hintergrund ihren Speicher frei — behebt Fälle, in denen beim erneuten Öffnen stillschweigend die Systemtastatur erschien
-• Die Tastaturgröße ist jetzt in Punkten verankert und bleibt über Geräte hinweg konsistent
+• Die Tastaturgröße bleibt jetzt über Geräte hinweg konsistent
 • Cursor-Bewegung über Emoji korrigiert
 • Schnelle Wischgesten werden zuverlässiger erkannt
 • Automatische Großschreibung greift jetzt in den richtigen Momenten

--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,15 +1,21 @@
-Version 1.3.1
+Version 1.4.0
 
 Neu:
+• 12 neue Tastatursprachen: Arabisch, Persisch, Urdu, Thai, Hindi, Koreanisch, Japanisch (Hiragana & Katakana), Griechisch, Portugiesisch und Ukrainisch
+• Koreanische Silben und japanische Kana werden beim Tippen zusammengesetzt; Arabisch, Persisch und Urdu mit Rechts-nach-links-Layouts
+• Native Ziffern für Arabisch, Persisch, Urdu, Hindi und Thai
+• Die App selbst gibt es jetzt in 10 weiteren Sprachen
+• Optional: Buchstabentaste gedrückt halten tippt die Ziffer
+• Optional: Doppel-Leerzeichen tippt einen Punkt
+• Optional: Eine Kreisgeste auf der Zwischenablage-Taste schneidet den ganzen Text aus
 • Überarbeitete Haptik — genau ein Impuls pro Anschlag und ein deutlich breiterer Intensitätsbereich
 • Label-Sichtbarkeit direkt per Geste auf der Leertaste umschalten
-• Compose-Hinweise (kleine Akzent-Labels) lassen sich jetzt ausblenden
 • Hebräisch: Endbuchstaben per Rück-Wisch
 
 Zuverlässigkeit:
-• Doppelte Vibration pro Tastendruck behoben
+• Die Tastatur gibt im Hintergrund ihren Speicher frei — behebt Fälle, in denen beim erneuten Öffnen stillschweigend die Systemtastatur erschien
+• Die Tastaturgröße ist jetzt in Punkten verankert und bleibt über Geräte hinweg konsistent
 • Cursor-Bewegung über Emoji korrigiert
 • Schnelle Wischgesten werden zuverlässiger erkannt
 • Automatische Großschreibung greift jetzt in den richtigen Momenten
 • Deaktivierte Sprachen bleiben deaktiviert
-• Vietnamesische Tonzeichen-Regeln wirken nicht mehr in andere Sprachen hinein

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,15 +1,21 @@
-Version 1.3.1
+Version 1.4.0
 
 New:
+• 12 new keyboard languages: Arabic, Persian, Urdu, Thai, Hindi, Korean, Japanese (Hiragana & Katakana), Greek, Portuguese, and Ukrainian
+• Korean syllables and Japanese kana combine as you type; Arabic, Persian, and Urdu come with right-to-left layouts
+• Native digits for Arabic, Persian, Urdu, Hindi, and Thai
+• The app itself is now available in 10 more languages
+• Optional: hold a letter key to type its digit
+• Optional: double-space types a period
+• Optional: a circular gesture on the clipboard key cuts the whole text
 • Reworked haptics — exactly one pulse per keystroke and a much wider intensity range
 • Toggle label visibility directly with a gesture on the space bar
-• Compose hints (small accent labels) can now be hidden
 • Hebrew: final letters via return swipes
 
 Reliability:
-• Fixed double vibration per key press
+• The keyboard frees its memory when backgrounded, fixing cases where reopening it silently fell back to the system keyboard
+• Keyboard size is now anchored in points and stays consistent across devices
 • Fixed cursor movement across emoji
 • Fast swipe gestures are recognized more reliably
 • Auto-capitalization now engages at the right moments
 • Disabled languages stay disabled
-• Vietnamese tone rules no longer leak into other languages

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -14,7 +14,7 @@ New:
 
 Reliability:
 • The keyboard frees its memory when backgrounded, fixing cases where reopening it silently fell back to the system keyboard
-• Keyboard size is now anchored in points and stays consistent across devices
+• Keyboard size now stays consistent across devices
 • Fixed cursor movement across emoji
 • Fast swipe gestures are recognized more reliably
 • Auto-capitalization now engages at the right moments

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,7 +1,7 @@
 Version 1.4.0
 
 New:
-• 12 new keyboard languages: Arabic, Persian, Urdu, Thai, Hindi, Korean, Japanese (Hiragana & Katakana), Greek, Portuguese, and Ukrainian
+• 10 new keyboard languages: Arabic, Persian, Urdu, Thai, Hindi, Korean, Japanese (Hiragana & Katakana), Greek, Portuguese, and Ukrainian
 • Korean syllables and Japanese kana combine as you type; Arabic, Persian, and Urdu come with right-to-left layouts
 • Native digits for Arabic, Persian, Urdu, Hindi, and Thai
 • The app itself is now available in 10 more languages

--- a/wurstfinger.xcodeproj/project.pbxproj
+++ b/wurstfinger.xcodeproj/project.pbxproj
@@ -559,7 +559,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfinger;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -592,7 +592,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfinger;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -610,7 +610,7 @@
 				CURRENT_PROJECT_VERSION = 2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfingerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -628,7 +628,7 @@
 				CURRENT_PROJECT_VERSION = 2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfingerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -644,7 +644,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfingerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -660,7 +660,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfingerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -688,7 +688,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfinger.keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -717,7 +717,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = de.akator.wurstfinger.keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary

Release preparation for 1.4.0. The last shipped release is **1.3.0** — 1.3.1 was approved by Apple but never released — so the App Store release notes are written against 1.3.0 and include the 1.3.1 changes users never saw. App Store Connect rejects any upload with a version ≤ 1.3.1 (see the failed 2026-07-22 nightly), hence the bump; 1.4.0 rather than 1.3.2 given the scope (12 new keyboard languages).

## Changes

- `MARKETING_VERSION` 1.3.1 → 1.4.0 in all 8 build configurations
- `CHANGELOG.md`: the sparse `Unreleased` section becomes a complete v1.4.0 entry covering v1.3.1..develop (languages, native digits, long-press numbers, double-space period, cut-all, localization, health log, review-fix series, suspension memory fix); also corrects the string-catalog collision reference from #260 to #264
- `fastlane/metadata/{en-US,de-DE}/release_notes.txt`: rewritten for 1.4.0 against the shipped 1.3.0 baseline

## Release steps after merge (per documented flow)

1. Decide in App Store Connect what to do with the approved-but-unreleased 1.3.1
2. Merge #274 (cut-all selection fix) alongside this PR
3. Publish the GitHub release (tag on develop) → triggers `appstore-release.yml`; fastlane reads the version from the project, deliver replaces the stretched 1.3.1-era screenshots with the committed square-key set
4. Submit manually in App Store Connect (`submit_for_review: false`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes for version 1.4.0 in English and German.
  * Added information about 10 new keyboard languages, improved multilingual typing, right-to-left layouts, native digits, and new typing gestures.
  * Documented expanded haptic controls, label visibility options, Hebrew swipe behavior, and clipboard gestures.
  * Added reliability highlights including improved emoji cursor movement, swipe recognition, capitalization timing, keyboard sizing, memory handling, and disabled-language behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->