### PR TITLE
Make Every Key Operable Under VoiceOver

### DIFF
--- a/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
+++ b/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
@@ -16,7 +16,9 @@ enum CommonKeys {
         var bindings: [GestureType: KeyBinding] = [:]
         // Tap is intentionally inert: switching the input method lives on the
         // swipe-left gesture below. The empty `.none` slot keeps the key's
-        // accessibility label without re-triggering the globe on a plain tap.
+        // accessibility label without re-triggering the globe on a plain tap;
+        // `accessibilityActivationGesture` routes a VoiceOver activation to
+        // that swipe so the label stays true for gesture-free input.
         bindings[.tap] = KeyBinding(
             label: "", action: .none,
             category: .utility, returnAction: nil,
@@ -24,7 +26,8 @@ enum CommonKeys {
         )
         bindings[.swipeLeft] = KeyBinding(
             label: "", action: .advanceToNextInputMode,
-            category: .utility, returnAction: nil, accessibilityLabel: nil
+            category: .utility, returnAction: nil,
+            accessibilityLabel: String(localized: "Switch keyboard")
         )
         bindings[.swipeDown] = KeyBinding(
             label: "", action: .dismissKeyboard,
@@ -33,12 +36,14 @@ enum CommonKeys {
         )
         bindings[.swipeRight] = KeyBinding(
             label: "", action: .switchToNextLanguage,
-            category: .utility, returnAction: nil, accessibilityLabel: nil
+            category: .utility, returnAction: nil,
+            accessibilityLabel: String(localized: "Next language")
         )
         return KeyConfig(
             id: UtilitySlot.globe, bindings: bindings,
             swipeMode: .fourWayCross, slideType: .none,
-            style: .utility, tapCycleActions: nil
+            style: .utility, tapCycleActions: nil,
+            accessibilityActivationGesture: .swipeLeft
         )
     }()
 

--- a/wurstfingerKeyboard/Definition/Language/KeyboardMode+Shifted.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardMode+Shifted.swift
@@ -46,7 +46,8 @@ extension KeyConfig {
     /// Creates an uppercase variant of this key.
     /// Only bindings with resolvedCategory == .letter are uppercased.
     func autoShifted(locale: Locale) -> KeyConfig {
-        let shiftedBindings = bindings.mapValues { binding -> KeyBinding in
+        var shifted = self
+        shifted.bindings = bindings.mapValues { binding -> KeyBinding in
             guard binding.resolvedCategory == .letter else { return binding }
             guard case let .commitText(text) = binding.action else { return binding }
             let upperLabel = binding.label.keyboardUppercased(with: locale)
@@ -59,9 +60,6 @@ extension KeyConfig {
                 accessibilityLabel: binding.accessibilityLabel
             )
         }
-        return KeyConfig(
-            id: id, bindings: shiftedBindings, swipeMode: swipeMode,
-            slideType: slideType, style: style, tapCycleActions: tapCycleActions
-        )
+        return shifted
     }
 }

--- a/wurstfingerKeyboard/Definition/Language/KeyboardMode.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardMode.swift
@@ -63,13 +63,7 @@ struct KeyboardMode: Codable, Equatable {
     /// Returns a copy with a specific binding removed from a key.
     func removingBinding(keyId: String, gesture: GestureType) -> KeyboardMode {
         guard var key = keys[keyId] else { return self }
-        var bindings = key.bindings
-        bindings.removeValue(forKey: gesture)
-        key = KeyConfig(
-            id: key.id, bindings: bindings, swipeMode: key.swipeMode,
-            slideType: key.slideType, style: key.style,
-            tapCycleActions: key.tapCycleActions
-        )
+        key.bindings.removeValue(forKey: gesture)
         var updatedKeys = keys
         updatedKeys[keyId] = key
         return KeyboardMode(
@@ -93,16 +87,10 @@ struct KeyboardMode: Codable, Equatable {
         guard var midRight = keys[GridSlot.midRight],
               let existing = midRight.bindings[.swipeUp]
         else { return self }
-        var bindings = midRight.bindings
-        bindings[.swipeUp] = KeyBinding(
+        midRight.bindings[.swipeUp] = KeyBinding(
             label: label, action: action,
             category: existing.category, returnAction: existing.returnAction,
             accessibilityLabel: existing.accessibilityLabel
-        )
-        midRight = KeyConfig(
-            id: midRight.id, bindings: bindings, swipeMode: midRight.swipeMode,
-            slideType: midRight.slideType, style: midRight.style,
-            tapCycleActions: midRight.tapCycleActions
         )
         var updatedKeys = keys
         updatedKeys[GridSlot.midRight] = midRight

--- a/wurstfingerKeyboard/Definition/Model/KeyConfig+Accessibility.swift
+++ b/wurstfingerKeyboard/Definition/Model/KeyConfig+Accessibility.swift
@@ -1,0 +1,61 @@
+//
+//  KeyConfig+Accessibility.swift
+//  Wurstfinger
+//
+//  What a key offers to assistive technologies, derived from its bindings.
+//
+
+import Foundation
+
+/// One named action a key offers to assistive technologies.
+struct KeyAccessibilityAction: Equatable {
+    let name: String
+    let gesture: GestureType
+}
+
+extension KeyConfig {
+    /// Gesture that must replace the synthesized tap when an assistive
+    /// technology activates this key, or nil when the tap already does
+    /// something — VoiceOver activation reaches the recognizer as a plain
+    /// tap, so those keys need no override and keep one code path.
+    var accessibilityActivationOverride: GestureType? {
+        // Annotated so `.none` reads as the key action, not `Optional.none`.
+        let tapAction: KeyAction = bindings[.tap]?.action ?? .none
+        guard tapAction == .none else { return nil }
+        guard let gesture = accessibilityActivationGesture,
+              let binding = bindings[gesture], binding.action != .none
+        else { return nil }
+        return gesture
+    }
+
+    /// Order the custom actions are offered in. Fixed because dictionary
+    /// iteration is seeded per process and the rotor order must not change
+    /// between launches; a `static let` for the same reason
+    /// `KeyView.hintGestureOrder` is one — `allCases` rebuilds its array on
+    /// every access, and this list is walked per key on every render. `.tap`
+    /// drops out: it is the element's own activation.
+    static let accessibilityActionGestures: [GestureType] = GestureType.allCases.filter { $0 != .tap }
+
+    /// Gestures offered as named custom actions. The activation override is
+    /// excluded alongside `.tap` — it is already reachable by activating the
+    /// key.
+    ///
+    /// A binding qualifies by carrying an `accessibilityLabel`: that label is
+    /// what a VoiceOver user hears, and it doubles as the opt-in, so a letter
+    /// or punctuation swipe does not add eight unnamed entries to every key.
+    /// Names are deduplicated — cut-all is bound to both circle directions
+    /// with one label, and two identical rotor entries read as a bug.
+    var accessibilityActions: [KeyAccessibilityAction] {
+        let skipped = accessibilityActivationOverride
+        var seen: Set<String> = []
+        var actions: [KeyAccessibilityAction] = []
+        for gesture in Self.accessibilityActionGestures where gesture != skipped {
+            guard let binding = bindings[gesture], binding.action != .none,
+                  let name = binding.accessibilityLabel, !name.isEmpty,
+                  seen.insert(name).inserted
+            else { continue }
+            actions.append(KeyAccessibilityAction(name: name, gesture: gesture))
+        }
+        return actions
+    }
+}

--- a/wurstfingerKeyboard/Definition/Model/KeyConfig.swift
+++ b/wurstfingerKeyboard/Definition/Model/KeyConfig.swift
@@ -13,7 +13,10 @@ struct KeyConfig: Codable, Equatable, Identifiable {
     let id: String
 
     /// Binding for each gesture. Only set entries are active.
-    let bindings: [GestureType: KeyBinding]
+    /// `var` so a derived key (shifted layer, removed binding) can be made by
+    /// copying this one and swapping the bindings — rebuilding it field by
+    /// field silently drops everything added to the type later.
+    var bindings: [GestureType: KeyBinding]
 
     /// Allowed swipe directions (default: .eightWay)
     let swipeMode: SwipeMode
@@ -27,4 +30,10 @@ struct KeyConfig: Codable, Equatable, Identifiable {
     /// Optional multi-tap actions (e.g. space → comma → period → ?)
     /// Inspired by Thumb-Key's nextTapActions
     let tapCycleActions: [KeyAction]?
+
+    /// Gesture an assistive technology performs instead of the tap it would
+    /// otherwise synthesize. Only needed where the tap is deliberately inert
+    /// (the globe, whose input-method switch lives on swipe-left): without it
+    /// a VoiceOver double tap resolves to `.none` and the key is unreachable.
+    var accessibilityActivationGesture: GestureType? = nil
 }

--- a/wurstfingerKeyboard/Localizable.xcstrings
+++ b/wurstfingerKeyboard/Localizable.xcstrings
@@ -277,6 +277,144 @@
       },
       "comment": "ACCESSIBILITY label for dismiss-keyboard gesture (VoiceOver)"
     },
+    "Next language": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nächste Sprache"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langue suivante"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma siguiente"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lingua successiva"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Следующий язык"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Następny język"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nästa språk"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seuraava kieli"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sljedeći jezik"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "השפה הבאה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ngôn ngữ tiếp theo"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Susunod na wika"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επόμενη γλώσσα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Próximo idioma"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Наступна мова"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اللغة التالية"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زبان بعدی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اگلی زبان"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ภาษาถัดไป"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अगली भाषा"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次の言語"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음 언어"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY action name for the switch-to-next-language gesture (VoiceOver)"
+    },
     "Delete": {
       "extractionState": "manual",
       "localizations": {

--- a/wurstfingerKeyboard/Runtime/Gesture/GestureTrailRecorder.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GestureTrailRecorder.swift
@@ -12,9 +12,11 @@ import Foundation
 import SwiftUI
 
 /// Identity of one gesture modifier, used to decide which touch sequence owns
-/// the shared trail. Each recognizer holds its own in `@State`, so it is stable
-/// for as long as that key exists.
-final class GestureTrailToken {}
+/// the shared trail. Each recognizer holds its own in `@StateObject`, so it is
+/// created once per key rather than on every body evaluation and is stable for
+/// as long as that key exists. It publishes nothing; the conformance exists
+/// only for `@StateObject`'s deferred construction.
+final class GestureTrailToken: ObservableObject {}
 
 /// Per-keyboard collector for the swipe trail.
 ///
@@ -50,6 +52,24 @@ final class GestureTrailRecorder: ObservableObject {
     /// half-recorded trail behind.
     private var isRecording = false
 
+    /// Travel at which the recognizer that owns the current touch stops
+    /// classifying it as a tap. Supplied per touch by that recognizer rather
+    /// than kept as a constant: it is the classifier's `minSwipeLength` on a
+    /// letter key, the slide activation threshold on space and delete.
+    /// `.infinity` until a touch begins, so nothing can draw unclaimed.
+    private var activationDistance: CGFloat = .infinity
+
+    /// Aspect ratio the owning recognizer classifies in. `classify` divides the
+    /// horizontal component by it before measuring travel, so its tap boundary
+    /// is an ellipse in screen space; measuring the trail the same way keeps
+    /// the two boundaries identical on non-square keys. 1 for recognizers that
+    /// classify in raw points.
+    private var aspectRatio: CGFloat = 1
+
+    /// Running maximum travel from the touch-down point, measured the way the
+    /// owning recognizer measures it.
+    private var maxNormalizedDisplacement: CGFloat = 0
+
     /// The gesture modifier whose touch sequence currently owns the trail.
     ///
     /// One recorder is shared by every key, and on a thumb keyboard two touch
@@ -70,26 +90,45 @@ final class GestureTrailRecorder: ObservableObject {
         self.now = now
     }
 
-    /// Records one drag sample. `isTouchDown` marks the first sample of a new
-    /// touch sequence, as reported by the gesture state machines; `token`
-    /// identifies the recognizer it came from.
-    func record(_ location: CGPoint, isTouchDown: Bool, from token: GestureTrailToken) {
-        if isTouchDown {
-            // First finger down wins the trail and keeps it until its sequence
-            // ends. A concurrent second touch is ignored rather than drawn as
-            // a second trail: one stroke matches the system keyboard, and the
-            // overlay renders a single path.
-            guard owner == nil else { return }
-            owner = token
-            beginTouch(at: location)
-            return
-        }
+    /// Starts recording a new touch sequence.
+    ///
+    /// `activationDistance` is the travel below which the calling recognizer
+    /// will dispatch this touch as a tap; drawing before it would advertise a
+    /// swipe that never happens. `aspectRatio` is the space that travel is
+    /// measured in. `token` identifies the recognizer.
+    func begin(
+        at location: CGPoint,
+        from token: GestureTrailToken,
+        activationDistance: CGFloat,
+        aspectRatio: CGFloat = 1
+    ) {
+        // First finger down wins the trail and keeps it until its sequence
+        // ends. A concurrent second touch is ignored rather than drawn as
+        // a second trail: one stroke matches the system keyboard, and the
+        // overlay renders a single path.
+        guard owner == nil else { return }
+        owner = token
+        self.activationDistance = activationDistance
+        // A zero, negative or non-finite ratio would divide the horizontal
+        // component into nothing and draw under every tap.
+        self.aspectRatio = aspectRatio.isFinite && aspectRatio > 0 ? aspectRatio : 1
+        maxNormalizedDisplacement = 0
+        beginTouch(at: location)
+    }
+
+    /// Records one drag sample of the sequence started by `begin`.
+    func extend(to location: CGPoint, from token: GestureTrailToken) {
         guard owner === token, isRecording else { return }
         trail.extend(to: location, time: now())
         // Suppress taps: every keystroke on this keyboard begins as a touch
         // down, so drawing from the first sample would flash a dot under every
         // letter typed.
-        if !isVisible, trail.maxDisplacement >= KeyboardConstants.GestureTrail.activationDistance {
+        guard !isVisible else { return }
+        if let origin = trail.origin {
+            let travel = hypot((location.x - origin.x) / aspectRatio, location.y - origin.y)
+            maxNormalizedDisplacement = max(maxNormalizedDisplacement, travel)
+        }
+        if maxNormalizedDisplacement >= activationDistance {
             setVisible(true)
         }
     }
@@ -165,4 +204,15 @@ final class GestureTrailRecorder: ObservableObject {
         guard isVisible != value else { return }
         isVisible = value
     }
+}
+
+/// Owns one `GestureTrailRecorder` for the lifetime of a view.
+///
+/// `@State` rebuilds its initial value on every `body` evaluation and throws
+/// it away again; `@StateObject` takes it as an autoclosure and evaluates it
+/// once. Going through a holder that publishes nothing keeps that without
+/// subscribing the grid to the recorder — an `isVisible` flip would otherwise
+/// re-render all ~40 keys twice per gesture.
+final class GestureTrailStore: ObservableObject {
+    let recorder = GestureTrailRecorder()
 }

--- a/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
@@ -8,6 +8,7 @@
 //
 
 import CoreGraphics
+import Foundation
 import SwiftUI
 
 /// Result of classifying a completed gesture.
@@ -107,7 +108,7 @@ struct KeyGestureRecognizer: ViewModifier {
     @State private var sequence = KeyGestureSequence()
     @State private var longPress = LongPressScheduler()
     /// Identifies this key's touch sequence to the shared trail recorder.
-    @State private var trailToken = GestureTrailToken()
+    @StateObject private var trailToken = GestureTrailToken()
     @Binding var isActive: Bool
 
     /// True while a touch sequence is in flight. Unlike `@State`, SwiftUI
@@ -137,7 +138,15 @@ struct KeyGestureRecognizer: ViewModifier {
                             return
                         }
                         let isTouchDown = sequence.handleChanged(translation: value.translation)
-                        trail?.record(value.location, isTouchDown: isTouchDown, from: trailToken)
+                        if isTouchDown {
+                            trail?.begin(
+                                at: value.location, from: trailToken,
+                                activationDistance: Self.tapBoundary(),
+                                aspectRatio: aspectRatio
+                            )
+                        } else {
+                            trail?.extend(to: value.location, from: trailToken)
+                        }
                         if isTouchDown {
                             onTouchDown()
                             scheduleLongPress()
@@ -231,6 +240,15 @@ struct KeyGestureRecognizer: ViewModifier {
     }
 
     // MARK: - Classification (Pure Function)
+
+    /// Travel at which `classify` stops calling a gesture a tap, measured in
+    /// the aspect-normalized space `classify` works in. The swipe trail starts
+    /// here, so a sloppy tap never flashes a streak and retuning
+    /// `minSwipeLength` in expert mode moves both together. Reads the store,
+    /// so callers evaluate it once per touch, never per drag sample.
+    static func tapBoundary(store: UserDefaults = SharedDefaults.store) -> CGFloat {
+        GestureClassificationThresholds.fromUserDefaults(store: store).minSwipeLength
+    }
 
     /// Classifies a sequence of touch positions into a `GestureType`, reading
     /// preprocessor config and thresholds from `SharedDefaults`.

--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -239,7 +239,7 @@ struct SlideGestureHandler: ViewModifier {
     @State private var state = SlideGestureState()
     @State private var longPress = LongPressScheduler()
     /// Identifies this key's touch sequence to the shared trail recorder.
-    @State private var trailToken = GestureTrailToken()
+    @StateObject private var trailToken = GestureTrailToken()
 
     /// True while a touch sequence is in flight. Unlike `@State`, SwiftUI
     /// guarantees `@GestureState` is reset when the system cancels the
@@ -272,14 +272,20 @@ struct SlideGestureHandler: ViewModifier {
                             translation: value.translation,
                             configuration: configuration
                         )
-                        trail?.record(value.location, isTouchDown: update.isTouchDown, from: trailToken)
                         if update.isTouchDown {
+                            trail?.begin(
+                                at: value.location, from: trailToken,
+                                activationDistance: configuration.activationThreshold
+                            )
                             onTouchDown()
                             scheduleLongPress()
-                        } else if longPress.isScheduled,
-                                  state.isSliding
-                                  || state.maxDisplacement > KeyboardConstants.LongPress.movementTolerance {
-                            longPress.cancel()
+                        } else {
+                            trail?.extend(to: value.location, from: trailToken)
+                            if longPress.isScheduled,
+                               state.isSliding
+                               || state.maxDisplacement > KeyboardConstants.LongPress.movementTolerance {
+                                longPress.cancel()
+                            }
                         }
                         for phase in update.phases {
                             onSlide(phase)
@@ -355,5 +361,13 @@ struct SlideGestureHandler: ViewModifier {
 
     private var configuration: SlideGestureConfiguration {
         .for(slideType)
+    }
+
+    // MARK: - Activation Threshold
+
+    /// Travel below which this key's touch is dispatched as a tap. `internal`
+    /// and static so the trail-threshold guard test can pin it.
+    static func activationThreshold(for slideType: SlideType) -> CGFloat {
+        SlideGestureConfiguration.for(slideType).activationThreshold
     }
 }

--- a/wurstfingerKeyboard/Runtime/View/KeyAccessibilityActions.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyAccessibilityActions.swift
@@ -1,0 +1,42 @@
+//
+//  KeyAccessibilityActions.swift
+//  Wurstfinger
+//
+//  Exposes a key's non-tap gestures to assistive technologies.
+//
+
+import SwiftUI
+
+/// Makes a key operable without gestures.
+///
+/// VoiceOver activates an element by synthesizing a touch, which reaches the
+/// gesture recognizer as a plain tap — so every swipe-only binding is out of
+/// reach, including the globe's input-method switch, whose tap is inert by
+/// design. Each labelled binding becomes a named custom action, and a key
+/// with an inert tap additionally overrides the element's default activation
+/// with the gesture it declares. Both dispatch through the same `onGesture`
+/// callback as a real touch, so they share the resolver chain and pipeline.
+struct KeyAccessibilityActions: ViewModifier {
+    let key: KeyConfig
+    let onGesture: (KeyConfig, GestureType, Bool) -> Void
+
+    func body(content: Content) -> some View {
+        withActivation(content)
+            .accessibilityActions {
+                ForEach(key.accessibilityActions, id: \.gesture) { action in
+                    Button(action.name) { onGesture(key, action.gesture, false) }
+                }
+            }
+    }
+
+    /// Applied only where it is needed: a key whose tap already acts keeps the
+    /// synthesized tap, so activation and touch stay one code path.
+    @ViewBuilder
+    private func withActivation(_ content: Content) -> some View {
+        if let gesture = key.accessibilityActivationOverride {
+            content.accessibilityAction { onGesture(key, gesture, false) }
+        } else {
+            content
+        }
+    }
+}

--- a/wurstfingerKeyboard/Runtime/View/KeyView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyView.swift
@@ -124,6 +124,7 @@ struct KeyView: View {
         .accessibilityLabel(accessibilityLabel)
         .accessibilityIdentifier(key.id)
         .accessibilityAddTraits(.isButton)
+        .modifier(KeyAccessibilityActions(key: key, onGesture: onGesture))
         // The whole cell is the touch target. Adjacent cells tile the surface
         // with no gaps, so a plain rectangle covers it fully.
         .contentShape(Rectangle())
@@ -198,19 +199,42 @@ struct KeyView: View {
         }
     }
 
+    /// Font size for a label whose reference size is `base`, scaled to the
+    /// rendered cell and clamped both for readability and against the cell.
+    /// Pure and `internal` so the "never wider than its key" relationship can
+    /// be locked by a test.
+    static func clampedFontSize(
+        base: CGFloat,
+        metrics: KeyboardLayoutMetrics,
+        minimum: CGFloat,
+        maximum: CGFloat,
+        cellFraction: CGFloat
+    ) -> CGFloat {
+        let scaled = min(max(base * metrics.fontScale, minimum), maximum)
+        return min(scaled, metrics.cellWidth * cellFraction)
+    }
+
     /// Scaled font size proportional to the rendered cell height
     /// (`metrics.fontScale` is cell height over the reference key height).
     private var scaledFontSize: CGFloat {
-        let base = Self.baseFontSize(for: key.style)
-        let scaled = base * metrics.fontScale
-        return min(max(scaled, KeyboardConstants.FontSizes.mainLabelMinSize), KeyboardConstants.FontSizes.mainLabelMaxSize)
+        Self.clampedFontSize(
+            base: Self.baseFontSize(for: key.style),
+            metrics: metrics,
+            minimum: KeyboardConstants.FontSizes.mainLabelMinSize,
+            maximum: KeyboardConstants.FontSizes.mainLabelMaxSize,
+            cellFraction: KeyboardConstants.FontSizes.mainLabelMaxCellFraction
+        )
     }
 
     /// Scaled hint font size proportional to the rendered cell height.
     private var scaledHintFontSize: CGFloat {
-        let base = KeyboardConstants.FontSizes.hintBaseSize
-        let scaled = base * metrics.fontScale
-        return min(max(scaled, KeyboardConstants.FontSizes.hintMinSize), KeyboardConstants.FontSizes.hintMaxSize)
+        Self.clampedFontSize(
+            base: KeyboardConstants.FontSizes.hintBaseSize,
+            metrics: metrics,
+            minimum: KeyboardConstants.FontSizes.hintMinSize,
+            maximum: KeyboardConstants.FontSizes.hintMaxSize,
+            cellFraction: KeyboardConstants.FontSizes.hintMaxCellFraction
+        )
     }
 
     /// Whether the key should be rendered as an icon-only key (no text label).
@@ -275,6 +299,10 @@ struct KeyView: View {
                 Text(primaryLabel)
                     .font(font)
                     .foregroundColor(.primary)
+                    // Multi-character labels ("123") outgrow the cell before
+                    // the size cap does; shrink instead of wrapping.
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.5)
             }
         }
     }

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -43,12 +43,17 @@ struct KeyboardGridView: View {
     /// showcase modes with `shouldPersistSettings: false`).
     let metrics: KeyboardLayoutMetrics
 
-    /// Collects the touch path for the swipe trail. `@State` rather than
-    /// `@StateObject`: it owns the object without subscribing to it, so the
-    /// samples arriving at up to 120 Hz cannot re-render the grid and all of
-    /// its keys. Only `GestureTrailOverlay` observes it, and only for the one
-    /// flag that says whether to draw.
-    @State private var gestureTrail = GestureTrailRecorder()
+    /// Collects the touch path for the swipe trail. Held through a
+    /// non-publishing store so the object is created once instead of on every
+    /// body evaluation, and the samples arriving at up to 120 Hz still cannot
+    /// re-render the grid and all of its keys. Only `GestureTrailOverlay`
+    /// observes the recorder, and only for the one flag that says whether to
+    /// draw.
+    @StateObject private var trailStore = GestureTrailStore()
+
+    private var gestureTrail: GestureTrailRecorder {
+        trailStore.recorder
+    }
 
     var body: some View {
         let cells = GridLayoutSolver.solve(arrangement)

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -74,6 +74,20 @@ enum KeyboardConstants {
         /// Reference font size for hint padding calculations.
         static let hintReferenceFontSize: CGFloat = 10
 
+        /// Largest share of the rendered cell width a main label may occupy.
+        /// The readability floors above are a wish, not a guarantee: at the
+        /// smallest keyboard width a cell is ~14 pt wide, where the 20 pt floor
+        /// draws a glyph across its neighbours. Because the aspect-ratio
+        /// setting never goes below 1.0, this cap sits above the proportional
+        /// size for every cell wide enough to honour the floor — so it only
+        /// ever cuts the floor, never the normal scaling.
+        static let mainLabelMaxCellFraction: CGFloat = 0.5
+
+        /// Same cap for the directional hints, which sit three across a row
+        /// (top-leading / top / top-trailing) and so may claim under a third
+        /// of the cell each.
+        static let hintMaxCellFraction: CGFloat = 0.3
+
         // Hint padding
         /// Horizontal padding around hint labels.
         static let hintBaseHorizontalPadding: CGFloat = 2
@@ -129,14 +143,6 @@ enum KeyboardConstants {
     /// tail, kept short so it reads as a comet tail rather than a drawing of
     /// the whole path.
     enum GestureTrail {
-        /// How far the finger must travel before any trail is drawn. Every
-        /// keystroke on this keyboard starts as a touch-down, so without a
-        /// threshold plain taps would flash a dot on every letter. Aliases
-        /// `SpaceGestures.dragActivationThreshold`, the smallest travel the
-        /// keyboard already treats as "not a tap", so retuning that threshold
-        /// cannot desynchronize the two.
-        static let activationDistance: CGFloat = SpaceGestures.dragActivationThreshold
-
         /// Minimum spacing between two recorded samples. Filters the duplicate
         /// positions a resting finger produces, which would otherwise fill the
         /// buffer and push the moving part of the path out of it. Kept coarse:

--- a/wurstfingerKeyboard/Settings/KeyboardLayoutMetrics.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardLayoutMetrics.swift
@@ -73,6 +73,11 @@ struct KeyboardLayoutMetrics: Equatable {
     /// landscapes the 0.70 floor governs (see `resolve`).
     static let minReservedScreenHeight: CGFloat = 120
 
+    /// Smallest cell either fit-clamp may produce. `cellAspectRatio`,
+    /// `fontScale` and the gesture geometry all divide by the cell, so a
+    /// degenerate render context must still yield a strictly positive one.
+    static let minCellSize: CGFloat = 1
+
     /// Reference metrics at the iPhone default wish (270 pt, square cells)
     /// with no fit-clamp engaged. For tests and previews that need a valid
     /// geometry without a render context.
@@ -117,7 +122,7 @@ struct KeyboardLayoutMetrics: Equatable {
         var width = availableWidth > 0 ? min(wish, availableWidth) : wish
 
         let horizontalChrome = Self.horizontalChrome(columns: columns)
-        var cellWidth = max((width - horizontalChrome) / CGFloat(columns), 1)
+        var cellWidth = max((width - horizontalChrome) / CGFloat(columns), Self.minCellSize)
         var cellHeight = cellWidth / aspect
 
         // Height guard (Option C — clamp only on genuine overflow): the cap is
@@ -142,7 +147,15 @@ struct KeyboardLayoutMetrics: Equatable {
             )
             let contentHeight = cellHeight * CGFloat(rows) + verticalChrome
             if contentHeight > maxHeight {
-                let scale = max(maxHeight - verticalChrome, 0) / (cellHeight * CGFloat(rows))
+                // Both axes take the same factor, so the aspect ratio survives
+                // exactly. Floored at the scale that still leaves a cell of
+                // `minCellSize`: for a small-positive screen height the cap
+                // falls below the constant chrome, and an unfloored scale of
+                // zero would hand the render tree zero-size cells.
+                let scale = max(
+                    (maxHeight - verticalChrome) / (cellHeight * CGFloat(rows)),
+                    Self.minCellSize / cellHeight
+                )
                 cellWidth *= scale
                 cellHeight *= scale
                 width = cellWidth * CGFloat(columns) + horizontalChrome

--- a/wurstfingerTests/AccessibilityLabelTests.swift
+++ b/wurstfingerTests/AccessibilityLabelTests.swift
@@ -73,4 +73,94 @@ struct AccessibilityLabelTests {
             }
         }
     }
+
+    // MARK: - Operability without gestures
+
+    /// VoiceOver activates a key by synthesizing a tap, so a key whose tap is
+    /// inert is unreachable unless it declares a substitute gesture. Also the
+    /// guard for the derived layers: shifted/capsLock keys are made by copying,
+    /// so a copy site that drops the declaration fails here.
+    @Test func everyKeyIsOperableWithoutGestures() {
+        for def in definitions {
+            for (modeName, mode) in def.modes {
+                for (keyId, key) in mode.keys {
+                    let tapAction: KeyAction = key.bindings[.tap]?.action ?? .none
+                    #expect(
+                        tapAction != .none || key.accessibilityActivationOverride != nil,
+                        "\(def.id)/\(modeName)/\(keyId) has an inert tap and no accessibility activation"
+                    )
+                }
+            }
+        }
+    }
+
+    @Test func globeActivationAdvancesTheInputMode() {
+        for def in definitions {
+            for (modeName, mode) in def.modes {
+                guard let globe = mode.keys[UtilitySlot.globe] else { continue }
+                #expect(
+                    globe.accessibilityActivationOverride == .swipeLeft,
+                    "\(def.id)/\(modeName) globe does not route activation to the input-mode switch"
+                )
+                #expect(globe.bindings[.swipeLeft]?.action == .advanceToNextInputMode)
+            }
+        }
+    }
+
+    /// Reachability is by name, not by gesture: bindings sharing a label
+    /// collapse into one rotor entry, so the entry must dispatch the same
+    /// action for every gesture that folded into it.
+    @Test func everyLabelledNonTapBindingIsReachableAsAnAction() {
+        for def in definitions {
+            for (modeName, mode) in def.modes {
+                for (keyId, key) in mode.keys {
+                    let offered = Dictionary(
+                        key.accessibilityActions.map { ($0.name, $0.gesture) },
+                        uniquingKeysWith: { first, _ in first }
+                    )
+                    for (gesture, binding) in key.bindings
+                        where gesture != .tap && binding.action != .none {
+                        guard let label = binding.accessibilityLabel, !label.isEmpty else { continue }
+                        guard gesture != key.accessibilityActivationOverride else { continue }
+                        let origin = "\(def.id)/\(modeName)/\(keyId) \(gesture)"
+                        guard let offeredGesture = offered[label] else {
+                            Issue.record("\(origin) is named \"\(label)\" but unreachable")
+                            continue
+                        }
+                        #expect(
+                            key.bindings[offeredGesture]?.action == binding.action,
+                            "\(origin) folds into \"\(label)\", which dispatches a different action"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /// Cut-all is bound to both circle directions under one name; two
+    /// identical rotor entries read as a bug.
+    @Test func accessibilityActionNamesAreUnique() {
+        for def in definitions {
+            for (modeName, mode) in def.modes {
+                for (keyId, key) in mode.keys {
+                    let names = key.accessibilityActions.map(\.name)
+                    #expect(
+                        Set(names).count == names.count,
+                        "\(def.id)/\(modeName)/\(keyId) offers duplicate action names: \(names)"
+                    )
+                }
+            }
+        }
+    }
+
+    /// End to end through the real resolver chain and pipeline: the gesture the
+    /// globe declares has to actually reach the input-mode switch.
+    @Test func globeActivationReachesTheInputModeSwitch() throws {
+        var advanced = 0
+        let (viewModel, _) = makeViewModel(advanceToNextInputMode: { advanced += 1 })
+        let globe = try #require(viewModel.currentMode?.keys[UtilitySlot.globe])
+        let gesture = try #require(globe.accessibilityActivationOverride)
+        viewModel.handleGesture(gesture, keyId: UtilitySlot.globe, isReturn: false)
+        #expect(advanced == 1)
+    }
 }

--- a/wurstfingerTests/GestureTrailTests.swift
+++ b/wurstfingerTests/GestureTrailTests.swift
@@ -263,19 +263,25 @@ struct GestureTrailGeometryTests {
 
 // MARK: - Recorder
 
+/// Travel below which a letter key dispatches its touch as a tap — what
+/// `KeyGestureRecognizer` hands the recorder at touch down.
+private let letterKeyTapBoundary = GestureClassificationThresholds.defaultMinSwipeLength
+
 struct GestureTrailRecorderTests {
-    /// Feeds a straight drag of `distance` points into the recorder.
+    /// Feeds a straight drag of `distance` points into the recorder, as a
+    /// letter key would.
     private func drag(
         _ recorder: GestureTrailRecorder,
         distance: CGFloat,
         steps: Int = 8,
         from token: GestureTrailToken = GestureTrailToken(),
-        origin: CGPoint = .zero
+        origin: CGPoint = .zero,
+        activationDistance: CGFloat = letterKeyTapBoundary
     ) {
-        recorder.record(origin, isTouchDown: true, from: token)
+        recorder.begin(at: origin, from: token, activationDistance: activationDistance)
         for step in 1 ... steps {
             let x = origin.x + distance * CGFloat(step) / CGFloat(steps)
-            recorder.record(CGPoint(x: x, y: origin.y), isTouchDown: false, from: token)
+            recorder.extend(to: CGPoint(x: x, y: origin.y), from: token)
         }
     }
 
@@ -303,10 +309,10 @@ struct GestureTrailRecorderTests {
         var clock: TimeInterval = 0
         let recorder = makeRecorder(enabled: true, clock: { clock })
         let token = GestureTrailToken()
-        recorder.record(.zero, isTouchDown: true, from: token)
+        recorder.begin(at: .zero, from: token, activationDistance: letterKeyTapBoundary)
         for step in 1 ... 8 {
             clock += 0.01
-            recorder.record(CGPoint(x: CGFloat(step) * 15, y: 0), isTouchDown: false, from: token)
+            recorder.extend(to: CGPoint(x: CGFloat(step) * 15, y: 0), from: token)
         }
         #expect(recorder.isVisible)
         #expect(recorder.trail.samples.count > 1)
@@ -317,16 +323,16 @@ struct GestureTrailRecorderTests {
         // the first sample would flash under every letter typed.
         let recorder = makeRecorder(enabled: true)
         let token = GestureTrailToken()
-        recorder.record(.zero, isTouchDown: true, from: token)
-        recorder.record(CGPoint(x: 2, y: 1), isTouchDown: false, from: token)
+        recorder.begin(at: .zero, from: token, activationDistance: letterKeyTapBoundary)
+        recorder.extend(to: CGPoint(x: 2, y: 1), from: token)
         #expect(!recorder.isVisible)
     }
 
     @Test func finishingATapDropsTheTrailWithoutAFade() {
         let recorder = makeRecorder(enabled: true)
         let token = GestureTrailToken()
-        recorder.record(.zero, isTouchDown: true, from: token)
-        recorder.record(CGPoint(x: 2, y: 0), isTouchDown: false, from: token)
+        recorder.begin(at: .zero, from: token, activationDistance: letterKeyTapBoundary)
+        recorder.extend(to: CGPoint(x: 2, y: 0), from: token)
         recorder.finish(from: token)
         #expect(!recorder.isVisible)
         #expect(recorder.trail.isEmpty)
@@ -360,7 +366,7 @@ struct GestureTrailRecorderTests {
         let first = GestureTrailToken()
         drag(recorder, distance: 120, from: first)
         recorder.finish(from: first)
-        recorder.record(CGPoint(x: 300, y: 300), isTouchDown: true, from: GestureTrailToken())
+        recorder.begin(at: CGPoint(x: 300, y: 300), from: GestureTrailToken(), activationDistance: letterKeyTapBoundary)
         #expect(!recorder.isVisible)
         #expect(recorder.trail.samples.map(\.point) == [CGPoint(x: 300, y: 300)])
     }
@@ -380,6 +386,81 @@ struct GestureTrailRecorderTests {
         #expect(recorder.isVisible)
     }
 
+    // MARK: - Activation Distance
+
+    @Test func nothingIsDrawnBelowTheActivationDistance() {
+        let recorder = makeRecorder(enabled: true)
+        let token = GestureTrailToken()
+        recorder.begin(at: .zero, from: token, activationDistance: 20)
+        for x in stride(from: 4.0, through: 16.0, by: 4.0) {
+            recorder.extend(to: CGPoint(x: x, y: 0), from: token)
+        }
+        #expect(!recorder.isVisible)
+        recorder.extend(to: CGPoint(x: 24, y: 0), from: token)
+        #expect(recorder.isVisible)
+    }
+
+    @Test func theActivationDistanceIsPerKeyNotGlobal() {
+        // The same 12 pt drag is still a tap on a letter key (20 pt boundary)
+        // and already a cursor slide on the space bar (8 pt), so the trail has
+        // to follow the key that recorded it — a sloppy tap must not flash a
+        // streak.
+        let letterKey = makeRecorder(enabled: true)
+        let spaceBar = makeRecorder(enabled: true)
+        let left = GestureTrailToken()
+        let right = GestureTrailToken()
+        letterKey.begin(at: .zero, from: left, activationDistance: letterKeyTapBoundary)
+        spaceBar.begin(
+            at: .zero, from: right,
+            activationDistance: KeyboardConstants.SpaceGestures.dragActivationThreshold
+        )
+        for x in stride(from: 4.0, through: 12.0, by: 4.0) {
+            letterKey.extend(to: CGPoint(x: x, y: 0), from: left)
+            spaceBar.extend(to: CGPoint(x: x, y: 0), from: right)
+        }
+        #expect(!letterKey.isVisible)
+        #expect(spaceBar.isVisible)
+    }
+
+    @Test func theTapBoundaryIsMeasuredInTheClassifiersSpace() {
+        // `classify` divides the horizontal component by the key's aspect
+        // ratio, so on a wide key a sideways slip stays a tap for longer than
+        // the same travel downwards. The trail has to use the same ellipse or
+        // it draws under a touch that is about to be dispatched as a tap.
+        let aspect: CGFloat = 1.62
+        let sideways = makeRecorder(enabled: true)
+        let downwards = makeRecorder(enabled: true)
+        let left = GestureTrailToken()
+        let right = GestureTrailToken()
+        sideways.begin(at: .zero, from: left, activationDistance: 20, aspectRatio: aspect)
+        downwards.begin(at: .zero, from: right, activationDistance: 20, aspectRatio: aspect)
+        sideways.extend(to: CGPoint(x: 25, y: 0), from: left)
+        downwards.extend(to: CGPoint(x: 0, y: 25), from: right)
+        #expect(!sideways.isVisible)
+        #expect(downwards.isVisible)
+        // 20 pt normalized is 32.4 raw points across.
+        sideways.extend(to: CGPoint(x: 33, y: 0), from: left)
+        #expect(sideways.isVisible)
+    }
+
+    @Test func aDegenerateAspectRatioFallsBackToRawTravel() {
+        let recorder = makeRecorder(enabled: true)
+        let token = GestureTrailToken()
+        recorder.begin(at: .zero, from: token, activationDistance: 20, aspectRatio: 0)
+        recorder.extend(to: CGPoint(x: 24, y: 0), from: token)
+        #expect(recorder.isVisible)
+    }
+
+    @Test func theLetterKeyTrailStartsAtTheClassifiersTapBoundary() {
+        let store = InMemoryUserDefaults()
+        #expect(KeyGestureRecognizer.tapBoundary(store: store) == letterKeyTapBoundary)
+        // Expert mode retunes the classification boundary; the trail follows
+        // it instead of keeping a threshold of its own.
+        store.set(true, forKey: SettingsKey.expertModeEnabled.rawValue)
+        store.set(42.0, forKey: GestureClassificationThresholds.minSwipeLengthKey)
+        #expect(KeyGestureRecognizer.tapBoundary(store: store) == 42)
+    }
+
     // MARK: - Touch-Sequence Ownership
 
     @Test func aSecondFingerDoesNotHijackTheTrail() {
@@ -391,8 +472,8 @@ struct GestureTrailRecorderTests {
         let right = GestureTrailToken()
         drag(recorder, distance: 120, from: left)
 
-        recorder.record(CGPoint(x: 300, y: 300), isTouchDown: true, from: right)
-        recorder.record(CGPoint(x: 340, y: 300), isTouchDown: false, from: right)
+        recorder.begin(at: CGPoint(x: 300, y: 300), from: right, activationDistance: letterKeyTapBoundary)
+        recorder.extend(to: CGPoint(x: 340, y: 300), from: right)
 
         #expect(recorder.isVisible)
         let points = recorder.trail.samples.map(\.point)
@@ -406,7 +487,7 @@ struct GestureTrailRecorderTests {
         let right = GestureTrailToken()
         drag(recorder, distance: 120, from: left)
 
-        recorder.record(CGPoint(x: 300, y: 300), isTouchDown: true, from: right)
+        recorder.begin(at: CGPoint(x: 300, y: 300), from: right, activationDistance: letterKeyTapBoundary)
         recorder.finish(from: right)
         #expect(recorder.trail.releaseTime == nil)
 
@@ -439,7 +520,7 @@ struct GestureTrailRecorderTests {
         // Only the recorder's weak `owner` refers to the token now.
         doomed = nil
 
-        recorder.record(CGPoint(x: 300, y: 300), isTouchDown: true, from: GestureTrailToken())
+        recorder.begin(at: CGPoint(x: 300, y: 300), from: GestureTrailToken(), activationDistance: letterKeyTapBoundary)
         #expect(recorder.trail.samples.map(\.point) == [CGPoint(x: 300, y: 300)])
     }
 

--- a/wurstfingerTests/KeyboardGridRenderingTests.swift
+++ b/wurstfingerTests/KeyboardGridRenderingTests.swift
@@ -233,4 +233,61 @@ struct KeyViewStyleTests {
         #expect(store.string(forKey: SettingsKey.keyboardStyle.rawValue) == nil)
         #expect(stock.keyboardStyle == .classic)
     }
+
+    // MARK: - Label sizing
+
+    /// The readability floors are a wish: at the smallest keyboard width a
+    /// cell is ~14 pt wide, where a 20 pt glyph is drawn across its
+    /// neighbours. The cell-relative cap has to win over the floor at every
+    /// size the settings allow (width 90-600 pt, aspect 1.0-1.62).
+    @Test func labelsNeverOutgrowTheirCell() {
+        for wish in stride(from: 90.0, through: 600.0, by: 10.0) {
+            for aspect in [1.0, 1.3, 1.62] {
+                for columns in [4, 5] {
+                    let metrics = KeyboardLayoutMetrics.resolve(
+                        wishWidth: wish, aspectRatio: aspect, columns: columns,
+                        availableWidth: 600, screenHeight: 900
+                    )
+                    let label = KeyView.clampedFontSize(
+                        base: KeyboardConstants.FontSizes.mainLabelBaseSize,
+                        metrics: metrics,
+                        minimum: KeyboardConstants.FontSizes.mainLabelMinSize,
+                        maximum: KeyboardConstants.FontSizes.mainLabelMaxSize,
+                        cellFraction: KeyboardConstants.FontSizes.mainLabelMaxCellFraction
+                    )
+                    let hint = KeyView.clampedFontSize(
+                        base: KeyboardConstants.FontSizes.hintBaseSize,
+                        metrics: metrics,
+                        minimum: KeyboardConstants.FontSizes.hintMinSize,
+                        maximum: KeyboardConstants.FontSizes.hintMaxSize,
+                        cellFraction: KeyboardConstants.FontSizes.hintMaxCellFraction
+                    )
+                    #expect(label > 0)
+                    #expect(label <= metrics.cellWidth / 2 + 0.0001)
+                    #expect(hint > 0)
+                    // Three hints share one row across the cell.
+                    #expect(hint * 3 <= metrics.cellWidth + 0.0001)
+                }
+            }
+        }
+    }
+
+    /// The cap must not move what a default keyboard renders — it only ever
+    /// cuts the readability floor on very small keyboards.
+    @Test func theCellCapLeavesTheReferenceKeyboardUntouched() {
+        let metrics = KeyboardLayoutMetrics.reference
+        let base = KeyboardConstants.FontSizes.mainLabelBaseSize
+        let uncapped = min(
+            max(base * metrics.fontScale, KeyboardConstants.FontSizes.mainLabelMinSize),
+            KeyboardConstants.FontSizes.mainLabelMaxSize
+        )
+        #expect(
+            KeyView.clampedFontSize(
+                base: base, metrics: metrics,
+                minimum: KeyboardConstants.FontSizes.mainLabelMinSize,
+                maximum: KeyboardConstants.FontSizes.mainLabelMaxSize,
+                cellFraction: KeyboardConstants.FontSizes.mainLabelMaxCellFraction
+            ) == uncapped
+        )
+    }
 }

--- a/wurstfingerTests/KeyboardLayoutMetricsTests.swift
+++ b/wurstfingerTests/KeyboardLayoutMetricsTests.swift
@@ -268,4 +268,25 @@ struct KeyboardLayoutMetricsTests {
         #expect(metrics.cellHeight > 0)
         #expect(metrics.totalHeight.isFinite)
     }
+
+    /// The height cap can fall below the constant chrome for a tiny screen
+    /// height. No shipping device does that, but the value arrives from the
+    /// host, and an unfloored scale would collapse every cell to zero — which
+    /// `cellAspectRatio`, `fontScale` and the gesture geometry divide by.
+    @Test(arguments: [CGFloat(1), 10, 50, 100, 149])
+    func tinyScreenHeightsStillProducePositiveCells(screenHeight: CGFloat) {
+        let metrics = KeyboardLayoutMetrics.resolve(
+            wishWidth: 270,
+            aspectRatio: 1.3,
+            columns: 4,
+            availableWidth: 393,
+            screenHeight: screenHeight
+        )
+        #expect(metrics.cellWidth > 0)
+        #expect(metrics.cellHeight > 0)
+        #expect(metrics.keyboardWidth > 0)
+        #expect(metrics.fontScale > 0)
+        // Scaling both axes by one factor keeps the aspect exact even at the floor.
+        #expect(abs(metrics.cellAspectRatio - 1.3) < 0.0001)
+    }
 }

--- a/wurstfingerTests/SlideGestureStateTests.swift
+++ b/wurstfingerTests/SlideGestureStateTests.swift
@@ -450,6 +450,26 @@ struct SlideGestureStateTests {
         _ = state.handleCancelled()
         #expect(state.maxDisplacement == 0)
     }
+
+    // MARK: - Trail activation distance
+
+    /// The trail's activation distance on a slide key is the same value that
+    /// decides tap vs. slide, so a tap can never draw one.
+    @Test(arguments: [SlideType.moveCursor, .delete])
+    func theActivationThresholdIsTheTapBoundary(slideType: SlideType) {
+        let configuration = SlideGestureConfiguration.for(slideType)
+        let boundary = SlideGestureHandler.activationThreshold(for: slideType)
+
+        var short = SlideGestureState()
+        let below = CGSize(width: boundary - 1, height: 0)
+        _ = short.handleChanged(translation: below, configuration: configuration)
+        #expect(short.handleEnded(translation: below, configuration: configuration) == .tap)
+
+        var long = SlideGestureState()
+        let above = CGSize(width: boundary + 1, height: 0)
+        _ = long.handleChanged(translation: above, configuration: configuration)
+        #expect(long.handleEnded(translation: above, configuration: configuration) == .ended)
+    }
 }
 
 // MARK: - ViewModel handling of .cancelled


### PR DESCRIPTION
Findings 4, 16, 18 and the two trail nitpicks of finding 25 from the 2026-08-08 stabilization review.

### The globe key was inoperable under VoiceOver (finding 4, P1)

Every key is one accessibility element with no custom actions, and a VoiceOver double-tap synthesizes a tap. The globe's tap is intentionally `.none` — switching lives on swipe-left — so a VoiceOver user could not leave Wurstfinger, dismiss the keyboard, cycle languages, or reach any swipe-only utility, while the element's label promised "Switch keyboard". App Review requires the input-mode switch to be operable.

Two derived properties on `KeyConfig` fix this generically rather than with a globe special case:

- `accessibilityActivationOverride` — the gesture that replaces the synthesized tap, for keys whose tap does nothing. It is **declared** in the layout data (`accessibilityActivationGesture`), not inferred: every ordering rule I checked picks the wrong binding for the globe, because `GestureType.allCases` puts `.swipeDown`/dismiss before `.swipeLeft`.
- `accessibilityActions` — one named rotor action per binding that already carries an `accessibilityLabel`, deduplicated by name and in a fixed order (dictionary iteration is seeded per process; the rotor order must not change between launches).

Using the existing `accessibilityLabel` as the opt-in means ~6 actions across 2 key types instead of 8 unnamed entries on ~40 keys, and it reuses strings that are already translated. One new key, "Next language", went into the extension's own catalog with all 22 translations.

`KeyConfig.bindings` became `var` so derived keys copy-and-mutate. This is load-bearing: `generateShifted` maps every key, and a field-by-field rebuild would silently drop the new declaration and leave the globe dead in the shifted and caps-lock modes of all 26 languages.

### Labels could outgrow their cell (finding 16, P3)

`mainLabelMinSize` is 20 pt while cells are ~14 pt wide at the minimum keyboard width, and hints floored at 10 pt overlapped each other. Instead of lowering the floor — which still overflows at *some* width — font size is now capped against the rendered cell (50 % for the main label, 30 % for hints). Since the aspect setting is clamped to ≥ 1.0, the cap can only ever cut the readability floor, never normal scaling. `.lineLimit(1)` plus `.minimumScaleFactor(0.5)` covers multi-character labels like "123".

### Zero-size cells for small-positive screen heights (finding 18, P3)

The hardening test probed only `.infinity`. The height-guard scale is now floored via `minCellSize`, and the floor is on the scale rather than the cells, which keeps the aspect ratio exact at the floor. No real device was affected.

### Trail nitpicks (finding 25)

- **Allocation churn** — `GestureTrailToken` and the recorder now live in `@StateObject`, so they are built once per key/grid instead of once per body evaluation.
- **Activation distance** — the trail used a global 8 pt while a letter key stays a tap up to 20 pt, so a sloppy tap flashed a streak. Each recognizer now supplies its own tap boundary per touch: the classifier's `minSwipeLength` on a letter key (so retuning it in expert mode moves both), the slide activation threshold on space and delete.

  A follow-up review caught that this was still not exact: `classify` divides the horizontal component by the key's aspect ratio, so its tap boundary is an *ellipse* in screen space, while the recorder compared raw travel. At aspect 1.62 a 25 pt sideways slip drew a trail and was then dispatched as a tap. The recorder now measures in the same normalized space, so the two boundaries are the same boundary at every aspect setting; degenerate ratios fall back to raw travel.

  Note for the record: the review's "~30 pt letter-key tap boundary" is wrong — it is 20 pt. The 30 belongs to a second, unrelated constant of the same name, which is exactly the doc drift finding 22 is about.

### Verification

1089 unit tests pass; SwiftFormat and SwiftLint `--strict` are clean. `everyKeyIsOperableWithoutGestures` fails on `develop` for the globe in 4 modes × 26 languages, and fails again if any `KeyConfig` copy site drops the new field.

Manual VoiceOver checklist, not yet run on device:

- globe double-tap advances the input mode;
- the rotor on the globe offers "Hide keyboard" and "Next language";
- the rotor on the symbols key offers Copy / Paste / Cut / Cut all;
- ordinary letter keys still activate with a plain double-tap and expose no actions.

One behaviour left as is: the globe offers "Next language" even with a single language enabled, because the binding is present then too (it dispatches as a no-op). Suppressing it would mean plumbing view-model state into a data-driven modifier; matching the gesture exactly seemed the more defensible invariant.
