### PR TITLE
Harden Keyboard Lifecycle Around Suspension and Resume

### DIFF
--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -15,6 +15,9 @@ final class KeyboardViewController: UIInputViewController {
     private var heightConstraint: NSLayoutConstraint?
     private var documentProxyTarget: DocumentProxyTarget?
     private var hostLifecycleObservers: [NSObjectProtocol] = []
+    /// Render-server snapshot standing in for the torn-down hosting view
+    /// while the host app is backgrounded (see `installSuspensionPlaceholder`).
+    private var suspensionPlaceholder: UIView?
 
     /// The language selected in the host app, normalised to an id that is
     /// guaranteed to exist in the registry (falling back to the system language,
@@ -85,24 +88,7 @@ final class KeyboardViewController: UIInputViewController {
         // of a "system keyboard showed instead" incident proves iOS never
         // launched the extension (as opposed to the extension failing).
         KeyboardHealthLog.shared.record("viewWillAppear")
-        // Persist Full Access status so the host app can show/hide haptic
-        // settings. Write only on change: every shared-defaults write fires the
-        // in-process didChangeNotification observer, which would run a second,
-        // redundant reloadSettings on every appearance.
-        let fullAccessKey = SettingsKey.keyboardFullAccess.rawValue
-        if SharedDefaults.store.bool(forKey: fullAccessKey) != hasFullAccess {
-            SharedDefaults.store.set(hasFullAccess, forKey: fullAccessKey)
-        }
-        // Reload settings every time keyboard appears
-        viewModel.reloadSettings()
-        // Reload definition only if language (or numpad style) changed while the
-        // keyboard was backgrounded — avoids rebuilding the pipeline every time.
-        loadDefinitionIfNeeded()
-        // Rebuild the SwiftUI host if it was torn down before suspension (see
-        // `shedMemoryBeforeSuspension`). Idempotent, so first appearance —
-        // where `viewDidLoad` already built it — is a no-op. Rebuild before the
-        // height constraint and layout pass below so the content exists first.
-        configureHosting()
+        refreshFromSharedState()
         // Reopen on the default (letters) layer: a keyboard dismissed on the
         // numeric or shifted layer must not resurface there.
         viewModel.resetToDefaultMode()
@@ -112,6 +98,44 @@ final class KeyboardViewController: UIInputViewController {
         // fires on appearance, but that is not guaranteed in every host app;
         // the refresh is idempotent, so evaluating in both paths is safe.
         viewModel.refreshAutoCapitalization()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // Pairs with the `viewWillAppear` entry: the timestamp delta bounds
+        // what an appearance actually costs. The suspension teardown makes
+        // every re-appearance rebuild the hosting graph, so a latency
+        // regression in that rebuild shows up in the health log on-device,
+        // without a Mac attached.
+        KeyboardHealthLog.shared.record("viewDidAppear")
+    }
+
+    /// Picks up state that may have changed outside this process while the
+    /// keyboard was off screen — settings edited in the host app, a language
+    /// or numpad-style switch, granted/revoked Full Access — and makes sure
+    /// the SwiftUI host exists. Cross-process defaults writes fire no
+    /// in-process `didChangeNotification` (see the observer note in
+    /// `KeyboardViewModel.init`), so this explicit reload is the only way
+    /// they reach the view model. Shared by `viewWillAppear` and the
+    /// host-foreground path, which the view lifecycle does not cover.
+    private func refreshFromSharedState() {
+        // Persist Full Access status so the host app can show/hide haptic
+        // settings. Write only on change: every shared-defaults write fires the
+        // in-process didChangeNotification observer, which would run a second,
+        // redundant reloadSettings on every appearance.
+        let fullAccessKey = SettingsKey.keyboardFullAccess.rawValue
+        if SharedDefaults.store.bool(forKey: fullAccessKey) != hasFullAccess {
+            SharedDefaults.store.set(hasFullAccess, forKey: fullAccessKey)
+        }
+        viewModel.reloadSettings()
+        // Reload definition only if language (or numpad style) changed while the
+        // keyboard was backgrounded — avoids rebuilding the pipeline every time.
+        loadDefinitionIfNeeded()
+        // Rebuild the SwiftUI host if it was torn down before suspension (see
+        // `shedMemoryBeforeSuspension`). Idempotent, so first appearance —
+        // where `viewDidLoad` already built it — is a no-op. Rebuild before any
+        // height constraint update so the content exists first.
+        configureHosting()
     }
 
     override func textDidChange(_ textInput: UITextInput?) {
@@ -167,8 +191,34 @@ final class KeyboardViewController: UIInputViewController {
     /// *after* shedding, so it measures what actually survives to suspension.
     private func shedMemoryBeforeSuspension(_ event: String) {
         KeyboardRegistry.evictAll(except: selectedLanguageId)
+        installSuspensionPlaceholder()
         teardownHosting()
-        KeyboardHealthLog.shared.record(event)
+        // Flushed, not queued: the suspended process may never run again — a
+        // resume-jetsam kills it on wake before an async write would get CPU
+        // time — and this entry, the footprint that actually survives to
+        // suspension, is the one those incidents need. Unlike launch, this
+        // path is not latency-critical.
+        KeyboardHealthLog.shared.recordAndFlush(event)
+    }
+
+    /// Covers the hole the hosting teardown would leave in the host app's
+    /// app-switcher card: iOS takes that snapshot *after* the host
+    /// backgrounds, i.e. after `shedMemoryBeforeSuspension` ran. A
+    /// `snapshotView` references the already-rendered surface owned by the
+    /// render server, so it keeps the keyboard visible in the card without
+    /// meaningfully adding to the suspended process's footprint. Skipped when
+    /// the view is not in a window (keyboard dismissed): nothing is on screen
+    /// to preserve. Removed when `configureHosting` rebuilds the live view.
+    private func installSuspensionPlaceholder() {
+        guard suspensionPlaceholder == nil,
+              let hostingView = hostingController?.view,
+              hostingView.window != nil,
+              let snapshot = hostingView.snapshotView(afterScreenUpdates: false)
+        else { return }
+        snapshot.frame = view.bounds
+        snapshot.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(snapshot)
+        suspensionPlaceholder = snapshot
     }
 
     /// Removes the SwiftUI hosting controller and releases its view graph.
@@ -203,11 +253,26 @@ final class KeyboardViewController: UIInputViewController {
             object: nil,
             queue: .main
         ) { [weak self] _ in
+            guard let self else { return }
             // Foreground return after a host-background suspension does not
-            // fire `viewWillAppear` (the view stayed in the hierarchy), so the
-            // hosting graph torn down in `shedMemoryBeforeSuspension` must be
-            // rebuilt here too — otherwise the keyboard returns blank.
-            self?.configureHosting()
+            // fire `viewWillAppear` (the view stayed in the hierarchy), so
+            // everything appearance normally refreshes must happen here too:
+            // the hosting graph torn down in `shedMemoryBeforeSuspension` —
+            // otherwise the keyboard returns blank — and any settings or
+            // language change made in the host app while this process was
+            // suspended, which no in-process defaults notification reports.
+            // Gated on being on screen: waking without a window (keyboard
+            // dismissed before the host backgrounded) must not pay the
+            // hosting rebuild — the biggest allocation — in the resume
+            // moment, where the jetsam limit is enforced; `viewWillAppear`
+            // covers that case when the keyboard is next shown. The active
+            // layer is deliberately kept (no `resetToDefaultMode`): the user
+            // returns to the same field mid-typing.
+            if viewIfLoaded?.window != nil {
+                refreshFromSharedState()
+                updateKeyboardHeight()
+                viewModel.refreshAutoCapitalization()
+            }
             KeyboardHealthLog.shared.record("hostWillEnterForeground")
         })
     }
@@ -289,5 +354,11 @@ final class KeyboardViewController: UIInputViewController {
 
         controller.didMove(toParent: self)
         hostingController = controller
+        // The live view is back — drop the app-switcher stand-in. It was
+        // added below the fresh hosting view (addSubview appends on top) and
+        // both changes commit in the same CA transaction, so no blank frame
+        // can slip in between.
+        suspensionPlaceholder?.removeFromSuperview()
+        suspensionPlaceholder = nil
     }
 }

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -88,16 +88,9 @@ final class KeyboardViewController: UIInputViewController {
         // of a "system keyboard showed instead" incident proves iOS never
         // launched the extension (as opposed to the extension failing).
         KeyboardHealthLog.shared.record("viewWillAppear")
-        refreshFromSharedState()
         // Reopen on the default (letters) layer: a keyboard dismissed on the
         // numeric or shifted layer must not resurface there.
-        viewModel.resetToDefaultMode()
-        updateKeyboardHeight()
-        // Engage/release shift for the field's current context (e.g. start
-        // uppercase in an empty compose field). `textDidChange` usually also
-        // fires on appearance, but that is not guaranteed in every host app;
-        // the refresh is idempotent, so evaluating in both paths is safe.
-        viewModel.refreshAutoCapitalization()
+        refreshForAppearance(resettingLayer: true)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -110,14 +103,41 @@ final class KeyboardViewController: UIInputViewController {
         KeyboardHealthLog.shared.record("viewDidAppear")
     }
 
+    /// The complete refresh an appearance owes the keyboard, in the order the
+    /// steps depend on each other: shared state first (it can swap the whole
+    /// definition), then the layer, then the height — `layoutMetrics` reads
+    /// the *active* mode's arrangement — then the shift state.
+    ///
+    /// Both paths that resurface a keyboard — `viewWillAppear` and the
+    /// host-foreground return — go through here, so neither can drift out of
+    /// sync with the other and resurface on stale state. `resettingLayer` is
+    /// the single deliberate difference: an appearance reopens on letters, a
+    /// foreground return keeps the layer because the user comes back to the
+    /// same field mid-typing.
+    private func refreshForAppearance(resettingLayer: Bool) {
+        refreshFromSharedState()
+        // Rebuild the SwiftUI host if it was torn down before suspension (see
+        // `shedMemoryBeforeSuspension`). Idempotent, so the first appearance —
+        // where `viewDidLoad` already built it — is a no-op. Rebuild before the
+        // height constraint update below so the content exists first.
+        configureHosting()
+        if resettingLayer {
+            viewModel.resetToDefaultMode()
+        }
+        updateKeyboardHeight()
+        // Engage/release shift for the field's current context (e.g. start
+        // uppercase in an empty compose field). `textDidChange` usually also
+        // fires on appearance, but that is not guaranteed in every host app;
+        // the refresh is idempotent, so evaluating in both paths is safe.
+        viewModel.refreshAutoCapitalization()
+    }
+
     /// Picks up state that may have changed outside this process while the
-    /// keyboard was off screen — settings edited in the host app, a language
-    /// or numpad-style switch, granted/revoked Full Access — and makes sure
-    /// the SwiftUI host exists. Cross-process defaults writes fire no
-    /// in-process `didChangeNotification` (see the observer note in
-    /// `KeyboardViewModel.init`), so this explicit reload is the only way
-    /// they reach the view model. Shared by `viewWillAppear` and the
-    /// host-foreground path, which the view lifecycle does not cover.
+    /// keyboard was off screen: settings edited in the host app, a language
+    /// or numpad-style switch, granted/revoked Full Access. Cross-process
+    /// defaults writes fire no in-process `didChangeNotification` (see the
+    /// observer note in `KeyboardViewModel.init`), so this explicit reload is
+    /// the only way they reach the view model.
     private func refreshFromSharedState() {
         // Persist Full Access status so the host app can show/hide haptic
         // settings. Write only on change: every shared-defaults write fires the
@@ -131,11 +151,6 @@ final class KeyboardViewController: UIInputViewController {
         // Reload definition only if language (or numpad style) changed while the
         // keyboard was backgrounded — avoids rebuilding the pipeline every time.
         loadDefinitionIfNeeded()
-        // Rebuild the SwiftUI host if it was torn down before suspension (see
-        // `shedMemoryBeforeSuspension`). Idempotent, so first appearance —
-        // where `viewDidLoad` already built it — is a no-op. Rebuild before any
-        // height constraint update so the content exists first.
-        configureHosting()
     }
 
     override func textDidChange(_ textInput: UITextInput?) {
@@ -217,6 +232,13 @@ final class KeyboardViewController: UIInputViewController {
         else { return }
         snapshot.frame = view.bounds
         snapshot.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        // The stand-in covers the whole keyboard with nothing live behind it,
+        // and it stays up until the rebuild — which the foreground handler
+        // skips for an off-screen keyboard, so possibly until the next
+        // appearance. A frozen image must never swallow a touch or reach
+        // VoiceOver, whatever it happens to outlive.
+        snapshot.isUserInteractionEnabled = false
+        snapshot.accessibilityElementsHidden = true
         view.addSubview(snapshot)
         suspensionPlaceholder = snapshot
     }
@@ -266,12 +288,11 @@ final class KeyboardViewController: UIInputViewController {
             // hosting rebuild — the biggest allocation — in the resume
             // moment, where the jetsam limit is enforced; `viewWillAppear`
             // covers that case when the keyboard is next shown. The active
-            // layer is deliberately kept (no `resetToDefaultMode`): the user
-            // returns to the same field mid-typing.
+            // layer is deliberately kept: the user returns to the same field
+            // mid-typing. (A definition reload inside the refresh still
+            // resets it — a new language's layout cannot keep the old mode.)
             if viewIfLoaded?.window != nil {
-                refreshFromSharedState()
-                updateKeyboardHeight()
-                viewModel.refreshAutoCapitalization()
+                refreshForAppearance(resettingLayer: false)
             }
             KeyboardHealthLog.shared.record("hostWillEnterForeground")
         })
@@ -289,8 +310,8 @@ final class KeyboardViewController: UIInputViewController {
     private func updateKeyboardHeight() {
         // Constraint height ≡ content height by construction: the metrics
         // are the same source the SwiftUI grid renders from, so the fixed
-        // paddings/spacing are no longer scaled by the constraint while the
-        // content keeps them constant (review finding M7).
+        // paddings/spacing are never scaled by the constraint while the
+        // content keeps them constant.
         let finalHeight = viewModel.layoutMetrics.totalHeight
 
         if let constraint = heightConstraint {

--- a/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
@@ -47,8 +47,10 @@ struct KeyboardHealthLog {
         let availableMB: Double
     }
 
-    /// Bounds the log file (~50 KB): a cold start records four entries, a
-    /// warm re-appearance two, so this covers days of typical usage.
+    /// Bounds the log file (~50 KB). A cold start records four entries, and
+    /// every open→close cycle three — `viewWillAppear`, `viewDidAppear`, and
+    /// the suspension entry that closes it — so this holds roughly a hundred
+    /// cycles: still days of typical usage.
     static let defaultMaxEntries = 300
 
     static let fileName = "keyboard-health-log.json"

--- a/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
@@ -28,9 +28,10 @@ import os
 /// `record` captures the footprint synchronously at the call site (so the
 /// measurement is attributed to the right lifecycle point) but persists on a
 /// serial utility queue — file I/O must not sit in the keyboard's launch
-/// path. A host-app clear racing an extension write can lose one side —
-/// acceptable for diagnostics, and the file stays bounded by `maxEntries`
-/// either way.
+/// path. The suspension path uses `recordAndFlush` instead: there the write
+/// must land before the process is frozen, and latency does not matter. A
+/// host-app clear racing an extension write can lose one side — acceptable
+/// for diagnostics, and the file stays bounded by `maxEntries` either way.
 struct KeyboardHealthLog {
     struct Entry: Codable, Equatable, Identifiable {
         let id: UUID
@@ -46,8 +47,8 @@ struct KeyboardHealthLog {
         let availableMB: Double
     }
 
-    /// Bounds the log file (~50 KB): a cold start records three entries, a
-    /// warm re-appearance one, so this covers days of typical usage.
+    /// Bounds the log file (~50 KB): a cold start records four entries, a
+    /// warm re-appearance two, so this covers days of typical usage.
     static let defaultMaxEntries = 300
 
     static let fileName = "keyboard-health-log.json"
@@ -100,6 +101,25 @@ struct KeyboardHealthLog {
 
     /// Records the current footprint under the given lifecycle label.
     func record(_ label: String) {
+        let entry = makeEntry(label)
+        Self.ioQueue.async { appendEntry(entry) }
+    }
+
+    /// Records like `record(_:)`, but returns only once the entry is on disk.
+    /// For the suspension path: a suspended process may never get CPU time
+    /// again — a resume-jetsam kills it on wake before queued writes run —
+    /// and the post-shedding footprint entry is exactly what those incidents
+    /// need. The serial queue also drains any earlier async records first.
+    /// Not for the launch path, where file I/O must stay off the main thread.
+    func recordAndFlush(_ label: String) {
+        let entry = makeEntry(label)
+        Self.ioQueue.sync { appendEntry(entry) }
+    }
+
+    /// Captures the footprint synchronously at the call site, so the
+    /// measurement is attributed to the right lifecycle point no matter when
+    /// the entry is persisted.
+    private func makeEntry(_ label: String) -> Entry {
         let entry = Entry(
             id: UUID(),
             date: Date(),
@@ -113,7 +133,7 @@ struct KeyboardHealthLog {
             let message = "[\(label)] used: \(used) MB, available: \(available) MB"
             Self.logger.log("\(message, privacy: .public)")
         #endif
-        Self.ioQueue.async { appendEntry(entry) }
+        return entry
     }
 
     /// All recorded entries, oldest first, capped at `maxEntries`. Empty when

--- a/wurstfingerTests/KeyboardHealthLogTests.swift
+++ b/wurstfingerTests/KeyboardHealthLogTests.swift
@@ -147,6 +147,42 @@ struct KeyboardHealthLogTests {
         #expect(perLine.count <= 2 * 3 + 2)
     }
 
+    /// `recordAndFlush` must not return before its entry is on disk: it
+    /// exists for the suspension path, where the process may be frozen (and
+    /// later jetsam-killed on resume) before an async queue hop would run.
+    /// The raw file is read directly — going through `entries()` would drain
+    /// a still-pending async write via its `ioQueue.sync` and mask a
+    /// regression to fire-and-forget behavior.
+    @Test func recordAndFlushPersistsBeforeReturning() throws {
+        let url = makeTestFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let log = KeyboardHealthLog(fileURL: url)
+
+        log.recordAndFlush("viewDidDisappear")
+
+        let data = try Data(contentsOf: url)
+        let entry = try JSONDecoder().decode(KeyboardHealthLog.Entry.self, from: data)
+        #expect(entry.label == "viewDidDisappear")
+        #expect(entry.usedMB > 0)
+    }
+
+    /// Flushing also drains earlier fire-and-forget records (the serial queue
+    /// preserves order), so the appearance entries from the same session hit
+    /// the disk before the process is frozen too.
+    @Test func recordAndFlushDrainsPriorAsyncRecords() throws {
+        let url = makeTestFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let log = KeyboardHealthLog(fileURL: url)
+
+        log.record("viewWillAppear")
+        log.recordAndFlush("hostDidEnterBackground")
+
+        let decoder = JSONDecoder()
+        let perLine = try Data(contentsOf: url).split(separator: 0x0A)
+            .compactMap { try? decoder.decode(KeyboardHealthLog.Entry.self, from: Data($0)) }
+        #expect(perLine.map(\.label) == ["viewWillAppear", "hostDidEnterBackground"])
+    }
+
     /// The file URL provider must not be invoked at construction — that is
     /// what keeps the shared instance's `containerURL(...)` IPC off the
     /// main/spawn thread. It is resolved lazily on first file access.

--- a/wurstfingerTests/KeyboardHealthLogTests.swift
+++ b/wurstfingerTests/KeyboardHealthLogTests.swift
@@ -160,8 +160,11 @@ struct KeyboardHealthLogTests {
 
         log.recordAndFlush("viewDidDisappear")
 
-        let data = try Data(contentsOf: url)
-        let entry = try JSONDecoder().decode(KeyboardHealthLog.Entry.self, from: data)
+        let decoder = JSONDecoder()
+        let persisted = try Data(contentsOf: url).split(separator: 0x0A)
+            .compactMap { try? decoder.decode(KeyboardHealthLog.Entry.self, from: Data($0)) }
+        let entry = try #require(persisted.first)
+        #expect(persisted.count == 1)
         #expect(entry.label == "viewDidDisappear")
         #expect(entry.usedMB > 0)
     }


### PR DESCRIPTION
## Summary

Follow-up to the suspension hardening in #273: a lifecycle review of the extension found that the host-foreground resume path restores less state than `viewWillAppear` does, plus three smaller gaps around the suspension teardown. All four are addressed here.

### 1. Host-foreground return now refreshes cross-process state (main fix)

`NSExtensionHostWillEnterForeground` only rebuilt the hosting graph. But cross-process defaults writes fire no in-process `didChangeNotification`, and this path — by its own documentation — never gets a `viewWillAppear`. So the flow *keyboard open in app X → switch to the Wurstfinger app → change language/width/numpad style → switch back* resurfaced the keyboard with stale settings, a stale definition, and a height constraint computed from stale layout settings.

The appearance-time refresh (Full Access persist, `reloadSettings`, `loadDefinitionIfNeeded`, `configureHosting`) is now factored into a shared `refreshFromSharedState()` used by both `viewWillAppear` and the foreground handler, followed by a height update and an auto-capitalization refresh. The active layer is deliberately **not** reset on foreground return: the user comes back to the same field mid-typing.

### 2. Foreground rebuild is gated on visibility

The hosting rebuild is the biggest allocation the extension makes, and the foreground handler ran it unconditionally — potentially for a keyboard that is not even on screen (dismissed before the host backgrounded), in exactly the resume moment where iOS re-enforces the jetsam limit. The handler now skips the refresh when `viewIfLoaded?.window == nil`; `viewWillAppear` covers that case when the keyboard is next shown. The health-log heartbeat still records every resume.

### 3. App-switcher card keeps showing the keyboard

iOS takes the host app's switcher snapshot *after* the host backgrounds, i.e. after the teardown — leaving a blank strip where the keyboard was. Before teardown, a `snapshotView(afterScreenUpdates: false)` of the hosting view is left in place: it references the render server's already-drawn surface, so it does not meaningfully add to the suspended footprint. `configureHosting` removes it in the same CA transaction that installs the live view.

### 4. Suspension health-log entries are flushed synchronously

`record` persists via an async queue hop; a process frozen right after suspension may never run it — and if the freeze ends in a resume-jetsam kill, the lost entry is the post-shedding footprint the log exists to capture. `shedMemoryBeforeSuspension` now uses a new `recordAndFlush`, which returns only once the entry (and, via the serial queue, all earlier records) is on disk. Launch-path records stay async.

Additionally, `viewDidAppear` now records a health-log entry so the `viewWillAppear → viewDidAppear` timestamp delta bounds the per-appearance rebuild cost on-device — every re-appearance pays a hosting rebuild since #273, and this makes latency regressions visible without a Mac attached.

## Testing

- Full `WurstfingerTests` suite on iPhone 17 Pro simulator: 1028 passed, 0 failed — including two new tests covering `recordAndFlush` durability and its drain-before-return ordering.
- SwiftFormat + SwiftLint clean.

### On-device verification still open

- Settings/language change in the host app while the keyboard is open in another app, then switching back (fix 1).
- App-switcher card showing the keyboard after backgrounding a host with the keyboard open (fix 3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the keyboard’s rendered appearance while its hosting view is temporarily unavailable.
  * Improved keyboard state, layout, height, and capitalization refreshes during reappearance and foreground transitions.
  * Removed stale placeholders when the keyboard is rebuilt.
  * Ensured health logs are saved reliably before suspension completes.

* **Tests**
  * Added coverage confirming health logs are written synchronously and remain in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->