### PR TITLE
Fix Delete Slides and Long-Press Teardown

### DIFF
--- a/wurstfinger/ExpertSettingsView.swift
+++ b/wurstfinger/ExpertSettingsView.swift
@@ -183,7 +183,7 @@ struct ExpertSettingsView: View {
             parameterSlider(
                 title: "Jitter Threshold",
                 value: $jitterThreshold,
-                range: 1 ... 10,
+                range: GesturePreprocessorConfig.jitterThresholdRange,
                 step: 0.5,
                 unit: "pt",
                 description: "Points closer than this are merged. Removes finger micro-movements."
@@ -192,13 +192,13 @@ struct ExpertSettingsView: View {
             parameterSlider(
                 title: "Max Jump Distance",
                 value: $maxJumpDistance,
-                range: 20 ... 100,
+                range: GesturePreprocessorConfig.maxJumpDistanceRange,
                 step: 5,
                 unit: "pt",
                 description: "Points further apart are removed as glitches."
             )
 
-            Stepper(value: $smoothingWindow, in: 3 ... 11, step: 2) {
+            Stepper(value: $smoothingWindow, in: GesturePreprocessorConfig.smoothingWindowRange, step: 2) {
                 VStack(alignment: .leading, spacing: 4) {
                     HStack {
                         Text("Smoothing Window")
@@ -225,7 +225,7 @@ struct ExpertSettingsView: View {
             parameterSlider(
                 title: "Min Swipe Length",
                 value: $minSwipeLength,
-                range: 10 ... 60,
+                range: GestureClassificationThresholds.minSwipeLengthRange,
                 step: 5,
                 unit: "pt",
                 description: "maxDisplacement below this = Tap. Above = continues to Step 2."
@@ -261,7 +261,7 @@ struct ExpertSettingsView: View {
             parameterSlider(
                 title: "Min Angular Span",
                 value: $minAngularSpan,
-                range: .pi ... (.pi * 2),
+                range: GestureClassificationThresholds.minAngularSpanRange,
                 step: .pi / 8,
                 unit: "°",
                 description: "Total angle traversed around centroid must exceed \(Int(minAngularSpan * 180 / .pi))°."
@@ -270,7 +270,7 @@ struct ExpertSettingsView: View {
             parameterSlider(
                 title: "Min Circularity",
                 value: $minCircularity,
-                range: 0.1 ... 0.7,
+                range: GestureClassificationThresholds.minCircularityRange,
                 step: 0.05,
                 unit: "",
                 description: "How uniform the radii are (1.0 = perfect circle). Spirals have lower values."
@@ -279,7 +279,7 @@ struct ExpertSettingsView: View {
             parameterSlider(
                 title: "Min Turn Consistency",
                 value: $minTurnConsistency,
-                range: 0.5 ... 1.0,
+                range: GestureClassificationThresholds.minTurnConsistencyRange,
                 step: 0.05,
                 unit: "",
                 description: "How consistently the path turns in one direction. "
@@ -289,7 +289,7 @@ struct ExpertSettingsView: View {
             parameterSlider(
                 title: "Min Oriented Compactness",
                 value: $minOrientedCompactness,
-                range: 0.2 ... 0.8,
+                range: GestureClassificationThresholds.minOrientedCompactnessRange,
                 step: 0.05,
                 unit: "",
                 description: "Width/length ratio along principal axis. 1.0 = square, 0 = line. Filters out narrow arcs."
@@ -316,7 +316,7 @@ struct ExpertSettingsView: View {
             parameterSlider(
                 title: "Max Return Ratio",
                 value: $maxReturnRatio,
-                range: 0.2 ... 0.8,
+                range: GestureClassificationThresholds.maxReturnRatioRange,
                 step: 0.05,
                 unit: "",
                 description: "chord/path ratio must be below \(String(format: "%.0f%%", maxReturnRatio * 100)). Low ratio = finger returned to start."
@@ -330,7 +330,11 @@ struct ExpertSettingsView: View {
                     Text(String(format: "%.0f%%", returnDisplacementStart * 100))
                         .font(.caption)
                         .foregroundColor(.secondary)
-                    Slider(value: $returnDisplacementStart, in: 0.1 ... 0.4, step: 0.05)
+                    Slider(
+                        value: $returnDisplacementStart,
+                        in: GestureClassificationThresholds.returnDisplacementStartRange,
+                        step: 0.05
+                    )
                     Text("Start")
                         .font(.caption)
                         .foregroundColor(.secondary)
@@ -340,7 +344,11 @@ struct ExpertSettingsView: View {
                     Text(String(format: "%.0f%%", returnDisplacementEnd * 100))
                         .font(.caption)
                         .foregroundColor(.secondary)
-                    Slider(value: $returnDisplacementEnd, in: 0.6 ... 0.9, step: 0.05)
+                    Slider(
+                        value: $returnDisplacementEnd,
+                        in: GestureClassificationThresholds.returnDisplacementEndRange,
+                        step: 0.05
+                    )
                     Text("End")
                         .font(.caption)
                         .foregroundColor(.secondary)

--- a/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
@@ -11,7 +11,7 @@
 //  ## Data Flow
 //
 //  ```
-//  Touch Events (KeyboardButton)
+//  Touch Events (KeyView)
 //       │
 //       ▼
 //  Raw CGPoint[] ──► GesturePreprocessor.preprocess()
@@ -67,12 +67,15 @@
 //
 //  ## Classification Logic
 //
-//  - **Tap**: maxDisplacement < minSwipeLength (~55% key height)
+//  - **Tap**: maxDisplacement < minSwipeLength (20pt by default)
 //  - **Return-swipe**: returnRatio < 0.5 AND maxDisplacement in middle of path
-//  - **Circular**: angularSpan > 270° AND pathSeparation > 0.5 (spiral, not return)
+//  - **Circular**: angularSpan > 270° AND consistent turn direction AND enough
+//    oriented compactness (a circle, not a narrow arc)
 //  - **Swipe**: Everything else, direction from maxDisplacementAngle
 //
-//  Note: Default key height is 54pt, so minSwipeLength (30pt) ≈ 55% of key height.
+//  Note: minSwipeLength is an absolute distance, so its share of the key
+//  depends on the user's size setting — 20pt is about a third of the ~58pt
+//  key height the layout metrics resolve at the default width.
 //
 //  ## Key Insight: Spiral vs Return-Swipe
 //
@@ -104,6 +107,16 @@ struct GesturePreprocessorConfig {
     static let defaultMaxJumpDistance: CGFloat = 50.0
     static let defaultSmoothingWindow: Int = 5
 
+    // MARK: - Value Ranges
+
+    /// The ranges the Expert UI offers, shared with the loaders below so a
+    /// stale or foreign store value (an older build's range, a hand-written
+    /// default) is clamped instead of reaching the pipeline.
+    static let jitterThresholdRange: ClosedRange<Double> = 1 ... 10
+    static let maxJumpDistanceRange: ClosedRange<Double> = 20 ... 100
+    /// Upper bound is odd on purpose: the loader rounds even windows up.
+    static let smoothingWindowRange: ClosedRange<Int> = 3 ... 11
+
     // MARK: - UserDefaults Keys
 
     static let jitterThresholdKey = "gesture.jitterThreshold"
@@ -119,14 +132,21 @@ struct GesturePreprocessorConfig {
     )
 
     /// Loads config from SharedDefaults with fallback to defaults.
-    /// Non-finite values (NaN, Inf) are replaced with defaults.
+    /// Non-finite values (NaN, Inf) are replaced with defaults, out-of-range
+    /// ones clamped to the Expert range.
     /// Custom values only apply while expert mode is enabled; when it is off,
     /// the defaults are returned. The stored values are kept so they survive
     /// toggling expert mode off and on again.
     static func fromUserDefaults(store: UserDefaults = SharedDefaults.store) -> GesturePreprocessorConfig {
         guard store.bool(forKey: SettingsKey.expertModeEnabled.rawValue) else { return .default }
-        let jitter = finiteCGFloat(from: store, key: jitterThresholdKey, default: defaultJitterThreshold)
-        let maxJump = finiteCGFloat(from: store, key: maxJumpDistanceKey, default: defaultMaxJumpDistance)
+        let jitter = clampedCGFloat(
+            from: store, key: jitterThresholdKey,
+            default: defaultJitterThreshold, range: jitterThresholdRange
+        )
+        let maxJump = clampedCGFloat(
+            from: store, key: maxJumpDistanceKey,
+            default: defaultMaxJumpDistance, range: maxJumpDistanceRange
+        )
         return GesturePreprocessorConfig(
             jitterThreshold: jitter,
             maxJumpDistance: maxJump,
@@ -136,17 +156,26 @@ struct GesturePreprocessorConfig {
         )
     }
 
-    /// Reads smoothingWindow from defaults, ensuring it's a positive odd integer.
+    /// Reads smoothingWindow from defaults, clamped to the Expert range and
+    /// forced to an odd width (the Savitzky-Golay window must be centred).
     private static func validSmoothingWindow(from store: UserDefaults) -> Int {
         let raw = store.object(forKey: smoothingWindowKey) as? Int ?? defaultSmoothingWindow
-        let clamped = max(3, raw)
+        let clamped = min(max(raw, smoothingWindowRange.lowerBound), smoothingWindowRange.upperBound)
         return clamped.isMultiple(of: 2) ? clamped + 1 : clamped
     }
 
-    private static func finiteCGFloat(from store: UserDefaults, key: String, default defaultValue: CGFloat) -> CGFloat {
+    /// Loads a CGFloat from the store, clamped to `range`. A missing key or a
+    /// NaN/Inf value falls back to `defaultValue`.
+    private static func clampedCGFloat(
+        from store: UserDefaults,
+        key: String,
+        default defaultValue: CGFloat,
+        range: ClosedRange<Double>
+    ) -> CGFloat {
         guard store.object(forKey: key) != nil else { return defaultValue }
-        let value = CGFloat(store.double(forKey: key))
-        return value.isFinite ? value : defaultValue
+        let value = store.double(forKey: key)
+        guard value.isFinite else { return defaultValue }
+        return CGFloat(min(max(value, range.lowerBound), range.upperBound))
     }
 
     /// Creates a config with custom aspect ratio.
@@ -390,6 +419,23 @@ struct GestureClassificationThresholds {
     static let defaultMinTurnConsistency: CGFloat = 0.8 // 80% turns in same direction
     static let defaultMinOrientedCompactness: CGFloat = 0.4 // width must be at least 40% of length
 
+    // MARK: - Value Ranges
+
+    /// The ranges the Expert UI offers, shared with the loader below so a
+    /// stale or foreign store value (an older build's range, a hand-written
+    /// default) is clamped instead of reaching classification.
+    static let minSwipeLengthRange: ClosedRange<Double> = 10 ... 60
+    static let maxReturnRatioRange: ClosedRange<Double> = 0.2 ... 0.8
+    static let returnDisplacementStartRange: ClosedRange<Double> = 0.1 ... 0.4
+    static let returnDisplacementEndRange: ClosedRange<Double> = 0.6 ... 0.9
+    static let minCircularityRange: ClosedRange<Double> = 0.1 ... 0.7
+    static let minAngularSpanRange: ClosedRange<Double> = .pi ... (2 * .pi)
+    static let minTurnConsistencyRange: ClosedRange<Double> = 0.5 ... 1.0
+    static let minOrientedCompactnessRange: ClosedRange<Double> = 0.2 ... 0.8
+    /// No Expert control (the circular branch does not read it); clamped to
+    /// the ratio's meaningful band so a stored value cannot be nonsense.
+    static let minPathSeparationRange: ClosedRange<Double> = 0 ... 1
+
     // MARK: - UserDefaults Keys
 
     static let minSwipeLengthKey = "gesture.minSwipeLength"
@@ -413,12 +459,18 @@ struct GestureClassificationThresholds {
         minOrientedCompactness: defaultMinOrientedCompactness
     )
 
-    /// Loads a finite CGFloat from UserDefaults, falling back to the default
-    /// if the key is missing or the stored value is NaN/Inf.
-    private static func loadCGFloat(from store: UserDefaults, key: String, default defaultValue: CGFloat) -> CGFloat {
+    /// Loads a CGFloat from UserDefaults, clamped to `range`. A missing key or
+    /// a NaN/Inf value falls back to `defaultValue`.
+    private static func clampedCGFloat(
+        from store: UserDefaults,
+        key: String,
+        default defaultValue: CGFloat,
+        range: ClosedRange<Double>
+    ) -> CGFloat {
         guard store.object(forKey: key) != nil else { return defaultValue }
-        let value = CGFloat(store.double(forKey: key))
-        return value.isFinite ? value : defaultValue
+        let value = store.double(forKey: key)
+        guard value.isFinite else { return defaultValue }
+        return CGFloat(min(max(value, range.lowerBound), range.upperBound))
     }
 
     /// Loads thresholds from SharedDefaults with fallback to defaults.
@@ -427,17 +479,44 @@ struct GestureClassificationThresholds {
     /// toggling expert mode off and on again.
     static func fromUserDefaults(store: UserDefaults = SharedDefaults.store) -> GestureClassificationThresholds {
         guard store.bool(forKey: SettingsKey.expertModeEnabled.rawValue) else { return .default }
-        let start = loadCGFloat(from: store, key: returnDisplacementStartKey, default: defaultReturnDisplacementStart)
-        let end = loadCGFloat(from: store, key: returnDisplacementEndKey, default: defaultReturnDisplacementEnd)
+        let start = clampedCGFloat(
+            from: store, key: returnDisplacementStartKey,
+            default: defaultReturnDisplacementStart, range: returnDisplacementStartRange
+        )
+        let end = clampedCGFloat(
+            from: store, key: returnDisplacementEndKey,
+            default: defaultReturnDisplacementEnd, range: returnDisplacementEndRange
+        )
         return GestureClassificationThresholds(
-            minSwipeLength: loadCGFloat(from: store, key: minSwipeLengthKey, default: defaultMinSwipeLength),
-            maxReturnRatio: loadCGFloat(from: store, key: maxReturnRatioKey, default: defaultMaxReturnRatio),
+            minSwipeLength: clampedCGFloat(
+                from: store, key: minSwipeLengthKey,
+                default: defaultMinSwipeLength, range: minSwipeLengthRange
+            ),
+            maxReturnRatio: clampedCGFloat(
+                from: store, key: maxReturnRatioKey,
+                default: defaultMaxReturnRatio, range: maxReturnRatioRange
+            ),
             returnDisplacementRange: min(start, end) ... max(start, end),
-            minCircularity: loadCGFloat(from: store, key: minCircularityKey, default: defaultMinCircularity),
-            minAngularSpan: loadCGFloat(from: store, key: minAngularSpanKey, default: defaultMinAngularSpan),
-            minPathSeparation: loadCGFloat(from: store, key: minPathSeparationKey, default: defaultMinPathSeparation),
-            minTurnConsistency: loadCGFloat(from: store, key: minTurnConsistencyKey, default: defaultMinTurnConsistency),
-            minOrientedCompactness: loadCGFloat(from: store, key: minOrientedCompactnessKey, default: defaultMinOrientedCompactness)
+            minCircularity: clampedCGFloat(
+                from: store, key: minCircularityKey,
+                default: defaultMinCircularity, range: minCircularityRange
+            ),
+            minAngularSpan: clampedCGFloat(
+                from: store, key: minAngularSpanKey,
+                default: defaultMinAngularSpan, range: minAngularSpanRange
+            ),
+            minPathSeparation: clampedCGFloat(
+                from: store, key: minPathSeparationKey,
+                default: defaultMinPathSeparation, range: minPathSeparationRange
+            ),
+            minTurnConsistency: clampedCGFloat(
+                from: store, key: minTurnConsistencyKey,
+                default: defaultMinTurnConsistency, range: minTurnConsistencyRange
+            ),
+            minOrientedCompactness: clampedCGFloat(
+                from: store, key: minOrientedCompactnessKey,
+                default: defaultMinOrientedCompactness, range: minOrientedCompactnessRange
+            )
         )
     }
 }

--- a/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
@@ -127,15 +127,17 @@ struct KeyGestureRecognizer: ViewModifier {
                         inFlight = true
                     }
                     .onChanged { value in
-                        let isTouchDown = sequence.handleChanged(translation: value.translation)
+                        // A fired long press owns the rest of this touch: the
+                        // digit is typed, the release is discarded in `onEnded`,
+                        // so neither the ring buffer nor the trail should keep
+                        // following the finger at the display rate.
                         if longPress.consumedTouch {
-                            // The long press already typed its digit. A trail
-                            // that kept following the finger would advertise a
-                            // gesture that will never be dispatched.
                             trail?.cancel(from: trailToken)
-                        } else {
-                            trail?.record(value.location, isTouchDown: isTouchDown, from: trailToken)
+                            isActive = true
+                            return
                         }
+                        let isTouchDown = sequence.handleChanged(translation: value.translation)
+                        trail?.record(value.location, isTouchDown: isTouchDown, from: trailToken)
                         if isTouchDown {
                             onTouchDown()
                             scheduleLongPress()
@@ -174,23 +176,29 @@ struct KeyGestureRecognizer: ViewModifier {
                 // cancelled the touches. Discard the partial gesture without
                 // classifying it.
                 guard !inFlight, sequence.isTracking else { return }
-                longPress.cancel()
-                longPress.clearConsumed()
-                sequence.handleCancelled()
-                trail?.cancel(from: trailToken)
+                abandonSequence()
                 isActive = false
             }
             .onDisappear {
-                // A key torn down mid-gesture (mode switch, rotation,
-                // definition reload) reaches neither `onEnded` nor the
-                // `sequenceInFlight` reset — both live on the view that went
-                // away — so it hands the trail back here. Otherwise the
-                // recorder keeps it marked visible with no fade scheduled and
-                // the overlay redraws at the display rate until the next
-                // touch. Ownership makes this a no-op for any key that is not
-                // the one drawing, including while a trail is fading.
-                trail?.cancel(from: trailToken)
+                // A key torn down mid-gesture hands its touch back here: the
+                // recorder would otherwise keep the trail marked visible with
+                // no fade scheduled, and the armed long press would still fire.
+                // Ownership makes the trail hand-back a no-op for any key that
+                // is not the one drawing, including while a trail is fading.
+                abandonSequence()
             }
+    }
+
+    /// Drops everything the in-flight touch owns: the armed long press, the
+    /// partial path, and the trail. Shared by the system-cancel path and by
+    /// teardown — a key removed mid-gesture (mode switch, rotation, definition
+    /// reload) reaches neither `onEnded` nor the `sequenceInFlight` reset,
+    /// because both live on the view that went away, so an armed work item
+    /// would fire 0.7 s later and type the old key's digit into the new mode.
+    private func abandonSequence() {
+        longPress.abandon()
+        sequence.handleCancelled()
+        trail?.cancel(from: trailToken)
     }
 
     // MARK: - Long Press
@@ -279,30 +287,40 @@ struct KeyGestureRecognizer: ViewModifier {
     }
 
     /// Maps an angle (radians, from `atan2`) to the corresponding swipe
-    /// `GestureType`. Sector boundaries match `KeyboardButton.angleToDirection`.
+    /// `GestureType`.
     static func angleToGestureType(_ angle: CGFloat) -> GestureType {
         let normalized = angle < 0 ? angle + 2 * .pi : angle
-        let degrees = normalized * 180 / .pi
+        return gestureType(forDegrees: normalized * 180 / .pi)
+    }
 
+    /// Maps a normalized angle in degrees (`atan2` convention: 0 = right,
+    /// 90 = down) to its 45° swipe sector. Every sector owns its lower
+    /// boundary and stops short of the next one, so exactly 22.5° is a
+    /// down-right swipe; the sector around 0° wraps across both ends of the
+    /// range, and anything outside it (including NaN) falls back to right.
+    /// Separate from `angleToGestureType` so the boundaries can be tested at
+    /// their exact values — the degree/radian round trip is one ulp off for
+    /// several of them, which is exactly where the convention lives.
+    static func gestureType(forDegrees degrees: CGFloat) -> GestureType {
         switch degrees {
         case 337.5 ... 360, 0 ..< 22.5:
-            return .swipeRight
+            .swipeRight
         case 22.5 ..< 67.5:
-            return .swipeDownRight
+            .swipeDownRight
         case 67.5 ..< 112.5:
-            return .swipeDown
+            .swipeDown
         case 112.5 ..< 157.5:
-            return .swipeDownLeft
+            .swipeDownLeft
         case 157.5 ..< 202.5:
-            return .swipeLeft
+            .swipeLeft
         case 202.5 ..< 247.5:
-            return .swipeUpLeft
+            .swipeUpLeft
         case 247.5 ..< 292.5:
-            return .swipeUp
+            .swipeUp
         case 292.5 ..< 337.5:
-            return .swipeUpRight
+            .swipeUpRight
         default:
-            return .swipeRight
+            .swipeRight
         }
     }
 }

--- a/wurstfingerKeyboard/Runtime/Gesture/LongPressScheduler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/LongPressScheduler.swift
@@ -14,11 +14,8 @@ import Foundation
 /// flag for a gesture recognizer.
 ///
 /// A reference type so it can live in `@State` and mutate in place across
-/// SwiftUI body re-evaluations (the same reason the recognizers previously
-/// held two `@State` values directly). The recognizer supplies its fire guard
-/// as the `fire` closure, evaluated at fire time exactly as the old
-/// `fireLongPress()` read live `@State` — so extracting this changes no
-/// timing or staleness behavior.
+/// SwiftUI body re-evaluations. The recognizer supplies its fire guard as the
+/// `fire` closure, evaluated at fire time so that it reads live `@State`.
 final class LongPressScheduler {
     private var pending: DispatchWorkItem?
 
@@ -60,5 +57,13 @@ final class LongPressScheduler {
     /// Clears the consumed-touch flag before the next touch sequence.
     func clearConsumed() {
         consumedTouch = false
+    }
+
+    /// Drops both halves of a touch that ends without a release: the armed
+    /// timer and the consumed-touch flag. Cancelling only the timer would
+    /// leave the next touch on this key starting out already consumed.
+    func abandon() {
+        cancel()
+        clearConsumed()
     }
 }

--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -30,6 +30,47 @@ enum SlidePhase: Equatable {
     case cancelled
 }
 
+/// Thresholds a slide key classifies against.
+///
+/// Bundled per key rather than passed as loose arguments: the delete key has
+/// no up-swipe binding (`KeyboardViewModel.handleDeleteSlide` ignores
+/// `.swipeUp`), so handing it the space bar's up-swipe threshold makes a
+/// diagonal delete drag latch no slide and end as an up-swipe nobody
+/// consumes — deleting nothing at all.
+struct SlideGestureConfiguration: Equatable {
+    /// Horizontal travel that latches the continuous slide.
+    let activationThreshold: CGFloat
+
+    /// Upward travel that classifies a vertical swipe, or nil for keys
+    /// without an up-swipe binding — those never let the vertical axis block
+    /// the latch and never report `.swipeUp`.
+    let swipeUpThreshold: CGFloat?
+
+    static let moveCursor = SlideGestureConfiguration(
+        activationThreshold: KeyboardConstants.SpaceGestures.dragActivationThreshold,
+        swipeUpThreshold: KeyboardConstants.SpaceGestures.swipeUpActivationThreshold
+    )
+
+    static let delete = SlideGestureConfiguration(
+        activationThreshold: KeyboardConstants.DeleteGestures.slideActivationThreshold,
+        swipeUpThreshold: nil
+    )
+
+    /// A key without slide behavior: nothing can latch.
+    static let inactive = SlideGestureConfiguration(
+        activationThreshold: .infinity,
+        swipeUpThreshold: nil
+    )
+
+    static func `for`(_ slideType: SlideType) -> SlideGestureConfiguration {
+        switch slideType {
+        case .moveCursor: .moveCursor
+        case .delete: .delete
+        case .none: .inactive
+        }
+    }
+}
+
 /// State machine backing `SlideGestureHandler`.
 ///
 /// Extracted as a pure value type so tap/slide classification and
@@ -55,8 +96,7 @@ struct SlideGestureState {
     /// Processes one `onChanged` sample.
     mutating func handleChanged(
         translation: CGSize,
-        activationThreshold: CGFloat,
-        swipeUpThreshold: CGFloat = KeyboardConstants.SpaceGestures.swipeUpActivationThreshold
+        configuration: SlideGestureConfiguration
     ) -> Update {
         var update = Update()
         if !dragStarted {
@@ -91,19 +131,24 @@ struct SlideGestureState {
         // terms (≥ the 30 pt up-swipe threshold) and strongly horizontal
         // (> 2× the vertical). Return-leg drift (~10 pt sideways) stays well
         // below the 30 pt floor, so this does not re-introduce the return-up
-        // mis-latch the peak guard was added to fix.
-        let dominantHorizontalSlide = abs(currentX) >= swipeUpThreshold
-            && abs(currentX) > abs(translation.height) * 2
+        // mis-latch the peak guard was added to fix. A key without an up-swipe
+        // binding has no threshold at all, so neither guard applies to it.
+        let upSwipeCommitted = configuration.swipeUpThreshold.map { -upwardPeakY >= $0 } ?? false
+        let dominantHorizontalSlide = configuration.swipeUpThreshold.map {
+            abs(currentX) >= $0 && abs(currentX) > abs(translation.height) * 2
+        } ?? false
         if !isSliding,
-           abs(currentX) >= activationThreshold,
+           abs(currentX) >= configuration.activationThreshold,
            abs(currentX) > abs(translation.height),
-           -upwardPeakY < swipeUpThreshold || dominantHorizontalSlide {
+           !upSwipeCommitted || dominantHorizontalSlide {
             isSliding = true
             // Anchor at the threshold crossing (not the full translation) so
             // the travel beyond the threshold is reported on the same tick
             // instead of being dropped — otherwise the first `threshold`
             // points are a dead zone.
-            lastTranslationX = currentX < 0 ? -activationThreshold : activationThreshold
+            lastTranslationX = currentX < 0
+                ? -configuration.activationThreshold
+                : configuration.activationThreshold
             update.phases.append(.began)
         }
 
@@ -122,8 +167,7 @@ struct SlideGestureState {
     /// gesture qualifies as neither a slide, an up-swipe, nor a tap.
     mutating func handleEnded(
         translation: CGSize,
-        activationThreshold: CGFloat,
-        swipeUpThreshold: CGFloat = KeyboardConstants.SpaceGestures.swipeUpActivationThreshold
+        configuration: SlideGestureConfiguration
     ) -> SlidePhase? {
         defer { reset() }
         if isSliding { return .ended }
@@ -131,7 +175,7 @@ struct SlideGestureState {
         // activated, so cursor drags with vertical drift are unaffected. It
         // must precede the tap check: a return-up swipe ends near its origin
         // and would otherwise be classified as a tap.
-        if -upwardPeakY >= swipeUpThreshold {
+        if let swipeUpThreshold = configuration.swipeUpThreshold, -upwardPeakY >= swipeUpThreshold {
             // The finger "returned" when it came back at least
             // (1 - returnSwipeThreshold) of the way from the peak toward the
             // origin. Compared signed (peak is negative, y grows downward) so
@@ -147,7 +191,7 @@ struct SlideGestureState {
         // horizontal travel alone would classify a vertical flick (e.g.
         // 80 pt up on the space bar) as a tap and commit its center action.
         let displacement = hypot(translation.width, translation.height)
-        return displacement < activationThreshold ? .tap : nil
+        return displacement < configuration.activationThreshold ? .tap : nil
     }
 
     /// Processes a system cancellation of the touch sequence (`onEnded` is
@@ -226,7 +270,7 @@ struct SlideGestureHandler: ViewModifier {
                         }
                         let update = state.handleChanged(
                             translation: value.translation,
-                            activationThreshold: activationThreshold
+                            configuration: configuration
                         )
                         trail?.record(value.location, isTouchDown: update.isTouchDown, from: trailToken)
                         if update.isTouchDown {
@@ -255,7 +299,7 @@ struct SlideGestureHandler: ViewModifier {
                         }
                         if let phase = state.handleEnded(
                             translation: value.translation,
-                            activationThreshold: activationThreshold
+                            configuration: configuration
                         ) {
                             onSlide(phase)
                         }
@@ -268,20 +312,27 @@ struct SlideGestureHandler: ViewModifier {
                 // if the sequence stops while a drag is still marked as in
                 // flight, the system cancelled the touches.
                 guard !inFlight else { return }
-                longPress.cancel()
-                longPress.clearConsumed()
-                if let phase = state.handleCancelled() {
-                    onSlide(phase)
-                }
-                trail?.cancel(from: trailToken)
+                if let phase = abandonSequence() { onSlide(phase) }
                 isActive = false
             }
             // A key removed mid-gesture reaches neither `onEnded` nor the
-            // cancel path, so it hands the trail back here instead of leaving
-            // the overlay redrawing at the display rate.
+            // cancel path, so it hands its touch back here — trail included,
+            // and before the armed long press can fire into the next mode. No
+            // phase is reported: the consumer's drag flags are re-initialized
+            // by the next `.began`, exactly like the consumed-long-press branch.
             .onDisappear {
-                trail?.cancel(from: trailToken)
+                _ = abandonSequence()
             }
+    }
+
+    /// Drops everything the in-flight touch owns: the armed long press, the
+    /// drag state, and the trail. Returns the phase the consumer must hear
+    /// about (`.cancelled` while a drag was in flight), or nil.
+    private func abandonSequence() -> SlidePhase? {
+        longPress.abandon()
+        let phase = state.handleCancelled()
+        trail?.cancel(from: trailToken)
+        return phase
     }
 
     // MARK: - Long Press
@@ -302,14 +353,7 @@ struct SlideGestureHandler: ViewModifier {
         }
     }
 
-    private var activationThreshold: CGFloat {
-        switch slideType {
-        case .moveCursor:
-            KeyboardConstants.SpaceGestures.dragActivationThreshold
-        case .delete:
-            KeyboardConstants.DeleteGestures.slideActivationThreshold
-        case .none:
-            .infinity
-        }
+    private var configuration: SlideGestureConfiguration {
+        .for(slideType)
     }
 }

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -510,17 +510,48 @@ extension KeyboardViewModel {
 
     /// Continuous (joystick) mode: emit one character move per `dragStep` of
     /// accumulated travel.
+    ///
+    /// The surrounding context is read once per drag update and then walked
+    /// locally. `adjustTextPosition` reaches the host application
+    /// asynchronously, so when a single update owes more than one step, the
+    /// context read back for the second step can still describe the caret
+    /// *before* the first move — measuring the same cluster twice and skipping
+    /// a character or landing inside an emoji. Device-only: the mock target
+    /// updates its context in place.
     private func stepContinuousCursor() {
-        while spaceDragResidual <= -KeyboardConstants.SpaceGestures.dragStep {
-            dispatchAction(.moveCursor(offset: singleGraphemeOffset(direction: -1)))
+        let step = KeyboardConstants.SpaceGestures.dragStep
+        // A legitimate 120 Hz update owes one or two steps; the cap keeps a
+        // corrupt residual (non-finite or absurd) from trapping the `Int`
+        // conversion or emitting an unbounded burst. Whatever is left over
+        // stays in the residual and is emitted by the following update.
+        let raw = (spaceDragResidual / step).rounded(.towardZero)
+        guard raw.isFinite, raw != 0 else { return }
+        let steps = Int(min(max(raw, -Self.maxCursorStepsPerUpdate), Self.maxCursorStepsPerUpdate))
+        let direction = steps < 0 ? -1 : 1
+        let context = direction > 0
+            ? textInputTarget?.documentContextAfterInput
+            : textInputTarget?.documentContextBeforeInput
+        for width in Self.clusterWidths(in: context ?? "", count: abs(steps), fromEnd: direction < 0) {
+            dispatchAction(.moveCursor(offset: direction * width))
             feedbackDrag()
-            spaceDragResidual += KeyboardConstants.SpaceGestures.dragStep
         }
-        while spaceDragResidual >= KeyboardConstants.SpaceGestures.dragStep {
-            dispatchAction(.moveCursor(offset: singleGraphemeOffset(direction: 1)))
-            feedbackDrag()
-            spaceDragResidual -= KeyboardConstants.SpaceGestures.dragStep
-        }
+        spaceDragResidual -= CGFloat(steps) * step
+    }
+
+    /// Upper bound on cursor steps emitted from one drag update.
+    private static let maxCursorStepsPerUpdate: CGFloat = 32
+
+    /// UTF-16 widths of the first `count` grapheme clusters of `context`,
+    /// ordered away from the caret (`fromEnd` walks the text behind the caret
+    /// backwards). Steps beyond the known context fall back to one code unit
+    /// each — the same fallback `singleGraphemeOffset` uses when the host
+    /// exposes no context at all.
+    static func clusterWidths(in context: String, count: Int, fromEnd: Bool) -> [Int] {
+        guard count > 0 else { return [] }
+        let clusters = fromEnd
+            ? Array(context.suffix(count).reversed())
+            : Array(context.prefix(count))
+        return (0 ..< count).map { $0 < clusters.count ? clusters[$0].utf16.count : 1 }
     }
 
     /// UTF-16 offset that moves the cursor across exactly one grapheme cluster
@@ -631,7 +662,8 @@ extension KeyboardViewModel {
             handleGesture(.tap, keyId: key.id, isReturn: false)
         case .swipeUp:
             // The delete key has no vertical gestures; label toggles are a
-            // space-bar feature. Vertical flicks stay ignored.
+            // space-bar feature. `SlideGestureConfiguration.delete` never
+            // classifies one, so this case only keeps the switch exhaustive.
             break
         }
     }

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -103,10 +103,6 @@ enum KeyboardConstants {
     // MARK: - Gesture Recognition
 
     enum Gesture {
-        /// Minimum swipe distance to register as a swipe (not a tap).
-        /// ~55% of key height (54pt × 0.55 ≈ 30pt) to avoid accidental swipes.
-        static let minSwipeLength: CGFloat = 30
-
         /// Tolerance for circular gesture end-point matching.
         /// How close the finger must return to the start point to complete a circle.
         static let circleCompletionTolerance: CGFloat = 16
@@ -230,9 +226,12 @@ enum KeyboardConstants {
         static let returnSwipeThreshold: CGFloat = 0.3
 
         /// Minimum upward travel to classify a vertical space-bar swipe
-        /// (label-visibility toggle). Mirrors `Gesture.minSwipeLength` so the
-        /// space bar demands the same commitment as a key swipe.
-        static let swipeUpActivationThreshold: CGFloat = Gesture.minSwipeLength
+        /// (label-visibility toggle). Deliberately above the classifier's
+        /// swipe-vs-tap boundary (`GestureClassificationThresholds`
+        /// `.defaultMinSwipeLength`, 20pt): the space bar lies under the
+        /// thumbs and collects incidental upward drift, so the toggle asks for
+        /// a longer, more deliberate flick.
+        static let swipeUpActivationThreshold: CGFloat = 30
     }
 
     // MARK: - Delete Key Gestures

--- a/wurstfingerTests/CursorMovementTests.swift
+++ b/wurstfingerTests/CursorMovementTests.swift
@@ -247,3 +247,63 @@ struct DiscreteCursorMovementTests {
         #expect(target.documentContextBeforeInput == "x")
     }
 }
+
+// MARK: - Continuous slides against a lagging document context
+
+/// Models the real `UITextDocumentProxy`: `adjustTextPosition` reaches the host
+/// application asynchronously, so the context read back inside the same runloop
+/// turn can still describe the caret before the move. `MockTextTarget` updates
+/// in place, which hides per-step context re-reads entirely.
+private final class FrozenContextTextTarget: TextInputTarget {
+    var offsets: [Int] = []
+    var documentContextBeforeInput: String?
+    var documentContextAfterInput: String?
+    var selectedText: String?
+    var hasFullAccess = false
+
+    func insertText(_ text: String) {}
+    func deleteBackward() {}
+    func adjustTextPosition(byCharacterOffset offset: Int) {
+        offsets.append(offset)
+    }
+}
+
+@Suite(.serialized)
+struct ContinuousCursorSnapshotTests {
+    private func makeViewModel() -> (KeyboardViewModel, FrozenContextTextTarget) {
+        let vm = KeyboardViewModel(userDefaults: InMemoryUserDefaults(), shouldPersistSettings: false)
+        let target = FrozenContextTextTarget()
+        vm.bindTextInputTarget(target)
+        vm.loadDefinition(for: "de_DE")
+        return (vm, target)
+    }
+
+    @Test func multiStepSlideMeasuresEveryClusterFromOneSnapshot() throws {
+        let (vm, target) = makeViewModel()
+        target.documentContextAfterInput = "👍x"
+        let key = try #require(vm.activeModeFromDefinition?.key(for: UtilitySlot.space))
+        vm.handleSlide(key, phase: .began)
+        vm.handleSlide(key, phase: .changed(deltaX: KeyboardConstants.SpaceGestures.dragStep * 2))
+        vm.handleSlide(key, phase: .ended)
+        // 👍 is a surrogate pair, x is one unit. Re-reading a context the host
+        // has not updated yet measures 👍 twice and jumps past x.
+        #expect(target.offsets == [2, 1])
+    }
+
+    @Test func nonFiniteDragDeltaMovesNothing() throws {
+        let (vm, target) = makeViewModel()
+        let key = try #require(vm.activeModeFromDefinition?.key(for: UtilitySlot.space))
+        vm.handleSlide(key, phase: .began)
+        vm.handleSlide(key, phase: .changed(deltaX: .nan))
+        vm.handleSlide(key, phase: .ended)
+        #expect(target.offsets.isEmpty)
+    }
+
+    @Test func clusterWidthsWalkAwayFromTheCaret() {
+        #expect(KeyboardViewModel.clusterWidths(in: "👍🏽x", count: 2, fromEnd: false) == [4, 1])
+        #expect(KeyboardViewModel.clusterWidths(in: "x👍", count: 2, fromEnd: true) == [2, 1])
+        // Beyond the known context: one code unit per step.
+        #expect(KeyboardViewModel.clusterWidths(in: "", count: 3, fromEnd: false) == [1, 1, 1])
+        #expect(KeyboardViewModel.clusterWidths(in: "abc", count: 0, fromEnd: false) == [])
+    }
+}

--- a/wurstfingerTests/GesturePreprocessorRobustnessTests.swift
+++ b/wurstfingerTests/GesturePreprocessorRobustnessTests.swift
@@ -103,3 +103,75 @@ struct GesturePreprocessorRobustnessTests {
         #expect(!features.isCircular)
     }
 }
+
+// MARK: - Expert-mode store values
+
+/// A stale or foreign value in the shared store must not reach classification:
+/// every expert value is clamped to the range the Expert UI offers.
+struct ExpertValueClampingTests {
+    private func expertStore() -> InMemoryUserDefaults {
+        let store = InMemoryUserDefaults()
+        store.set(true, forKey: SettingsKey.expertModeEnabled.rawValue)
+        return store
+    }
+
+    @Test func nonPositiveMinSwipeLengthCannotTurnEveryTouchIntoASwipe() {
+        let store = expertStore()
+        store.set(0.0, forKey: GestureClassificationThresholds.minSwipeLengthKey)
+        let thresholds = GestureClassificationThresholds.fromUserDefaults(store: store)
+        #expect(thresholds.minSwipeLength
+            == CGFloat(GestureClassificationThresholds.minSwipeLengthRange.lowerBound))
+        let result = KeyGestureRecognizer.classify(
+            positions: [.zero, CGPoint(x: 2, y: 1)], config: .default, thresholds: thresholds
+        )
+        #expect(result.gesture == .tap)
+    }
+
+    @Test func storeValuesAboveTheExpertRangeClampToItsUpperBound() {
+        let store = expertStore()
+        store.set(9999.0, forKey: GesturePreprocessorConfig.jitterThresholdKey)
+        store.set(9999.0, forKey: GesturePreprocessorConfig.maxJumpDistanceKey)
+        store.set(99, forKey: GesturePreprocessorConfig.smoothingWindowKey)
+        store.set(9999.0, forKey: GestureClassificationThresholds.minSwipeLengthKey)
+        store.set(9999.0, forKey: GestureClassificationThresholds.maxReturnRatioKey)
+        store.set(9999.0, forKey: GestureClassificationThresholds.minCircularityKey)
+        let config = GesturePreprocessorConfig.fromUserDefaults(store: store)
+        let thresholds = GestureClassificationThresholds.fromUserDefaults(store: store)
+        #expect(config.jitterThreshold == CGFloat(GesturePreprocessorConfig.jitterThresholdRange.upperBound))
+        #expect(config.maxJumpDistance == CGFloat(GesturePreprocessorConfig.maxJumpDistanceRange.upperBound))
+        #expect(config.smoothingWindow == GesturePreprocessorConfig.smoothingWindowRange.upperBound)
+        #expect(thresholds.minSwipeLength
+            == CGFloat(GestureClassificationThresholds.minSwipeLengthRange.upperBound))
+        #expect(thresholds.maxReturnRatio
+            == CGFloat(GestureClassificationThresholds.maxReturnRatioRange.upperBound))
+        #expect(thresholds.minCircularity
+            == CGFloat(GestureClassificationThresholds.minCircularityRange.upperBound))
+    }
+
+    @Test func negativeStoreValuesClampToTheExpertLowerBound() {
+        let store = expertStore()
+        store.set(-5.0, forKey: GesturePreprocessorConfig.jitterThresholdKey)
+        store.set(-5.0, forKey: GesturePreprocessorConfig.maxJumpDistanceKey)
+        store.set(-5, forKey: GesturePreprocessorConfig.smoothingWindowKey)
+        let config = GesturePreprocessorConfig.fromUserDefaults(store: store)
+        #expect(config.jitterThreshold == CGFloat(GesturePreprocessorConfig.jitterThresholdRange.lowerBound))
+        #expect(config.maxJumpDistance == CGFloat(GesturePreprocessorConfig.maxJumpDistanceRange.lowerBound))
+        #expect(config.smoothingWindow == GesturePreprocessorConfig.smoothingWindowRange.lowerBound)
+    }
+
+    @Test func evenSmoothingWindowStillRoundsUpInsideTheRange() {
+        let store = expertStore()
+        store.set(10, forKey: GesturePreprocessorConfig.smoothingWindowKey)
+        #expect(GesturePreprocessorConfig.fromUserDefaults(store: store).smoothingWindow == 11)
+    }
+
+    @Test func nonFiniteStoreValueStillFallsBackToTheDefault() {
+        let store = expertStore()
+        store.set(Double.nan, forKey: GestureClassificationThresholds.minSwipeLengthKey)
+        store.set(Double.infinity, forKey: GesturePreprocessorConfig.jitterThresholdKey)
+        #expect(GestureClassificationThresholds.fromUserDefaults(store: store).minSwipeLength
+            == GestureClassificationThresholds.defaultMinSwipeLength)
+        #expect(GesturePreprocessorConfig.fromUserDefaults(store: store).jitterThreshold
+            == GesturePreprocessorConfig.defaultJitterThreshold)
+    }
+}

--- a/wurstfingerTests/GesturePreprocessorTests.swift
+++ b/wurstfingerTests/GesturePreprocessorTests.swift
@@ -491,12 +491,14 @@ struct ExpertModeGatingTests {
     private func storeWithCustomValues(expertModeEnabled: Bool) -> InMemoryUserDefaults {
         let store = InMemoryUserDefaults()
         store.set(expertModeEnabled, forKey: SettingsKey.expertModeEnabled.rawValue)
+        // Inside the Expert ranges: out-of-range values are clamped (see
+        // ExpertValueClampingTests).
         store.set(9.0, forKey: GesturePreprocessorConfig.jitterThresholdKey)
-        store.set(120.0, forKey: GesturePreprocessorConfig.maxJumpDistanceKey)
+        store.set(90.0, forKey: GesturePreprocessorConfig.maxJumpDistanceKey)
         store.set(7, forKey: GesturePreprocessorConfig.smoothingWindowKey)
         store.set(42.0, forKey: GestureClassificationThresholds.minSwipeLengthKey)
-        store.set(0.9, forKey: GestureClassificationThresholds.maxReturnRatioKey)
-        store.set(0.75, forKey: GestureClassificationThresholds.minCircularityKey)
+        store.set(0.7, forKey: GestureClassificationThresholds.maxReturnRatioKey)
+        store.set(0.6, forKey: GestureClassificationThresholds.minCircularityKey)
         return store
     }
 
@@ -516,7 +518,7 @@ struct ExpertModeGatingTests {
         let config = GesturePreprocessorConfig.fromUserDefaults(store: store)
 
         #expect(config.jitterThreshold == 9.0)
-        #expect(config.maxJumpDistance == 120.0)
+        #expect(config.maxJumpDistance == 90.0)
         #expect(config.smoothingWindow == 7)
     }
 
@@ -545,8 +547,8 @@ struct ExpertModeGatingTests {
         let thresholds = GestureClassificationThresholds.fromUserDefaults(store: store)
 
         #expect(thresholds.minSwipeLength == 42.0)
-        #expect(thresholds.maxReturnRatio == 0.9)
-        #expect(thresholds.minCircularity == 0.75)
+        #expect(thresholds.maxReturnRatio == 0.7)
+        #expect(thresholds.minCircularity == 0.6)
     }
 
     @Test func customValuesSurviveExpertModeRoundTrip() {
@@ -569,6 +571,6 @@ struct ExpertModeGatingTests {
 
         store.set(true, forKey: SettingsKey.expertModeEnabled.rawValue)
         #expect(GesturePreprocessorConfig.fromUserDefaults(store: store).jitterThreshold == 9.0)
-        #expect(GesturePreprocessorConfig.fromUserDefaults(store: store).maxJumpDistance == 120.0)
+        #expect(GesturePreprocessorConfig.fromUserDefaults(store: store).maxJumpDistance == 90.0)
     }
 }

--- a/wurstfingerTests/KeyGestureClassificationTests.swift
+++ b/wurstfingerTests/KeyGestureClassificationTests.swift
@@ -89,6 +89,34 @@ struct AngleToGestureTypeTests {
         // Slightly negative (≈ -5.7°) normalizes to ≈ 354° → right sector.
         #expect(KeyGestureRecognizer.angleToGestureType(-0.1) == .swipeRight)
     }
+
+    /// Every sector owns its lower boundary; one ulp below belongs to the
+    /// previous sector. Flipping any `..<` to `...` moves a boundary and fails
+    /// here.
+    @Test(arguments: [
+        (degrees: CGFloat(22.5), sector: GestureType.swipeDownRight, previous: GestureType.swipeRight),
+        (degrees: 67.5, sector: .swipeDown, previous: .swipeDownRight),
+        (degrees: 112.5, sector: .swipeDownLeft, previous: .swipeDown),
+        (degrees: 157.5, sector: .swipeLeft, previous: .swipeDownLeft),
+        (degrees: 202.5, sector: .swipeUpLeft, previous: .swipeLeft),
+        (degrees: 247.5, sector: .swipeUp, previous: .swipeUpLeft),
+        (degrees: 292.5, sector: .swipeUpRight, previous: .swipeUp),
+        (degrees: 337.5, sector: .swipeRight, previous: .swipeUpRight),
+    ])
+    func sectorsOwnTheirLowerBoundary(
+        boundary: (degrees: CGFloat, sector: GestureType, previous: GestureType)
+    ) {
+        #expect(KeyGestureRecognizer.gestureType(forDegrees: boundary.degrees) == boundary.sector)
+        #expect(KeyGestureRecognizer.gestureType(forDegrees: boundary.degrees.nextDown) == boundary.previous)
+    }
+
+    @Test func wrapAroundSectorCoversBothEndsOfTheRange() {
+        #expect(KeyGestureRecognizer.gestureType(forDegrees: 0) == .swipeRight)
+        #expect(KeyGestureRecognizer.gestureType(forDegrees: 360) == .swipeRight)
+        #expect(KeyGestureRecognizer.gestureType(forDegrees: CGFloat(360).nextDown) == .swipeRight)
+        // Nothing outside the normalized range reaches a sector.
+        #expect(KeyGestureRecognizer.gestureType(forDegrees: .nan) == .swipeRight)
+    }
 }
 
 // MARK: - classify(features:)

--- a/wurstfingerTests/LongPressSchedulerTests.swift
+++ b/wurstfingerTests/LongPressSchedulerTests.swift
@@ -57,4 +57,54 @@ struct LongPressSchedulerTests {
             #expect(!scheduler.isScheduled)
         }
     }
+
+    @Test func cancelledWorkItemNeverFiresItsGuard() async {
+        await confirmation(expectedCount: 0) { fired in
+            let scheduler = LongPressScheduler()
+            scheduler.schedule(after: 0.02) {
+                fired()
+                return true
+            }
+            scheduler.cancel()
+            try? await Task.sleep(for: .milliseconds(200))
+            #expect(!scheduler.consumedTouch)
+            #expect(!scheduler.isScheduled)
+        }
+    }
+
+    /// Both halves matter: a teardown that only cancels the timer leaves the
+    /// consumed flag set, and the next touch on the key produces no tap.
+    @Test func abandonDropsTheArmedItemAndTheConsumedFlag() async {
+        await confirmation(expectedCount: 0) { fired in
+            let scheduler = LongPressScheduler()
+            scheduler.runFire { true }
+            #expect(scheduler.consumedTouch)
+            scheduler.schedule(after: 0.02) {
+                fired()
+                return true
+            }
+            scheduler.abandon()
+            try? await Task.sleep(for: .milliseconds(200))
+            #expect(!scheduler.isScheduled)
+            #expect(!scheduler.consumedTouch)
+        }
+    }
+
+    @Test func rescheduleCancelsThePreviouslyArmedItem() async {
+        await confirmation(expectedCount: 0) { superseded in
+            await confirmation { fired in
+                let scheduler = LongPressScheduler()
+                scheduler.schedule(after: 0.02) {
+                    superseded()
+                    return true
+                }
+                scheduler.schedule(after: 0.05) {
+                    fired()
+                    return true
+                }
+                try? await Task.sleep(for: .milliseconds(300))
+                #expect(scheduler.consumedTouch)
+            }
+        }
+    }
 }

--- a/wurstfingerTests/SlideGestureStateTests.swift
+++ b/wurstfingerTests/SlideGestureStateTests.swift
@@ -21,11 +21,11 @@ struct SlideGestureStateTests {
     @Test func firstChangeReportsTouchDown() {
         var state = SlideGestureState()
         let update = state.handleChanged(
-            translation: CGSize(width: 1, height: 0), activationThreshold: threshold
+            translation: CGSize(width: 1, height: 0), configuration: .moveCursor
         )
         #expect(update.isTouchDown)
         let second = state.handleChanged(
-            translation: CGSize(width: 2, height: 0), activationThreshold: threshold
+            translation: CGSize(width: 2, height: 0), configuration: .moveCursor
         )
         #expect(!second.isTouchDown)
     }
@@ -33,10 +33,10 @@ struct SlideGestureStateTests {
     @Test func smallMovementEndsAsTap() {
         var state = SlideGestureState()
         _ = state.handleChanged(
-            translation: CGSize(width: 2, height: 2), activationThreshold: threshold
+            translation: CGSize(width: 2, height: 2), configuration: .moveCursor
         )
         let phase = state.handleEnded(
-            translation: CGSize(width: 2, height: 2), activationThreshold: threshold
+            translation: CGSize(width: 2, height: 2), configuration: .moveCursor
         )
         #expect(phase == .tap)
     }
@@ -45,14 +45,14 @@ struct SlideGestureStateTests {
         var state = SlideGestureState()
         let update = state.handleChanged(
             translation: CGSize(width: threshold + 4, height: 0),
-            activationThreshold: threshold
+            configuration: .moveCursor
         )
         // Anchored at the threshold crossing: the overshoot is reported
         // immediately instead of being dropped.
         #expect(update.phases == [.began, .changed(deltaX: 4)])
         let phase = state.handleEnded(
             translation: CGSize(width: threshold + 4, height: 0),
-            activationThreshold: threshold
+            configuration: .moveCursor
         )
         #expect(phase == .ended)
     }
@@ -64,13 +64,13 @@ struct SlideGestureStateTests {
         // 80 pt vertical flick with almost no horizontal travel: previously
         // classified as a tap (space inserted / character deleted).
         _ = state.handleChanged(
-            translation: CGSize(width: 2, height: 40), activationThreshold: threshold
+            translation: CGSize(width: 2, height: 40), configuration: .moveCursor
         )
         _ = state.handleChanged(
-            translation: CGSize(width: 2, height: 80), activationThreshold: threshold
+            translation: CGSize(width: 2, height: 80), configuration: .moveCursor
         )
         let phase = state.handleEnded(
-            translation: CGSize(width: 2, height: 80), activationThreshold: threshold
+            translation: CGSize(width: 2, height: 80), configuration: .moveCursor
         )
         #expect(phase == nil)
     }
@@ -80,8 +80,8 @@ struct SlideGestureStateTests {
         // Horizontal travel alone is under the threshold, but the total
         // displacement is not — this is a drag, not a tap.
         let translation = CGSize(width: threshold * 0.75, height: threshold * 0.75)
-        _ = state.handleChanged(translation: translation, activationThreshold: threshold)
-        let phase = state.handleEnded(translation: translation, activationThreshold: threshold)
+        _ = state.handleChanged(translation: translation, configuration: .moveCursor)
+        let phase = state.handleEnded(translation: translation, configuration: .moveCursor)
         #expect(phase == nil)
     }
 
@@ -93,13 +93,13 @@ struct SlideGestureStateTests {
     @Test func upSwipeBeyondThresholdClassifiesAsSwipeUp() {
         var state = SlideGestureState()
         _ = state.handleChanged(
-            translation: CGSize(width: 2, height: -upThreshold), activationThreshold: threshold
+            translation: CGSize(width: 2, height: -upThreshold), configuration: .moveCursor
         )
         _ = state.handleChanged(
-            translation: CGSize(width: 2, height: -upThreshold - 30), activationThreshold: threshold
+            translation: CGSize(width: 2, height: -upThreshold - 30), configuration: .moveCursor
         )
         let phase = state.handleEnded(
-            translation: CGSize(width: 2, height: -upThreshold - 30), activationThreshold: threshold
+            translation: CGSize(width: 2, height: -upThreshold - 30), configuration: .moveCursor
         )
         #expect(phase == .swipeUp(isReturn: false))
     }
@@ -107,13 +107,13 @@ struct SlideGestureStateTests {
     @Test func upSwipeReturningToOriginClassifiesAsReturn() {
         var state = SlideGestureState()
         _ = state.handleChanged(
-            translation: CGSize(width: 0, height: -upThreshold - 30), activationThreshold: threshold
+            translation: CGSize(width: 0, height: -upThreshold - 30), configuration: .moveCursor
         )
         _ = state.handleChanged(
-            translation: CGSize(width: 0, height: -4), activationThreshold: threshold
+            translation: CGSize(width: 0, height: -4), configuration: .moveCursor
         )
         let phase = state.handleEnded(
-            translation: CGSize(width: 0, height: -4), activationThreshold: threshold
+            translation: CGSize(width: 0, height: -4), configuration: .moveCursor
         )
         // Ends near the origin (below the tap threshold!) but the peak makes
         // it a return-up swipe, not a tap.
@@ -128,17 +128,17 @@ struct SlideGestureStateTests {
         // never fired.
         let drift = threshold + 4
         let first = state.handleChanged(
-            translation: CGSize(width: drift, height: -drift - 6), activationThreshold: threshold
+            translation: CGSize(width: drift, height: -drift - 6), configuration: .moveCursor
         )
         #expect(first.phases.isEmpty)
         let second = state.handleChanged(
             translation: CGSize(width: drift, height: -upThreshold - 20),
-            activationThreshold: threshold
+            configuration: .moveCursor
         )
         #expect(second.phases.isEmpty)
         let phase = state.handleEnded(
             translation: CGSize(width: drift, height: -upThreshold - 20),
-            activationThreshold: threshold
+            configuration: .moveCursor
         )
         #expect(phase == .swipeUp(isReturn: false))
     }
@@ -149,17 +149,17 @@ struct SlideGestureStateTests {
         // block a genuine cursor slide once the horizontal axis takes over.
         let wobble = state.handleChanged(
             translation: CGSize(width: threshold, height: -threshold - 2),
-            activationThreshold: threshold
+            configuration: .moveCursor
         )
         #expect(wobble.phases.isEmpty)
         let sliding = state.handleChanged(
             translation: CGSize(width: threshold * 3, height: -threshold - 2),
-            activationThreshold: threshold
+            configuration: .moveCursor
         )
         #expect(sliding.phases.first == .began)
         let phase = state.handleEnded(
             translation: CGSize(width: threshold * 3, height: -threshold - 2),
-            activationThreshold: threshold
+            configuration: .moveCursor
         )
         #expect(phase == .ended)
     }
@@ -170,13 +170,13 @@ struct SlideGestureStateTests {
         // Measured as absolute distance from the origin this looked like a
         // plain up-swipe and toggled the wrong label group.
         _ = state.handleChanged(
-            translation: CGSize(width: 0, height: -upThreshold - 10), activationThreshold: threshold
+            translation: CGSize(width: 0, height: -upThreshold - 10), configuration: .moveCursor
         )
         _ = state.handleChanged(
-            translation: CGSize(width: 0, height: 20), activationThreshold: threshold
+            translation: CGSize(width: 0, height: 20), configuration: .moveCursor
         )
         let phase = state.handleEnded(
-            translation: CGSize(width: 0, height: 20), activationThreshold: threshold
+            translation: CGSize(width: 0, height: 20), configuration: .moveCursor
         )
         #expect(phase == .swipeUp(isReturn: true))
     }
@@ -184,16 +184,16 @@ struct SlideGestureStateTests {
     @Test func upSwipeBelowThresholdIsIgnored() {
         var state = SlideGestureState()
         let translation = CGSize(width: 0, height: -upThreshold + 4)
-        _ = state.handleChanged(translation: translation, activationThreshold: threshold)
-        let phase = state.handleEnded(translation: translation, activationThreshold: threshold)
+        _ = state.handleChanged(translation: translation, configuration: .moveCursor)
+        let phase = state.handleEnded(translation: translation, configuration: .moveCursor)
         #expect(phase == nil)
     }
 
     @Test func downwardSwipeIsIgnored() {
         var state = SlideGestureState()
         let translation = CGSize(width: 0, height: upThreshold + 30)
-        _ = state.handleChanged(translation: translation, activationThreshold: threshold)
-        let phase = state.handleEnded(translation: translation, activationThreshold: threshold)
+        _ = state.handleChanged(translation: translation, configuration: .moveCursor)
+        let phase = state.handleEnded(translation: translation, configuration: .moveCursor)
         #expect(phase == nil)
     }
 
@@ -211,11 +211,11 @@ struct SlideGestureStateTests {
             CGSize(width: 10, height: -6),
         ]
         for sample in samples {
-            let update = state.handleChanged(translation: sample, activationThreshold: threshold)
+            let update = state.handleChanged(translation: sample, configuration: .moveCursor)
             #expect(update.phases.isEmpty)
         }
         let phase = state.handleEnded(
-            translation: CGSize(width: 10, height: -6), activationThreshold: threshold
+            translation: CGSize(width: 10, height: -6), configuration: .moveCursor
         )
         #expect(phase == .swipeUp(isReturn: true))
     }
@@ -225,15 +225,15 @@ struct SlideGestureStateTests {
         // Horizontal slide activates first, then the finger drifts far up:
         // the gesture stays a cursor slide, never a label toggle.
         _ = state.handleChanged(
-            translation: CGSize(width: threshold + 4, height: 0), activationThreshold: threshold
+            translation: CGSize(width: threshold + 4, height: 0), configuration: .moveCursor
         )
         _ = state.handleChanged(
             translation: CGSize(width: threshold + 4, height: -upThreshold - 30),
-            activationThreshold: threshold
+            configuration: .moveCursor
         )
         let phase = state.handleEnded(
             translation: CGSize(width: threshold + 4, height: -upThreshold - 30),
-            activationThreshold: threshold
+            configuration: .moveCursor
         )
         #expect(phase == .ended)
     }
@@ -241,10 +241,10 @@ struct SlideGestureStateTests {
     @Test func tapWithSmallVerticalJitterIsStillATap() {
         var state = SlideGestureState()
         _ = state.handleChanged(
-            translation: CGSize(width: 1, height: -3), activationThreshold: threshold
+            translation: CGSize(width: 1, height: -3), configuration: .moveCursor
         )
         let phase = state.handleEnded(
-            translation: CGSize(width: 1, height: -3), activationThreshold: threshold
+            translation: CGSize(width: 1, height: -3), configuration: .moveCursor
         )
         #expect(phase == .tap)
     }
@@ -252,17 +252,17 @@ struct SlideGestureStateTests {
     @Test func cancellationResetsVerticalTracking() {
         var state = SlideGestureState()
         _ = state.handleChanged(
-            translation: CGSize(width: 0, height: -upThreshold - 70), activationThreshold: threshold
+            translation: CGSize(width: 0, height: -upThreshold - 70), configuration: .moveCursor
         )
         _ = state.handleCancelled()
 
         // Next touch: a small movement must be a tap — a stale upward peak
         // would classify it as a return-up swipe and toggle labels.
         _ = state.handleChanged(
-            translation: CGSize(width: 1, height: -2), activationThreshold: threshold
+            translation: CGSize(width: 1, height: -2), configuration: .moveCursor
         )
         let phase = state.handleEnded(
-            translation: CGSize(width: 1, height: -2), activationThreshold: threshold
+            translation: CGSize(width: 1, height: -2), configuration: .moveCursor
         )
         #expect(phase == .tap)
     }
@@ -277,15 +277,15 @@ struct SlideGestureStateTests {
         // as an up-swipe and the cursor never moved. The dominant-horizontal
         // re-arm now latches the slide.
         let flick = state.handleChanged(
-            translation: CGSize(width: 2, height: -35), activationThreshold: threshold
+            translation: CGSize(width: 2, height: -35), configuration: .moveCursor
         )
         #expect(flick.phases.isEmpty)
         let latch = state.handleChanged(
-            translation: CGSize(width: 100, height: -20), activationThreshold: threshold
+            translation: CGSize(width: 100, height: -20), configuration: .moveCursor
         )
         #expect(latch.phases.first == .began)
         let phase = state.handleEnded(
-            translation: CGSize(width: 100, height: -20), activationThreshold: threshold
+            translation: CGSize(width: 100, height: -20), configuration: .moveCursor
         )
         #expect(phase == .ended)
     }
@@ -302,13 +302,52 @@ struct SlideGestureStateTests {
             CGSize(width: 10, height: -6),
         ]
         for sample in samples {
-            let update = state.handleChanged(translation: sample, activationThreshold: threshold)
+            let update = state.handleChanged(translation: sample, configuration: .moveCursor)
             #expect(update.phases.isEmpty)
         }
         let phase = state.handleEnded(
-            translation: CGSize(width: 10, height: -6), activationThreshold: threshold
+            translation: CGSize(width: 10, height: -6), configuration: .moveCursor
         )
         #expect(phase == .swipeUp(isReturn: true))
+    }
+
+    // MARK: - Delete configuration (no up-swipe binding)
+
+    @Test func diagonalDeleteDragLatchesInsteadOfReportingAnUpSwipe() {
+        var state = SlideGestureState()
+        // Up-left drag with the horizontal axis dominating. An up-swipe
+        // threshold would block the latch here and end the drag as a
+        // `.swipeUp` the delete handler discards: no deletion, no tap, no
+        // feedback at all.
+        let translation = CGSize(width: -40, height: -35)
+        let update = state.handleChanged(translation: translation, configuration: .delete)
+        #expect(update.phases == [.began, .changed(deltaX: -12)])
+        #expect(state.handleEnded(translation: translation, configuration: .delete) == .ended)
+    }
+
+    @Test func verticalDeleteDragNeverReportsAnUpSwipe() {
+        var state = SlideGestureState()
+        let translation = CGSize(width: 0, height: -80)
+        _ = state.handleChanged(translation: translation, configuration: .delete)
+        #expect(state.handleEnded(translation: translation, configuration: .delete) == nil)
+    }
+
+    @Test func deleteTapUsesTheDeleteActivationDistance() {
+        var state = SlideGestureState()
+        // 20 pt is a slide on the space bar (8 pt) and still a tap on delete (28 pt).
+        let translation = CGSize(width: 20, height: 0)
+        let update = state.handleChanged(translation: translation, configuration: .delete)
+        #expect(update.phases.isEmpty)
+        #expect(state.handleEnded(translation: translation, configuration: .delete) == .tap)
+    }
+
+    @Test func slideTypesResolveToTheirConfiguration() {
+        #expect(SlideGestureConfiguration.for(.moveCursor) == .moveCursor)
+        #expect(SlideGestureConfiguration.for(.delete) == .delete)
+        #expect(SlideGestureConfiguration.for(.none) == .inactive)
+        // The delete key has no up-swipe binding: the vertical axis must not be
+        // able to swallow a delete drag.
+        #expect(SlideGestureConfiguration.delete.swipeUpThreshold == nil)
     }
 
     // MARK: - Touch cancellation (Bug 1)
@@ -317,7 +356,7 @@ struct SlideGestureStateTests {
         var state = SlideGestureState()
         _ = state.handleChanged(
             translation: CGSize(width: threshold + 50, height: 0),
-            activationThreshold: threshold
+            configuration: .moveCursor
         )
         #expect(state.handleCancelled() == .cancelled)
     }
@@ -325,7 +364,7 @@ struct SlideGestureStateTests {
     @Test func cancellationBeforeSlideReportsCancelled() {
         var state = SlideGestureState()
         _ = state.handleChanged(
-            translation: CGSize(width: 2, height: 0), activationThreshold: threshold
+            translation: CGSize(width: 2, height: 0), configuration: .moveCursor
         )
         #expect(state.handleCancelled() == .cancelled)
     }
@@ -339,7 +378,7 @@ struct SlideGestureStateTests {
         var state = SlideGestureState()
         // Drag far to the right, then get cancelled by the system.
         _ = state.handleChanged(
-            translation: CGSize(width: 100, height: 0), activationThreshold: threshold
+            translation: CGSize(width: 100, height: 0), configuration: .moveCursor
         )
         _ = state.handleCancelled()
 
@@ -347,7 +386,7 @@ struct SlideGestureStateTests {
         // phases — a stale anchor would replay a large negative delta here
         // (burst of deletions on the delete key, cursor jump on space).
         let update = state.handleChanged(
-            translation: CGSize(width: 2, height: 0), activationThreshold: threshold
+            translation: CGSize(width: 2, height: 0), configuration: .moveCursor
         )
         #expect(update.isTouchDown)
         #expect(update.phases.isEmpty)
@@ -356,7 +395,7 @@ struct SlideGestureStateTests {
         // previous gesture's translation.
         let sliding = state.handleChanged(
             translation: CGSize(width: threshold + 2, height: 0),
-            activationThreshold: threshold
+            configuration: .moveCursor
         )
         #expect(sliding.phases == [.began, .changed(deltaX: 2)])
     }
@@ -364,14 +403,14 @@ struct SlideGestureStateTests {
     @Test func sequenceAfterNormalEndStartsFresh() {
         var state = SlideGestureState()
         _ = state.handleChanged(
-            translation: CGSize(width: 100, height: 0), activationThreshold: threshold
+            translation: CGSize(width: 100, height: 0), configuration: .moveCursor
         )
         _ = state.handleEnded(
-            translation: CGSize(width: 100, height: 0), activationThreshold: threshold
+            translation: CGSize(width: 100, height: 0), configuration: .moveCursor
         )
 
         let update = state.handleChanged(
-            translation: CGSize(width: 2, height: 0), activationThreshold: threshold
+            translation: CGSize(width: 2, height: 0), configuration: .moveCursor
         )
         #expect(update.isTouchDown)
         #expect(update.phases.isEmpty)
@@ -382,10 +421,10 @@ struct SlideGestureStateTests {
     @Test func maxDisplacementTracksPeakDistanceFromOrigin() {
         var state = SlideGestureState()
         _ = state.handleChanged(
-            translation: CGSize(width: 30, height: 40), activationThreshold: threshold
+            translation: CGSize(width: 30, height: 40), configuration: .moveCursor
         ) // 50pt out ...
         _ = state.handleChanged(
-            translation: CGSize(width: 3, height: 4), activationThreshold: threshold
+            translation: CGSize(width: 3, height: 4), configuration: .moveCursor
         ) // ... then back
         // The running maximum must survive the return leg - a pending long
         // press stays cancelled after an out-and-back movement.
@@ -395,10 +434,10 @@ struct SlideGestureStateTests {
     @Test func maxDisplacementResetsAfterEnd() {
         var state = SlideGestureState()
         _ = state.handleChanged(
-            translation: CGSize(width: 100, height: 0), activationThreshold: threshold
+            translation: CGSize(width: 100, height: 0), configuration: .moveCursor
         )
         _ = state.handleEnded(
-            translation: CGSize(width: 100, height: 0), activationThreshold: threshold
+            translation: CGSize(width: 100, height: 0), configuration: .moveCursor
         )
         #expect(state.maxDisplacement == 0)
     }
@@ -406,7 +445,7 @@ struct SlideGestureStateTests {
     @Test func maxDisplacementResetsAfterCancellation() {
         var state = SlideGestureState()
         _ = state.handleChanged(
-            translation: CGSize(width: 100, height: 0), activationThreshold: threshold
+            translation: CGSize(width: 100, height: 0), configuration: .moveCursor
         )
         _ = state.handleCancelled()
         #expect(state.maxDisplacement == 0)


### PR DESCRIPTION
Findings 2, 3, 15, 17, 22, 24 and 34 of the 2026-08-08 stabilization review.

### Diagonal delete drags were silently dropped (finding 3, P1)

`SlideGestureState` applied the space bar's `swipeUpActivationThreshold` (30 pt) to both slide keys, but the delete key has no vertical feature — its handler ignores `.swipeUp`. A drag of (−40, −35) passed the latch conditions, failed the peak guard, never latched, and came back as `.swipeUp`, which the delete handler discarded: no deletion, no tap, no feedback.

Rather than passing `.infinity` at the delete call site, the vertical policy is now part of a `SlideGestureConfiguration` per `SlideType` (`.moveCursor` 8/30, `.delete` 28/nil, `.inactive` ∞/nil). With `swipeUpThreshold == nil` both the peak guard and the `.swipeUp` classification are unreachable, so no call site can inherit another key's vertical policy by omission. The space bar's arithmetic is bit-identical.

### An armed long press outlived its key (finding 2, P1)

`onDisappear` handed back only the trail. The queued `DispatchWorkItem` stayed armed, and its fire guard read a `@State` box where `isTracking` was still true, because teardown reaches neither `onEnded` nor the `@GestureState` reset. With long-press numbers on, a second finger switching mode inside the 0.7 s hold made the orphan type the old key's digit into the new mode.

Both recognizers now route teardown and the system-cancel path through one `abandonSequence()`, and the scheduler pairs its two halves in `LongPressScheduler.abandon()` — cancelling the timer without clearing `consumedTouch` would leave the next touch on that key starting out already consumed. The pairing is unit-tested; the `onDisappear` wiring itself is not reachable from the unit harness, so it needs an on-device check (see below).

### Smaller items

- **Finding 15** — `stepContinuousCursor` re-read `documentContextAfterInput` on every iteration, which the proxy may not have updated yet after `adjustTextPosition`. It now takes one snapshot per drag update and walks it locally through `clusterWidths(in:count:fromEnd:)`. Step count and residual accounting are unchanged; the batch is capped at 32 steps and guarded against a non-finite delta.
- **Finding 17** — expert-mode values were checked for finiteness but not clamped, so a stale `minSwipeLength ≤ 0` made every touch a swipe. All eleven values now clamp at load against ranges that live next to the defaults, and `ExpertSettingsView`'s sliders read the same constants, so UI and loader cannot drift. Three fixtures in `ExpertModeGatingTests` were outside the Expert ranges and moved rather than the ranges being widened to keep them green.
- **Finding 22** — the header claimed `minSwipeLength (30pt)` while classification uses 20. The 30 belonged to a second, unrelated constant of the same name whose only consumer was `SpaceGestures.swipeUpActivationThreshold`; that constant is deleted and the value inlined where it is actually used, so the two cannot be confused again.
- **Finding 24** — a touch already consumed by a long press still fed the 120 Hz ring buffer. `KeyGestureRecognizer` now early-returns like its twin in `SlideGestureHandler`.
- **Finding 34** — the sector switch is extracted into `gestureType(forDegrees:)` and pinned by boundary tests at every sector edge ±1 ulp, including the wrap-around, so flipping `..<` to `...` fails loudly.

### Verification

1092 unit tests pass; SwiftFormat and SwiftLint `--strict` are clean.

Two things a build cannot show and that belong on the manual checklist:

- **Finding 2's repro** — long-press numbers on, finger resting on a key, second finger switches mode inside 0.7 s: no stray digit should appear.
- **Delete-key feel** — a mostly-vertical delete drag now falls through to no phase instead of `.swipeUp`. No deletion either way, but delete's tap classification is gated purely on the 28 pt activation distance now.

Known and deliberately left: `KeyboardGridView` keys its cells by `keyId` alone, so a slot whose id is identical across modes (space, delete, globe) keeps its view identity through a mode switch and runs no teardown hook. Closing that means folding the mode into the view identity, which belongs to the view layer.
