### PR TITLE
Add Optional Gesture Trail Under the Finger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Optional gesture trail — a soft, tapered stroke follows the finger while it swipes and fades out when it lifts, in the style of the iOS keyboard's swipe trail. Off by default, enabled under Settings › Gestures
+
 ## v1.4.0 — 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Optional gesture trail — a soft, tapered stroke follows the finger while it swipes and fades out when it lifts, in the style of the iOS keyboard's swipe trail. Off by default, enabled under Settings › Gestures
+- Optional gesture trail — a soft, tapered stroke follows the finger while it swipes and fades out when it lifts, in the style of the iOS keyboard's swipe trail. Off by default, enabled under Settings › Gestures (#279)
 
 ## v1.4.0 — 2026-07-23
 

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -17941,6 +17941,282 @@
       },
       "comment": "Footer on the language selection screen"
     },
+    "Gesture Trail": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أثر الإيماءة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wischspur"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ίχνος κίνησης"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estela del gesto"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رد اشاره"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eleen jälki"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bakas ng galaw"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tracé du geste"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שובל התנועה"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इशारे का निशान"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trag geste"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scia del gesto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ジェスチャの軌跡"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제스처 궤적"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ślad gestu"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rasto do gesto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "След жеста"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestspår"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เส้นทางการปัด"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Слід жесту"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اشارے کا نشان"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vệt vuốt"
+          }
+        }
+      },
+      "comment": "Toggle title: draws a fading trail under the finger while it swipes"
+    },
+    "Draw the path your finger takes": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يرسم المسار الذي يسلكه إصبعك"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeichnet den Weg deines Fingers nach"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Σχεδιάζει τη διαδρομή που ακολουθεί το δάχτυλο"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dibuja el recorrido de tu dedo"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مسیری را که انگشت شما طی می‌کند رسم می‌کند"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piirtää sormesi kulkeman reitin"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iguguhit ang dinaanan ng iyong daliri"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trace le chemin parcouru par votre doigt"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מצייר את המסלול שהאצבע עוברת"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आपकी उंगली के रास्ते को दिखाता है"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crta putanju kojom prolazi prst"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disegna il percorso del tuo dito"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "指がなぞった軌跡を描きます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "손가락이 지나간 경로를 그립니다"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rysuje ścieżkę, którą pokonuje palec"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desenha o caminho percorrido pelo dedo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Рисует путь, по которому движется палец"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ritar vägen som fingret tar"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วาดเส้นทางที่นิ้วของคุณลากผ่าน"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Малює шлях, яким рухається палець"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "آپ کی انگلی جس راستے سے گزرے، اسے کھینچتا ہے"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vẽ đường đi của ngón tay bạn"
+          }
+        }
+      },
+      "comment": "Toggle subtitle explaining the gesture trail"
+    },
     "Cut All by Circling": {
       "extractionState": "manual",
       "localizations": {

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -49,6 +49,9 @@ struct SettingsView: View {
     @AppStorage(SettingsKey.cutAllEnabled.rawValue, store: SharedDefaults.store)
     private var cutAllEnabled = false
 
+    @AppStorage(SettingsKey.gestureTrailEnabled.rawValue, store: SharedDefaults.store)
+    private var gestureTrailEnabled = false
+
     @AppStorage(SettingsKey.keyboardFullAccess.rawValue, store: SharedDefaults.store)
     private var hasFullAccess = false
 
@@ -143,6 +146,14 @@ struct SettingsView: View {
 
     private var gesturesSection: some View {
         Section {
+            Toggle(isOn: $gestureTrailEnabled) {
+                SettingsRow(
+                    icon: "scribble.variable", color: .purple,
+                    title: "Gesture Trail",
+                    subtitle: String(localized: "Draw the path your finger takes")
+                )
+            }
+
             Toggle(isOn: $cutAllEnabled) {
                 SettingsRow(icon: "scissors", color: .red, title: "Cut All by Circling")
             }

--- a/wurstfingerKeyboard/Runtime/Gesture/GestureTrail.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GestureTrail.swift
@@ -1,0 +1,133 @@
+//
+//  GestureTrail.swift
+//  Wurstfinger
+//
+//  Time-stamped sample buffer behind the optional swipe trail, plus the
+//  age and fade math the overlay renders from.
+//
+
+import CoreGraphics
+import Foundation
+
+/// One recorded touch position together with the time it was sampled.
+struct GestureTrailSample: Equatable {
+    let point: CGPoint
+    let time: TimeInterval
+}
+
+/// Rolling buffer of touch positions for the swipe trail.
+///
+/// Two independent mechanisms shorten what is drawn:
+/// * while the finger is down, samples older than `visibleDuration` drop out
+///   of the visible window, so the trail follows the finger as a comet tail
+///   rather than painting the entire route of a long drag;
+/// * once the finger lifts the shape freezes and the whole trail fades out
+///   over `fadeOutDuration`.
+///
+/// A pure value type, so both can be unit-tested with explicit timestamps and
+/// without rendering anything.
+struct GestureTrail: Equatable {
+    private(set) var samples: [GestureTrailSample] = []
+
+    /// Time the finger lifted, or nil while it is still down.
+    private(set) var releaseTime: TimeInterval?
+
+    /// Touch-down position. Retained separately from `samples` so it survives
+    /// the eviction of the oldest samples and tap suppression keeps measuring
+    /// against the true origin of the gesture.
+    private(set) var origin: CGPoint?
+
+    /// Largest straight-line distance from `origin` seen so far. A running
+    /// maximum rather than a distance to the current point, so an out-and-back
+    /// return swipe still counts as movement at the moment it turns around.
+    private(set) var maxDisplacement: CGFloat = 0
+
+    var isEmpty: Bool {
+        samples.isEmpty
+    }
+
+    /// Starts a fresh gesture, discarding anything recorded before.
+    mutating func begin(at point: CGPoint, time: TimeInterval) {
+        samples = [GestureTrailSample(point: point, time: time)]
+        origin = point
+        maxDisplacement = 0
+        releaseTime = nil
+    }
+
+    /// Records a move of the finger.
+    ///
+    /// Samples closer than `minimumSpacing` to the previous one are dropped:
+    /// a resting finger keeps producing positions at the display refresh rate,
+    /// and storing them would evict the moving part of the path from a
+    /// capacity-bounded buffer. The dropped sample still updates
+    /// `maxDisplacement`, so tap suppression is unaffected by the decimation.
+    mutating func extend(
+        to point: CGPoint,
+        time: TimeInterval,
+        minimumSpacing: CGFloat = KeyboardConstants.GestureTrail.minimumSampleSpacing,
+        capacity: Int = KeyboardConstants.GestureTrail.sampleCapacity
+    ) {
+        guard let last = samples.last else {
+            begin(at: point, time: time)
+            return
+        }
+        if let origin {
+            maxDisplacement = max(maxDisplacement, hypot(point.x - origin.x, point.y - origin.y))
+        }
+        guard hypot(point.x - last.point.x, point.y - last.point.y) >= minimumSpacing else { return }
+        samples.append(GestureTrailSample(point: point, time: time))
+        if samples.count > capacity {
+            samples.removeFirst(samples.count - capacity)
+        }
+    }
+
+    /// Freezes the trail at `time` and starts its fade-out.
+    mutating func release(at time: TimeInterval) {
+        releaseTime = time
+    }
+
+    mutating func clear() {
+        samples.removeAll()
+        releaseTime = nil
+        origin = nil
+        maxDisplacement = 0
+    }
+
+    /// Points still inside the visible age window at `now`, oldest first.
+    ///
+    /// After release the window is anchored to the release time instead of
+    /// `now`, so the lifted trail fades out as a whole rather than also
+    /// shrinking away from its tail.
+    func visiblePoints(
+        at now: TimeInterval,
+        visibleDuration: TimeInterval = KeyboardConstants.GestureTrail.visibleDuration
+    ) -> [CGPoint] {
+        let reference = releaseTime ?? now
+        let cutoff = reference - visibleDuration
+        // Samples are appended in time order, so the expired ones are always a
+        // prefix — dropping it beats filtering the whole buffer every frame.
+        return samples.drop { $0.time < cutoff }.map(\.point)
+    }
+
+    /// Overall opacity multiplier: 1 while the finger is down, ramping to 0
+    /// across `fadeOutDuration` after it lifts.
+    func fadeOpacity(
+        at now: TimeInterval,
+        fadeOutDuration: TimeInterval = KeyboardConstants.GestureTrail.fadeOutDuration
+    ) -> Double {
+        guard let releaseTime else { return 1 }
+        guard fadeOutDuration > 0 else { return 0 }
+        let remaining = 1 - (now - releaseTime) / fadeOutDuration
+        return min(max(remaining, 0), 1)
+    }
+
+    /// Whether the fade-out has run out and the trail can be discarded.
+    /// Always false while the finger is still down.
+    func isFinished(
+        at now: TimeInterval,
+        fadeOutDuration: TimeInterval = KeyboardConstants.GestureTrail.fadeOutDuration
+    ) -> Bool {
+        guard let releaseTime else { return false }
+        return now >= releaseTime + fadeOutDuration
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Gesture/GestureTrailRecorder.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GestureTrailRecorder.swift
@@ -1,0 +1,134 @@
+//
+//  GestureTrailRecorder.swift
+//  Wurstfinger
+//
+//  Collects touch positions for the swipe trail and tells the overlay when
+//  there is something to draw.
+//
+
+import Combine
+import CoreGraphics
+import Foundation
+
+/// Per-keyboard collector for the swipe trail.
+///
+/// Owned by `KeyboardGridView`, fed by the gesture modifiers with positions in
+/// the shared `coordinateSpace`, and read by `GestureTrailOverlay`.
+///
+/// It deliberately publishes **only** `isVisible`, which flips at most twice
+/// per gesture. The sample buffer itself is a plain property that the overlay
+/// re-reads every frame from its `TimelineView`. Publishing per sample would
+/// invalidate every observer at the drag sample rate — up to 120 Hz — and the
+/// grid owns this object, so that would re-render all ~40 keys per sample.
+final class GestureTrailRecorder: ObservableObject {
+    /// Name of the coordinate space every recorded point is expressed in.
+    /// Registered by `KeyboardGridView` on the grid layout, which is both an
+    /// ancestor of every `KeyView` and the exact bounds the overlay draws in,
+    /// so recorded points need no offset correction to be drawn.
+    static let coordinateSpace = "wurstfinger.gestureTrail"
+
+    /// Whether the overlay should be rendering. False for taps (below the
+    /// activation distance), while the setting is off, and once the fade-out
+    /// has finished.
+    @Published private(set) var isVisible = false
+
+    /// The trail to draw. Not published on purpose — see the type comment.
+    private(set) var trail = GestureTrail()
+
+    private let defaults: UserDefaults
+    private let now: () -> TimeInterval
+
+    /// Whether the setting was on when the current touch went down. Sampled
+    /// once per gesture so a toggle flipped mid-swipe cannot leave a
+    /// half-recorded trail behind.
+    private var isRecording = false
+
+    private var fadeOut: DispatchWorkItem?
+
+    init(
+        defaults: UserDefaults = SharedDefaults.store,
+        now: @escaping () -> TimeInterval = { Date().timeIntervalSinceReferenceDate }
+    ) {
+        self.defaults = defaults
+        self.now = now
+    }
+
+    /// Records one drag sample. `isTouchDown` marks the first sample of a new
+    /// touch sequence, as reported by the gesture state machines.
+    func record(_ location: CGPoint, isTouchDown: Bool) {
+        if isTouchDown {
+            beginTouch(at: location)
+            return
+        }
+        guard isRecording else { return }
+        trail.extend(to: location, time: now())
+        // Suppress taps: every keystroke on this keyboard begins as a touch
+        // down, so drawing from the first sample would flash a dot under every
+        // letter typed.
+        if !isVisible, trail.maxDisplacement >= KeyboardConstants.GestureTrail.activationDistance {
+            setVisible(true)
+        }
+    }
+
+    /// Ends the current touch. A trail that became visible freezes and fades
+    /// out; one that stayed below the activation distance is dropped silently.
+    func finish() {
+        guard isRecording else { return }
+        isRecording = false
+        guard isVisible else {
+            trail.clear()
+            return
+        }
+        trail.release(at: now())
+        scheduleFadeOut()
+    }
+
+    /// Discards the trail immediately, without a fade. Used for the paths that
+    /// end a touch without a gesture: a system cancellation, and a long press
+    /// that consumed the touch.
+    func cancel() {
+        isRecording = false
+        fadeOut?.cancel()
+        fadeOut = nil
+        trail.clear()
+        setVisible(false)
+    }
+
+    // MARK: - Private
+
+    private func beginTouch(at location: CGPoint) {
+        fadeOut?.cancel()
+        fadeOut = nil
+        trail.clear()
+        setVisible(false)
+        // Read the setting per touch rather than observing the store: the host
+        // app can flip the toggle while the extension is alive, and one
+        // dictionary lookup per gesture is far cheaper than the re-render an
+        // observed value would cost on every key.
+        isRecording = defaults.bool(forKey: SettingsKey.gestureTrailEnabled.rawValue)
+        guard isRecording else { return }
+        trail.begin(at: location, time: now())
+    }
+
+    private func scheduleFadeOut() {
+        let item = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            fadeOut = nil
+            trail.clear()
+            setVisible(false)
+        }
+        fadeOut = item
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + KeyboardConstants.GestureTrail.fadeOutDuration,
+            execute: item
+        )
+    }
+
+    /// Publishes only on an actual transition. The recorder is observed by the
+    /// overlay, and a redundant publish per drag sample would defeat the whole
+    /// point of keeping the samples unpublished.
+    private func setVisible(_ value: Bool) {
+        guard isVisible != value else { return }
+        isVisible = value
+    }
+}

--- a/wurstfingerKeyboard/Runtime/Gesture/GestureTrailRecorder.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GestureTrailRecorder.swift
@@ -21,11 +21,11 @@ final class GestureTrailToken {}
 /// Owned by `KeyboardGridView`, fed by the gesture modifiers with positions in
 /// the shared `coordinateSpace`, and read by `GestureTrailOverlay`.
 ///
-/// It deliberately publishes **only** `isVisible`, which flips at most twice
-/// per gesture. The sample buffer itself is a plain property that the overlay
-/// re-reads every frame from its `TimelineView`. Publishing per sample would
-/// invalidate every observer at the drag sample rate — up to 120 Hz — and the
-/// grid owns this object, so that would re-render all ~40 keys per sample.
+/// It publishes only `isVisible`, which flips at most twice per gesture. The
+/// sample buffer itself is a plain property that the overlay re-reads every
+/// frame from its `TimelineView`. Publishing per sample would invalidate every
+/// observer at the drag sample rate — up to 120 Hz — and the grid owns this
+/// object, so that would re-render all ~40 keys per sample.
 final class GestureTrailRecorder: ObservableObject {
     /// The coordinate space every recorded point is expressed in. Registered
     /// by `KeyboardGridView` on the grid layout, which is both an ancestor of
@@ -38,7 +38,8 @@ final class GestureTrailRecorder: ObservableObject {
     /// has finished.
     @Published private(set) var isVisible = false
 
-    /// The trail to draw. Not published on purpose — see the type comment.
+    /// The trail to draw. Unpublished, so drag samples cannot invalidate the
+    /// grid; the overlay re-reads it each frame.
     private(set) var trail = GestureTrail()
 
     private let defaults: UserDefaults
@@ -111,8 +112,9 @@ final class GestureTrailRecorder: ObservableObject {
     }
 
     /// Discards the trail immediately, without a fade. Used for the paths that
-    /// end a touch without a gesture: a system cancellation, and a long press
-    /// that consumed the touch.
+    /// end a touch without a gesture: a system cancellation, a long press that
+    /// consumed the touch, and the teardown of a key that was mid-gesture
+    /// (which reaches neither `onEnded` nor the cancel path).
     func cancel(from token: GestureTrailToken) {
         // Also gates the recognizers' unconditional cancel paths: a key whose
         // gesture never started is not the owner and must not clear a trail
@@ -156,9 +158,9 @@ final class GestureTrailRecorder: ObservableObject {
         )
     }
 
-    /// Publishes only on an actual transition. The recorder is observed by the
-    /// overlay, and a redundant publish per drag sample would defeat the whole
-    /// point of keeping the samples unpublished.
+    /// Publishes only on an actual transition: the recorder is observed by the
+    /// overlay, so a redundant publish per drag sample would invalidate it at
+    /// the drag sample rate.
     private func setVisible(_ value: Bool) {
         guard isVisible != value else { return }
         isVisible = value

--- a/wurstfingerKeyboard/Runtime/Gesture/GestureTrailRecorder.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GestureTrailRecorder.swift
@@ -9,6 +9,12 @@
 import Combine
 import CoreGraphics
 import Foundation
+import SwiftUI
+
+/// Identity of one gesture modifier, used to decide which touch sequence owns
+/// the shared trail. Each recognizer holds its own in `@State`, so it is stable
+/// for as long as that key exists.
+final class GestureTrailToken {}
 
 /// Per-keyboard collector for the swipe trail.
 ///
@@ -21,11 +27,11 @@ import Foundation
 /// invalidate every observer at the drag sample rate — up to 120 Hz — and the
 /// grid owns this object, so that would re-render all ~40 keys per sample.
 final class GestureTrailRecorder: ObservableObject {
-    /// Name of the coordinate space every recorded point is expressed in.
-    /// Registered by `KeyboardGridView` on the grid layout, which is both an
-    /// ancestor of every `KeyView` and the exact bounds the overlay draws in,
-    /// so recorded points need no offset correction to be drawn.
-    static let coordinateSpace = "wurstfinger.gestureTrail"
+    /// The coordinate space every recorded point is expressed in. Registered
+    /// by `KeyboardGridView` on the grid layout, which is both an ancestor of
+    /// every `KeyView` and the exact bounds the overlay draws in, so recorded
+    /// points need no offset correction to be drawn.
+    static let coordinateSpace = NamedCoordinateSpace.named("wurstfinger.gestureTrail")
 
     /// Whether the overlay should be rendering. False for taps (below the
     /// activation distance), while the setting is off, and once the fade-out
@@ -43,6 +49,16 @@ final class GestureTrailRecorder: ObservableObject {
     /// half-recorded trail behind.
     private var isRecording = false
 
+    /// The gesture modifier whose touch sequence currently owns the trail.
+    ///
+    /// One recorder is shared by every key, and on a thumb keyboard two touch
+    /// sequences overlap routinely. Without an owner the second thumb's touch
+    /// down would restart the stroke and its release would freeze it, so the
+    /// trail would jump between the fingers and vanish under the one still
+    /// moving. Weak, so a key torn down mid-gesture releases the trail rather
+    /// than blocking it forever.
+    private weak var owner: GestureTrailToken?
+
     private var fadeOut: DispatchWorkItem?
 
     init(
@@ -54,13 +70,20 @@ final class GestureTrailRecorder: ObservableObject {
     }
 
     /// Records one drag sample. `isTouchDown` marks the first sample of a new
-    /// touch sequence, as reported by the gesture state machines.
-    func record(_ location: CGPoint, isTouchDown: Bool) {
+    /// touch sequence, as reported by the gesture state machines; `token`
+    /// identifies the recognizer it came from.
+    func record(_ location: CGPoint, isTouchDown: Bool, from token: GestureTrailToken) {
         if isTouchDown {
+            // First finger down wins the trail and keeps it until its sequence
+            // ends. A concurrent second touch is ignored rather than drawn as
+            // a second trail: one stroke matches the system keyboard, and the
+            // overlay renders a single path.
+            guard owner == nil else { return }
+            owner = token
             beginTouch(at: location)
             return
         }
-        guard isRecording else { return }
+        guard owner === token, isRecording else { return }
         trail.extend(to: location, time: now())
         // Suppress taps: every keystroke on this keyboard begins as a touch
         // down, so drawing from the first sample would flash a dot under every
@@ -72,7 +95,11 @@ final class GestureTrailRecorder: ObservableObject {
 
     /// Ends the current touch. A trail that became visible freezes and fades
     /// out; one that stayed below the activation distance is dropped silently.
-    func finish() {
+    func finish(from token: GestureTrailToken) {
+        guard owner === token else { return }
+        // Released before the `isRecording` check so a touch taken while the
+        // setting was off still hands the trail back to the next gesture.
+        owner = nil
         guard isRecording else { return }
         isRecording = false
         guard isVisible else {
@@ -86,7 +113,12 @@ final class GestureTrailRecorder: ObservableObject {
     /// Discards the trail immediately, without a fade. Used for the paths that
     /// end a touch without a gesture: a system cancellation, and a long press
     /// that consumed the touch.
-    func cancel() {
+    func cancel(from token: GestureTrailToken) {
+        // Also gates the recognizers' unconditional cancel paths: a key whose
+        // gesture never started is not the owner and must not clear a trail
+        // another key is drawing.
+        guard owner === token else { return }
+        owner = nil
         isRecording = false
         fadeOut?.cancel()
         fadeOut = nil

--- a/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
@@ -119,9 +119,9 @@ struct KeyGestureRecognizer: ViewModifier {
     func body(content: Content) -> some View {
         content
             .gesture(
-                // The coordinate space only affects `value.location`, which
-                // the trail records; `value.translation` is a delta and stays
-                // identical, so gesture classification is untouched.
+                // The coordinate space affects only `value.location`, which the
+                // trail records. `value.translation` is a delta, so the
+                // classification below reads the same values in any space.
                 DragGesture(minimumDistance: 0, coordinateSpace: GestureTrailRecorder.coordinateSpace)
                     .updating($sequenceInFlight) { _, inFlight, _ in
                         inFlight = true
@@ -179,6 +179,17 @@ struct KeyGestureRecognizer: ViewModifier {
                 sequence.handleCancelled()
                 trail?.cancel(from: trailToken)
                 isActive = false
+            }
+            .onDisappear {
+                // A key torn down mid-gesture (mode switch, rotation,
+                // definition reload) reaches neither `onEnded` nor the
+                // `sequenceInFlight` reset — both live on the view that went
+                // away — so it hands the trail back here. Otherwise the
+                // recorder keeps it marked visible with no fade scheduled and
+                // the overlay redraws at the display rate until the next
+                // touch. Ownership makes this a no-op for any key that is not
+                // the one drawing, including while a trail is fading.
+                trail?.cancel(from: trailToken)
             }
     }
 

--- a/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
@@ -106,6 +106,8 @@ struct KeyGestureRecognizer: ViewModifier {
 
     @State private var sequence = KeyGestureSequence()
     @State private var longPress = LongPressScheduler()
+    /// Identifies this key's touch sequence to the shared trail recorder.
+    @State private var trailToken = GestureTrailToken()
     @Binding var isActive: Bool
 
     /// True while a touch sequence is in flight. Unlike `@State`, SwiftUI
@@ -120,7 +122,7 @@ struct KeyGestureRecognizer: ViewModifier {
                 // The coordinate space only affects `value.location`, which
                 // the trail records; `value.translation` is a delta and stays
                 // identical, so gesture classification is untouched.
-                DragGesture(minimumDistance: 0, coordinateSpace: .named(GestureTrailRecorder.coordinateSpace))
+                DragGesture(minimumDistance: 0, coordinateSpace: GestureTrailRecorder.coordinateSpace)
                     .updating($sequenceInFlight) { _, inFlight, _ in
                         inFlight = true
                     }
@@ -130,9 +132,9 @@ struct KeyGestureRecognizer: ViewModifier {
                             // The long press already typed its digit. A trail
                             // that kept following the finger would advertise a
                             // gesture that will never be dispatched.
-                            trail?.cancel()
+                            trail?.cancel(from: trailToken)
                         } else {
-                            trail?.record(value.location, isTouchDown: isTouchDown)
+                            trail?.record(value.location, isTouchDown: isTouchDown, from: trailToken)
                         }
                         if isTouchDown {
                             onTouchDown()
@@ -153,7 +155,7 @@ struct KeyGestureRecognizer: ViewModifier {
                             sequence.handleCancelled()
                             // No gesture was produced, so nothing should be
                             // left drawn: drop the trail instead of fading it.
-                            trail?.cancel()
+                            trail?.cancel(from: trailToken)
                             isActive = false
                             return
                         }
@@ -161,7 +163,7 @@ struct KeyGestureRecognizer: ViewModifier {
                             translation: value.translation,
                             aspectRatio: aspectRatio
                         )
-                        trail?.finish()
+                        trail?.finish(from: trailToken)
                         isActive = false
                         onGestureRecognized(classification)
                     }
@@ -175,7 +177,7 @@ struct KeyGestureRecognizer: ViewModifier {
                 longPress.cancel()
                 longPress.clearConsumed()
                 sequence.handleCancelled()
-                trail?.cancel()
+                trail?.cancel(from: trailToken)
                 isActive = false
             }
     }

--- a/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
@@ -99,6 +99,11 @@ struct KeyGestureRecognizer: ViewModifier {
     /// disables long-press detection entirely.
     var onLongPress: (() -> Bool)?
 
+    /// Collects the touch path for the swipe trail overlay. Nil disables the
+    /// feed entirely (previews and tests); when set, the recorder itself
+    /// decides whether the user has the trail turned on.
+    var trail: GestureTrailRecorder?
+
     @State private var sequence = KeyGestureSequence()
     @State private var longPress = LongPressScheduler()
     @Binding var isActive: Bool
@@ -112,12 +117,24 @@ struct KeyGestureRecognizer: ViewModifier {
     func body(content: Content) -> some View {
         content
             .gesture(
-                DragGesture(minimumDistance: 0)
+                // The coordinate space only affects `value.location`, which
+                // the trail records; `value.translation` is a delta and stays
+                // identical, so gesture classification is untouched.
+                DragGesture(minimumDistance: 0, coordinateSpace: .named(GestureTrailRecorder.coordinateSpace))
                     .updating($sequenceInFlight) { _, inFlight, _ in
                         inFlight = true
                     }
                     .onChanged { value in
-                        if sequence.handleChanged(translation: value.translation) {
+                        let isTouchDown = sequence.handleChanged(translation: value.translation)
+                        if longPress.consumedTouch {
+                            // The long press already typed its digit. A trail
+                            // that kept following the finger would advertise a
+                            // gesture that will never be dispatched.
+                            trail?.cancel()
+                        } else {
+                            trail?.record(value.location, isTouchDown: isTouchDown)
+                        }
+                        if isTouchDown {
                             onTouchDown()
                             scheduleLongPress()
                         } else if longPress.isScheduled,
@@ -134,6 +151,9 @@ struct KeyGestureRecognizer: ViewModifier {
                             // releasing doesn't produce a second key event.
                             longPress.clearConsumed()
                             sequence.handleCancelled()
+                            // No gesture was produced, so nothing should be
+                            // left drawn: drop the trail instead of fading it.
+                            trail?.cancel()
                             isActive = false
                             return
                         }
@@ -141,6 +161,7 @@ struct KeyGestureRecognizer: ViewModifier {
                             translation: value.translation,
                             aspectRatio: aspectRatio
                         )
+                        trail?.finish()
                         isActive = false
                         onGestureRecognized(classification)
                     }
@@ -154,6 +175,7 @@ struct KeyGestureRecognizer: ViewModifier {
                 longPress.cancel()
                 longPress.clearConsumed()
                 sequence.handleCancelled()
+                trail?.cancel()
                 isActive = false
             }
     }

--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -193,6 +193,8 @@ struct SlideGestureHandler: ViewModifier {
 
     @State private var state = SlideGestureState()
     @State private var longPress = LongPressScheduler()
+    /// Identifies this key's touch sequence to the shared trail recorder.
+    @State private var trailToken = GestureTrailToken()
 
     /// True while a touch sequence is in flight. Unlike `@State`, SwiftUI
     /// guarantees `@GestureState` is reset when the system cancels the
@@ -206,7 +208,7 @@ struct SlideGestureHandler: ViewModifier {
                 // The coordinate space only affects `value.location`, which
                 // the trail records; `value.translation` is a delta and stays
                 // identical, so the slide state machine is untouched.
-                DragGesture(minimumDistance: 0, coordinateSpace: .named(GestureTrailRecorder.coordinateSpace))
+                DragGesture(minimumDistance: 0, coordinateSpace: GestureTrailRecorder.coordinateSpace)
                     .updating($sequenceInFlight) { _, inFlight, _ in
                         inFlight = true
                     }
@@ -218,7 +220,7 @@ struct SlideGestureHandler: ViewModifier {
                             // Same as in `KeyGestureRecognizer`: the digit is
                             // already typed, so stop drawing a gesture that
                             // will never be dispatched.
-                            trail?.cancel()
+                            trail?.cancel(from: trailToken)
                             isActive = true
                             return
                         }
@@ -226,7 +228,7 @@ struct SlideGestureHandler: ViewModifier {
                             translation: value.translation,
                             activationThreshold: activationThreshold
                         )
-                        trail?.record(value.location, isTouchDown: update.isTouchDown)
+                        trail?.record(value.location, isTouchDown: update.isTouchDown, from: trailToken)
                         if update.isTouchDown {
                             onTouchDown()
                             scheduleLongPress()
@@ -247,7 +249,7 @@ struct SlideGestureHandler: ViewModifier {
                             // release produces neither a tap nor a slide end.
                             longPress.clearConsumed()
                             _ = state.handleCancelled()
-                            trail?.cancel()
+                            trail?.cancel(from: trailToken)
                             isActive = false
                             return
                         }
@@ -257,7 +259,7 @@ struct SlideGestureHandler: ViewModifier {
                         ) {
                             onSlide(phase)
                         }
-                        trail?.finish()
+                        trail?.finish(from: trailToken)
                         isActive = false
                     }
             )
@@ -271,7 +273,7 @@ struct SlideGestureHandler: ViewModifier {
                 if let phase = state.handleCancelled() {
                     onSlide(phase)
                 }
-                trail?.cancel()
+                trail?.cancel(from: trailToken)
                 isActive = false
             }
     }

--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -184,6 +184,11 @@ struct SlideGestureHandler: ViewModifier {
     /// handled. A handled long press consumes the touch (no tap, no slide
     /// on release). `nil` disables detection.
     var onLongPress: (() -> Bool)?
+
+    /// Collects the touch path for the swipe trail overlay. Same contract as
+    /// `KeyGestureRecognizer.trail`.
+    var trail: GestureTrailRecorder?
+
     @Binding var isActive: Bool
 
     @State private var state = SlideGestureState()
@@ -198,7 +203,10 @@ struct SlideGestureHandler: ViewModifier {
     func body(content: Content) -> some View {
         content
             .gesture(
-                DragGesture(minimumDistance: 0)
+                // The coordinate space only affects `value.location`, which
+                // the trail records; `value.translation` is a delta and stays
+                // identical, so the slide state machine is untouched.
+                DragGesture(minimumDistance: 0, coordinateSpace: .named(GestureTrailRecorder.coordinateSpace))
                     .updating($sequenceInFlight) { _, inFlight, _ in
                         inFlight = true
                     }
@@ -207,6 +215,10 @@ struct SlideGestureHandler: ViewModifier {
                         // don't feed the state machine, or the movement would
                         // start a cursor slide after the digit was typed.
                         if longPress.consumedTouch {
+                            // Same as in `KeyGestureRecognizer`: the digit is
+                            // already typed, so stop drawing a gesture that
+                            // will never be dispatched.
+                            trail?.cancel()
                             isActive = true
                             return
                         }
@@ -214,6 +226,7 @@ struct SlideGestureHandler: ViewModifier {
                             translation: value.translation,
                             activationThreshold: activationThreshold
                         )
+                        trail?.record(value.location, isTouchDown: update.isTouchDown)
                         if update.isTouchDown {
                             onTouchDown()
                             scheduleLongPress()
@@ -234,6 +247,7 @@ struct SlideGestureHandler: ViewModifier {
                             // release produces neither a tap nor a slide end.
                             longPress.clearConsumed()
                             _ = state.handleCancelled()
+                            trail?.cancel()
                             isActive = false
                             return
                         }
@@ -243,6 +257,7 @@ struct SlideGestureHandler: ViewModifier {
                         ) {
                             onSlide(phase)
                         }
+                        trail?.finish()
                         isActive = false
                     }
             )
@@ -256,6 +271,7 @@ struct SlideGestureHandler: ViewModifier {
                 if let phase = state.handleCancelled() {
                     onSlide(phase)
                 }
+                trail?.cancel()
                 isActive = false
             }
     }

--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -185,8 +185,9 @@ struct SlideGestureHandler: ViewModifier {
     /// on release). `nil` disables detection.
     var onLongPress: (() -> Bool)?
 
-    /// Collects the touch path for the swipe trail overlay. Same contract as
-    /// `KeyGestureRecognizer.trail`.
+    /// Collects the touch path for the swipe trail overlay. Nil disables the
+    /// feed entirely (previews and tests); when set, the recorder itself
+    /// decides whether the user has the trail turned on.
     var trail: GestureTrailRecorder?
 
     @Binding var isActive: Bool
@@ -205,9 +206,9 @@ struct SlideGestureHandler: ViewModifier {
     func body(content: Content) -> some View {
         content
             .gesture(
-                // The coordinate space only affects `value.location`, which
-                // the trail records; `value.translation` is a delta and stays
-                // identical, so the slide state machine is untouched.
+                // The coordinate space affects only `value.location`, which the
+                // trail records. `value.translation` is a delta, so the slide
+                // state machine reads the same values in any space.
                 DragGesture(minimumDistance: 0, coordinateSpace: GestureTrailRecorder.coordinateSpace)
                     .updating($sequenceInFlight) { _, inFlight, _ in
                         inFlight = true
@@ -217,9 +218,8 @@ struct SlideGestureHandler: ViewModifier {
                         // don't feed the state machine, or the movement would
                         // start a cursor slide after the digit was typed.
                         if longPress.consumedTouch {
-                            // Same as in `KeyGestureRecognizer`: the digit is
-                            // already typed, so stop drawing a gesture that
-                            // will never be dispatched.
+                            // The digit is already typed, so stop drawing a
+                            // gesture that will never be dispatched.
                             trail?.cancel(from: trailToken)
                             isActive = true
                             return
@@ -275,6 +275,12 @@ struct SlideGestureHandler: ViewModifier {
                 }
                 trail?.cancel(from: trailToken)
                 isActive = false
+            }
+            // A key removed mid-gesture reaches neither `onEnded` nor the
+            // cancel path, so it hands the trail back here instead of leaving
+            // the overlay redrawing at the display rate.
+            .onDisappear {
+                trail?.cancel(from: trailToken)
             }
     }
 

--- a/wurstfingerKeyboard/Runtime/View/GestureTrailGeometry.swift
+++ b/wurstfingerKeyboard/Runtime/View/GestureTrailGeometry.swift
@@ -67,7 +67,7 @@ enum GestureTrailGeometry {
     /// tail and rounded at the finger. Returns an empty path for anything too
     /// short or too thin to draw.
     ///
-    /// The taper is measured **along the path**, over at most
+    /// The taper is measured along the path, over at most
     /// `headWidth * taperLengthFactor`. Tapering by index fraction instead
     /// would stretch the wedge across the whole trail, so a long cursor slide
     /// would render as one thin spike rather than as a stroke with a short
@@ -124,8 +124,10 @@ enum GestureTrailGeometry {
 
     /// Arc length from the tail to each point, in the same order.
     static func cumulativeDistances(along points: [CGPoint]) -> [CGFloat] {
-        var distances: [CGFloat] = [0]
-        distances.reserveCapacity(points.count)
+        var distances: [CGFloat] = []
+        // Reserved before the tail seed, so the growth below never reallocates.
+        distances.reserveCapacity(max(points.count, 1))
+        distances.append(0)
         for index in 1 ..< max(points.count, 1) {
             let previous = points[index - 1]
             let point = points[index]

--- a/wurstfingerKeyboard/Runtime/View/GestureTrailGeometry.swift
+++ b/wurstfingerKeyboard/Runtime/View/GestureTrailGeometry.swift
@@ -1,0 +1,197 @@
+//
+//  GestureTrailGeometry.swift
+//  Wurstfinger
+//
+//  Turns recorded touch positions into the tapered ribbon the swipe trail
+//  is drawn as. Pure functions, no view state.
+//
+
+import CoreGraphics
+import Foundation
+import SwiftUI
+
+/// Path construction for the swipe trail.
+///
+/// The trail is built as a single closed outline rather than as a stroked
+/// polyline: a translucent stroke made of overlapping round-capped segments
+/// accumulates alpha at every joint and at every place the path crosses
+/// itself, which shows up as dark blotches exactly where the finger changed
+/// direction. One filled contour has uniform alpha everywhere.
+enum GestureTrailGeometry {
+    /// Resamples `points` through a uniform Catmull-Rom spline.
+    ///
+    /// A fast flick only produces a handful of drag samples, and drawing those
+    /// directly renders as a visible polyline. The spline passes through every
+    /// original sample, so this rounds the corners without moving the trail
+    /// off the path the finger actually took.
+    static func smoothed(
+        _ points: [CGPoint],
+        subdivisions: Int = KeyboardConstants.GestureTrail.smoothingSubdivisions
+    ) -> [CGPoint] {
+        guard points.count > 2, subdivisions > 1 else { return points }
+        let last = points.count - 1
+        var result: [CGPoint] = []
+        result.reserveCapacity(last * subdivisions + 1)
+        for index in 0 ..< last {
+            // Duplicate the endpoints so the first and last segment get the
+            // control points the spline needs without extrapolating past them.
+            let p0 = points[max(index - 1, 0)]
+            let p1 = points[index]
+            let p2 = points[index + 1]
+            let p3 = points[min(index + 2, last)]
+            for step in 0 ..< subdivisions {
+                let t = CGFloat(step) / CGFloat(subdivisions)
+                result.append(interpolate(p0, p1, p2, p3, t: t))
+            }
+        }
+        result.append(points[last])
+        return result
+    }
+
+    /// Half the ribbon width at `progress`, which runs 0 at the tail to 1 at
+    /// the point where the taper is complete.
+    ///
+    /// The exponent is below 1, so the ribbon reaches nearly full width early
+    /// and thins only near its very end. That is what makes it read as a
+    /// stroke trailing the finger rather than as a wedge.
+    static func halfWidth(
+        atProgress progress: CGFloat,
+        headWidth: CGFloat,
+        taperExponent: CGFloat = KeyboardConstants.GestureTrail.taperExponent
+    ) -> CGFloat {
+        let clamped = min(max(progress, 0), 1)
+        return headWidth / 2 * pow(clamped, taperExponent)
+    }
+
+    /// Builds the closed, tapered outline through `points`, pointed at the
+    /// tail and rounded at the finger. Returns an empty path for anything too
+    /// short or too thin to draw.
+    ///
+    /// The taper is measured **along the path**, over at most
+    /// `headWidth * taperLengthFactor`. Tapering by index fraction instead
+    /// would stretch the wedge across the whole trail, so a long cursor slide
+    /// would render as one thin spike rather than as a stroke with a short
+    /// tail — the opposite of how the system trail behaves.
+    static func ribbon(
+        through points: [CGPoint],
+        headWidth: CGFloat,
+        taperExponent: CGFloat = KeyboardConstants.GestureTrail.taperExponent,
+        taperLengthFactor: CGFloat = KeyboardConstants.GestureTrail.taperLengthFactor
+    ) -> Path {
+        var path = Path()
+        guard points.count >= 2, headWidth > 0 else { return path }
+
+        let last = points.count - 1
+        let distances = cumulativeDistances(along: points)
+        // A path shorter than the nominal taper simply tapers across all of
+        // itself, so a quick flick still reaches full width at the finger.
+        let taperSpan = min(headWidth * taperLengthFactor, distances[last])
+
+        var leftEdge: [CGPoint] = []
+        var rightEdge: [CGPoint] = []
+        leftEdge.reserveCapacity(points.count)
+        rightEdge.reserveCapacity(points.count)
+
+        // Carried forward so a degenerate segment (two coincident points, which
+        // the spline can produce) reuses the last known orientation instead of
+        // collapsing the ribbon to zero width there.
+        var normal = CGVector(dx: 0, dy: 0)
+        for (index, point) in points.enumerated() {
+            if let tangent = unitTangent(at: index, in: points) {
+                normal = CGVector(dx: -tangent.dy, dy: tangent.dx)
+            }
+            let progress = taperSpan > 0 ? distances[index] / taperSpan : 1
+            let half = halfWidth(
+                atProgress: progress,
+                headWidth: headWidth,
+                taperExponent: taperExponent
+            )
+            leftEdge.append(CGPoint(x: point.x + normal.dx * half, y: point.y + normal.dy * half))
+            rightEdge.append(CGPoint(x: point.x - normal.dx * half, y: point.y - normal.dy * half))
+        }
+
+        path.move(to: leftEdge[0])
+        for point in leftEdge.dropFirst() {
+            path.addLine(to: point)
+        }
+        appendHeadCap(to: &path, head: points[last], normal: normal, radius: headWidth / 2)
+        for point in rightEdge.reversed() {
+            path.addLine(to: point)
+        }
+        path.closeSubpath()
+        return path
+    }
+
+    /// Arc length from the tail to each point, in the same order.
+    static func cumulativeDistances(along points: [CGPoint]) -> [CGFloat] {
+        var distances: [CGFloat] = [0]
+        distances.reserveCapacity(points.count)
+        for index in 1 ..< max(points.count, 1) {
+            let previous = points[index - 1]
+            let point = points[index]
+            distances.append(distances[index - 1] + hypot(point.x - previous.x, point.y - previous.y))
+        }
+        return distances
+    }
+
+    // MARK: - Private
+
+    /// Closes the ribbon around the finger with a semicircle.
+    ///
+    /// Drawn as explicit segments rather than `Path.addArc`, which needs the
+    /// caller to reason about sweep direction in a y-down coordinate system —
+    /// getting that backwards produces a cap on the wrong side of the head.
+    /// Kept as part of the one closed contour so there is no second subpath
+    /// whose winding could punch a hole through the ribbon under a non-zero
+    /// fill.
+    private static func appendHeadCap(
+        to path: inout Path,
+        head: CGPoint,
+        normal: CGVector,
+        radius: CGFloat,
+        segments: Int = 8
+    ) {
+        guard radius > 0, normal.dx != 0 || normal.dy != 0 else { return }
+        // The normal is the tangent rotated by +90°, so sweeping from its angle
+        // by -180° passes through the direction the finger is moving in — i.e.
+        // the cap bulges ahead of the head, not back over the ribbon.
+        let start = atan2(normal.dy, normal.dx)
+        for step in 1 ..< segments {
+            let angle = start - .pi * CGFloat(step) / CGFloat(segments)
+            path.addLine(to: CGPoint(
+                x: head.x + cos(angle) * radius,
+                y: head.y + sin(angle) * radius
+            ))
+        }
+    }
+
+    /// Unit direction of travel at `index`, from its neighbours. Nil when the
+    /// neighbours coincide and no direction can be derived.
+    private static func unitTangent(at index: Int, in points: [CGPoint]) -> CGVector? {
+        let previous = points[max(index - 1, 0)]
+        let next = points[min(index + 1, points.count - 1)]
+        let dx = next.x - previous.x
+        let dy = next.y - previous.y
+        let length = hypot(dx, dy)
+        guard length > .ulpOfOne else { return nil }
+        return CGVector(dx: dx / length, dy: dy / length)
+    }
+
+    /// Uniform Catmull-Rom evaluation between `p1` and `p2`.
+    private static func interpolate(
+        _ p0: CGPoint, _ p1: CGPoint, _ p2: CGPoint, _ p3: CGPoint, t: CGFloat
+    ) -> CGPoint {
+        let t2 = t * t
+        let t3 = t2 * t
+        func axis(_ a: CGFloat, _ b: CGFloat, _ c: CGFloat, _ d: CGFloat) -> CGFloat {
+            0.5 * (2 * b
+                + (-a + c) * t
+                + (2 * a - 5 * b + 4 * c - d) * t2
+                + (-a + 3 * b - 3 * c + d) * t3)
+        }
+        return CGPoint(
+            x: axis(p0.x, p1.x, p2.x, p3.x),
+            y: axis(p0.y, p1.y, p2.y, p3.y)
+        )
+    }
+}

--- a/wurstfingerKeyboard/Runtime/View/GestureTrailOverlay.swift
+++ b/wurstfingerKeyboard/Runtime/View/GestureTrailOverlay.swift
@@ -1,0 +1,61 @@
+//
+//  GestureTrailOverlay.swift
+//  Wurstfinger
+//
+//  Draws the optional swipe trail on top of the key grid.
+//
+
+import SwiftUI
+
+/// Renders the swipe trail recorded by `GestureTrailRecorder`.
+///
+/// Sits in an `.overlay` on the grid layout, which is also where the recorder's
+/// coordinate space is registered — so the recorded points map onto this view's
+/// bounds one to one, with no padding or offset correction.
+struct GestureTrailOverlay: View {
+    @ObservedObject var recorder: GestureTrailRecorder
+
+    /// Width of the ribbon at the finger, scaled from the rendered key size by
+    /// `headWidth(for:)`.
+    let headWidth: CGFloat
+
+    var body: some View {
+        // Nothing is rendered — and no display-linked timer runs — unless a
+        // trail is actually in flight. `isVisible` is the recorder's only
+        // published property for exactly this reason.
+        if recorder.isVisible {
+            TimelineView(.animation) { timeline in
+                Canvas { context, _ in
+                    draw(in: &context, at: timeline.date.timeIntervalSinceReferenceDate)
+                }
+            }
+            .allowsHitTesting(false)
+        }
+    }
+
+    /// Head width for a rendered key size, clamped so the trail stays
+    /// proportionate on both a compact one-handed keyboard and a full-width
+    /// iPad layout.
+    static func headWidth(for metrics: KeyboardLayoutMetrics) -> CGFloat {
+        let scaled = metrics.rowHeight * KeyboardConstants.GestureTrail.widthFraction
+        return min(
+            max(scaled, KeyboardConstants.GestureTrail.minWidth),
+            KeyboardConstants.GestureTrail.maxWidth
+        )
+    }
+
+    private func draw(in context: inout GraphicsContext, at now: TimeInterval) {
+        let trail = recorder.trail
+        let points = trail.visiblePoints(at: now)
+        guard points.count >= 2 else { return }
+
+        let path = GestureTrailGeometry.ribbon(
+            through: GestureTrailGeometry.smoothed(points),
+            headWidth: headWidth
+        )
+        // One fill of one closed contour, so the alpha is uniform even where
+        // the path crosses itself — see GestureTrailGeometry.
+        context.opacity = KeyboardConstants.GestureTrail.opacity * trail.fadeOpacity(at: now)
+        context.fill(path, with: .color(.primary))
+    }
+}

--- a/wurstfingerKeyboard/Runtime/View/GestureTrailOverlay.swift
+++ b/wurstfingerKeyboard/Runtime/View/GestureTrailOverlay.swift
@@ -21,8 +21,7 @@ struct GestureTrailOverlay: View {
 
     var body: some View {
         // Nothing is rendered — and no display-linked timer runs — unless a
-        // trail is actually in flight. `isVisible` is the recorder's only
-        // published property for exactly this reason.
+        // trail is in flight.
         if recorder.isVisible {
             TimelineView(.animation) { timeline in
                 Canvas { context, _ in
@@ -30,6 +29,10 @@ struct GestureTrailOverlay: View {
                 }
             }
             .allowsHitTesting(false)
+            // Purely decorative: it echoes a gesture the user is making right
+            // now, so it has nothing to announce and must not sit between
+            // VoiceOver and the keys underneath.
+            .accessibilityHidden(true)
         }
     }
 
@@ -46,6 +49,11 @@ struct GestureTrailOverlay: View {
 
     private func draw(in context: inout GraphicsContext, at now: TimeInterval) {
         let trail = recorder.trail
+        // The recorder drops a faded-out trail from a main-queue work item, so
+        // a busy main thread can hand this a trail whose fade already expired.
+        // Those frames would build the full ribbon only to fill it at zero
+        // opacity; bail before the geometry instead.
+        guard !trail.isFinished(at: now) else { return }
         let points = trail.visiblePoints(at: now)
         guard points.count >= 2 else { return }
 
@@ -54,7 +62,7 @@ struct GestureTrailOverlay: View {
             headWidth: headWidth
         )
         // One fill of one closed contour, so the alpha is uniform even where
-        // the path crosses itself — see GestureTrailGeometry.
+        // the path crosses itself.
         context.opacity = KeyboardConstants.GestureTrail.opacity * trail.fadeOpacity(at: now)
         context.fill(path, with: .color(.primary))
     }

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -24,6 +24,10 @@ struct KeyView: View {
     /// action (a handled long press consumes the touch). Long-press detection
     /// only runs when this is set and the user setting is enabled.
     var onLongPress: ((KeyConfig) -> Bool)?
+    /// Shared swipe-trail collector, supplied by `KeyboardGridView`. Forwarded
+    /// to whichever gesture modifier this key uses; nil simply means no trail
+    /// (previews, tests).
+    var gestureTrail: GestureTrailRecorder?
     var spanRatio: CGFloat = 1.0
 
     /// Inset between the full touch cell and the key's visible bounds. The cell
@@ -125,6 +129,7 @@ struct KeyView: View {
                 onSlide: { phase in onSlide?(key, phase) },
                 onTouchDown: { onTouchDown?() },
                 onLongPress: longPressHandler,
+                trail: gestureTrail,
                 isActive: $isActive
             ))
         } else {
@@ -139,6 +144,7 @@ struct KeyView: View {
                 // to classify swipes against the real geometry.
                 aspectRatio: metrics.cellAspectRatio * spanRatio,
                 onLongPress: longPressHandler,
+                trail: gestureTrail,
                 isActive: $isActive
             ))
         }

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -25,7 +25,7 @@ struct KeyView: View {
     /// only runs when this is set and the user setting is enabled.
     var onLongPress: ((KeyConfig) -> Bool)?
     /// Shared swipe-trail collector, supplied by `KeyboardGridView`. Forwarded
-    /// to whichever gesture modifier this key uses; nil simply means no trail
+    /// to whichever gesture modifier this key uses; nil means no trail
     /// (previews, tests).
     var gestureTrail: GestureTrailRecorder?
     var spanRatio: CGFloat = 1.0

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -60,7 +60,7 @@ struct KeyboardGridView: View {
         // key is rendered — showcase, screenshot and preview hosts included —
         // and so the recorded points land in exactly the bounds the overlay
         // below draws in, with no padding or offset math to keep in sync.
-        .coordinateSpace(name: GestureTrailRecorder.coordinateSpace)
+        .coordinateSpace(GestureTrailRecorder.coordinateSpace)
         .overlay {
             GestureTrailOverlay(
                 recorder: gestureTrail,

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -35,6 +35,13 @@ struct KeyboardGridView: View {
     /// showcase modes with `shouldPersistSettings: false`).
     let metrics: KeyboardLayoutMetrics
 
+    /// Collects the touch path for the swipe trail. Held in `@State` rather
+    /// than `@StateObject` on purpose: `@State` owns the object without
+    /// subscribing to it, so the samples arriving at up to 120 Hz cannot
+    /// re-render the grid and all of its keys. Only `GestureTrailOverlay`
+    /// observes it, and only for the one flag that says whether to draw.
+    @State private var gestureTrail = GestureTrailRecorder()
+
     var body: some View {
         let cells = GridLayoutSolver.solve(arrangement)
         let totalRows = cells.map { $0.row + $0.rowSpan }.max() ?? 0
@@ -49,6 +56,17 @@ struct KeyboardGridView: View {
                 cellContent(for: cell, totalRows: totalRows)
             }
         }
+        // Registered here rather than on the root view so it exists wherever a
+        // key is rendered — showcase, screenshot and preview hosts included —
+        // and so the recorded points land in exactly the bounds the overlay
+        // below draws in, with no padding or offset math to keep in sync.
+        .coordinateSpace(name: GestureTrailRecorder.coordinateSpace)
+        .overlay {
+            GestureTrailOverlay(
+                recorder: gestureTrail,
+                headWidth: GestureTrailOverlay.headWidth(for: metrics)
+            )
+        }
     }
 
     @ViewBuilder
@@ -60,6 +78,7 @@ struct KeyboardGridView: View {
                 onTouchDown: onTouchDown,
                 onSlide: onSlide,
                 onLongPress: onLongPress,
+                gestureTrail: gestureTrail,
                 spanRatio: CGFloat(cell.columnSpan) / CGFloat(cell.rowSpan),
                 visualInset: visualInset(for: cell, totalRows: totalRows),
                 metrics: metrics,

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -35,11 +35,11 @@ struct KeyboardGridView: View {
     /// showcase modes with `shouldPersistSettings: false`).
     let metrics: KeyboardLayoutMetrics
 
-    /// Collects the touch path for the swipe trail. Held in `@State` rather
-    /// than `@StateObject` on purpose: `@State` owns the object without
-    /// subscribing to it, so the samples arriving at up to 120 Hz cannot
-    /// re-render the grid and all of its keys. Only `GestureTrailOverlay`
-    /// observes it, and only for the one flag that says whether to draw.
+    /// Collects the touch path for the swipe trail. `@State` rather than
+    /// `@StateObject`: it owns the object without subscribing to it, so the
+    /// samples arriving at up to 120 Hz cannot re-render the grid and all of
+    /// its keys. Only `GestureTrailOverlay` observes it, and only for the one
+    /// flag that says whether to draw.
     @State private var gestureTrail = GestureTrailRecorder()
 
     var body: some View {

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -125,6 +125,76 @@ enum KeyboardConstants {
         static let positionBufferSize: Int = 120
     }
 
+    // MARK: - Gesture Trail
+
+    /// Tuning for the optional swipe trail drawn under the finger.
+    ///
+    /// The look follows the iOS system keyboard's swipe trail rather than
+    /// MessagEase's hard polyline: a soft ribbon that is widest at the finger
+    /// and tapers to a point at its tail, kept short so it reads as a comet
+    /// tail instead of a drawing of the whole path.
+    enum GestureTrail {
+        /// How far the finger must travel before any trail is drawn. Every
+        /// keystroke on this keyboard starts as a touch-down, so without a
+        /// threshold plain taps would flash a dot on every letter. Matches
+        /// `SpaceGestures.dragActivationThreshold`, the smallest travel the
+        /// keyboard already treats as "not a tap".
+        static let activationDistance: CGFloat = 8
+
+        /// Minimum spacing between two recorded samples. Filters the duplicate
+        /// positions a resting finger produces, which would otherwise fill the
+        /// buffer and push the moving part of the path out of it. Kept coarse
+        /// on purpose: the curve smoothing below rounds the path back out, so
+        /// storing sub-pixel steps only costs memory.
+        static let minimumSampleSpacing: CGFloat = 4
+
+        /// Maximum number of retained samples. At `minimumSampleSpacing` this
+        /// covers ~250pt of path — more than the visible window ever shows,
+        /// while bounding memory in an extension with a tight jetsam limit.
+        static let sampleCapacity: Int = 64
+
+        /// Age after which a sample stops being drawn while the finger is
+        /// still down. Long enough to show a whole flick swipe at once, short
+        /// enough that a slow cursor slide trails the finger instead of
+        /// painting its entire route.
+        static let visibleDuration: TimeInterval = 0.55
+
+        /// How long the frozen trail takes to fade out after the finger lifts.
+        static let fadeOutDuration: TimeInterval = 0.22
+
+        /// Head width as a fraction of the row height, so the trail scales
+        /// with the user's key size instead of overwhelming small keyboards.
+        static let widthFraction: CGFloat = 0.16
+
+        /// Clamps for the scaled head width.
+        static let minWidth: CGFloat = 5
+        static let maxWidth: CGFloat = 14
+
+        /// Exponent of the tail taper: `width = maxWidth * progress^exponent`
+        /// with `progress` running 0 (tail) → 1 (finger). Below 1 the ribbon
+        /// reaches nearly full width early and thins only near its very end,
+        /// which is what makes the system trail read as a stroke rather than
+        /// a wedge.
+        static let taperExponent: CGFloat = 0.55
+
+        /// Length of the tapered tail, as a multiple of the head width.
+        ///
+        /// The taper is measured along the path rather than as a fraction of
+        /// it, so a long cursor slide keeps a constant-width stroke with a
+        /// short tapered tail instead of stretching into one long wedge. A
+        /// path shorter than this simply tapers across its whole length.
+        static let taperLengthFactor: CGFloat = 3.5
+
+        /// Catmull-Rom segments inserted between two recorded samples. A fast
+        /// flick only produces a handful of samples before it ends — without
+        /// interpolation those would draw as a visible polyline.
+        static let smoothingSubdivisions: Int = 6
+
+        /// Opacity of the ribbon. Translucent enough to keep the key labels
+        /// underneath readable while the finger passes over them.
+        static let opacity: Double = 0.38
+    }
+
     // MARK: - Long Press
 
     enum LongPress {

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -129,23 +129,23 @@ enum KeyboardConstants {
 
     /// Tuning for the optional swipe trail drawn under the finger.
     ///
-    /// The look follows the iOS system keyboard's swipe trail rather than
-    /// MessagEase's hard polyline: a soft ribbon that is widest at the finger
-    /// and tapers to a point at its tail, kept short so it reads as a comet
-    /// tail instead of a drawing of the whole path.
+    /// A soft ribbon, widest at the finger and tapering to a point at its
+    /// tail, kept short so it reads as a comet tail rather than a drawing of
+    /// the whole path.
     enum GestureTrail {
         /// How far the finger must travel before any trail is drawn. Every
         /// keystroke on this keyboard starts as a touch-down, so without a
-        /// threshold plain taps would flash a dot on every letter. Matches
+        /// threshold plain taps would flash a dot on every letter. Aliases
         /// `SpaceGestures.dragActivationThreshold`, the smallest travel the
-        /// keyboard already treats as "not a tap".
-        static let activationDistance: CGFloat = 8
+        /// keyboard already treats as "not a tap", so retuning that threshold
+        /// cannot desynchronize the two.
+        static let activationDistance: CGFloat = SpaceGestures.dragActivationThreshold
 
         /// Minimum spacing between two recorded samples. Filters the duplicate
         /// positions a resting finger produces, which would otherwise fill the
-        /// buffer and push the moving part of the path out of it. Kept coarse
-        /// on purpose: the curve smoothing below rounds the path back out, so
-        /// storing sub-pixel steps only costs memory.
+        /// buffer and push the moving part of the path out of it. Kept coarse:
+        /// the curve smoothing below rounds the path back out, so storing
+        /// sub-pixel steps only costs memory.
         static let minimumSampleSpacing: CGFloat = 4
 
         /// Maximum number of retained samples. At `minimumSampleSpacing` this
@@ -170,11 +170,12 @@ enum KeyboardConstants {
         static let minWidth: CGFloat = 5
         static let maxWidth: CGFloat = 14
 
-        /// Exponent of the tail taper: `width = maxWidth * progress^exponent`
-        /// with `progress` running 0 (tail) → 1 (finger). Below 1 the ribbon
-        /// reaches nearly full width early and thins only near its very end,
-        /// which is what makes the system trail read as a stroke rather than
-        /// a wedge.
+        /// Exponent of the tail taper: `width = headWidth * progress^exponent`
+        /// with `progress` running 0 (tail) → 1 (finger). `headWidth` is the
+        /// per-render width from `GestureTrailOverlay.headWidth(for:)`, not
+        /// the `maxWidth` clamp above. Below 1 the ribbon reaches nearly full
+        /// width early and thins only near its very end, which is what makes
+        /// the system trail read as a stroke rather than a wedge.
         static let taperExponent: CGFloat = 0.55
 
         /// Length of the tapered tail, as a multiple of the head width.

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -52,6 +52,11 @@ enum SettingsKey: String {
     /// Opt-in: the action is destructive and unaided by undo, so it stays off
     /// until asked for rather than surprising anyone who circles the key.
     case cutAllEnabled
+    /// Draws a fading trail under the finger while it swipes.
+    /// Opt-in: it is a learning and demonstration aid, and continuous
+    /// redrawing costs battery, so experienced users are not made to pay for
+    /// it. Off also keeps the keyboard visually identical to before.
+    case gestureTrailEnabled
 }
 
 // MARK: - Haptic Settings

--- a/wurstfingerTests/GestureTrailTests.swift
+++ b/wurstfingerTests/GestureTrailTests.swift
@@ -1,0 +1,398 @@
+//
+//  GestureTrailTests.swift
+//  WurstfingerTests
+//
+//  Tests for the swipe trail: sample buffer, ribbon geometry and the
+//  recorder that gates both on the user setting.
+//
+
+import CoreGraphics
+import Foundation
+import SwiftUI
+import Testing
+@testable import WurstfingerApp
+
+// MARK: - Sample Buffer
+
+struct GestureTrailBufferTests {
+    @Test func beginSeedsOriginAndFirstSample() {
+        var trail = GestureTrail()
+        trail.begin(at: CGPoint(x: 10, y: 20), time: 100)
+        #expect(trail.samples.count == 1)
+        #expect(trail.origin == CGPoint(x: 10, y: 20))
+        #expect(trail.maxDisplacement == 0)
+        #expect(trail.releaseTime == nil)
+    }
+
+    @Test func extendBeforeBeginStartsTheTrail() {
+        var trail = GestureTrail()
+        trail.extend(to: CGPoint(x: 5, y: 5), time: 100)
+        #expect(trail.origin == CGPoint(x: 5, y: 5))
+        #expect(trail.samples.count == 1)
+    }
+
+    @Test func samplesCloserThanTheSpacingAreDropped() {
+        var trail = GestureTrail()
+        trail.begin(at: .zero, time: 100)
+        trail.extend(to: CGPoint(x: 1, y: 0), time: 101, minimumSpacing: 4)
+        trail.extend(to: CGPoint(x: 2, y: 0), time: 102, minimumSpacing: 4)
+        #expect(trail.samples.count == 1)
+
+        trail.extend(to: CGPoint(x: 4, y: 0), time: 103, minimumSpacing: 4)
+        #expect(trail.samples.count == 2)
+    }
+
+    @Test func droppedSamplesStillAdvanceMaxDisplacement() {
+        // Tap suppression must not depend on the decimation: a finger that
+        // creeps outward in sub-spacing steps has still travelled.
+        var trail = GestureTrail()
+        trail.begin(at: .zero, time: 100)
+        for step in 1 ... 3 {
+            trail.extend(to: CGPoint(x: CGFloat(step), y: 0), time: 100 + Double(step), minimumSpacing: 4)
+        }
+        #expect(trail.samples.count == 1)
+        #expect(trail.maxDisplacement == 3)
+    }
+
+    @Test func maxDisplacementIsARunningMaximum() {
+        // An out-and-back return swipe ends near its origin but has clearly
+        // moved, so the peak — not the final distance — has to be reported.
+        var trail = GestureTrail()
+        trail.begin(at: .zero, time: 100)
+        trail.extend(to: CGPoint(x: 40, y: 0), time: 101)
+        trail.extend(to: CGPoint(x: 1, y: 0), time: 102)
+        #expect(trail.maxDisplacement == 40)
+    }
+
+    @Test func capacityEvictsTheOldestSamples() {
+        var trail = GestureTrail()
+        trail.begin(at: .zero, time: 100)
+        for step in 1 ... 10 {
+            trail.extend(to: CGPoint(x: CGFloat(step) * 10, y: 0), time: 100 + Double(step), capacity: 4)
+        }
+        #expect(trail.samples.count == 4)
+        // The newest samples survive; the head must stay at the finger.
+        #expect(trail.samples.last?.point == CGPoint(x: 100, y: 0))
+    }
+
+    @Test func visibleWindowDropsExpiredSamples() {
+        var trail = GestureTrail()
+        trail.begin(at: .zero, time: 100)
+        trail.extend(to: CGPoint(x: 10, y: 0), time: 100.4)
+        trail.extend(to: CGPoint(x: 20, y: 0), time: 100.9)
+
+        let visible = trail.visiblePoints(at: 100.9, visibleDuration: 0.55)
+        #expect(visible == [CGPoint(x: 10, y: 0), CGPoint(x: 20, y: 0)])
+    }
+
+    @Test func releaseFreezesTheVisibleWindow() {
+        // After lift the shape must stop shrinking from its tail, otherwise
+        // the trail both fades and retracts and reads as two effects at once.
+        var trail = GestureTrail()
+        trail.begin(at: .zero, time: 100)
+        trail.extend(to: CGPoint(x: 10, y: 0), time: 100.1)
+        trail.release(at: 100.2)
+
+        let atRelease = trail.visiblePoints(at: 100.2, visibleDuration: 0.55)
+        let laterOn = trail.visiblePoints(at: 105, visibleDuration: 0.55)
+        #expect(atRelease == laterOn)
+        #expect(laterOn.count == 2)
+    }
+
+    @Test func fadeOpacityIsFullWhileTheFingerIsDown() {
+        var trail = GestureTrail()
+        trail.begin(at: .zero, time: 100)
+        #expect(trail.fadeOpacity(at: 200, fadeOutDuration: 0.22) == 1)
+        #expect(!trail.isFinished(at: 200, fadeOutDuration: 0.22))
+    }
+
+    @Test func fadeOpacityRampsToZeroAfterRelease() {
+        var trail = GestureTrail()
+        trail.begin(at: .zero, time: 100)
+        trail.release(at: 100)
+        #expect(trail.fadeOpacity(at: 100, fadeOutDuration: 0.2) == 1)
+        #expect(abs(trail.fadeOpacity(at: 100.1, fadeOutDuration: 0.2) - 0.5) < 0.0001)
+        #expect(trail.fadeOpacity(at: 100.2, fadeOutDuration: 0.2) == 0)
+        // Never negative, however late the frame arrives.
+        #expect(trail.fadeOpacity(at: 999, fadeOutDuration: 0.2) == 0)
+    }
+
+    @Test func isFinishedOnlyAfterTheFadeCompletes() {
+        var trail = GestureTrail()
+        trail.begin(at: .zero, time: 100)
+        trail.release(at: 100)
+        #expect(!trail.isFinished(at: 100.1, fadeOutDuration: 0.2))
+        #expect(trail.isFinished(at: 100.2, fadeOutDuration: 0.2))
+    }
+
+    @Test func clearResetsEverything() {
+        var trail = GestureTrail()
+        trail.begin(at: .zero, time: 100)
+        trail.extend(to: CGPoint(x: 40, y: 0), time: 101)
+        trail.release(at: 102)
+        trail.clear()
+        #expect(trail.isEmpty)
+        #expect(trail.origin == nil)
+        #expect(trail.maxDisplacement == 0)
+        #expect(trail.releaseTime == nil)
+    }
+}
+
+// MARK: - Ribbon Geometry
+
+struct GestureTrailGeometryTests {
+    @Test func smoothingKeepsTheOriginalSamplesOnThePath() {
+        // Catmull-Rom interpolates rather than approximates, so the trail must
+        // still pass through every position the finger actually visited.
+        let points = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 20, y: 10),
+            CGPoint(x: 40, y: 0),
+            CGPoint(x: 60, y: 30),
+        ]
+        let smoothed = GestureTrailGeometry.smoothed(points, subdivisions: 4)
+        for point in points {
+            #expect(smoothed.contains { hypot($0.x - point.x, $0.y - point.y) < 0.0001 })
+        }
+        #expect(smoothed.first == points.first)
+        #expect(smoothed.last == points.last)
+        #expect(smoothed.count == (points.count - 1) * 4 + 1)
+    }
+
+    @Test func smoothingPassesShortPathsThrough() {
+        let two = [CGPoint(x: 0, y: 0), CGPoint(x: 10, y: 0)]
+        #expect(GestureTrailGeometry.smoothed(two, subdivisions: 4) == two)
+        #expect(GestureTrailGeometry.smoothed([], subdivisions: 4).isEmpty)
+    }
+
+    @Test func widthTapersFromTailToHead() {
+        let head: CGFloat = 12
+        let tail = GestureTrailGeometry.halfWidth(atProgress: 0, headWidth: head, taperExponent: 0.55)
+        let middle = GestureTrailGeometry.halfWidth(atProgress: 0.5, headWidth: head, taperExponent: 0.55)
+        let finger = GestureTrailGeometry.halfWidth(atProgress: 1, headWidth: head, taperExponent: 0.55)
+
+        #expect(tail == 0)
+        #expect(finger == head / 2)
+        #expect(middle > tail && middle < finger)
+        // Below 1 the exponent has to keep the ribbon thick well before the
+        // head — a linear taper would sit at exactly half here.
+        #expect(middle > head / 4)
+    }
+
+    @Test func widthClampsProgressOutsideTheUnitRange() {
+        #expect(GestureTrailGeometry.halfWidth(atProgress: -1, headWidth: 10) == 0)
+        #expect(GestureTrailGeometry.halfWidth(atProgress: 2, headWidth: 10) == 5)
+    }
+
+    @Test func ribbonIsEmptyForDegenerateInput() {
+        #expect(GestureTrailGeometry.ribbon(through: [], headWidth: 10).isEmpty)
+        #expect(GestureTrailGeometry.ribbon(through: [.zero], headWidth: 10).isEmpty)
+        #expect(GestureTrailGeometry.ribbon(through: [.zero, CGPoint(x: 10, y: 0)], headWidth: 0).isEmpty)
+    }
+
+    @Test func ribbonWrapsTheStraightPathWithinItsWidth() {
+        let path = [CGPoint(x: 0, y: 50), CGPoint(x: 100, y: 50)]
+        let head: CGFloat = 12
+        let box = GestureTrailGeometry.ribbon(through: path, headWidth: head).boundingRect
+
+        // The tail is a point and the head a semicircle, so the ribbon spans
+        // the path plus one radius beyond the finger and nothing behind it.
+        #expect(abs(box.minX - 0) < 0.5)
+        #expect(abs(box.maxX - (100 + head / 2)) < 0.5)
+        #expect(box.height <= head + 0.5)
+        #expect(abs(box.midY - 50) < 0.5)
+    }
+
+    @Test func cumulativeDistancesMeasureAlongThePath() {
+        let path = [CGPoint(x: 0, y: 0), CGPoint(x: 3, y: 4), CGPoint(x: 3, y: 14)]
+        #expect(GestureTrailGeometry.cumulativeDistances(along: path) == [0, 5, 15])
+        #expect(GestureTrailGeometry.cumulativeDistances(along: []) == [0])
+    }
+
+    @Test func taperSpansAFixedLengthNotAFractionOfThePath() {
+        // A long cursor slide must stay a constant-width stroke with a short
+        // tail. Tapering by index fraction instead would stretch the wedge
+        // across the whole trail and render it as one thin spike.
+        let head: CGFloat = 10
+        let longPath = (0 ... 40).map { CGPoint(x: CGFloat($0) * 10, y: 100) }
+        let box = GestureTrailGeometry.ribbon(
+            through: longPath, headWidth: head, taperLengthFactor: 3.5
+        ).boundingRect
+
+        // Sample the ribbon halfway along a 400pt path: far past the ~35pt
+        // taper, so it has to be at full width there.
+        let midX = 200.0
+        let ribbon = GestureTrailGeometry.ribbon(through: longPath, headWidth: head, taperLengthFactor: 3.5)
+        #expect(ribbon.contains(CGPoint(x: midX, y: 100 + head / 2 - 0.5)))
+        #expect(!ribbon.contains(CGPoint(x: midX, y: 100 + head / 2 + 1)))
+        #expect(box.height <= head + 0.5)
+    }
+
+    @Test func shortPathsStillReachFullWidthAtTheFinger() {
+        // A quick flick is shorter than the nominal taper; it must taper across
+        // itself rather than never getting thick enough to see.
+        let head: CGFloat = 10
+        let flick = [CGPoint(x: 0, y: 50), CGPoint(x: 12, y: 50), CGPoint(x: 24, y: 50)]
+        let ribbon = GestureTrailGeometry.ribbon(through: flick, headWidth: head, taperLengthFactor: 3.5)
+        #expect(ribbon.contains(CGPoint(x: 23, y: 50 + head / 2 - 0.5)))
+    }
+
+    @Test func ribbonIsPointedAtTheTail() {
+        // The tail carries zero width, so the outline has to converge on the
+        // oldest sample rather than starting with a blunt edge.
+        let path = [CGPoint(x: 0, y: 0), CGPoint(x: 50, y: 0), CGPoint(x: 100, y: 0)]
+        let box = GestureTrailGeometry.ribbon(through: path, headWidth: 12).boundingRect
+        #expect(box.minX >= -0.5)
+    }
+
+    @Test func ribbonSurvivesCoincidentPoints() {
+        // The spline can emit duplicate positions; the ribbon must still be a
+        // usable shape instead of collapsing or producing NaN coordinates.
+        let path = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 30, y: 0),
+            CGPoint(x: 30, y: 0),
+        ]
+        let box = GestureTrailGeometry.ribbon(through: path, headWidth: 10).boundingRect
+        #expect(box.width.isFinite)
+        #expect(box.height.isFinite)
+        #expect(box.width > 0)
+    }
+}
+
+// MARK: - Recorder
+
+struct GestureTrailRecorderTests {
+    /// Feeds a straight drag of `distance` points into the recorder.
+    private func drag(_ recorder: GestureTrailRecorder, distance: CGFloat, steps: Int = 8) {
+        recorder.record(.zero, isTouchDown: true)
+        for step in 1 ... steps {
+            let x = distance * CGFloat(step) / CGFloat(steps)
+            recorder.record(CGPoint(x: x, y: 0), isTouchDown: false)
+        }
+    }
+
+    private func makeRecorder(enabled: Bool, clock: @escaping () -> TimeInterval = { 0 }) -> GestureTrailRecorder {
+        let defaults = InMemoryUserDefaults()
+        defaults.set(enabled, forKey: SettingsKey.gestureTrailEnabled.rawValue)
+        return GestureTrailRecorder(defaults: defaults, now: clock)
+    }
+
+    @Test func offByDefaultRecordsNothing() {
+        let recorder = GestureTrailRecorder(defaults: InMemoryUserDefaults(), now: { 0 })
+        drag(recorder, distance: 120)
+        #expect(!recorder.isVisible)
+        #expect(recorder.trail.isEmpty)
+    }
+
+    @Test func disabledRecordsNothing() {
+        let recorder = makeRecorder(enabled: false)
+        drag(recorder, distance: 120)
+        #expect(!recorder.isVisible)
+        #expect(recorder.trail.isEmpty)
+    }
+
+    @Test func enabledSwipeBecomesVisible() {
+        var clock: TimeInterval = 0
+        let recorder = makeRecorder(enabled: true, clock: { clock })
+        recorder.record(.zero, isTouchDown: true)
+        for step in 1 ... 8 {
+            clock += 0.01
+            recorder.record(CGPoint(x: CGFloat(step) * 15, y: 0), isTouchDown: false)
+        }
+        #expect(recorder.isVisible)
+        #expect(recorder.trail.samples.count > 1)
+    }
+
+    @Test func tapStaysInvisible() {
+        // Every keystroke starts as a touch down, so a trail that drew from
+        // the first sample would flash under every letter typed.
+        let recorder = makeRecorder(enabled: true)
+        recorder.record(.zero, isTouchDown: true)
+        recorder.record(CGPoint(x: 2, y: 1), isTouchDown: false)
+        #expect(!recorder.isVisible)
+    }
+
+    @Test func finishingATapDropsTheTrailWithoutAFade() {
+        let recorder = makeRecorder(enabled: true)
+        recorder.record(.zero, isTouchDown: true)
+        recorder.record(CGPoint(x: 2, y: 0), isTouchDown: false)
+        recorder.finish()
+        #expect(!recorder.isVisible)
+        #expect(recorder.trail.isEmpty)
+    }
+
+    @Test func finishingASwipeFreezesTheTrailForItsFade() {
+        var clock: TimeInterval = 500
+        let recorder = makeRecorder(enabled: true, clock: { clock })
+        drag(recorder, distance: 120)
+        clock = 501
+        recorder.finish()
+        // Still drawn — the fade-out runs on a timer, not on this call.
+        #expect(recorder.isVisible)
+        #expect(recorder.trail.releaseTime == 501)
+    }
+
+    @Test func cancelDropsEverythingImmediately() {
+        let recorder = makeRecorder(enabled: true)
+        drag(recorder, distance: 120)
+        recorder.cancel()
+        #expect(!recorder.isVisible)
+        #expect(recorder.trail.isEmpty)
+    }
+
+    @Test func aNewTouchDiscardsThePreviousTrail() {
+        // Typing fast starts the next gesture while the last one is still
+        // fading; the old path must not be extended by the new touch.
+        let recorder = makeRecorder(enabled: true)
+        drag(recorder, distance: 120)
+        recorder.finish()
+        recorder.record(CGPoint(x: 300, y: 300), isTouchDown: true)
+        #expect(!recorder.isVisible)
+        #expect(recorder.trail.samples.map(\.point) == [CGPoint(x: 300, y: 300)])
+    }
+
+    @Test func theSettingIsSampledPerTouch() {
+        // Flipping the toggle in the host app has to take effect on the next
+        // gesture, without the extension observing the store on every key.
+        let defaults = InMemoryUserDefaults()
+        let recorder = GestureTrailRecorder(defaults: defaults, now: { 0 })
+        drag(recorder, distance: 120)
+        #expect(!recorder.isVisible)
+
+        recorder.finish()
+        defaults.set(true, forKey: SettingsKey.gestureTrailEnabled.rawValue)
+        drag(recorder, distance: 120)
+        #expect(recorder.isVisible)
+    }
+}
+
+// MARK: - Overlay Sizing
+
+struct GestureTrailOverlaySizingTests {
+    @Test func headWidthScalesWithTheRowHeight() {
+        let small = KeyboardLayoutMetrics.resolve(
+            wishWidth: 200, aspectRatio: 1, columns: 5, rows: 4,
+            availableWidth: 400, screenHeight: 900
+        )
+        let large = KeyboardLayoutMetrics.resolve(
+            wishWidth: 390, aspectRatio: 1, columns: 5, rows: 4,
+            availableWidth: 400, screenHeight: 900
+        )
+        #expect(large.rowHeight > small.rowHeight)
+        #expect(GestureTrailOverlay.headWidth(for: large) >= GestureTrailOverlay.headWidth(for: small))
+    }
+
+    @Test func headWidthStaysInsideTheClamps() {
+        for wish in stride(from: 90.0, through: 600.0, by: 30.0) {
+            let metrics = KeyboardLayoutMetrics.resolve(
+                wishWidth: wish, aspectRatio: 1.3, columns: 5, rows: 4,
+                availableWidth: 600, screenHeight: 1000
+            )
+            let width = GestureTrailOverlay.headWidth(for: metrics)
+            #expect(width >= KeyboardConstants.GestureTrail.minWidth)
+            #expect(width <= KeyboardConstants.GestureTrail.maxWidth)
+        }
+    }
+}

--- a/wurstfingerTests/GestureTrailTests.swift
+++ b/wurstfingerTests/GestureTrailTests.swift
@@ -265,11 +265,17 @@ struct GestureTrailGeometryTests {
 
 struct GestureTrailRecorderTests {
     /// Feeds a straight drag of `distance` points into the recorder.
-    private func drag(_ recorder: GestureTrailRecorder, distance: CGFloat, steps: Int = 8) {
-        recorder.record(.zero, isTouchDown: true)
+    private func drag(
+        _ recorder: GestureTrailRecorder,
+        distance: CGFloat,
+        steps: Int = 8,
+        from token: GestureTrailToken = GestureTrailToken(),
+        origin: CGPoint = .zero
+    ) {
+        recorder.record(origin, isTouchDown: true, from: token)
         for step in 1 ... steps {
-            let x = distance * CGFloat(step) / CGFloat(steps)
-            recorder.record(CGPoint(x: x, y: 0), isTouchDown: false)
+            let x = origin.x + distance * CGFloat(step) / CGFloat(steps)
+            recorder.record(CGPoint(x: x, y: origin.y), isTouchDown: false, from: token)
         }
     }
 
@@ -296,10 +302,11 @@ struct GestureTrailRecorderTests {
     @Test func enabledSwipeBecomesVisible() {
         var clock: TimeInterval = 0
         let recorder = makeRecorder(enabled: true, clock: { clock })
-        recorder.record(.zero, isTouchDown: true)
+        let token = GestureTrailToken()
+        recorder.record(.zero, isTouchDown: true, from: token)
         for step in 1 ... 8 {
             clock += 0.01
-            recorder.record(CGPoint(x: CGFloat(step) * 15, y: 0), isTouchDown: false)
+            recorder.record(CGPoint(x: CGFloat(step) * 15, y: 0), isTouchDown: false, from: token)
         }
         #expect(recorder.isVisible)
         #expect(recorder.trail.samples.count > 1)
@@ -309,16 +316,18 @@ struct GestureTrailRecorderTests {
         // Every keystroke starts as a touch down, so a trail that drew from
         // the first sample would flash under every letter typed.
         let recorder = makeRecorder(enabled: true)
-        recorder.record(.zero, isTouchDown: true)
-        recorder.record(CGPoint(x: 2, y: 1), isTouchDown: false)
+        let token = GestureTrailToken()
+        recorder.record(.zero, isTouchDown: true, from: token)
+        recorder.record(CGPoint(x: 2, y: 1), isTouchDown: false, from: token)
         #expect(!recorder.isVisible)
     }
 
     @Test func finishingATapDropsTheTrailWithoutAFade() {
         let recorder = makeRecorder(enabled: true)
-        recorder.record(.zero, isTouchDown: true)
-        recorder.record(CGPoint(x: 2, y: 0), isTouchDown: false)
-        recorder.finish()
+        let token = GestureTrailToken()
+        recorder.record(.zero, isTouchDown: true, from: token)
+        recorder.record(CGPoint(x: 2, y: 0), isTouchDown: false, from: token)
+        recorder.finish(from: token)
         #expect(!recorder.isVisible)
         #expect(recorder.trail.isEmpty)
     }
@@ -326,9 +335,10 @@ struct GestureTrailRecorderTests {
     @Test func finishingASwipeFreezesTheTrailForItsFade() {
         var clock: TimeInterval = 500
         let recorder = makeRecorder(enabled: true, clock: { clock })
-        drag(recorder, distance: 120)
+        let token = GestureTrailToken()
+        drag(recorder, distance: 120, from: token)
         clock = 501
-        recorder.finish()
+        recorder.finish(from: token)
         // Still drawn — the fade-out runs on a timer, not on this call.
         #expect(recorder.isVisible)
         #expect(recorder.trail.releaseTime == 501)
@@ -336,8 +346,9 @@ struct GestureTrailRecorderTests {
 
     @Test func cancelDropsEverythingImmediately() {
         let recorder = makeRecorder(enabled: true)
-        drag(recorder, distance: 120)
-        recorder.cancel()
+        let token = GestureTrailToken()
+        drag(recorder, distance: 120, from: token)
+        recorder.cancel(from: token)
         #expect(!recorder.isVisible)
         #expect(recorder.trail.isEmpty)
     }
@@ -346,9 +357,10 @@ struct GestureTrailRecorderTests {
         // Typing fast starts the next gesture while the last one is still
         // fading; the old path must not be extended by the new touch.
         let recorder = makeRecorder(enabled: true)
-        drag(recorder, distance: 120)
-        recorder.finish()
-        recorder.record(CGPoint(x: 300, y: 300), isTouchDown: true)
+        let first = GestureTrailToken()
+        drag(recorder, distance: 120, from: first)
+        recorder.finish(from: first)
+        recorder.record(CGPoint(x: 300, y: 300), isTouchDown: true, from: GestureTrailToken())
         #expect(!recorder.isVisible)
         #expect(recorder.trail.samples.map(\.point) == [CGPoint(x: 300, y: 300)])
     }
@@ -358,12 +370,74 @@ struct GestureTrailRecorderTests {
         // gesture, without the extension observing the store on every key.
         let defaults = InMemoryUserDefaults()
         let recorder = GestureTrailRecorder(defaults: defaults, now: { 0 })
-        drag(recorder, distance: 120)
+        let first = GestureTrailToken()
+        drag(recorder, distance: 120, from: first)
         #expect(!recorder.isVisible)
 
-        recorder.finish()
+        recorder.finish(from: first)
         defaults.set(true, forKey: SettingsKey.gestureTrailEnabled.rawValue)
         drag(recorder, distance: 120)
+        #expect(recorder.isVisible)
+    }
+
+    // MARK: - Touch-Sequence Ownership
+
+    @Test func aSecondFingerDoesNotHijackTheTrail() {
+        // Two-thumb typing overlaps touch sequences. Without ownership the
+        // second thumb's touch down restarts the stroke, so the trail jumps
+        // across the keyboard between the two fingers.
+        let recorder = makeRecorder(enabled: true)
+        let left = GestureTrailToken()
+        let right = GestureTrailToken()
+        drag(recorder, distance: 120, from: left)
+
+        recorder.record(CGPoint(x: 300, y: 300), isTouchDown: true, from: right)
+        recorder.record(CGPoint(x: 340, y: 300), isTouchDown: false, from: right)
+
+        #expect(recorder.isVisible)
+        let points = recorder.trail.samples.map(\.point)
+        #expect(points.allSatisfy { $0.y == 0 })
+        #expect(recorder.trail.origin == .zero)
+    }
+
+    @Test func aSecondFingerLiftingDoesNotEndTheOwnersTrail() {
+        let recorder = makeRecorder(enabled: true)
+        let left = GestureTrailToken()
+        let right = GestureTrailToken()
+        drag(recorder, distance: 120, from: left)
+
+        recorder.record(CGPoint(x: 300, y: 300), isTouchDown: true, from: right)
+        recorder.finish(from: right)
+        #expect(recorder.trail.releaseTime == nil)
+
+        recorder.cancel(from: right)
+        #expect(recorder.isVisible)
+        #expect(!recorder.trail.isEmpty)
+    }
+
+    @Test func ownershipIsReleasedForTheNextGesture() {
+        let recorder = makeRecorder(enabled: true)
+        let first = GestureTrailToken()
+        drag(recorder, distance: 120, from: first)
+        recorder.cancel(from: first)
+
+        let second = GestureTrailToken()
+        drag(recorder, distance: 120, from: second)
+        #expect(recorder.isVisible)
+    }
+
+    @Test func ownershipIsReleasedEvenWhenTheSettingWasOff() {
+        // A touch taken while the trail was disabled still claims the trail,
+        // so it has to hand it back — otherwise enabling the setting would
+        // leave the feature dead until the view is rebuilt.
+        let defaults = InMemoryUserDefaults()
+        let recorder = GestureTrailRecorder(defaults: defaults, now: { 0 })
+        let first = GestureTrailToken()
+        drag(recorder, distance: 120, from: first)
+        recorder.finish(from: first)
+
+        defaults.set(true, forKey: SettingsKey.gestureTrailEnabled.rawValue)
+        drag(recorder, distance: 120, from: GestureTrailToken())
         #expect(recorder.isVisible)
     }
 }

--- a/wurstfingerTests/GestureTrailTests.swift
+++ b/wurstfingerTests/GestureTrailTests.swift
@@ -426,6 +426,41 @@ struct GestureTrailRecorderTests {
         #expect(recorder.isVisible)
     }
 
+    @Test func aDeallocatedOwnerDoesNotLockTheTrail() {
+        // A key torn down mid-gesture (mode switch, rotation, definition
+        // reload) never reaches `finish`. The owner reference is weak, so the
+        // token dies with the view and the next touch has to be able to claim
+        // the trail instead of finding it owned forever.
+        let recorder = makeRecorder(enabled: true)
+        var doomed: GestureTrailToken? = GestureTrailToken()
+        if let doomed {
+            drag(recorder, distance: 120, from: doomed)
+        }
+        // Only the recorder's weak `owner` refers to the token now.
+        doomed = nil
+
+        recorder.record(CGPoint(x: 300, y: 300), isTouchDown: true, from: GestureTrailToken())
+        #expect(recorder.trail.samples.map(\.point) == [CGPoint(x: 300, y: 300)])
+    }
+
+    @Test func teardownAfterAFinishedSwipeLeavesTheFadeRunning() {
+        // Every key runs the same teardown hook, so a mode switch after a
+        // completed swipe fires it ~40 times while the trail is fading —
+        // including on the key that drew it. None of those may cut the fade
+        // short: the owner already handed the trail back in `finish`.
+        var clock: TimeInterval = 500
+        let recorder = makeRecorder(enabled: true, clock: { clock })
+        let owner = GestureTrailToken()
+        drag(recorder, distance: 120, from: owner)
+        clock = 501
+        recorder.finish(from: owner)
+
+        recorder.cancel(from: owner)
+        recorder.cancel(from: GestureTrailToken())
+        #expect(recorder.isVisible)
+        #expect(recorder.trail.releaseTime == 501)
+    }
+
     @Test func ownershipIsReleasedEvenWhenTheSettingWasOff() {
         // A touch taken while the trail was disabled still claims the trail,
         // so it has to hand it back — otherwise enabling the setting would


### PR DESCRIPTION
Adds the gesture trail Wurstfinger was still missing. Rather than reproducing the MessagEase original's hard polyline, this follows the look of the iOS keyboard's swipe trail: a soft, tapered stroke that trails the finger and fades out when it lifts.

**Off by default**, enabled under **Settings › Gestures**. It is a learning and demonstration aid, and a display-linked redraw costs battery, so nobody pays for it unasked — with the toggle off the keyboard is visually and behaviorally identical to before.

## Behavior

- Draws along the real touch path, across key boundaries, for both swipe keys and the space/delete slide keys.
- Widest at the finger, tapering to a point at the tail; rounded at the head.
- While the finger is down, samples older than 0.55 s drop out, so the trail reads as a comet tail rather than a drawing of the whole route. On lift the shape freezes and fades out over 0.22 s.
- **Taps draw nothing.** Every keystroke here starts as a touch down, so the trail only appears past 8 pt of travel — the same threshold the keyboard already uses for "not a tap".
- The head width scales with the rendered key size, clamped to 5–14 pt.
- A long press that consumed the touch, and a system cancellation, both drop the trail immediately instead of fading it: no gesture was dispatched, so nothing should be left drawn.

## Implementation

**`GestureTrail`** — pure value type holding time-stamped samples plus the age and fade math. Samples closer than 4 pt are dropped (a resting finger would otherwise fill the buffer and push the moving part of the path out of it) while still advancing `maxDisplacement`, so tap suppression is unaffected by the decimation. Capacity-bounded at 64 samples.

**`GestureTrailGeometry`** — Catmull-Rom resampling plus the ribbon outline. Two decisions worth calling out:

- The ribbon is **one filled closed contour**, not a stroked polyline. A translucent stroke made of overlapping round-capped segments accumulates alpha at every joint and wherever the path crosses itself, which shows up as dark blotches exactly where the finger changed direction. One filled contour has uniform alpha everywhere. The head cap is part of the same contour rather than a second subpath, so no winding can punch a hole through it.
- The taper is measured **along the path** over a fixed length (3.5× the head width), not as a fraction of the trail. Tapering by index fraction renders a long cursor slide as one thin wedge; measuring along the path keeps it a constant-width stroke with a short tail, which is what the system trail does. A path shorter than the taper simply tapers across itself, so a quick flick still reaches full width.

**`GestureTrailRecorder`** — publishes **only** `isVisible`, which flips at most twice per gesture. The sample buffer is a plain property the overlay re-reads each frame from its `TimelineView`. The grid owns the recorder, so publishing per sample would invalidate every one of the ~40 keys at up to 120 Hz — the same concern `KeyboardStateHygieneTests` guards elsewhere. It is held in `@State`, not `@StateObject`, precisely so the grid owns it without subscribing. The setting is read once per touch instead of observed, so a toggle flipped in the host app takes effect on the next gesture without costing a re-render per key.

**`GestureTrailOverlay`** — renders nothing, and starts no display-linked timer, unless a trail is actually in flight.

**Gesture wiring** — both modifiers now read `value.location` in a named coordinate space. `value.translation` is a delta and is unchanged by the coordinate space, so gesture classification is bit-identical; only a `location` read was added. The space is registered on the grid layout rather than the root view, so it exists in every host that renders a key (showcase, screenshot and preview views included) and the recorded points land in exactly the bounds the overlay draws in — no padding or offset math to keep in sync.

## Tests

`GestureTrailTests` — 33 tests across three suites, all green alongside the rest of `WurstfingerTests`:

- **Buffer**: decimation, capacity eviction, running-maximum displacement, the visible window, frozen-on-release, the fade ramp and its clamps.
- **Geometry**: that smoothing still passes through every recorded sample, the taper curve, the fixed-length taper vs. a fraction of the path, degenerate and coincident-point input, bounding boxes.
- **Recorder**: off by default, disabled, tap suppression, freeze-on-finish, cancel, a new touch discarding a fading trail, and per-touch setting sampling.

## Verification

Built and exercised in the simulator (iPhone 17 Pro) via the interactive keyboard preview: verified the trail renders live under the finger during both a space-bar cursor slide and a letter swipe crossing key boundaries, that it is positioned correctly in the shared coordinate space, and that key labels stay readable underneath. Geometry was additionally rendered offline in light and dark mode while tuning the taper. SwiftFormat and SwiftLint `--strict` clean.

Title and subtitle added to the app String Catalog for all 22 supported languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Gesture Trail that follows swipe gestures and fades after release.
  * Added a **Gesture Trail** toggle under **Settings › Gestures**, disabled by default.
  * Added localized descriptions for the new setting across supported languages.
* **Documentation**
  * Documented the feature in the unreleased changelog, including iOS-style swipe-trail behavior and styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->