### PR TITLE
Shrink the Keyboard Render Graph

### DIFF
--- a/wurstfingerKeyboard/Definition/Layout/GridArrangement.swift
+++ b/wurstfingerKeyboard/Definition/Layout/GridArrangement.swift
@@ -9,7 +9,8 @@ import Foundation
 
 /// A concrete spatial arrangement of keys.
 /// Multiple arrangements can lay out the same key pool differently.
-struct GridArrangement: Codable, Equatable {
+/// Hashable so `GridLayoutSolver` can memoize solved cells per arrangement.
+struct GridArrangement: Codable, Hashable {
     /// Number of logical columns.
     /// The sum of widthMultipliers in each row (plus columns spanned by keys from
     /// previous rows via heightMultiplier) must equal this value.

--- a/wurstfingerKeyboard/Definition/Layout/GridLayoutSolver.swift
+++ b/wurstfingerKeyboard/Definition/Layout/GridLayoutSolver.swift
@@ -26,10 +26,30 @@ struct SolvedCell: Equatable {
 /// consumes the result to place each key, including across multiple rows — the
 /// case the old `Grid`-based renderer could not draw and trapped on.
 enum GridLayoutSolver {
+    /// Memoized results per arrangement. `solve` runs in `KeyboardGridView.body`
+    /// on every grid render, but its result depends only on the arrangement —
+    /// a stored value inside the (registry-cached) definition — so re-solving
+    /// per render is pure allocation churn. Bounded by the distinct
+    /// arrangements ever rendered (languages × modes × contexts, each a few
+    /// hundred bytes), so the cache is not worth evicting under memory
+    /// pressure. Locked for the same reason as `KeyboardRegistry.cache`:
+    /// production access is main-thread only, but tests run in parallel.
+    private static var cache: [GridArrangement: [SolvedCell]] = [:]
+    private static let cacheLock = NSLock()
+
     /// Resolves an arrangement using first-fit, row-major placement: each
     /// placement takes the next free column in its row, skipping cells already
-    /// occupied by a span descending from an earlier row.
+    /// occupied by a span descending from an earlier row. Memoized.
     static func solve(_ arrangement: GridArrangement) -> [SolvedCell] {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        if let cached = cache[arrangement] { return cached }
+        let cells = resolve(arrangement)
+        cache[arrangement] = cells
+        return cells
+    }
+
+    private static func resolve(_ arrangement: GridArrangement) -> [SolvedCell] {
         let columns = max(arrangement.columns, 1)
         var occupied: [[Bool]] = []
 

--- a/wurstfingerKeyboard/Definition/Layout/GridLayoutSolver.swift
+++ b/wurstfingerKeyboard/Definition/Layout/GridLayoutSolver.swift
@@ -23,17 +23,21 @@ struct SolvedCell: Equatable {
 /// This is what makes height-spanning keys (e.g. the landscape return key with
 /// `heightMultiplier == 2`) renderable: the geometry lives in a pure, testable
 /// function instead of being approximated in the SwiftUI tree. `KeyboardGridView`
-/// consumes the result to place each key, including across multiple rows — the
-/// case the old `Grid`-based renderer could not draw and trapped on.
+/// consumes the result to place each key, including across multiple rows.
 enum GridLayoutSolver {
     /// Memoized results per arrangement. `solve` runs in `KeyboardGridView.body`
     /// on every grid render, but its result depends only on the arrangement —
     /// a stored value inside the (registry-cached) definition — so re-solving
     /// per render is pure allocation churn. Bounded by the distinct
     /// arrangements ever rendered (languages × modes × contexts, each a few
-    /// hundred bytes), so the cache is not worth evicting under memory
-    /// pressure. Locked for the same reason as `KeyboardRegistry.cache`:
-    /// production access is main-thread only, but tests run in parallel.
+    /// hundred bytes), but *not* self-limiting: the keys are `GridArrangement`
+    /// values whose row arrays are shared with the definitions, so a cached
+    /// entry keeps the arrangement storage of an evicted language alive. It is
+    /// therefore dropped alongside the definition cache on the memory-pressure
+    /// and pre-suspension paths (`GridLayoutSolver.evictAll`); re-solving takes
+    /// microseconds, once per arrangement per appearance. Locked for the same
+    /// reason as `KeyboardRegistry.cache`: production access is main-thread
+    /// only, but tests run in parallel.
     private static var cache: [GridArrangement: [SolvedCell]] = [:]
     private static let cacheLock = NSLock()
 
@@ -47,6 +51,27 @@ enum GridLayoutSolver {
         let cells = resolve(arrangement)
         cache[arrangement] = cells
         return cells
+    }
+
+    /// Drops every memoized result. Called from the keyboard's memory-warning
+    /// and pre-suspension paths next to `KeyboardRegistry.evictAll`: the
+    /// entries are cheap to rebuild but hold arrangement storage that the
+    /// definition eviction is trying to free. Nothing observes the cache, so
+    /// clearing it is invisible apart from one re-solve per arrangement.
+    static func evictAll() {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        cache.removeAll()
+    }
+
+    /// Whether an arrangement is currently memoized (for testing). Mirrors
+    /// `KeyboardRegistry.isCached(id:)`: per-arrangement rather than a global
+    /// count, so a test probing its own arrangement cannot race the suites
+    /// solving theirs in parallel.
+    static func isCached(_ arrangement: GridArrangement) -> Bool {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        return cache[arrangement] != nil
     }
 
     private static func resolve(_ arrangement: GridArrangement) -> [SolvedCell] {

--- a/wurstfingerKeyboard/Definition/Layout/KeyPlacement.swift
+++ b/wurstfingerKeyboard/Definition/Layout/KeyPlacement.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// References a key by ID and determines its size in the grid.
 /// The same key can be placed differently in different arrangements.
-struct KeyPlacement: Codable, Equatable {
+struct KeyPlacement: Codable, Hashable {
     /// Reference to a KeyConfig.id
     let keyId: String
 

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -192,20 +192,24 @@ final class KeyboardViewController: UIInputViewController {
 
     /// Sheds weight before the process gets suspended: iOS enforces the
     /// per-process memory limit again when a suspended keyboard extension is
-    /// resumed by the next host. A device log capture (2026-07-07) showed
-    /// exactly this — resume by Spotlight, immediate `jetsam
-    /// per-process-limit` kill, silent system-keyboard fallback. Suspending
-    /// small is what makes the next resume survive; a memory warning never
-    /// fires on suspension, so this cannot wait for didReceiveMemoryWarning.
+    /// resumed by the next host, and a keyboard that suspended large is killed
+    /// on resume (`jetsam per-process-limit`, with a silent fallback to the
+    /// system keyboard). Suspending small is what makes the next resume
+    /// survive; a memory warning never fires on suspension, so this cannot
+    /// wait for `didReceiveMemoryWarning`.
     ///
-    /// Evicting the definition cache alone freed only a few MB: a device-log
-    /// audit (2026-07-22) found the suspended process sitting at ~140 MB with
-    /// the *SwiftUI hosting graph* — not any app data structure — as the bulk
-    /// of the footprint. So the hosting controller is torn down here too and
-    /// rebuilt in `viewWillAppear`. The health-log entry records the footprint
-    /// *after* shedding, so it measures what actually survives to suspension.
+    /// The definition caches account for only a few MB of a suspended
+    /// keyboard's footprint — the bulk of it is the *SwiftUI hosting graph*,
+    /// not any app data structure — so the hosting controller is torn down
+    /// here too and rebuilt in `viewWillAppear`. The health-log entry records
+    /// the footprint *after* shedding, so it measures what actually survives
+    /// to suspension.
     private func shedMemoryBeforeSuspension(_ event: String) {
         KeyboardRegistry.evictAll(except: selectedLanguageId)
+        // The memoized grid layouts hold arrangement storage shared with the
+        // definitions just evicted, so dropping them is part of the same
+        // shedding step. The next appearance re-solves in microseconds.
+        GridLayoutSolver.evictAll()
         installSuspensionPlaceholder()
         teardownHosting()
         // Flushed, not queued: the suspended process may never run again — a
@@ -305,6 +309,10 @@ final class KeyboardViewController: UIInputViewController {
         // active definition stays resident (the view model holds a strong
         // reference) and remains cached for fast reuse.
         KeyboardRegistry.evictAll(except: selectedLanguageId)
+        // Same for the memoized grid layouts: they pin the arrangement storage
+        // of the definitions evicted above and cost microseconds to rebuild,
+        // including the active one on the next render.
+        GridLayoutSolver.evictAll()
     }
 
     private func updateKeyboardHeight() {

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -19,24 +19,24 @@ struct DataDrivenKeyboardRootView: View {
     var overrideWidth: CGFloat?
 
     // Single read site for the per-key render settings: one observation per
-    // setting for the whole keyboard instead of one per key (`KeyView` used
-    // to carry five `@AppStorage` wrappers each — ~100 defaults observations
-    // per layer, re-registered on every hosting rebuild). The root re-renders
-    // on changes and passes fresh values down.
+    // setting for the whole keyboard rather than one per key view. The root
+    // re-renders on changes and passes fresh values down. The unstored-value
+    // defaults come from `KeyRenderSettings.stock`, so this site and the
+    // snapshot type agree on what an untouched installation renders.
     @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
-    private var keyboardStyle: KeyboardStyle = .classic
+    private var keyboardStyle: KeyboardStyle = KeyRenderSettings.stock.keyboardStyle
 
     @AppStorage(SettingsKey.hideLetters.rawValue, store: SharedDefaults.store)
-    private var hideLetters = false
+    private var hideLetters = KeyRenderSettings.stock.hideLetters
 
     @AppStorage(SettingsKey.hideStandardSymbols.rawValue, store: SharedDefaults.store)
-    private var hideStandardSymbols = false
+    private var hideStandardSymbols = KeyRenderSettings.stock.hideStandardSymbols
 
     @AppStorage(SettingsKey.hideExtraSymbols.rawValue, store: SharedDefaults.store)
-    private var hideExtraSymbols = false
+    private var hideExtraSymbols = KeyRenderSettings.stock.hideExtraSymbols
 
     @AppStorage(SettingsKey.longPressNumbersEnabled.rawValue, store: SharedDefaults.store)
-    private var longPressNumbersEnabled = false
+    private var longPressNumbersEnabled = KeyRenderSettings.stock.longPressNumbersEnabled
 
     private var renderSettings: KeyRenderSettings {
         KeyRenderSettings(
@@ -52,8 +52,8 @@ struct DataDrivenKeyboardRootView: View {
         let currentWidth = overrideWidth ?? viewModel.viewWidth
         // Single geometry source: the resolved metrics drive the keyboard
         // width here and the row/cell sizes in the grid, so they can never
-        // desynchronize (the old split between the view-model width path and
-        // @AppStorage-read row heights was review finding M8/H3).
+        // desynchronize — which a second, `@AppStorage`-read source of row
+        // heights would allow.
         let metrics = viewModel.layoutMetrics(forContainerWidth: currentWidth)
         let availableSpace = currentWidth - metrics.keyboardWidth
         let horizontalOffset = availableSpace * (viewModel.keyboardHorizontalPosition - 0.5)

--- a/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
+++ b/wurstfingerKeyboard/Runtime/View/DataDrivenKeyboardRootView.swift
@@ -18,8 +18,35 @@ struct DataDrivenKeyboardRootView: View {
     /// When nil, falls back to `viewModel.viewWidth`.
     var overrideWidth: CGFloat?
 
+    // Single read site for the per-key render settings: one observation per
+    // setting for the whole keyboard instead of one per key (`KeyView` used
+    // to carry five `@AppStorage` wrappers each — ~100 defaults observations
+    // per layer, re-registered on every hosting rebuild). The root re-renders
+    // on changes and passes fresh values down.
     @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
     private var keyboardStyle: KeyboardStyle = .classic
+
+    @AppStorage(SettingsKey.hideLetters.rawValue, store: SharedDefaults.store)
+    private var hideLetters = false
+
+    @AppStorage(SettingsKey.hideStandardSymbols.rawValue, store: SharedDefaults.store)
+    private var hideStandardSymbols = false
+
+    @AppStorage(SettingsKey.hideExtraSymbols.rawValue, store: SharedDefaults.store)
+    private var hideExtraSymbols = false
+
+    @AppStorage(SettingsKey.longPressNumbersEnabled.rawValue, store: SharedDefaults.store)
+    private var longPressNumbersEnabled = false
+
+    private var renderSettings: KeyRenderSettings {
+        KeyRenderSettings(
+            keyboardStyle: keyboardStyle,
+            hideLetters: hideLetters,
+            hideStandardSymbols: hideStandardSymbols,
+            hideExtraSymbols: hideExtraSymbols,
+            longPressNumbersEnabled: longPressNumbersEnabled
+        )
+    }
 
     var body: some View {
         let currentWidth = overrideWidth ?? viewModel.viewWidth
@@ -54,6 +81,7 @@ struct DataDrivenKeyboardRootView: View {
                     },
                     languageLabel: viewModel.currentLanguageLabel,
                     showLanguageLabel: viewModel.hasMultipleLanguages,
+                    renderSettings: renderSettings,
                     metrics: metrics
                 )
                 .padding(.horizontal, KeyboardConstants.Layout.horizontalPadding)

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -8,22 +8,25 @@
 
 import SwiftUI
 
-/// Snapshot of the user settings a key needs to render, read once at the
-/// root view and passed down by value.
+/// Snapshot of the user settings a key needs to render, read once in
+/// `DataDrivenKeyboardRootView` and passed down by value.
 ///
-/// Previously every `KeyView` carried five `@AppStorage` wrappers, so each
-/// keyboard build registered ~5 defaults observations per key (~100 per
-/// layer) — all rebuilt on every hosting rebuild and all notified on every
-/// defaults write. One read site at the root keeps the semantics (the root
-/// re-renders on changes and passes fresh values) at a fraction of the
-/// graph size. Defaults match the `@AppStorage` defaults they replace, so
-/// previews and tests that construct keys directly render unchanged.
+/// The whole keyboard holds one defaults observation per setting, and the
+/// ~100 key views a layer builds hold none: the root re-renders when a
+/// setting changes and hands every key the fresh values.
 struct KeyRenderSettings: Equatable {
     var keyboardStyle: KeyboardStyle = .classic
     var hideLetters = false
     var hideStandardSymbols = false
     var hideExtraSymbols = false
     var longPressNumbersEnabled = false
+
+    /// The values a key renders with when nothing is stored yet. Single source
+    /// for those defaults: `DataDrivenKeyboardRootView` initializes its
+    /// `@AppStorage` wrappers from it, so the snapshot a test or preview builds
+    /// with `KeyRenderSettings()` cannot drift from what an untouched
+    /// installation actually renders.
+    static let stock = KeyRenderSettings()
 }
 
 /// Generic key view that renders any `KeyConfig`.
@@ -57,9 +60,12 @@ struct KeyView: View {
     @State private var isActive = false
 
     /// User settings affecting key rendering, injected by `KeyboardGridView`
-    /// (ultimately read once in `DataDrivenKeyboardRootView`) instead of five
-    /// per-key `@AppStorage` observations — see `KeyRenderSettings`.
-    var settings: KeyRenderSettings = .init()
+    /// (ultimately read once in `DataDrivenKeyboardRootView`) — see
+    /// `KeyRenderSettings`. No default, for the same reason as `metrics`: a
+    /// defaulted snapshot would let a missing injection compile and silently
+    /// render stock settings (labels shown, long-press numbers off) instead of
+    /// failing the build.
+    let settings: KeyRenderSettings
 
     /// Resolved layout metrics injected by `KeyboardGridView` (same reasoning
     /// as there: an `@AppStorage` read desynchronizes from the width path
@@ -294,6 +300,14 @@ struct KeyView: View {
         .swipeDownRight: .bottomTrailing,
     ]
 
+    /// The gestures `hintOverlay` draws, in a fixed order. A static list keeps
+    /// the hint layer order stable across launches (dictionary iteration order
+    /// is seeded per process) and allocates nothing per render; gestures a key
+    /// does not bind drop out via the `key.bindings[gesture]` lookup. Must
+    /// cover exactly `hintAlignments` — a missing entry silently hides that
+    /// hint. `internal` (not `private`) so the guard test can lock it.
+    static let hintGestureOrder: [GestureType] = GestureType.allCases.filter(\.isSwipe)
+
     /// Maps certain key actions to SF Symbol names for hint rendering.
     private static func hintIcon(for action: KeyAction) -> String? {
         switch action {
@@ -349,12 +363,11 @@ struct KeyView: View {
         let hPad = KeyboardConstants.FontSizes.hintBaseHorizontalPadding * fontRatio
         let vPad = KeyboardConstants.FontSizes.hintBaseVerticalPadding * fontRatio
 
-        // No GeometryReader: each hint fills the cell via an infinity frame
-        // and pins to its directional alignment — the same geometry the
-        // previous proxy-sized frames produced, minus one layout container
-        // (and its extra layout pass) per key.
+        // Each hint fills the cell via an infinity frame and pins to its
+        // directional alignment, so the overlay needs no size measurement —
+        // and the key no extra layout container.
         return ZStack {
-            ForEach(Array(key.bindings.keys), id: \.self) { gesture in
+            ForEach(Self.hintGestureOrder, id: \.self) { gesture in
                 // Render a hint when it has a text label, or when the action
                 // maps to an icon (globe, dismiss, copy/cut/paste). Utility
                 // icon hints carry an empty label on purpose — their glyph is

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -8,6 +8,24 @@
 
 import SwiftUI
 
+/// Snapshot of the user settings a key needs to render, read once at the
+/// root view and passed down by value.
+///
+/// Previously every `KeyView` carried five `@AppStorage` wrappers, so each
+/// keyboard build registered ~5 defaults observations per key (~100 per
+/// layer) — all rebuilt on every hosting rebuild and all notified on every
+/// defaults write. One read site at the root keeps the semantics (the root
+/// re-renders on changes and passes fresh values) at a fraction of the
+/// graph size. Defaults match the `@AppStorage` defaults they replace, so
+/// previews and tests that construct keys directly render unchanged.
+struct KeyRenderSettings: Equatable {
+    var keyboardStyle: KeyboardStyle = .classic
+    var hideLetters = false
+    var hideStandardSymbols = false
+    var hideExtraSymbols = false
+    var longPressNumbersEnabled = false
+}
+
 /// Generic key view that renders any `KeyConfig`.
 ///
 /// Visual appearance is driven by `key.style`. Hints derive directly from
@@ -38,8 +56,10 @@ struct KeyView: View {
 
     @State private var isActive = false
 
-    @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
-    private var keyboardStyle: KeyboardStyle = .classic
+    /// User settings affecting key rendering, injected by `KeyboardGridView`
+    /// (ultimately read once in `DataDrivenKeyboardRootView`) instead of five
+    /// per-key `@AppStorage` observations — see `KeyRenderSettings`.
+    var settings: KeyRenderSettings = .init()
 
     /// Resolved layout metrics injected by `KeyboardGridView` (same reasoning
     /// as there: an `@AppStorage` read desynchronizes from the width path
@@ -57,25 +77,13 @@ struct KeyView: View {
     var languageLabel: String = ""
     var showLanguageLabel: Bool = false
 
-    @AppStorage(SettingsKey.hideLetters.rawValue, store: SharedDefaults.store)
-    private var hideLetters = false
-
-    @AppStorage(SettingsKey.hideStandardSymbols.rawValue, store: SharedDefaults.store)
-    private var hideStandardSymbols = false
-
-    @AppStorage(SettingsKey.hideExtraSymbols.rawValue, store: SharedDefaults.store)
-    private var hideExtraSymbols = false
-
-    @AppStorage(SettingsKey.longPressNumbersEnabled.rawValue, store: SharedDefaults.store)
-    private var longPressNumbersEnabled = false
-
     /// Whether the label of `binding` should be drawn, honouring the user's
     /// label-visibility toggles (numbers and functional keys always show).
     private func isLabelVisible(_ binding: KeyBinding) -> Bool {
         LabelCategory.of(binding).isVisible(
-            hideLetters: hideLetters,
-            hideStandardSymbols: hideStandardSymbols,
-            hideExtraSymbols: hideExtraSymbols
+            hideLetters: settings.hideLetters,
+            hideStandardSymbols: settings.hideStandardSymbols,
+            hideExtraSymbols: settings.hideExtraSymbols
         )
     }
 
@@ -223,7 +231,7 @@ struct KeyView: View {
     /// Long-press handler for the gesture recognizer, or nil when the
     /// opt-in setting is off or no handler is wired up (preview contexts).
     private var longPressHandler: (() -> Bool)? {
-        guard longPressNumbersEnabled, let onLongPress else { return nil }
+        guard settings.longPressNumbersEnabled, let onLongPress else { return nil }
         return { onLongPress(key) }
     }
 
@@ -232,7 +240,7 @@ struct KeyView: View {
     @ViewBuilder
     private var background: some View {
         let shape = RoundedRectangle(cornerRadius: KeyboardConstants.KeyDimensions.cornerRadius)
-        switch keyboardStyle {
+        switch settings.keyboardStyle {
         case .classic:
             shape.fill(Self.backgroundColor(for: key.style, active: isActive))
         case .liquidGlass:
@@ -336,13 +344,16 @@ struct KeyView: View {
     }
 
     private var hintOverlay: some View {
-        GeometryReader { proxy in
-            let size = proxy.size
-            // Scale padding proportionally with font size
-            let fontRatio = scaledHintFontSize / KeyboardConstants.FontSizes.hintReferenceFontSize
-            let hPad = KeyboardConstants.FontSizes.hintBaseHorizontalPadding * fontRatio
-            let vPad = KeyboardConstants.FontSizes.hintBaseVerticalPadding * fontRatio
+        // Scale padding proportionally with font size
+        let fontRatio = scaledHintFontSize / KeyboardConstants.FontSizes.hintReferenceFontSize
+        let hPad = KeyboardConstants.FontSizes.hintBaseHorizontalPadding * fontRatio
+        let vPad = KeyboardConstants.FontSizes.hintBaseVerticalPadding * fontRatio
 
+        // No GeometryReader: each hint fills the cell via an infinity frame
+        // and pins to its directional alignment — the same geometry the
+        // previous proxy-sized frames produced, minus one layout container
+        // (and its extra layout pass) per key.
+        return ZStack {
             ForEach(Array(key.bindings.keys), id: \.self) { gesture in
                 // Render a hint when it has a text label, or when the action
                 // maps to an icon (globe, dismiss, copy/cut/paste). Utility
@@ -358,22 +369,14 @@ struct KeyView: View {
                                 .foregroundStyle(Color.primary.opacity(0.5))
                                 .fixedSize()
                                 .padding(Self.hintEdgePadding(for: gesture, horizontal: hPad, vertical: vPad))
-                                .frame(
-                                    width: size.width,
-                                    height: size.height,
-                                    alignment: alignment
-                                )
+                                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
                         }
                     } else if !binding.label.isEmpty || Self.hintIcon(for: binding.action) != nil,
                               isLabelVisible(binding) {
                         hintContent(for: binding)
                             .fixedSize()
                             .padding(Self.hintEdgePadding(for: gesture, horizontal: hPad, vertical: vPad))
-                            .frame(
-                                width: size.width,
-                                height: size.height,
-                                alignment: alignment
-                            )
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
                     }
                 }
             }

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -27,6 +27,12 @@ struct KeyboardGridView: View {
     var languageLabel: String = ""
     var showLanguageLabel: Bool = false
 
+    /// Render settings snapshot forwarded to every `KeyView` — read once in
+    /// `DataDrivenKeyboardRootView` instead of per-key `@AppStorage` (see
+    /// `KeyRenderSettings`). Defaulted so previews and tests that build the
+    /// grid directly keep the stock appearance.
+    var renderSettings: KeyRenderSettings = .init()
+
     /// Resolved layout metrics injected by `DataDrivenKeyboardRootView` from
     /// the view model rather than read via `@AppStorage`: the root view
     /// derives the keyboard *width* from the same metrics, and reading the
@@ -81,6 +87,7 @@ struct KeyboardGridView: View {
                 gestureTrail: gestureTrail,
                 spanRatio: CGFloat(cell.columnSpan) / CGFloat(cell.rowSpan),
                 visualInset: visualInset(for: cell, totalRows: totalRows),
+                settings: renderSettings,
                 metrics: metrics,
                 languageLabel: languageLabel,
                 showLanguageLabel: showLanguageLabel

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -27,11 +27,13 @@ struct KeyboardGridView: View {
     var languageLabel: String = ""
     var showLanguageLabel: Bool = false
 
-    /// Render settings snapshot forwarded to every `KeyView` — read once in
-    /// `DataDrivenKeyboardRootView` instead of per-key `@AppStorage` (see
-    /// `KeyRenderSettings`). Defaulted so previews and tests that build the
-    /// grid directly keep the stock appearance.
-    var renderSettings: KeyRenderSettings = .init()
+    /// Render settings snapshot forwarded to every `KeyView`, read once in
+    /// `DataDrivenKeyboardRootView` (see `KeyRenderSettings`). Undefaulted
+    /// like `metrics`: the snapshot must come from the one observing read
+    /// site, so a missing injection is a build error rather than a keyboard
+    /// that silently ignores the user's label-visibility and long-press
+    /// settings.
+    let renderSettings: KeyRenderSettings
 
     /// Resolved layout metrics injected by `DataDrivenKeyboardRootView` from
     /// the view model rather than read via `@AppStorage`: the root view

--- a/wurstfingerTests/GridLayoutSolverTests.swift
+++ b/wurstfingerTests/GridLayoutSolverTests.swift
@@ -98,3 +98,71 @@ struct GridLayoutSolverInvariantTests {
         return result
     }()
 }
+
+/// Locks the memoization contract: `solve` is called from `KeyboardGridView.body`
+/// on every render, so a cached result must be indistinguishable from a fresh
+/// one — including after the memory-pressure paths drop the cache.
+///
+/// Every test works on its own probe arrangement (unique key ids), so the
+/// cache assertions never observe entries other suites solve in parallel.
+/// `.serialized` because `evictAll` is global: it must not land between
+/// another test in this suite solving and asserting.
+@Suite(.serialized)
+struct GridLayoutSolverMemoizationTests {
+    /// A 2×2 arrangement whose key ids are unique per test.
+    private static func probe(_ name: String) -> GridArrangement {
+        GridArrangement(
+            columns: 2,
+            rows: [
+                [KeyPlacement(keyId: "\(name)-a"), KeyPlacement(keyId: "\(name)-b")],
+                [KeyPlacement(keyId: "\(name)-c", widthMultiplier: 2)],
+            ]
+        )
+    }
+
+    @Test func solvingMemoizesTheArrangement() {
+        let arrangement = Self.probe("memoizes")
+        #expect(!GridLayoutSolver.isCached(arrangement))
+        _ = GridLayoutSolver.solve(arrangement)
+        #expect(GridLayoutSolver.isCached(arrangement))
+    }
+
+    @Test func repeatedSolvesReturnEqualCells() {
+        let arrangement = Self.probe("repeated")
+        let first = GridLayoutSolver.solve(arrangement)
+        let second = GridLayoutSolver.solve(arrangement)
+        #expect(first == second)
+        #expect(!first.isEmpty)
+    }
+
+    /// The cache is keyed by value, so a structurally identical arrangement
+    /// built somewhere else hits the same entry — and must get the same cells.
+    @Test func equalArrangementValuesShareTheResult() {
+        let original = Self.probe("shared")
+        let copy = Self.probe("shared")
+        let cells = GridLayoutSolver.solve(original)
+        #expect(GridLayoutSolver.isCached(copy))
+        #expect(GridLayoutSolver.solve(copy) == cells)
+    }
+
+    /// `KeyboardViewController` drops the cache on memory warnings and before
+    /// suspension; the next solve must rebuild the identical result.
+    @Test func evictAllDropsEntriesAndKeepsSolverCorrect() {
+        let arrangement = Self.probe("evicted")
+        let before = GridLayoutSolver.solve(arrangement)
+        GridLayoutSolver.evictAll()
+        #expect(!GridLayoutSolver.isCached(arrangement))
+        #expect(GridLayoutSolver.solve(arrangement) == before)
+    }
+
+    /// `rowCount` shares the memoized cells, so it must agree with the solver
+    /// whether the arrangement was solved before or not.
+    @Test func rowCountMatchesSolvedSpansRegardlessOfCacheState() {
+        let arrangement = Self.probe("rowCount")
+        let cold = GridLayoutSolver.rowCount(arrangement)
+        let warm = GridLayoutSolver.rowCount(arrangement)
+        let expected = GridLayoutSolver.solve(arrangement).map { $0.row + $0.rowSpan }.max()
+        #expect(cold == warm)
+        #expect(cold == expected)
+    }
+}

--- a/wurstfingerTests/HintAlignmentTests.swift
+++ b/wurstfingerTests/HintAlignmentTests.swift
@@ -2,16 +2,16 @@
 //  HintAlignmentTests.swift
 //  WurstfingerTests
 //
-//  Regression guards for the RTL fix (finding #4). The keyboard's render
-//  tree is pinned to physical `.leftToRight`, so the directional hint tables
-//  map each swipe direction to its PHYSICAL edge. These tests lock that
-//  mapping so a mistaken "RTL fix" that mirrors the tables (swapping
-//  leading/trailing) is caught in CI — mirroring would place a hint glyph on
-//  the opposite edge from the swipe that produces it.
+//  Guards for the directional hint tables. The keyboard's render tree is
+//  pinned to physical `.leftToRight`, so the tables map each swipe direction
+//  to its PHYSICAL edge. These tests lock that mapping so a mistaken "RTL fix"
+//  that mirrors the tables (swapping leading/trailing) is caught in CI —
+//  mirroring would place a hint glyph on the opposite edge from the swipe that
+//  produces it.
 //
 //  Note: the actual RTL flip is a rendering effect of SwiftUI's layout engine
-//  under an RTL locale and is verified manually/UI (hints are not
-//  accessibility-queryable). See the PR description.
+//  under an RTL locale and is verified manually/UI, since hints are not
+//  accessibility-queryable.
 //
 
 import SwiftUI
@@ -29,6 +29,22 @@ struct HintAlignmentTests {
         #expect(KeyView.hintAlignments[.swipeUpRight] == .topTrailing)
         #expect(KeyView.hintAlignments[.swipeDownLeft] == .bottomLeading)
         #expect(KeyView.hintAlignments[.swipeDownRight] == .bottomTrailing)
+    }
+
+    /// `hintOverlay` draws one hint per entry in `hintGestureOrder`, so a
+    /// direction missing from that list silently renders no hint at all, and a
+    /// duplicated one draws its hint twice. The list must therefore cover
+    /// `hintAlignments` exactly, without duplicates.
+    @Test func hintGestureOrderCoversEveryAlignedDirectionExactlyOnce() {
+        let order = KeyView.hintGestureOrder
+        #expect(Set(order) == Set(KeyView.hintAlignments.keys))
+        #expect(order.count == KeyView.hintAlignments.count)
+        // Rendering order is fixed, not dictionary-seeded — pinned explicitly
+        // so any per-process ordering creeping in fails here.
+        #expect(order == [
+            .swipeUp, .swipeDown, .swipeLeft, .swipeRight,
+            .swipeUpLeft, .swipeUpRight, .swipeDownLeft, .swipeDownRight,
+        ])
     }
 
     @Test func hintEdgePaddingAppliesInsetOnlyOnTheAlignedPhysicalEdge() {

--- a/wurstfingerTests/KeyboardGridRenderingTests.swift
+++ b/wurstfingerTests/KeyboardGridRenderingTests.swift
@@ -155,7 +155,13 @@ struct KeyViewStyleTests {
             style: .primary,
             tapCycleActions: nil
         )
-        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {}, metrics: .reference)
+        let view = KeyView(
+            key: key,
+            onGesture: { _, _, _ in },
+            onTouchDown: {},
+            settings: KeyRenderSettings(),
+            metrics: .reference
+        )
         #expect(view.primaryLabel == "midLeft")
     }
 
@@ -174,7 +180,13 @@ struct KeyViewStyleTests {
             style: .primary,
             tapCycleActions: nil
         )
-        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {}, metrics: .reference)
+        let view = KeyView(
+            key: key,
+            onGesture: { _, _, _ in },
+            onTouchDown: {},
+            settings: KeyRenderSettings(),
+            metrics: .reference
+        )
         #expect(view.primaryLabel == "d")
     }
 
@@ -193,7 +205,32 @@ struct KeyViewStyleTests {
             style: .utility,
             tapCycleActions: nil
         )
-        let view = KeyView(key: key, onGesture: { _, _, _ in }, onTouchDown: {}, metrics: .reference)
+        let view = KeyView(
+            key: key,
+            onGesture: { _, _, _ in },
+            onTouchDown: {},
+            settings: KeyRenderSettings(),
+            metrics: .reference
+        )
         #expect(view.accessibilityLabel == "Löschen")
+    }
+
+    /// The stock snapshot describes what an untouched installation renders:
+    /// nothing hidden, classic style, long-press numbers off. It is what keys
+    /// built without a store render with (tests, previews) *and* what
+    /// `DataDrivenKeyboardRootView` seeds its `@AppStorage` wrappers with, so a
+    /// silent change here would move both at once.
+    @Test func stockRenderSettingsMatchAnUntouchedStore() {
+        let store = InMemoryUserDefaults()
+        let stock = KeyRenderSettings.stock
+
+        #expect(stock == KeyRenderSettings())
+        #expect(stock.hideLetters == store.bool(forKey: SettingsKey.hideLetters.rawValue))
+        #expect(stock.hideStandardSymbols == store.bool(forKey: SettingsKey.hideStandardSymbols.rawValue))
+        #expect(stock.hideExtraSymbols == store.bool(forKey: SettingsKey.hideExtraSymbols.rawValue))
+        #expect(stock.longPressNumbersEnabled == store.bool(forKey: SettingsKey.longPressNumbersEnabled.rawValue))
+        // No stored style either, so the enum default is what renders.
+        #expect(store.string(forKey: SettingsKey.keyboardStyle.rawValue) == nil)
+        #expect(stock.keyboardStyle == .classic)
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to the lifecycle review: since #273 every keyboard re-appearance rebuilds the SwiftUI hosting graph — the object the 2026-07-22 device audit identified as the dominant memory cost. This PR shrinks that graph and removes redundant per-render work, cutting both the rebuild latency paid on every appearance and the transient allocation peak paid at resume (where the jetsam limit is enforced). Three changes:

### 1. Hoist per-key `@AppStorage` into the root view

Every `KeyView` carried five `@AppStorage` wrappers (keyboard style, three label-visibility flags, long-press toggle) — ~5 defaults observations per key, ~100 per layer, re-registered on every hosting rebuild and all notified on every defaults write. They are replaced by a `KeyRenderSettings` value struct read once in `DataDrivenKeyboardRootView` (which already observed `keyboardStyle`) and passed down by value. Semantics are unchanged: the root re-renders on changes and passes fresh values; defaults in the struct match the `@AppStorage` defaults, so previews and tests that build keys directly render identically.

### 2. Drop the per-key `GeometryReader` in the hint overlay

The reader's `proxy.size` was only used to give each hint a cell-sized frame. An infinity frame with the same directional alignment produces identical geometry without the extra layout container (and its deferred layout pass) per key.

### 3. Memoize `GridLayoutSolver.solve`

`solve` ran inside `KeyboardGridView.body` on every grid render, but its result depends only on the arrangement — a stored value inside the registry-cached definition. Results are now cached per arrangement (`GridArrangement`/`KeyPlacement` gain `Hashable`), locked for parallel test access like `KeyboardRegistry.cache`. The cache is bounded by the distinct arrangements ever rendered (languages × modes × contexts, a few hundred bytes each), and is dropped by `GridLayoutSolver.evictAll()` on the memory-warning and pre-suspension paths: its keys are `GridArrangement` values whose row arrays are shared with the definitions, so keeping entries would pin the storage `KeyboardRegistry.evictAll` is freeing.

### 4. Injected render settings, injected hint order

`KeyView.settings` and `KeyboardGridView.renderSettings` carry no default, matching the rule documented on `metrics`: the snapshot must come from the one observing read site, so a missing injection is a build error rather than a keyboard that silently ignores the label-visibility and long-press settings. `KeyRenderSettings.stock` is the single source for the unstored-value defaults, and the root view seeds its `@AppStorage` wrappers from it.

`hintOverlay` draws from a static `hintGestureOrder` list rather than the binding dictionary, so the hint layer order no longer depends on the per-process dictionary seed and no keys array is allocated per render. Rendering is byte-identical either way (verified with `ImageRenderer` at 3×).

## Measurements

Throwaway harness (not committed; see below): builds the real German keyboard hosting graph in a window and measures build+layout latency (median of 30 builds) and retained footprint per graph (Δ`phys_footprint` across 20 retained graphs). iPhone 17 Pro simulator, Debug, 3 runs per variant, median-of-medians:

| | before | after | delta |
|---|---|---|---|
| Graph build+layout (median) | 12.10 ms | 10.55 ms | **−13 %** |
| Retained memory per graph | ~2810 KB | ~2640 KB | **−170 KB (−6 %)** |

Memory runs separate cleanly (all after-values below all before-values); latency is noisier but consistently directional. The remaining big lever — collapsing the ~100 hint `Text` nodes into a per-key `Canvas` — is deliberately left out pending on-device data from the `viewWillAppear→viewDidAppear` telemetry added in #277.

<details>
<summary>Measurement harness (temporary test, removed before commit)</summary>

```swift
@MainActor
struct RenderGraphPerfHarness {
    @Test func measureHostingGraphBuild() throws {
        let viewModel = KeyboardViewModel(
            userDefaults: UserDefaults(suiteName: "render-graph-perf-harness")!,
            shouldPersistSettings: true
        )
        viewModel.loadDefinition(for: "de_DE")
        viewModel.updateViewWidth(390)
        func buildOnce() -> (UIWindow, UIHostingController<DataDrivenKeyboardRootView>) {
            let host = UIHostingController(rootView: DataDrivenKeyboardRootView(viewModel: viewModel))
            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 320))
            window.rootViewController = host
            window.isHidden = false
            window.layoutIfNeeded()
            return (window, host)
        }
        // 3 warm-ups; 30 timed builds → median/p90; then Δphys_footprint across 20 retained graphs.
    }
}
```
</details>

## Testing

- Full `WurstfingerTests` suite green (locally and in CI), alongside the lint and dead-code jobs.
- Visual regression check: `KeyboardShowcaseView` screenshot (SCREENSHOT_MODE) before vs. after is **pixel-identical** (`ImageChops.difference` bbox = None) — hint positions, fonts, and paddings are unchanged. The hint-order change was re-checked the same way and renders byte-identically.
- New coverage: `GridLayoutSolverMemoizationTests` (memoization, value-equal arrangements, eviction, `rowCount`), a `hintGestureOrder` guard in `HintAlignmentTests`, and a stock-defaults guard in `KeyViewStyleTests`.
- SwiftFormat + SwiftLint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard appearance and visibility settings are now applied consistently across the keyboard grid and individual keys.
  * Improved hint rendering with deterministic swipe-direction ordering and clearer alignment behavior.

* **Performance**
  * Grid layouts are reused for faster repeated calculations.
  * Layout data is cleared during memory cleanup to support efficient resource use.

* **Bug Fixes**
  * Improved layout consistency across repeated and equivalent keyboard arrangements.

* **Tests**
  * Added coverage for layout caching, hint alignment, rendering settings, and default keyboard appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
