### PR TITLE
Guard Text Actions Against an Active Selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
 
 ### Fixed
 
-- Characters that could not be typed at all on the non-Latin layouts: Thai ฬ ฒ ฑ ฏ (circle gesture, matching the reference's center return) and the baht sign ฿, the Japanese 、 and 。 plus the small kana on return swipes, the Persian/Urdu half-space (ZWNJ), Arabic-script punctuation ؟ ، ؛ ٭ in place of the Latin marks, the Hindi rupee sign ₹, and the Hebrew geresh and gershayim ׳ ״
+- Characters that could not be typed at all on the non-Latin layouts: Thai ฬ ฒ ฑ ฏ (circle gesture, matching the reference's center return) and the baht sign ฿, the Japanese 、 and 。 plus the small kana on return swipes, the Persian/Urdu half-space (ZWNJ), Arabic-script punctuation ؟ ، ؛ ٭ in place of the Latin marks, the Hindi rupee sign ₹, and the Hebrew geresh and gershayim ׳ ״ (#284)
+- Forward-delete and capitalize-word with an active selection: forward-delete now removes the selection, and capitalize-word changes the case of the selection instead of eating the word in front of it (#281)
+- The double-space shortcut now requires two consecutive space presses within a short window, so a space typed into an already-finished sentence is no longer rewritten and a deliberate double space stays typable; it also inserts the script's own sentence mark (Devanagari danda, Japanese full-width stop, Urdu full stop) (#281)
+- Cut-all is bounded by the same size ceiling as a paste instead of issuing an unbounded number of delete round-trips to the host app (#281)
 
 ## v1.4.0 — 2026-07-23
 

--- a/wurstfingerKeyboard/Definition/Model/AutoCapitalization.swift
+++ b/wurstfingerKeyboard/Definition/Model/AutoCapitalization.swift
@@ -2,7 +2,8 @@
 //  AutoCapitalization.swift
 //  wurstfingerKeyboard
 //
-//  Helper for auto-capitalization logic after sentence-ending punctuation.
+//  Sentence punctuation: what ends a sentence (auto-capitalization) and what
+//  a keyboard inserts to end one (the double-space shortcut).
 //
 
 import Foundation
@@ -13,6 +14,8 @@ enum AutoCapitalization {
         ".", "!", "?", // Standard Western punctuation
         "…", // Ellipsis
         "。", "！", "？", // CJK punctuation
+        "।", // Devanagari danda
+        "۔", // Arabic full stop (Urdu)
     ]
 
     /// CJK sentence-ending punctuation. CJK text has no inter-sentence spaces,
@@ -25,6 +28,32 @@ enum AutoCapitalization {
     static let sentenceOpeners: Set<Character> = [
         "¿", "¡", // Spanish inverted punctuation
     ]
+
+    /// Sentence terminator for the scripts that write the Western full stop.
+    static let defaultSentenceTerminator = ". "
+
+    /// Sentence terminators that differ from `defaultSentenceTerminator`, keyed
+    /// by language code. Each carries the trailing space its script writes
+    /// after the mark — the full-width CJK stop takes none.
+    ///
+    /// Keyed by language rather than script on purpose: Arabic, Persian and
+    /// Urdu all write the Arabic script, but only Urdu ends a sentence with
+    /// `"۔"`; the other two use the Western full stop and fall through to the
+    /// default.
+    static let sentenceTerminators: [String: String] = [
+        "hi": "। ", // Devanagari danda
+        "ja": "。", // Ideographic full stop, written without a following space
+        "ur": "۔ ", // Arabic full stop
+    ]
+
+    /// The text a keyboard for `locale` inserts to end a sentence: the mark
+    /// plus the trailing space its script writes after it.
+    static func sentenceTerminator(for locale: Locale) -> String {
+        guard let language = locale.language.languageCode?.identifier else {
+            return defaultSentenceTerminator
+        }
+        return sentenceTerminators[language] ?? defaultSentenceTerminator
+    }
 
     /// Determines if the next character should be capitalized based on context.
     /// Returns true at the start of text or after sentence-ending punctuation followed by whitespace.

--- a/wurstfingerKeyboard/Runtime/Pipeline/AdvancedTextMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/AdvancedTextMiddleware.swift
@@ -62,6 +62,14 @@ struct AdvancedTextMiddleware: ActionMiddleware {
     // MARK: - Delete Forward
 
     private func deleteForward(target: TextInputTarget) {
+        // The proxy deletes a selected range as one unit, so forward-delete
+        // over a selection *is* a plain deleteBackward. Stepping over the
+        // trailing context first would move past the selection and delete an
+        // unrelated character — or, with nothing behind it, do nothing at all.
+        if let selected = target.selectedText, !selected.isEmpty {
+            target.deleteBackward()
+            return
+        }
         guard let next = target.documentContextAfterInput?.first else { return }
         // `adjustTextPosition` moves by UTF-16 code units, so cross the whole
         // grapheme cluster (emoji can span 2+ units); a fixed +1 would land
@@ -73,6 +81,14 @@ struct AdvancedTextMiddleware: ActionMiddleware {
     // MARK: - Capitalize Word
 
     private func capitalizeWord(target: TextInputTarget, uppercased: Bool) {
+        // With a selection the case change applies to the selection itself:
+        // inserting over it replaces it in one step. The word lookback below
+        // would instead consume the whole selection with its first
+        // deleteBackward and then eat the word in front of it.
+        if let selected = target.selectedText, !selected.isEmpty {
+            target.insertText(cased(selected, uppercased: uppercased))
+            return
+        }
         guard let context = target.documentContextBeforeInput, !context.isEmpty else { return }
 
         var characters: [Character] = []
@@ -86,13 +102,19 @@ struct AdvancedTextMiddleware: ActionMiddleware {
         guard !characters.isEmpty else { return }
 
         let word = String(characters.reversed())
-        let locale = localeProvider()
-        let transformed = uppercased ? word.uppercased(with: locale) : word.lowercased(with: locale)
+        let transformed = cased(word, uppercased: uppercased)
 
         for _ in 0 ..< word.count {
             target.deleteBackward()
         }
         target.insertText(transformed)
+    }
+
+    /// Case change in the active layout's locale (German `ß → SS`, Turkish
+    /// dotless `i`, …).
+    private func cased(_ text: String, uppercased: Bool) -> String {
+        let locale = localeProvider()
+        return uppercased ? text.uppercased(with: locale) : text.lowercased(with: locale)
     }
 
     // MARK: - Clipboard
@@ -155,6 +177,11 @@ struct AdvancedTextMiddleware: ActionMiddleware {
         let after = target.documentContextAfterInput ?? ""
         let all = before + selected + after
         guard !all.isEmpty else { return }
+        // Bounded like a paste: every character below costs one deleteBackward
+        // round-trip to the host app, and the proxy imposes no size limit of
+        // its own. Past the cap the cut is refused rather than half-applied —
+        // a silent no-op like the guards above.
+        guard !Self.exceedsCutLimit(all) else { return }
 
         UIPasteboard.general.string = all
 
@@ -195,5 +222,18 @@ struct AdvancedTextMiddleware: ActionMiddleware {
             end = next
         }
         return String(text[..<end])
+    }
+
+    /// Whether `text` is too large to cut in one gesture. Shares
+    /// `KeyboardConstants.TextInput.maxPasteUTF16Length` with
+    /// `cappedForInsertion`, so a single action moves at most that much text in
+    /// either direction: an oversized insertion truncates, an oversized
+    /// deletion is refused — truncating it would mangle the document while
+    /// putting only part of it on the pasteboard.
+    static func exceedsCutLimit(
+        _ text: String,
+        maxUTF16Length: Int = KeyboardConstants.TextInput.maxPasteUTF16Length
+    ) -> Bool {
+        text.utf16.count > maxUTF16Length
     }
 }

--- a/wurstfingerKeyboard/Runtime/Pipeline/DoubleSpacePeriodMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/DoubleSpacePeriodMiddleware.swift
@@ -2,51 +2,107 @@
 //  DoubleSpacePeriodMiddleware.swift
 //  Wurstfinger
 //
-//  Rewrites a second consecutive space into a period + space,
+//  Rewrites a second consecutive space into the script's sentence terminator,
 //  matching the iOS system keyboard's "." Shortcut.
 //
 
 import Foundation
 
-/// Turns a double space into `". "` when the character before the pending
-/// space is a letter or digit, matching the iOS system keyboard's "." Shortcut
-/// and MessagEase's Auto Period-Space.
+/// Turns two consecutive spaces into a sentence terminator when the character
+/// before the pending space is a letter or digit, matching the iOS system
+/// keyboard's "." Shortcut and MessagEase's Auto Period-Space.
 ///
-/// The middleware is stateless: on a `.space` action it inspects the document
-/// context immediately before the cursor and, when the text already ends in a
-/// letter or digit followed by a single space, deletes that pending space and
-/// rewrites the action to `.commitText(". ")`. Everything else passes through
-/// untouched, so keys other than the space bar are unaffected and the feature
-/// costs a single settings read plus a two-character lookback per space press.
+/// Both halves of "double space" are enforced:
+/// - *double*: the pending space must have been typed on this keyboard less
+///   than `KeyboardConstants.TextInput.doubleSpacePeriodWindow` ago, with no
+///   other action in between. Without that window a lone space behind an
+///   existing "word + space" is rewritten no matter how much later, and a
+///   deliberate double space cannot be typed at all while the setting is on.
+/// - *space*: the document context must end in a letter or digit followed by a
+///   single space (see `shouldSubstitute`).
+///
+/// What gets committed comes from the definition's locale via
+/// `AutoCapitalization.sentenceTerminator(for:)`, so Hindi gets a danda and
+/// Japanese the full-width stop instead of a Western period.
 ///
 /// Rewriting to `.commitText` keeps auto-capitalization working for free:
 /// `AutoCapitalizationMiddleware.affectsCapitalization` already covers
-/// `.commitText`, so the letter after the inserted period is capitalized when
-/// auto-capitalization is enabled.
+/// `.commitText`, and every terminator's mark is a member of
+/// `AutoCapitalization.sentenceEnders`, so the letter after it is capitalized
+/// when auto-capitalization is enabled.
 ///
 /// Inert unless `isEnabled` returns `true` (off by default, like
 /// auto-capitalization), so existing users' typing does not change until they
 /// opt in.
-struct DoubleSpacePeriodMiddleware: ActionMiddleware {
-    /// Whether the double-space-to-period substitution is enabled.
-    let isEnabled: () -> Bool
+///
+/// A reference type, unlike its sibling middlewares: the timestamp of the
+/// pending space is state, and the pipeline holds its middlewares as an array
+/// of existentials it cannot mutate in place.
+final class DoubleSpacePeriodMiddleware: ActionMiddleware {
+    /// Whether the double-space substitution is enabled.
+    private let isEnabled: () -> Bool
 
     /// Returns the document context immediately before the cursor. Only the
     /// last two characters are inspected.
-    let documentContextBefore: () -> String?
+    private let documentContextBefore: () -> String?
 
     /// Returns the currently selected text, if any. With an active selection
     /// the substitution must not fire: `deleteBackward` would delete the
     /// selection instead of the pending space, so a space press has to keep
     /// its plain replace-selection-with-space semantics.
-    let selectedText: () -> String?
+    private let selectedText: () -> String?
 
     /// Deletes the pending trailing space before the rewritten commit.
-    let deleteBackward: () -> Void
+    private let deleteBackward: () -> Void
+
+    /// What the double space is replaced with: the script's sentence-ending
+    /// mark plus the trailing space it is written with.
+    private let sentenceTerminator: String
+
+    /// Clock for the double-space window, injected so tests can drive it.
+    private let now: () -> TimeInterval
+
+    /// When the pending space was pressed, or nil when the previous action was
+    /// not a space.
+    private var lastSpace: TimeInterval?
+
+    init(
+        isEnabled: @escaping () -> Bool,
+        documentContextBefore: @escaping () -> String?,
+        selectedText: @escaping () -> String?,
+        deleteBackward: @escaping () -> Void,
+        sentenceTerminator: String = AutoCapitalization.defaultSentenceTerminator,
+        now: @escaping () -> TimeInterval = { Date().timeIntervalSinceReferenceDate }
+    ) {
+        self.isEnabled = isEnabled
+        self.documentContextBefore = documentContextBefore
+        self.selectedText = selectedText
+        self.deleteBackward = deleteBackward
+        self.sentenceTerminator = sentenceTerminator
+        self.now = now
+    }
 
     func process(_ context: ActionContext, next: (ActionContext) -> Void) {
-        guard isEnabled(),
-              case .space = context.action,
+        guard isEnabled() else {
+            next(context)
+            return
+        }
+        guard case .space = context.action else {
+            // Only two *consecutive* space presses substitute: a letter, a
+            // delete or a cursor move in between disarms the window.
+            lastSpace = nil
+            next(context)
+            return
+        }
+
+        let pressed = now()
+        let window = KeyboardConstants.TextInput.doubleSpacePeriodWindow
+        // A range check rather than a plain difference: a clock stepped
+        // backwards by the system must not read as an instant second press.
+        let isSecondPress = lastSpace.map { (0 ... window).contains(pressed - $0) } ?? false
+        lastSpace = pressed
+
+        guard isSecondPress,
               selectedText()?.isEmpty != false,
               let text = documentContextBefore(),
               Self.shouldSubstitute(before: text)
@@ -54,9 +110,11 @@ struct DoubleSpacePeriodMiddleware: ActionMiddleware {
             next(context)
             return
         }
+        // The pair is consumed; a following space starts a new one.
+        lastSpace = nil
         deleteBackward()
         var rewritten = context
-        rewritten.action = .commitText(". ")
+        rewritten.action = .commitText(sentenceTerminator)
         next(rewritten)
     }
 

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -190,9 +190,10 @@ extension KeyboardViewModel {
             }
         ))
 
-        // 4c. Double-space → period (the iOS "." Shortcut). Runs right before
-        //     the text-input middleware so it can rewrite the pending `.space`
-        //     into `. `. Inert unless enabled in settings.
+        // 4c. Double-space → sentence terminator (the iOS "." Shortcut). Runs
+        //     right before the text-input middleware so it can rewrite the
+        //     pending `.space`. The terminator comes from the definition, so
+        //     Hindi and Japanese get their own marks. Inert unless enabled.
         middlewares.append(DoubleSpacePeriodMiddleware(
             isEnabled: { [weak self] in
                 self?.sharedDefaults.bool(forKey: SettingsKey.doubleSpacePeriodEnabled.rawValue) ?? false
@@ -205,7 +206,8 @@ extension KeyboardViewModel {
             },
             deleteBackward: { [weak self] in
                 self?.textInputTarget?.deleteBackward()
-            }
+            },
+            sentenceTerminator: AutoCapitalization.sentenceTerminator(for: definition.locale)
         ))
 
         // 5. Basic text input (commitText, deleteBackward, space, newline, moveCursor)

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -271,6 +271,15 @@ enum KeyboardConstants {
         /// input in the jetsam-constrained keyboard extension; longer text is
         /// silently truncated at a grapheme boundary before insertion.
         static let maxPasteUTF16Length = 200_000
+
+        /// How long after a space press a second one still reads as a double
+        /// space. Without a window every space typed behind an existing
+        /// "word + space" is rewritten — hours later, or after the caret moved
+        /// back into an old sentence — and a deliberate double space becomes
+        /// untypable while the shortcut is on. Deliberately longer than a UIKit
+        /// double tap: two spaces on a gesture keyboard are a typing rhythm,
+        /// not a double tap.
+        static let doubleSpacePeriodWindow: TimeInterval = 1.1
     }
 
     // MARK: - Preview Settings

--- a/wurstfingerTests/AdvancedTextMiddlewareTests.swift
+++ b/wurstfingerTests/AdvancedTextMiddlewareTests.swift
@@ -149,6 +149,38 @@ struct AdvancedTextMiddlewareDeleteForwardTests {
         #expect(target.documentContextBeforeInput == "")
         #expect(target.documentContextAfterInput == "!")
     }
+
+    @Test func deletesActiveSelectionAsOneUnit() {
+        let target = MockTextTarget()
+        target.documentContextBeforeInput = "abc"
+        target.selectedText = "def"
+        target.documentContextAfterInput = "!"
+        let middleware = AdvancedTextFixtures.middleware(target: target)
+
+        middleware.process(AdvancedTextFixtures.context(.deleteForward)) { _ in }
+
+        // The proxy removes a selected range with a single deleteBackward;
+        // stepping over "!" first would delete that instead of the selection.
+        #expect(target.events == [.deleteBackward])
+        #expect(target.selectedText == nil)
+        #expect(target.documentContextBeforeInput == "abc")
+        #expect(target.documentContextAfterInput == "!")
+    }
+
+    @Test func deletesActiveSelectionAtEndOfDocument() {
+        let target = MockTextTarget()
+        target.documentContextBeforeInput = "abc"
+        target.selectedText = "def"
+        target.documentContextAfterInput = ""
+        let middleware = AdvancedTextFixtures.middleware(target: target)
+
+        middleware.process(AdvancedTextFixtures.context(.deleteForward)) { _ in }
+
+        // Nothing follows the selection, so the "nothing to delete forward"
+        // guard must not swallow it.
+        #expect(target.events == [.deleteBackward])
+        #expect(target.selectedText == nil)
+    }
 }
 
 // MARK: - Capitalize word
@@ -230,6 +262,33 @@ struct AdvancedTextCapitalizeWordTests {
         // Trailing space means no word characters collected → no-op.
         #expect(target.events.isEmpty)
         #expect(target.documentContextBeforeInput == "hallo ")
+    }
+
+    @Test func uppercasesActiveSelectionInsteadOfPrecedingWord() {
+        let target = MockTextTarget()
+        target.documentContextBeforeInput = "abc"
+        target.selectedText = "def"
+        let middleware = AdvancedTextFixtures.middleware(target: target)
+
+        middleware.process(AdvancedTextFixtures.context(.capitalizeWord(uppercased: true))) { _ in }
+
+        // The selection is replaced in a single insert, so the word in front
+        // of it stays untouched.
+        #expect(target.events == [.insertText("DEF")])
+        #expect(target.selectedText == nil)
+        #expect(target.documentContextBeforeInput == "abcDEF")
+    }
+
+    @Test func lowercasesActiveSelection() {
+        let target = MockTextTarget()
+        target.documentContextBeforeInput = "abc"
+        target.selectedText = "DEF"
+        let middleware = AdvancedTextFixtures.middleware(target: target)
+
+        middleware.process(AdvancedTextFixtures.context(.capitalizeWord(uppercased: false))) { _ in }
+
+        #expect(target.events == [.insertText("def")])
+        #expect(target.documentContextBeforeInput == "abcdef")
     }
 }
 
@@ -573,6 +632,27 @@ final class AdvancedTextMiddlewareClipboardTests {
         #expect(UIPasteboard.general.string == marker) // pasteboard untouched
         #expect(successTicks == 0, "A guarded no-op must not fire a success tick")
     }
+
+    @Test func cutAllRefusesAnOversizedDocument() {
+        let marker = "untouched-\(UUID().uuidString)"
+        UIPasteboard.general.string = marker
+
+        let target = MockTextTarget()
+        target.hasFullAccess = true
+        // One unit past the shared cap: cutting it would mean 200k+
+        // deleteBackward round-trips to the host app.
+        target.documentContextBeforeInput = String(
+            repeating: "a", count: KeyboardConstants.TextInput.maxPasteUTF16Length + 1
+        )
+        var successTicks = 0
+        let middleware = AdvancedTextFixtures.middleware(target: target) { successTicks += 1 }
+
+        middleware.process(AdvancedTextFixtures.context(.cutAll)) { _ in }
+
+        #expect(target.events.isEmpty)
+        #expect(UIPasteboard.general.string == marker) // pasteboard untouched
+        #expect(successTicks == 0, "A guarded no-op must not fire a success tick")
+    }
 }
 
 // MARK: - Paste size cap
@@ -611,5 +691,33 @@ struct AdvancedTextPasteCapTests {
         let text = "ab" + family
         #expect(AdvancedTextMiddleware.cappedForInsertion(text, maxUTF16Length: 12) == "ab")
         #expect(AdvancedTextMiddleware.cappedForInsertion(text, maxUTF16Length: 13) == text)
+    }
+}
+
+// MARK: - Cut size cap
+
+/// `exceedsCutLimit` is pure, so the boundary is tested directly with small
+/// caps; that it is wired into cut-all is covered by
+/// `cutAllRefusesAnOversizedDocument` above.
+struct AdvancedTextCutLimitTests {
+    @Test func acceptsTextExactlyAtCap() {
+        #expect(!AdvancedTextMiddleware.exceedsCutLimit("abc", maxUTF16Length: 3))
+    }
+
+    @Test func rejectsTextAboveCap() {
+        #expect(AdvancedTextMiddleware.exceedsCutLimit("abcd", maxUTF16Length: 3))
+    }
+
+    @Test func countsUTF16UnitsNotCharacters() {
+        // 👍🏽 = one Character, 4 UTF-16 units.
+        #expect(AdvancedTextMiddleware.exceedsCutLimit("👍🏽", maxUTF16Length: 3))
+        #expect(!AdvancedTextMiddleware.exceedsCutLimit("👍🏽", maxUTF16Length: 4))
+    }
+
+    @Test func cutAndPasteShareTheSameCeiling() {
+        let atCap = String(repeating: "a", count: KeyboardConstants.TextInput.maxPasteUTF16Length)
+        #expect(!AdvancedTextMiddleware.exceedsCutLimit(atCap))
+        #expect(AdvancedTextMiddleware.exceedsCutLimit(atCap + "a"))
+        #expect(AdvancedTextMiddleware.cappedForInsertion(atCap) == atCap)
     }
 }

--- a/wurstfingerTests/AutoCapitalizationTests.swift
+++ b/wurstfingerTests/AutoCapitalizationTests.swift
@@ -120,13 +120,40 @@ struct AutoCapitalizationTests {
     // MARK: - sentenceEnders and sentenceOpeners (pure constants)
 
     @Test func sentenceEndersContainsExpectedCharacters() {
-        let expected: Set<Character> = [".", "!", "?", "…", "。", "！", "？"]
+        let expected: Set<Character> = [".", "!", "?", "…", "。", "！", "？", "।", "۔"]
         #expect(AutoCapitalization.sentenceEnders == expected)
     }
 
     @Test func sentenceOpenersContainsExpectedCharacters() {
         let expected: Set<Character> = ["¿", "¡"]
         #expect(AutoCapitalization.sentenceOpeners == expected)
+    }
+
+    // MARK: - sentenceTerminator
+
+    @Test("Sentence terminator per language", arguments: [
+        ("de_DE", ". "), ("en_US", ". "), ("ar", ". "), ("fa_IR", ". "),
+        ("hi_IN", "। "), ("ja_JP", "。"), ("ur", "۔ "),
+    ])
+    func sentenceTerminatorForLocale(_ identifier: String, _ expected: String) {
+        #expect(AutoCapitalization.sentenceTerminator(for: Locale(identifier: identifier)) == expected)
+    }
+
+    @Test func everySentenceTerminatorEndsASentence() throws {
+        // The double-space shortcut commits these, and auto-capitalization
+        // after the commit only engages if the mark is a known sentence ender.
+        for (language, terminator) in AutoCapitalization.sentenceTerminators {
+            let mark = try #require(terminator.first)
+            #expect(AutoCapitalization.sentenceEnders.contains(mark), "\(language): \(terminator)")
+        }
+        let defaultMark = try #require(AutoCapitalization.defaultSentenceTerminator.first)
+        #expect(AutoCapitalization.sentenceEnders.contains(defaultMark))
+    }
+
+    @Test func katakanaLayoutResolvesToTheJapaneseTerminator() throws {
+        // The katakana *id* is not a locale; its definition carries "ja_JP".
+        let definition = try #require(KeyboardRegistry.load(id: "ja_JP_katakana"))
+        #expect(AutoCapitalization.sentenceTerminator(for: definition.locale) == "。")
     }
 
     // MARK: - Integration tests (pipeline API)

--- a/wurstfingerTests/DoubleSpacePeriodMiddlewareTests.swift
+++ b/wurstfingerTests/DoubleSpacePeriodMiddlewareTests.swift
@@ -2,11 +2,13 @@
 //  DoubleSpacePeriodMiddlewareTests.swift
 //  WurstfingerTests
 //
-//  Verifies the double-space → period substitution (the iOS "." Shortcut):
-//  the rule, the isolated middleware behavior, and end-to-end wiring through
-//  the action pipeline including the free auto-capitalization follow-up.
+//  Verifies the double-space → sentence terminator substitution (the iOS "."
+//  Shortcut): the rule, the timing window, the per-script terminator, and
+//  end-to-end wiring through the action pipeline including the free
+//  auto-capitalization follow-up.
 //
 
+import Foundation
 import Testing
 @testable import WurstfingerApp
 
@@ -30,35 +32,44 @@ struct DoubleSpacePeriodMiddlewareTests {
 
     // MARK: - Isolated middleware
 
-    /// Runs one action through the middleware, returning the forwarded action,
-    /// the target's recorded events, and the resulting pre-cursor context.
+    /// Drives one middleware instance through a timeline of `(time, action)`
+    /// pairs on an injected clock, returning every forwarded action, the
+    /// target's recorded events, and the resulting pre-cursor context.
+    /// The default timeline is two space presses well inside the window.
     private func run(
         before: String?,
+        timeline: [(TimeInterval, KeyAction)] = [(0, .space), (0.2, .space)],
         enabled: Bool = true,
-        action: KeyAction = .space,
-        selection: String? = nil
+        selection: String? = nil,
+        terminator: String = ". "
     )
-        -> (forwarded: KeyAction, events: [MockTextTarget.Event], contextAfter: String?) {
+        -> (forwarded: [KeyAction], events: [MockTextTarget.Event], contextAfter: String?) {
         let target = MockTextTarget()
         target.documentContextBeforeInput = before
         target.selectedText = selection
+        var clock: TimeInterval = 0
         let middleware = DoubleSpacePeriodMiddleware(
             isEnabled: { enabled },
             documentContextBefore: { target.documentContextBeforeInput },
             selectedText: { target.selectedText },
-            deleteBackward: { target.deleteBackward() }
+            deleteBackward: { target.deleteBackward() },
+            sentenceTerminator: terminator,
+            now: { clock }
         )
-        var forwarded: KeyAction = .none
-        middleware.process(ActionContext(action: action, binding: nil, mode: ModeNames.main)) { context in
-            forwarded = context.action
+        var forwarded: [KeyAction] = []
+        for (time, action) in timeline {
+            clock = time
+            middleware.process(ActionContext(action: action, binding: nil, mode: ModeNames.main)) { context in
+                forwarded.append(context.action)
+            }
         }
         return (forwarded, target.events, target.documentContextBeforeInput)
     }
 
-    @Test("Deletes the pending space and rewrites to a period commit")
+    @Test("Deletes the pending space and rewrites to a terminator commit")
     func rewritesAfterLetter() {
         let result = run(before: "hello ")
-        #expect(result.forwarded == .commitText(". "))
+        #expect(result.forwarded == [.space, .commitText(". ")])
         #expect(result.events == [.deleteBackward])
         // The middleware only removes the pending space; the commit itself is
         // applied later by TextInputMiddleware.
@@ -68,7 +79,7 @@ struct DoubleSpacePeriodMiddlewareTests {
     @Test("Passes a space through untouched after punctuation")
     func passesThroughAfterPunctuation() {
         let result = run(before: "hello. ")
-        #expect(result.forwarded == .space)
+        #expect(result.forwarded == [.space, .space])
         #expect(result.events.isEmpty)
         #expect(result.contextAfter == "hello. ")
     }
@@ -80,7 +91,7 @@ struct DoubleSpacePeriodMiddlewareTests {
         // replace-selection semantics even when the pre-selection context
         // matches the substitution rule.
         let result = run(before: "hello ", selection: "world")
-        #expect(result.forwarded == .space)
+        #expect(result.forwarded == [.space, .space])
         #expect(result.events.isEmpty)
         #expect(result.contextAfter == "hello ")
     }
@@ -88,23 +99,96 @@ struct DoubleSpacePeriodMiddlewareTests {
     @Test("Passes a third space through untouched")
     func passesThroughOnDoubleSpace() {
         let result = run(before: "hello  ")
-        #expect(result.forwarded == .space)
+        #expect(result.forwarded == [.space, .space])
         #expect(result.events.isEmpty)
     }
 
     @Test("Does nothing when disabled")
     func inertWhenDisabled() {
         let result = run(before: "hello ", enabled: false)
-        #expect(result.forwarded == .space)
+        #expect(result.forwarded == [.space, .space])
         #expect(result.events.isEmpty)
         #expect(result.contextAfter == "hello ")
     }
 
     @Test("Ignores non-space actions")
     func ignoresNonSpaceActions() {
-        let result = run(before: "hello ", action: .commitText("x"))
-        #expect(result.forwarded == .commitText("x"))
+        let result = run(before: "hello ", timeline: [(0, .commitText("x"))])
+        #expect(result.forwarded == [.commitText("x")])
         #expect(result.events.isEmpty)
+    }
+
+    // MARK: - Timing window
+
+    @Test("A lone space is never a double space")
+    func loneSpaceDoesNotSubstitute() {
+        // The rule alone matches "hello " — only the missing first press keeps
+        // a space typed into an already-finished word from being rewritten.
+        let result = run(before: "hello ", timeline: [(0, .space)])
+        #expect(result.forwarded == [.space])
+        #expect(result.events.isEmpty)
+        #expect(result.contextAfter == "hello ")
+    }
+
+    @Test("A space after the window has closed inserts a plain space")
+    func windowExpires() {
+        let window = KeyboardConstants.TextInput.doubleSpacePeriodWindow
+        let result = run(before: "hello ", timeline: [(0, .space), (window + 0.01, .space)])
+        #expect(result.forwarded == [.space, .space])
+        #expect(result.events.isEmpty)
+    }
+
+    @Test("A space at the edge of the window still substitutes")
+    func windowBoundarySubstitutes() {
+        let window = KeyboardConstants.TextInput.doubleSpacePeriodWindow
+        let result = run(before: "hello ", timeline: [(0, .space), (window, .space)])
+        #expect(result.forwarded.last == .commitText(". "))
+    }
+
+    @Test("A keystroke between the two spaces disarms the window")
+    func interveningActionDisarms() {
+        let result = run(
+            before: "hello ",
+            timeline: [(0, .space), (0.1, .commitText("x")), (0.2, .space)]
+        )
+        #expect(result.forwarded == [.space, .commitText("x"), .space])
+        #expect(result.events.isEmpty)
+    }
+
+    @Test("A cursor move between the two spaces disarms the window")
+    func cursorMoveDisarms() {
+        let result = run(
+            before: "hello ",
+            timeline: [(0, .space), (0.1, .moveCursor(offset: -1)), (0.2, .space)]
+        )
+        #expect(result.forwarded.last == .space)
+        #expect(result.events.isEmpty)
+    }
+
+    @Test("A consumed pair does not arm the next space")
+    func thirdSpaceStartsAFreshPair() {
+        // "hello" + space + space substitutes; the third space must insert a
+        // plain space rather than substituting again on its own.
+        let result = run(
+            before: "hello ",
+            timeline: [(0, .space), (0.2, .space), (0.4, .space)]
+        )
+        #expect(result.forwarded == [.space, .commitText(". "), .space])
+        #expect(result.events == [.deleteBackward])
+    }
+
+    // MARK: - Per-script terminator
+
+    @Test("Commits the sentence terminator the definition supplies", arguments: [
+        ("hello ", ". "),
+        ("क ", "। "),
+        ("س ", "۔ "),
+        ("あ ", "。"),
+    ])
+    func commitsScriptTerminator(_ before: String, _ terminator: String) {
+        let result = run(before: before, terminator: terminator)
+        #expect(result.forwarded.last == .commitText(terminator))
+        #expect(result.events == [.deleteBackward])
     }
 
     // MARK: - Pipeline integration
@@ -113,18 +197,20 @@ struct DoubleSpacePeriodMiddlewareTests {
     func integrationSubstitutes() {
         let (viewModel, target) = makeViewModel(languageId: "de_DE")
         viewModel.sharedDefaults.set(true, forKey: SettingsKey.doubleSpacePeriodEnabled.rawValue)
-        target.documentContextBeforeInput = "hi "
+        target.documentContextBeforeInput = "hi"
         viewModel.dispatchAction(.space)
-        #expect(target.events == [.deleteBackward, .insertText(". ")])
+        viewModel.dispatchAction(.space)
+        #expect(target.events == [.insertText(" "), .deleteBackward, .insertText(". ")])
         #expect(target.documentContextBeforeInput == "hi. ")
     }
 
-    @Test("Disabled by default: a second space just inserts another space")
+    @Test("Disabled by default: two spaces just insert two spaces")
     func integrationDisabledByDefault() {
         let (viewModel, target) = makeViewModel(languageId: "de_DE")
-        target.documentContextBeforeInput = "hi "
+        target.documentContextBeforeInput = "hi"
         viewModel.dispatchAction(.space)
-        #expect(target.events == [.insertText(" ")])
+        viewModel.dispatchAction(.space)
+        #expect(target.events == [.insertText(" "), .insertText(" ")])
         #expect(target.documentContextBeforeInput == "hi  ")
     }
 
@@ -134,11 +220,22 @@ struct DoubleSpacePeriodMiddlewareTests {
         try #require(viewModel.currentDefinition?.settings.autoCapitalize == true)
         viewModel.sharedDefaults.set(true, forKey: SettingsKey.doubleSpacePeriodEnabled.rawValue)
         viewModel.sharedDefaults.set(true, forKey: SettingsKey.autoCapitalizeEnabled.rawValue)
-        target.documentContextBeforeInput = "hi "
+        target.documentContextBeforeInput = "hi"
+        viewModel.dispatchAction(.space)
         viewModel.dispatchAction(.space)
         #expect(target.documentContextBeforeInput == "hi. ")
         // ". " is a sentence boundary, so the shifted layer engages for the
         // next letter without any extra wiring in this middleware.
         #expect(viewModel.activeModeName == ModeNames.shifted)
+    }
+
+    @Test("Hindi commits a danda instead of a period")
+    func integrationHindiDanda() {
+        let (viewModel, target) = makeViewModel(languageId: "hi_IN")
+        viewModel.sharedDefaults.set(true, forKey: SettingsKey.doubleSpacePeriodEnabled.rawValue)
+        target.documentContextBeforeInput = "क"
+        viewModel.dispatchAction(.space)
+        viewModel.dispatchAction(.space)
+        #expect(target.documentContextBeforeInput == "क। ")
     }
 }


### PR DESCRIPTION
Findings 1, 12 and 14 of the 2026-08-08 stabilization review.

### Selection guards for `capitalizeWord` and `deleteForward` (finding 1, P1)

Both handlers read `documentContextBeforeInput`/`AfterInput` — the text *around* a selection — without checking `selectedText`. The proxy removes a selected range with a single `deleteBackward`, so the delete count computed from the surrounding context was off by the whole selection.

- `deleteForward` with a selection now deletes the selection, which is what the proxy already does in one call and what every text editor does.
- `capitalizeWord` with a selection transforms the selection in a single `insertText`. Skipping (the `ComposeMiddleware` idiom) does not transfer: nothing downstream handles `.capitalizeWord`, so the gesture would do nothing at all.

The locale-aware case change moved into one shared helper, so `ß → ẞ` behaviour is unchanged.

Two corrections to the review's write-up, found while reproducing it: its example (`before = "hello "`, selection `"world"`) is a no-op rather than corruption — the real failing case needs no trailing space. And it missed a second branch: with nothing *after* the selection, the old `deleteForward` did nothing at all. Both are now covered.

### A time window and a script-aware terminator for double-space (finding 12, P3)

`shouldSubstitute` only looked at `suffix(2)`, so a lone space typed behind an existing "word + space" was rewritten hours later, and a deliberate double space could not be typed at all while the setting was on.

The middleware now keeps one nilable timestamp that carries both halves of the rule: the previous action was a space, *and* it was within `doubleSpacePeriodWindow` (1.1 s). Any other action disarms it. The clock is injected, so the window is unit-tested rather than slept through.

The committed text comes from `AutoCapitalization.sentenceTerminator(for:)` instead of a hardcoded `". "`: Hindi gets `। `, Urdu `۔ `, Japanese `。` without a trailing space. The table is keyed by language, not script — Arabic, Persian and Urdu all write the Arabic script but only Urdu ends a sentence with `۔`. `sentenceEnders` gained the same two marks so that "what ends a sentence" and "what we insert to end one" cannot drift apart.

1.1 s is a judgement call, deliberately longer than UIKit's ~0.3 s double-tap interval, which would break the feature for normal thumb typing. If it feels wrong on device, only the constant changes.

### A ceiling for cut-all (finding 14, P3)

Pastes were capped at 200k UTF-16 units, cut-all was not, and every character costs one `deleteBackward` round-trip to the host app. Cut-all now refuses above the same cap rather than truncating: a partial cut would mangle the document while only part of it reached the pasteboard. The round-trip count itself is irreducible — neither `TextInputTarget` nor `UITextDocumentProxy` exposes a ranged delete.

### Notes

- `DoubleSpacePeriodMiddleware` becomes a `final class`, the only reference type in the pipeline: it holds state now, and `ActionPipeline` stores its middlewares as existentials it cannot mutate in place. No retain cycle — the closures are `[weak self]`, and `rebuildPipeline()` only runs on definition/target changes, so the state survives a typing session.
- Residual edge case: a caret move performed by the *host* does not pass through the pipeline and so cannot disarm the window. Tapping elsewhere in the field between two space presses within 1.1 s can still substitute. Disarming from `textDidChange` was rejected — it fires after our own space insertion and would kill the feature.
- Thai keeps `". "`. It has no sentence-ending mark (a space is the boundary), so arguably the shortcut should be inert there; left for a follow-up.
- The settings subtitle "Type two spaces to insert a period" is now slightly Western-centric for hi/ja/ur. Rewording it means a new key in 22 languages, so it is not smuggled into a bug-fix PR.

1095 unit tests pass; SwiftFormat and SwiftLint `--strict` are clean.
