### PR TITLE
Complete the Thai, Kana, Arabic-Script, Hindi and Hebrew Layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Optional gesture trail — a soft, tapered stroke follows the finger while it swipes and fades out when it lifts, in the style of the iOS keyboard's swipe trail. Off by default, enabled under Settings › Gestures (#279)
 
+### Fixed
+
+- Characters that could not be typed at all on the non-Latin layouts: Thai ฬ ฒ ฑ ฏ (circle gesture, matching the reference's center return) and the baht sign ฿, the Japanese 、 and 。 plus the small kana on return swipes, the Persian/Urdu half-space (ZWNJ), Arabic-script punctuation ؟ ، ؛ ٭ in place of the Latin marks, the Hindi rupee sign ₹, and the Hebrew geresh and gershayim ׳ ״
+
 ## v1.4.0 — 2026-07-23
 
 ### Added

--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -23,6 +23,11 @@ enum GridKeyboardFactory {
     ///     auto-generated uppercase return action (e.g. Hebrew final forms:
     ///     a return swipe on כ produces ך). Each entry must target a gesture
     ///     that already has a binding on that slot.
+    ///   - circularOverrides: Per-slot output of the circle gesture. This is
+    ///     the reference layout's "center return": uppercasing the center
+    ///     character (the runtime's generic fallback) covers it on cased
+    ///     scripts, but a caseless script needs its own glyph — Thai ม → ฒ,
+    ///     kana つ → っ.
     ///   - composeRuleOverrides: Language-specific compose rules merged over the
     ///     global base rules at runtime (override wins for the same trigger +
     ///     base character). Defaults to nil (global rules only).
@@ -48,6 +53,7 @@ enum GridKeyboardFactory {
         centerCharacters: [[String]],
         directionalOverrides: [String: [GestureType: String]] = [:],
         returnOverrides: [String: [GestureType: String]] = [:],
+        circularOverrides: [String: String] = [:],
         composeRuleOverrides: ComposeRuleSet? = nil,
         supportsCapitalization: Bool = true,
         numericBackToAlphaLabel: String = NumericLayouts.defaultBackToAlphaLabel,
@@ -73,12 +79,18 @@ enum GridKeyboardFactory {
                 var bindings = CommonKeys.defaultSlotBindings[slotId] ?? [:]
 
                 // Apply language-specific overrides (replace default binding for that gesture).
-                // Letters get an auto-generated uppercase return action.
+                // Letters get an auto-generated uppercase return action — but only where
+                // uppercasing actually changes the letter. On a caseless script it is the
+                // identity, and a return action that repeats its own swipe is a silent
+                // no-op hiding a missing `returnOverrides` entry: without a return action
+                // the resolver falls through to the primary binding and commits the same
+                // glyph anyway.
                 if let overrides = directionalOverrides[slotId] {
                     for (gesture, text) in overrides {
                         let isLetter = text.unicodeScalars.contains { CharacterSet.letters.contains($0) }
-                        let returnAction: KeyAction? = isLetter
-                            ? .commitText(text.keyboardUppercased(with: locale))
+                        let uppercased = text.keyboardUppercased(with: locale)
+                        let returnAction: KeyAction? = isLetter && uppercased != text
+                            ? .commitText(uppercased)
                             : nil
                         bindings[gesture] = KeyBinding(
                             label: text, action: .commitText(text),
@@ -114,6 +126,20 @@ enum GridKeyboardFactory {
                             accessibilityLabel: base.accessibilityLabel
                         )
                     }
+                }
+
+                // Circle gesture. `handleCircular` falls back to the uppercased
+                // center character, which is the identity on a caseless script,
+                // so a distinct circle output has to be declared here. Both
+                // directions get the same binding — a thumb circle rarely comes
+                // out the way it was intended (same reasoning as `CommonKeys.cutAll`).
+                if let text = circularOverrides[slotId] {
+                    let circle = KeyBinding(
+                        label: text, action: .commitText(text),
+                        category: nil, returnAction: nil, accessibilityLabel: nil
+                    )
+                    bindings[.circularClockwise] = circle
+                    bindings[.circularCounterclockwise] = circle
                 }
 
                 letterKeys[slotId] = KeyConfig(

--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions+MessagEase.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions+MessagEase.swift
@@ -145,7 +145,7 @@ extension LanguageDefinitions {
                 ["ي", "ا", "ر"],
                 ["و", "ن", "د"],
             ],
-            directionalOverrides: [
+            directionalOverrides: ScriptPunctuation.arabicScript(adding: [
                 GridSlot.topLeft: [.swipeRight: "ـ", .swipeDown: "ة", .swipeDownRight: "ق"],
                 GridSlot.topCenter: [
                     .swipeUp: "ُ", .swipeUpLeft: "ِ", .swipeUpRight: "َ",
@@ -171,13 +171,13 @@ extension LanguageDefinitions {
                     .swipeUp: "ً", .swipeUpLeft: "ۋ", .swipeUpRight: "ْ",
                     .swipeLeft: "ذ",
                 ],
-            ],
-            returnOverrides: [
+            ]),
+            returnOverrides: ScriptPunctuation.arabicScriptReturns(adding: [
                 GridSlot.topCenter: [.swipeUp: "ٌ", .swipeUpLeft: "ٍ", .swipeUpRight: "ً"],
                 GridSlot.midLeft: [.swipeDown: "ئ"],
                 GridSlot.bottomCenter: [.swipeRight: "إ"],
                 GridSlot.bottomRight: [.swipeUpLeft: "گ"],
-            ],
+            ]),
             supportsCapitalization: false,
             numericBackToAlphaLabel: "ابت",
             numericDigits: NumericLayouts.arabicIndicDigits
@@ -198,7 +198,7 @@ extension LanguageDefinitions {
                 ["ی", "ا", "ر"],
                 ["و", "ن", "د"],
             ],
-            directionalOverrides: [
+            directionalOverrides: ScriptPunctuation.arabicScript(adding: [
                 GridSlot.topLeft: [.swipeRight: "ـ", .swipeDown: "ۀ", .swipeDownRight: "ق"],
                 GridSlot.topCenter: [
                     .swipeUp: "ُ", .swipeUpLeft: "ِ", .swipeUpRight: "َ",
@@ -221,9 +221,13 @@ extension LanguageDefinitions {
                     .swipeUp: "ً", .swipeUpLeft: "گ", .swipeUpRight: "ْ",
                     .swipeLeft: "ذ",
                 ],
-            ],
-            returnOverrides: [
-                GridSlot.topLeft: [.swipeDown: "ة", .swipeDownRight: "ف"],
+            ]),
+            returnOverrides: ScriptPunctuation.arabicScriptReturns(adding: [
+                // The tatweel key's return swipe types ZWNJ (U+200C) — the
+                // half-space standard Persian orthography puts inside a word to
+                // keep a prefix or suffix from joining the stem. Written as an
+                // escape so the source carries no invisible character.
+                GridSlot.topLeft: [.swipeRight: "\u{200C}", .swipeDown: "ة", .swipeDownRight: "ف"],
                 GridSlot.topCenter: [
                     .swipeUp: "ٌ", .swipeUpLeft: "ٍ", .swipeUpRight: "ً",
                     .swipeDown: "ح", .swipeDownLeft: "ص", .swipeDownRight: "ب",
@@ -241,7 +245,7 @@ extension LanguageDefinitions {
                     .swipeRight: "إ",
                 ],
                 GridSlot.bottomRight: [.swipeUpLeft: "ک", .swipeLeft: "د"],
-            ],
+            ]),
             supportsCapitalization: false,
             numericBackToAlphaLabel: "ابپ",
             numericDigits: NumericLayouts.persianDigits
@@ -262,7 +266,7 @@ extension LanguageDefinitions {
                 ["ی", "ا", "ر"],
                 ["و", "ن", "د"],
             ],
-            directionalOverrides: [
+            directionalOverrides: ScriptPunctuation.arabicScript(adding: [
                 GridSlot.topLeft: [
                     .swipeUp: "ٹ", .swipeRight: "ـ", .swipeDown: "ۀ",
                     .swipeDownRight: "ق",
@@ -294,11 +298,12 @@ extension LanguageDefinitions {
                     .swipeUp: "ً", .swipeUpLeft: "گ", .swipeUpRight: "ْ",
                     .swipeLeft: "ذ",
                 ],
-            ],
-            returnOverrides: [
-                GridSlot.topLeft: [.swipeDown: "ة"],
+            ]),
+            returnOverrides: ScriptPunctuation.arabicScriptReturns(adding: [
+                // See the Persian layout: the tatweel return types ZWNJ (U+200C).
+                GridSlot.topLeft: [.swipeRight: "\u{200C}", .swipeDown: "ة"],
                 GridSlot.topCenter: [.swipeUp: "ٌ", .swipeUpLeft: "ٍ", .swipeUpRight: "ً"],
-            ],
+            ]),
             supportsCapitalization: false,
             numericBackToAlphaLabel: "ابپ",
             numericDigits: NumericLayouts.persianDigits
@@ -381,9 +386,10 @@ extension LanguageDefinitions {
                     .swipeLeft: "ฉ", .swipeRight: "ษ", .swipeDown: "ฎ",
                     .swipeDownLeft: "ฮ", .swipeDownRight: "ช",
                 ],
+                // ฿ rides the ท key's return swipe, matching the reference.
                 GridSlot.midRight: [
-                    .swipeUpLeft: "ฝ", .swipeUpRight: "ภ", .swipeDownLeft: "ฟ",
-                    .swipeDownRight: "ณ",
+                    .swipeUpLeft: "ฝ", .swipeUpRight: "ภ", .swipeLeft: "฿",
+                    .swipeDownLeft: "ฟ", .swipeDownRight: "ณ",
                 ],
                 GridSlot.bottomLeft: [
                     .swipeUp: "์", .swipeUpLeft: "แ", .swipeUpRight: "๎",
@@ -391,6 +397,14 @@ extension LanguageDefinitions {
                 ],
                 GridSlot.bottomCenter: [.swipeUp: "ๆ", .swipeRight: "ํ"],
                 GridSlot.bottomRight: [.swipeUp: "ฌ", .swipeRight: "ซ", .swipeDownLeft: "ำ"],
+            ],
+            // The reference's center returns: circling a key types a second
+            // consonant. Four of them (ฬ ฒ ฑ ฏ) have no other position in the
+            // layout, so without this they cannot be typed at all.
+            circularOverrides: [
+                GridSlot.topLeft: "ฬ", GridSlot.topCenter: "ณ", GridSlot.topRight: "ฎ",
+                GridSlot.midLeft: "ธ", GridSlot.center: "ฮ", GridSlot.midRight: "ฐ",
+                GridSlot.bottomLeft: "ฒ", GridSlot.bottomCenter: "ฑ", GridSlot.bottomRight: "ฏ",
             ],
             supportsCapitalization: false,
             numericBackToAlphaLabel: "กขค",
@@ -445,8 +459,8 @@ extension LanguageDefinitions {
                     .swipeLeft: "ण",
                 ],
                 GridSlot.bottomCenter: [
-                    .swipeUp: "ए", .swipeUpRight: "औ", .swipeRight: "ग",
-                    .swipeDownRight: "ष",
+                    .swipeUp: "ए", .swipeUpRight: "औ", .swipeLeft: "₹",
+                    .swipeRight: "ग", .swipeDownRight: "ष",
                 ],
                 GridSlot.bottomRight: [
                     .swipeUp: "च", .swipeUpLeft: "य", .swipeUpRight: "भ",
@@ -483,6 +497,8 @@ extension LanguageDefinitions {
             localeIdentifier: meta.localeIdentifier,
             centerCharacters: hiraganaCenterCharacters,
             directionalOverrides: hiraganaDirectionalOverrides,
+            returnOverrides: hiraganaReturnOverrides,
+            circularOverrides: hiraganaCircularOverrides,
             supportsCapitalization: false,
             numericBackToAlphaLabel: "かな",
             combineRuleSet: hiraganaCombineRules
@@ -519,14 +535,41 @@ extension LanguageDefinitions {
             .swipeUp: "の", .swipeUpLeft: "ゝ", .swipeUpRight: "む",
             .swipeLeft: "を", .swipeRight: "う", .swipeDown: "な",
         ],
+        // 、 and 。 replace the shared Latin comma and full stop, which stay one
+        // return swipe away (see `hiraganaReturnOverrides`) and keep their
+        // positions on the numeric layer. `AutoCapitalization` counts 。 as a
+        // sentence ender.
         GridSlot.bottomCenter: [
             .swipeUp: "て", .swipeUpLeft: "゛", .swipeLeft: "ね",
-            .swipeRight: "け",
+            .swipeRight: "け", .swipeDown: "。", .swipeDownLeft: "、",
         ],
         GridSlot.bottomRight: [
             .swipeUp: "え", .swipeUpLeft: "こ", .swipeLeft: "よ",
             .swipeRight: "ぬ", .swipeDownLeft: "お",
         ],
+    ]
+
+    /// Small kana are the reference's *return* outputs on their full-size
+    /// counterparts (や → ゃ, あ → ぁ). A caseless script gets no auto-generated
+    /// return, so without these a return swipe just repeats the plain kana and
+    /// ゃゅょ / ぁぅぇぉ are reachable only through the accent-cycle key. Voicing
+    /// stays on the ゛ key (`hiraganaCombineRules`), as in the reference.
+    /// `bottomCenter` keeps the Latin comma and full stop that 、 and 。 displace.
+    private static let hiraganaReturnOverrides: [String: [GestureType: String]] = [
+        GridSlot.topLeft: [.swipeDown: "ゃ"],
+        GridSlot.center: [.swipeUp: "ぁ"],
+        GridSlot.midRight: [.swipeUpLeft: "ゅ"],
+        GridSlot.bottomLeft: [.swipeRight: "ぅ"],
+        GridSlot.bottomCenter: [.swipeDown: ".", .swipeDownLeft: ","],
+        GridSlot.bottomRight: [.swipeUp: "ぇ", .swipeLeft: "ょ", .swipeDownLeft: "ぉ"],
+    ]
+
+    /// Circle gesture, the reference's center return: the voiced form of the
+    /// key's own kana, or the small form for い and つ. ぃ has no other position
+    /// in the layout.
+    private static let hiraganaCircularOverrides: [String: String] = [
+        GridSlot.topLeft: "ぐ", GridSlot.topCenter: "っ", GridSlot.topRight: "ぃ",
+        GridSlot.midLeft: "ぶ", GridSlot.bottomLeft: "ど", GridSlot.bottomRight: "ず",
     ]
 
     /// Dakuten voicing (kana + ゛ → voiced kana), from MessagEase hiraganaCombine.
@@ -556,6 +599,8 @@ extension LanguageDefinitions {
             localeIdentifier: meta.localeIdentifier,
             centerCharacters: katakanaCenterCharacters,
             directionalOverrides: katakanaDirectionalOverrides,
+            returnOverrides: katakanaReturnOverrides,
+            circularOverrides: katakanaCircularOverrides,
             supportsCapitalization: false,
             numericBackToAlphaLabel: "カナ",
             combineRuleSet: katakanaCombineRules
@@ -569,9 +614,11 @@ extension LanguageDefinitions {
     /// (`KatakanaDerivationTests`) pins the derived tables to the previously
     /// hand-authored values, proving zero behavior change.
     ///
-    /// Two genuine katakana-only deltas are layered on top: the ・ separator on
-    /// `bottomCenter.swipeDownRight` (below) and the wa-row voiced combine
-    /// entries in `katakanaCombineRules` (which the transform cannot supply).
+    /// Four genuine katakana-only deltas are layered on top: the ・ separator on
+    /// `bottomCenter.swipeDownRight` (below), the ":" it displaces on that
+    /// gesture's return swipe, the small ヮ on `midLeft.swipeDown`, and the
+    /// wa-row voiced combine entries in `katakanaCombineRules` (which the
+    /// transform cannot supply).
     static let katakanaCenterCharacters: [[String]] =
         hiraganaCenterCharacters.map { $0.map(katakanize) }
 
@@ -584,6 +631,20 @@ extension LanguageDefinitions {
         derived[GridSlot.bottomCenter, default: [:]][.swipeDownRight] = "・"
         return derived
     }()
+
+    static let katakanaReturnOverrides: [String: [GestureType: String]] = {
+        var derived = hiraganaReturnOverrides.mapValues { returns in
+            returns.mapValues(katakanize)
+        }
+        // Katakana-only deltas, both from the reference: ヮ has no hiragana
+        // counterpart on this key, and the ・ separator keeps the ":" it displaces.
+        derived[GridSlot.midLeft, default: [:]][.swipeDown] = "ヮ"
+        derived[GridSlot.bottomCenter, default: [:]][.swipeDownRight] = ":"
+        return derived
+    }()
+
+    static let katakanaCircularOverrides: [String: String] =
+        hiraganaCircularOverrides.mapValues(katakanize)
 
     /// Maps a single hiragana glyph to its katakana counterpart. The shared
     /// sound/iteration marks (゛ ゜ → unchanged, ゝ → ヽ) and the prolonged-sound

--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions.swift
@@ -245,7 +245,11 @@ enum LanguageDefinitions {
                     .swipeDownLeft: "כ", .swipeLeft: "ע",
                 ],
                 GridSlot.bottomLeft: [.swipeUpRight: "ז"],
-                GridSlot.bottomCenter: [.swipeUp: "ס"],
+                // Geresh and gershayim carry Hebrew abbreviations, acronyms and
+                // numerals (ד״ר, צה״ל); the reference puts them where the Latin
+                // quotes sit. Those stay one return swipe away, and on the
+                // numeric layer.
+                GridSlot.bottomCenter: [.swipeUp: "ס", .swipeUpLeft: "״", .swipeUpRight: "׳"],
                 GridSlot.bottomRight: [.swipeUpLeft: "ט"],
             ],
             // MessagEase convention: a return swipe on a base letter produces
@@ -255,6 +259,7 @@ enum LanguageDefinitions {
                 GridSlot.center: [
                     .swipeUpRight: "ף", .swipeDown: "ן", .swipeDownLeft: "ך",
                 ],
+                GridSlot.bottomCenter: [.swipeUpLeft: "\"", .swipeUpRight: "'"],
             ],
             // Hebrew is caseless: no shift key, no shifted/capsLock modes,
             // no auto-capitalization.

--- a/wurstfingerKeyboard/Definition/Language/ScriptPunctuation.swift
+++ b/wurstfingerKeyboard/Definition/Language/ScriptPunctuation.swift
@@ -1,0 +1,57 @@
+//
+//  ScriptPunctuation.swift
+//  Wurstfinger
+//
+//  Punctuation shared by every layout of one writing system.
+//
+
+import Foundation
+
+/// Punctuation a whole writing system shares. One table per script, shared by
+/// every layout of that script, so those layouts cannot drift apart.
+enum ScriptPunctuation {
+    /// Arabic-script punctuation (؟ ، ؛ ٭) at its MessagEase reference
+    /// positions, merged into a layout's own directional overrides — the
+    /// layout wins for the same slot and gesture, so a language can still
+    /// deviate. Used by the Arabic, Persian, and Urdu layouts.
+    ///
+    /// The Latin `? , ; *` render with the wrong directionality and spacing
+    /// inside right-to-left text. They stay one return swipe away (see
+    /// `arabicScriptReturns`) and keep their positions on the numeric layer.
+    static func arabicScript(
+        adding own: [String: [GestureType: String]]
+    ) -> [String: [GestureType: String]] {
+        merging(arabicPunctuation, into: own)
+    }
+
+    /// The Latin marks `arabicScript` displaces, on the same gestures' return
+    /// swipes. `؛ → ;` is the reference's own pairing; the other three follow it.
+    static func arabicScriptReturns(
+        adding own: [String: [GestureType: String]]
+    ) -> [String: [GestureType: String]] {
+        merging(arabicPunctuationReturns, into: own)
+    }
+
+    private static let arabicPunctuation: [String: [GestureType: String]] = [
+        GridSlot.topRight: [.swipeLeft: "؟"],
+        GridSlot.bottomLeft: [.swipeRight: "٭"],
+        GridSlot.bottomCenter: [.swipeDownLeft: "،"],
+        GridSlot.bottomRight: [.swipeDownLeft: "؛"],
+    ]
+
+    private static let arabicPunctuationReturns: [String: [GestureType: String]] = [
+        GridSlot.topRight: [.swipeLeft: "?"],
+        GridSlot.bottomLeft: [.swipeRight: "*"],
+        GridSlot.bottomCenter: [.swipeDownLeft: ","],
+        GridSlot.bottomRight: [.swipeDownLeft: ";"],
+    ]
+
+    private static func merging(
+        _ shared: [String: [GestureType: String]],
+        into own: [String: [GestureType: String]]
+    ) -> [String: [GestureType: String]] {
+        shared.merging(own) { sharedSlot, ownSlot in
+            sharedSlot.merging(ownSlot) { _, ownText in ownText }
+        }
+    }
+}

--- a/wurstfingerTests/KatakanaDerivationTests.swift
+++ b/wurstfingerTests/KatakanaDerivationTests.swift
@@ -4,10 +4,10 @@
 //
 //  Characterization tests for the katakana layout, which is now derived from
 //  the hiragana tables via ICU `.hiraganaToKatakana` instead of a hand-authored
-//  glyph-for-glyph mirror. The expected values below are the exact values that
-//  were hand-authored before the refactor, so equality proves zero behavior
-//  change. Also pins the two genuine katakana-only deltas (the ・ separator and
-//  the wa-row voiced combine entries) and the #268 ゛-cascade / ja_JP locale.
+//  glyph-for-glyph mirror. The expected values below spell the tables out in
+//  katakana, so equality proves the derivation maps every kana glyph-for-glyph.
+//  Also pins the genuine katakana-only deltas (the ・ separator, the small ヮ,
+//  and the wa-row voiced combine entries) and the #268 ゛-cascade / ja_JP locale.
 //
 
 import Foundation
@@ -53,7 +53,8 @@ struct KatakanaDerivationTests {
             ],
             GridSlot.bottomCenter: [
                 .swipeUp: "テ", .swipeUpLeft: "゛", .swipeLeft: "ネ",
-                .swipeRight: "ケ", .swipeDownRight: "・",
+                .swipeRight: "ケ", .swipeDown: "。", .swipeDownLeft: "、",
+                .swipeDownRight: "・",
             ],
             GridSlot.bottomRight: [
                 .swipeUp: "エ", .swipeUpLeft: "コ", .swipeLeft: "ヨ",
@@ -61,6 +62,27 @@ struct KatakanaDerivationTests {
             ],
         ]
         #expect(LanguageDefinitions.katakanaDirectionalOverrides == expected)
+    }
+
+    @Test func derivedReturnOverridesMatchHiraganaSmallKana() {
+        let expected: [String: [GestureType: String]] = [
+            GridSlot.topLeft: [.swipeDown: "ャ"],
+            GridSlot.center: [.swipeUp: "ァ"],
+            GridSlot.midLeft: [.swipeDown: "ヮ"],
+            GridSlot.midRight: [.swipeUpLeft: "ュ"],
+            GridSlot.bottomLeft: [.swipeRight: "ゥ"],
+            GridSlot.bottomCenter: [.swipeDown: ".", .swipeDownLeft: ",", .swipeDownRight: ":"],
+            GridSlot.bottomRight: [.swipeUp: "ェ", .swipeLeft: "ョ", .swipeDownLeft: "ォ"],
+        ]
+        #expect(LanguageDefinitions.katakanaReturnOverrides == expected)
+    }
+
+    @Test func derivedCircularOverridesMatchHiraganaVoicing() {
+        let expected: [String: String] = [
+            GridSlot.topLeft: "グ", GridSlot.topCenter: "ッ", GridSlot.topRight: "ィ",
+            GridSlot.midLeft: "ブ", GridSlot.bottomLeft: "ド", GridSlot.bottomRight: "ズ",
+        ]
+        #expect(LanguageDefinitions.katakanaCircularOverrides == expected)
     }
 
     // MARK: - Genuine katakana-only deltas survive

--- a/wurstfingerTests/LanguageAlphabetCoverageTests.swift
+++ b/wurstfingerTests/LanguageAlphabetCoverageTests.swift
@@ -1,0 +1,203 @@
+//
+//  LanguageAlphabetCoverageTests.swift
+//  WurstfingerTests
+//
+//  Content coverage for every layout: the characters a native writer needs must
+//  be producible from the definition. `KeyboardDefinition.validate()` checks
+//  structure only, so a layout can ship with an untypeable letter and still
+//  pass CI.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+/// One layout's required characters and where that list comes from. Characters
+/// a layout knowingly does not provide are named in the entry's comment —
+/// never left silent.
+private struct AlphabetInventory {
+    let id: String
+    let source: String
+    /// Groups of characters, iterated by Unicode scalar (several of these
+    /// scripts use combining marks, which grapheme iteration would fuse with
+    /// the preceding letter).
+    let groups: [String]
+}
+
+struct LanguageAlphabetCoverageTests {
+    @Test(arguments: LanguageDefinitions.all)
+    func layoutProducesItsAlphabet(descriptor: LanguageDescriptor) throws {
+        let inventory = try #require(
+            Self.inventories.first(where: { $0.id == descriptor.id }),
+            "No alphabet inventory for \(descriptor.id) — add one to `inventories`"
+        )
+        let producible = Self.producibleText(of: descriptor.makeDefinition())
+        let missing = inventory.groups
+            .flatMap(\.unicodeScalars)
+            .map { String($0) }
+            .filter { !producible.contains($0) }
+        #expect(
+            missing.isEmpty,
+            "[\(descriptor.id)] cannot produce \(Self.describe(missing)) — inventory: \(inventory.source)"
+        )
+    }
+
+    /// Names the missing characters by code point as well: ZWNJ, the Thai tone
+    /// marks and the Devanagari matras are invisible on their own.
+    private static func describe(_ characters: [String]) -> String {
+        characters
+            .map { character in
+                let scalars = character.unicodeScalars
+                    .map { String(format: "U+%04X", $0.value) }
+                    .joined(separator: " ")
+                return "\(character) (\(scalars))"
+            }
+            .joined(separator: ", ")
+    }
+
+    /// Everything the definition can put into the document: every `commitText`
+    /// (primary and return swipe, all modes), every output of a compose rule
+    /// whose trigger is actually bound, every sequential-combine result, and
+    /// everything reachable from those through the 🅒 accent-cycle key.
+    private static func producibleText(of definition: KeyboardDefinition) -> Set<String> {
+        var direct: Set<String> = []
+        var composeTriggers: Set<String> = []
+        for mode in definition.modes.values {
+            for key in mode.keys.values {
+                for binding in key.bindings.values {
+                    collect(binding.action, into: &direct, triggers: &composeTriggers)
+                    if let returnAction = binding.returnAction {
+                        collect(returnAction, into: &direct, triggers: &composeTriggers)
+                    }
+                }
+            }
+        }
+
+        let engine = definition.settings.composeRuleOverrides
+            .map { ComposeEngine.withGlobalRules(overrides: $0) } ?? ComposeEngine.shared
+        for trigger in composeTriggers {
+            if let outputs = engine.ruleSet.rules[trigger]?.values {
+                direct.formUnion(outputs)
+            }
+        }
+        if let combine = definition.settings.combineRuleSet {
+            for map in combine.rules.values {
+                direct.formUnion(map.values)
+            }
+        }
+        return cycleClosure(of: direct, engine: engine)
+    }
+
+    private static func collect(
+        _ action: KeyAction, into direct: inout Set<String>, triggers: inout Set<String>
+    ) {
+        switch action {
+        case let .commitText(text): direct.insert(text)
+        case let .compose(trigger): triggers.insert(trigger)
+        default: break
+        }
+    }
+
+    /// The 🅒 key cycles the character before the cursor through its accent
+    /// variants, so everything on a reachable character's cycle is producible.
+    private static func cycleClosure(of seeds: Set<String>, engine: ComposeEngine) -> Set<String> {
+        var result = seeds
+        var pending = Array(seeds)
+        while let character = pending.popLast() {
+            guard let next = engine.cycleAccent(for: character),
+                  result.insert(next).inserted
+            else { continue }
+            pending.append(next)
+        }
+        return result
+    }
+
+    // MARK: - Inventories
+
+    private static let latin = "abcdefghijklmnopqrstuvwxyz"
+
+    private static let inventories: [AlphabetInventory] = [
+        AlphabetInventory(id: "en_US", source: "ISO basic Latin alphabet", groups: [latin]),
+        AlphabetInventory(id: "hr_HR", source: "Croatian alphabet (Gaj's Latin)", groups: [latin, "čćđšž"]),
+        AlphabetInventory(id: "et_EE", source: "Estonian and Finnish alphabets", groups: [latin, "äöõüšžå"]),
+        AlphabetInventory(id: "fi_FI", source: "Finnish alphabet", groups: [latin, "äöå"]),
+        AlphabetInventory(
+            id: "fr_FR", source: "French accented letters and ligatures",
+            groups: [latin, "àâçèéêëîïôùûüÿœæ"]
+        ),
+        AlphabetInventory(id: "de_DE", source: "German umlauts and ß", groups: [latin, "äöüß"]),
+        AlphabetInventory(id: "it_IT", source: "Italian accented vowels", groups: [latin, "àèéìòù"]),
+        AlphabetInventory(id: "pl_PL", source: "Polish alphabet", groups: [latin, "ąćęłńóśźż"]),
+        AlphabetInventory(id: "pt_PT", source: "Portuguese diacritics", groups: [latin, "àáâãçéêíóôõú"]),
+        AlphabetInventory(id: "es_ES", source: "Spanish diacritics", groups: [latin, "áéíñóúü"]),
+        AlphabetInventory(id: "ca_ES", source: "Spanish and Catalan diacritics", groups: [latin, "àáçèéíïñòóúü"]),
+        AlphabetInventory(id: "sv_SE", source: "Swedish alphabet", groups: [latin, "åäö"]),
+        AlphabetInventory(id: "tl_PH", source: "Filipino alphabet", groups: [latin, "ñ"]),
+        // Base letters only: the tone marks come from the Telex input method and
+        // are covered by TelexTypingTests, not by a binding.
+        AlphabetInventory(
+            id: "vi_VN", source: "Vietnamese 29-letter alphabet",
+            groups: ["abcdeghiklmnopqrstuvxy", "ăâđêôơư"]
+        ),
+        AlphabetInventory(id: "ru_RU", source: "Russian alphabet", groups: ["абвгдеёжзийклмнопрстуфхцчшщъыьэюя"]),
+        AlphabetInventory(id: "uk_UA", source: "Ukrainian alphabet", groups: ["абвгґдеєжзиіїйклмнопрстуфхцчшщьюя"]),
+        AlphabetInventory(
+            id: "el_GR", source: "Greek alphabet, final sigma, monotonic accented vowels",
+            groups: ["αβγδεζηθικλμνξοπρστυφχψω", "ς", "άέήίόύώϊϋΐΰ"]
+        ),
+        AlphabetInventory(
+            id: "he_IL", source: "Hebrew alphabet, final forms, geresh and gershayim",
+            groups: ["אבגדהוזחטיכלמנסעפצקרשת", "ךםןףץ", "׳״"]
+        ),
+        // The tense consonants ㄲㄸㅃㅆㅉ are produced by HangulComposer (typing the
+        // base consonant twice), not by a binding — see HangulComposerTests.
+        AlphabetInventory(
+            id: "ko_KR", source: "Basic jamo plus the complex vowels the layout binds",
+            groups: ["ㄱㄴㄷㄹㅁㅂㅅㅇㅈㅊㅋㅌㅍㅎ", "ㅏㅑㅓㅕㅗㅛㅜㅠㅡㅣ", "ㅐㅔㅒㅖ"]
+        ),
+        AlphabetInventory(
+            id: "ar", source: "Arabic alphabet, hamza carriers, Arabic punctuation",
+            groups: ["ابتثجحخدذرزسشصضطظعغفقكلمنهوي", "ءآأؤإئةى", "؟،؛٭"]
+        ),
+        AlphabetInventory(
+            id: "fa_IR", source: "Persian alphabet, hamza carriers, ZWNJ, Arabic-script punctuation",
+            groups: ["ابپتثجچحخدذرزژسشصضطظعغفقکگلمنوهی", "ءآأؤئةۀ", "؟،؛٭", "\u{200C}"]
+        ),
+        // The reference layout has no ہ (heh goal) and no ھ (do-chashmi heh)
+        // anywhere; adding them would mean inventing positions.
+        AlphabetInventory(
+            id: "ur", source: "Urdu alphabet as the reference layout defines it",
+            groups: ["ابپتٹثجچحخدڈذرڑزژسشصضطظعغفقکگلمنںوی", "ےۓءآؤئۀ", "؟،؛٭", "\u{200C}"]
+        ),
+        // Without ฅ (khokhon): obsolete, and absent from the reference layout.
+        AlphabetInventory(
+            id: "th_TH", source: "Thai consonants, vowel signs, tone marks, baht sign",
+            groups: [
+                "กขฃคฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรลวศษสหฬอฮ", "ฤฦ",
+                "ะัาำิีึืุูเแโใไๅ", "็่้๊๋์ํ๎", "ๆฯ฿",
+            ]
+        ),
+        // Without ङ (nga): absent from the reference layout.
+        AlphabetInventory(
+            id: "hi_IN", source: "Devanagari consonants, vowels, matras, signs, danda, rupee sign",
+            groups: [
+                "कखगघचछजझञटठडढणतथदधनपफबभमयरलवशषसह", "अआइईउऊऋएऐऑओऔ",
+                "ािीुूृॅेैॉोौ्", "ंःँ़", "।₹",
+            ]
+        ),
+        AlphabetInventory(
+            id: "ja_JP", source: "Hiragana gojūon, voiced and small kana, Japanese punctuation",
+            groups: [
+                "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん",
+                "がぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽ", "ぁぃぅぇぉゃゅょっ", "ー、。",
+            ]
+        ),
+        AlphabetInventory(
+            id: "ja_JP_katakana", source: "Katakana gojūon, plus small ヮ and the nakaguro separator",
+            groups: [
+                "アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン",
+                "ガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポ", "ァィゥェォャュョッヮ", "ー、。・",
+            ]
+        ),
+    ]
+}

--- a/wurstfingerTests/ReturnSwipeLanguageTests.swift
+++ b/wurstfingerTests/ReturnSwipeLanguageTests.swift
@@ -26,12 +26,16 @@ struct ReturnSwipeLanguageTests {
         )
     }
 
-    /// Regression guard: for every language, the center key's return swipe overrides
-    /// for letter bindings should match the uppercased version of the regular swipe output.
-    /// Caseless letters (uppercasing is the identity) are exempt — there the return
-    /// swipe may carry an explicit `returnOverrides` output instead (e.g. Hebrew
-    /// final forms: return swipe on כ produces ך).
-    @Test func centerKeyReturnSwipeMatchesUppercasedSwipeForAllLanguages() {
+    /// Regression guard: for every language and every letter key, the return
+    /// swipe must produce the uppercased version of the plain swipe. Where
+    /// uppercasing is the identity (caseless scripts) the factory must not
+    /// synthesize a return action at all — only an explicit `returnOverrides`
+    /// entry may set one there, and it must differ from the plain swipe (Hebrew
+    /// final forms כ → ך, Thai ท → ฿, kana や → ゃ). A return action that repeats
+    /// its own swipe is a silent no-op and hides a missing override.
+    @Test func letterKeyReturnSwipesMatchUppercasedSwipeForAllLanguages() {
+        let swipeGestures = GestureType.allCases.filter(\.isSwipe)
+
         for info in KeyboardRegistry.available {
             guard let definition = KeyboardRegistry.load(id: info.id) else {
                 Issue.record("Failed to load definition for \(info.id)")
@@ -41,41 +45,36 @@ struct ReturnSwipeLanguageTests {
                 Issue.record("No main mode for \(info.id)")
                 continue
             }
-            guard let centerKey = mainMode.key(for: GridSlot.center) else {
-                Issue.record("No center key for \(info.id)")
-                continue
-            }
-
             let locale = definition.locale
 
-            // Check all swipe directions on the center key
-            let swipeGestures: [GestureType] = [
-                .swipeUp, .swipeDown, .swipeLeft, .swipeRight,
-                .swipeUpLeft, .swipeUpRight, .swipeDownLeft, .swipeDownRight,
-            ]
+            for slotId in GridSlot.allSlots.flatMap(\.self) {
+                guard let key = mainMode.key(for: slotId) else {
+                    Issue.record("[\(info.id)] no key for slot \(slotId)")
+                    continue
+                }
+                for gesture in swipeGestures {
+                    // Only letter outputs that carry a return action.
+                    guard let binding = key.bindings[gesture],
+                          case let .commitText(swipeText) = binding.action,
+                          swipeText.first?.isLetter == true,
+                          case let .commitText(returnText)? = binding.returnAction
+                    else { continue }
 
-            for gesture in swipeGestures {
-                guard let binding = centerKey.bindings[gesture] else { continue }
-
-                // Only check letter outputs (commitText with a letter)
-                guard case let .commitText(swipeText) = binding.action,
-                      swipeText.first?.isLetter == true
-                else { continue }
-
-                // Check if there's a return action
-                guard let returnAction = binding.returnAction,
-                      case let .commitText(returnText) = returnAction
-                else { continue }
-
-                let expected = swipeText.uppercased(with: locale)
-
-                // Caseless letters have no meaningful uppercase — explicit
-                // return overrides (final forms) are legitimate there.
-                guard expected != swipeText else { continue }
-                #expect(
-                    returnText == expected,
-                    "[\(info.id)] center key return swipe \(gesture): expected '\(expected)', got '\(returnText)'"
-                )
+                    // keyboardUppercased, not uppercased: ß maps to ẞ, matching
+                    // the factory that generated the return action.
+                    let expected = swipeText.keyboardUppercased(with: locale)
+                    if expected == swipeText {
+                        #expect(
+                            returnText != swipeText,
+                            "[\(info.id)] \(slotId) \(gesture): return swipe silently repeats '\(swipeText)'"
+                        )
+                    } else {
+                        #expect(
+                            returnText == expected,
+                            "[\(info.id)] \(slotId) \(gesture): expected '\(expected)', got '\(returnText)'"
+                        )
+                    }
+                }
             }
         }
     }

--- a/wurstfingerTests/ScriptLayoutTests.swift
+++ b/wurstfingerTests/ScriptLayoutTests.swift
@@ -1,0 +1,232 @@
+//
+//  ScriptLayoutTests.swift
+//  WurstfingerTests
+//
+//  Script-specific characters of the non-Latin layouts, driven end-to-end
+//  through the pipeline (makeViewModel + handleGesture) so the binding, the
+//  resolver chain and the circle-gesture fallback are all covered.
+//  Every position here comes from the MessagEase reference layout.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+private func inserts(_ target: MockTextTarget) -> [String] {
+    target.events.compactMap { if case let .insertText(t) = $0 { t } else { nil } }
+}
+
+// MARK: - Thai
+
+struct ThaiLayoutTests {
+    /// The reference's center returns live on the circle gesture. ฬ ฒ ฑ ฏ have
+    /// no other position in the layout.
+    @Test func circleGestureTypesTheReferenceCenterReturns() {
+        let (vm, target) = makeViewModel(languageId: "th_TH")
+
+        vm.handleGesture(.circularClockwise, keyId: GridSlot.topLeft, isReturn: false)
+        vm.handleGesture(.circularClockwise, keyId: GridSlot.bottomLeft, isReturn: false)
+        vm.handleGesture(.circularClockwise, keyId: GridSlot.bottomCenter, isReturn: false)
+        vm.handleGesture(.circularClockwise, keyId: GridSlot.bottomRight, isReturn: false)
+
+        #expect(inserts(target) == ["ฬ", "ฒ", "ฑ", "ฏ"])
+    }
+
+    /// Both directions carry the same binding — otherwise the wrong-direction
+    /// circle falls into the uppercase fallback, which is the identity here.
+    @Test func bothCircleDirectionsProduceTheSameConsonant() {
+        let (vm, target) = makeViewModel(languageId: "th_TH")
+
+        vm.handleGesture(.circularCounterclockwise, keyId: GridSlot.topLeft, isReturn: false)
+
+        #expect(inserts(target) == ["ฬ"])
+    }
+
+    @Test func bahtSignRidesTheThoThahanReturnSwipe() {
+        let (vm, target) = makeViewModel(languageId: "th_TH")
+
+        vm.handleGesture(.swipeLeft, keyId: GridSlot.midRight, isReturn: false)
+        vm.handleGesture(.swipeLeft, keyId: GridSlot.midRight, isReturn: true)
+
+        #expect(inserts(target) == ["ท", "฿"])
+    }
+}
+
+// MARK: - Japanese kana
+
+struct KanaLayoutTests {
+    @Test func hiraganaTypesIdeographicCommaAndFullStop() {
+        let (vm, target) = makeViewModel(languageId: "ja_JP")
+
+        vm.handleGesture(.swipeDown, keyId: GridSlot.bottomCenter, isReturn: false)
+        vm.handleGesture(.swipeDownLeft, keyId: GridSlot.bottomCenter, isReturn: false)
+
+        #expect(inserts(target) == ["。", "、"])
+    }
+
+    /// The Latin marks that 、 and 。 displace stay one return swipe away.
+    @Test func hiraganaKeepsLatinPunctuationOnTheReturnSwipe() {
+        let (vm, target) = makeViewModel(languageId: "ja_JP")
+
+        vm.handleGesture(.swipeDown, keyId: GridSlot.bottomCenter, isReturn: true)
+        vm.handleGesture(.swipeDownLeft, keyId: GridSlot.bottomCenter, isReturn: true)
+
+        #expect(inserts(target) == [".", ","])
+    }
+
+    @Test func katakanaTypesIdeographicCommaAndFullStop() {
+        let (vm, target) = makeViewModel(languageId: "ja_JP_katakana")
+
+        vm.handleGesture(.swipeDown, keyId: GridSlot.bottomCenter, isReturn: false)
+        vm.handleGesture(.swipeDownLeft, keyId: GridSlot.bottomCenter, isReturn: false)
+
+        #expect(inserts(target) == ["。", "、"])
+    }
+
+    /// Small kana sit on the return swipe of their full-size counterpart; ぃ is
+    /// the い key's circle output.
+    @Test func hiraganaReturnSwipesTypeSmallKana() {
+        let (vm, target) = makeViewModel(languageId: "ja_JP")
+
+        vm.handleGesture(.swipeDown, keyId: GridSlot.topLeft, isReturn: true)
+        vm.handleGesture(.swipeUp, keyId: GridSlot.center, isReturn: true)
+        vm.handleGesture(.swipeUpLeft, keyId: GridSlot.midRight, isReturn: true)
+        vm.handleGesture(.swipeRight, keyId: GridSlot.bottomLeft, isReturn: true)
+        vm.handleGesture(.swipeUp, keyId: GridSlot.bottomRight, isReturn: true)
+        vm.handleGesture(.swipeLeft, keyId: GridSlot.bottomRight, isReturn: true)
+        vm.handleGesture(.swipeDownLeft, keyId: GridSlot.bottomRight, isReturn: true)
+        vm.handleGesture(.circularClockwise, keyId: GridSlot.topRight, isReturn: false)
+
+        #expect(inserts(target) == ["ゃ", "ぁ", "ゅ", "ぅ", "ぇ", "ょ", "ぉ", "ぃ"])
+    }
+
+    @Test func katakanaSmallKanaAreDerivedFromHiragana() {
+        let (vm, target) = makeViewModel(languageId: "ja_JP_katakana")
+
+        vm.handleGesture(.swipeDown, keyId: GridSlot.topLeft, isReturn: true)
+        vm.handleGesture(.swipeUp, keyId: GridSlot.center, isReturn: true)
+        vm.handleGesture(.swipeUpLeft, keyId: GridSlot.midRight, isReturn: true)
+        vm.handleGesture(.swipeRight, keyId: GridSlot.bottomLeft, isReturn: true)
+        vm.handleGesture(.swipeUp, keyId: GridSlot.bottomRight, isReturn: true)
+        vm.handleGesture(.swipeLeft, keyId: GridSlot.bottomRight, isReturn: true)
+        vm.handleGesture(.swipeDownLeft, keyId: GridSlot.bottomRight, isReturn: true)
+        vm.handleGesture(.circularClockwise, keyId: GridSlot.topRight, isReturn: false)
+        // ヮ has no hiragana counterpart on this key, so it is layered on.
+        vm.handleGesture(.swipeDown, keyId: GridSlot.midLeft, isReturn: true)
+
+        #expect(inserts(target) == ["ャ", "ァ", "ュ", "ゥ", "ェ", "ョ", "ォ", "ィ", "ヮ"])
+    }
+
+    @Test func katakanaSeparatorKeepsTheColonOnItsReturnSwipe() {
+        let (vm, target) = makeViewModel(languageId: "ja_JP_katakana")
+
+        vm.handleGesture(.swipeDownRight, keyId: GridSlot.bottomCenter, isReturn: false)
+        vm.handleGesture(.swipeDownRight, keyId: GridSlot.bottomCenter, isReturn: true)
+
+        #expect(inserts(target) == ["・", ":"])
+    }
+}
+
+// MARK: - Arabic script
+
+struct ArabicScriptLayoutTests {
+    static let ids = ["ar", "fa_IR", "ur"]
+
+    /// Slot and gesture of every mark `ScriptPunctuation.arabicScript` places.
+    static let punctuationPositions: [(slot: String, gesture: GestureType)] = [
+        (GridSlot.topRight, .swipeLeft),
+        (GridSlot.bottomCenter, .swipeDownLeft),
+        (GridSlot.bottomRight, .swipeDownLeft),
+        (GridSlot.bottomLeft, .swipeRight),
+    ]
+
+    @Test(arguments: ArabicScriptLayoutTests.ids)
+    func layoutsUseArabicPunctuation(id: String) {
+        let (vm, target) = makeViewModel(languageId: id)
+
+        for position in Self.punctuationPositions {
+            vm.handleGesture(position.gesture, keyId: position.slot, isReturn: false)
+        }
+
+        #expect(inserts(target) == ["؟", "،", "؛", "٭"], "[\(id)] Latin punctuation in right-to-left text")
+    }
+
+    @Test(arguments: ArabicScriptLayoutTests.ids)
+    func displacedLatinPunctuationStaysOnTheReturnSwipe(id: String) {
+        let (vm, target) = makeViewModel(languageId: id)
+
+        for position in Self.punctuationPositions {
+            vm.handleGesture(position.gesture, keyId: position.slot, isReturn: true)
+        }
+
+        #expect(inserts(target) == ["?", ",", ";", "*"], "[\(id)] displaced Latin mark is unreachable")
+    }
+
+    /// The three layouts share one punctuation table, so they cannot drift.
+    @Test func punctuationPositionsCannotDriftApart() throws {
+        let modes = try Self.ids.map { id in
+            try #require(KeyboardRegistry.load(id: id)?.mode(ModeNames.main), "no main mode for \(id)")
+        }
+
+        for position in Self.punctuationPositions {
+            let bindings = modes.map { $0.key(for: position.slot)?.bindings[position.gesture] }
+            let reference = try #require(
+                bindings.first ?? nil,
+                "\(position.slot) \(position.gesture) is unbound in \(Self.ids[0])"
+            )
+            #expect(
+                bindings.allSatisfy { $0?.action == reference.action },
+                "\(position.slot) \(position.gesture) differs between the Arabic-script layouts"
+            )
+            #expect(
+                bindings.allSatisfy { $0?.returnAction == reference.returnAction },
+                "\(position.slot) \(position.gesture) return differs between the Arabic-script layouts"
+            )
+        }
+    }
+
+    /// Standard Persian and Urdu orthography needs the half-space inside words.
+    @Test(arguments: ["fa_IR", "ur"])
+    func persianAndUrduTatweelReturnTypesZeroWidthNonJoiner(id: String) {
+        let (vm, target) = makeViewModel(languageId: id)
+
+        vm.handleGesture(.swipeRight, keyId: GridSlot.topLeft, isReturn: false)
+        vm.handleGesture(.swipeRight, keyId: GridSlot.topLeft, isReturn: true)
+
+        #expect(inserts(target) == ["ـ", "\u{200C}"])
+    }
+}
+
+// MARK: - Hindi
+
+struct HindiLayoutTests {
+    @Test func rupeeSignIsTypable() {
+        let (vm, target) = makeViewModel(languageId: "hi_IN")
+
+        vm.handleGesture(.swipeLeft, keyId: GridSlot.bottomCenter, isReturn: false)
+
+        #expect(inserts(target) == ["₹"])
+    }
+}
+
+// MARK: - Hebrew
+
+struct HebrewPunctuationTests {
+    @Test func gereshAndGershayimAreTypable() {
+        let (vm, target) = makeViewModel(languageId: "he_IL")
+
+        vm.handleGesture(.swipeUpRight, keyId: GridSlot.bottomCenter, isReturn: false)
+        vm.handleGesture(.swipeUpLeft, keyId: GridSlot.bottomCenter, isReturn: false)
+
+        #expect(inserts(target) == ["׳", "״"])
+    }
+
+    @Test func latinQuotesStayOnTheReturnSwipe() {
+        let (vm, target) = makeViewModel(languageId: "he_IL")
+
+        vm.handleGesture(.swipeUpRight, keyId: GridSlot.bottomCenter, isReturn: true)
+        vm.handleGesture(.swipeUpLeft, keyId: GridSlot.bottomCenter, isReturn: true)
+
+        #expect(inserts(target) == ["'", "\""])
+    }
+}


### PR DESCRIPTION
Findings 5 to 11 of the 2026-08-08 stabilization review: characters that native writers need and that no gesture on the affected layout could produce.

Every added character sits where the MessagEase layout Wurstfinger is modelled on puts it, checked against that layout directly rather than taken from the review. Where the reference has no opinion, a layout that displaces a shared Latin mark puts that mark on the *same gesture's* return swipe — the reference's own `؛ → ;` pairing is the precedent, and nothing is lost either way because the numeric layer carries the Latin defaults verbatim.

| Finding | Layout | Added |
| --- | --- | --- |
| 5 | Thai | `ฬ ฒ ฑ ฏ` (plus the five other reference center returns, for a uniform gesture) and `฿` |
| 6 | Hiragana + katakana | `、` `。`, and the small kana on their return swipes |
| 7 | Persian, Urdu | ZWNJ (U+200C) on the tatweel return |
| 8 | Arabic, Persian, Urdu | `؟ ، ؛ ٭` instead of the Latin defaults |
| 9 | Hindi | `₹` |
| 10 | Hebrew | `׳` and `״` |

### Mechanism

The reference's per-key `center.ret` is the **circle** gesture, which I verified against three unrelated layouts (English `a → A`, Korean `ㄷ → ㄸ`, Hebrew `מ → ם`). So `GridKeyboardFactory.layout` gained a declarative `circularOverrides` parameter that binds both circle directions from one table — `.circularClockwise` entries inside `directionalOverrides` would leave the counterclockwise circle in the identity fallback. `NumericLayouts` and `CommonKeys.cutAll` already bind both directions the same way.

Arabic-script punctuation lives in a new `ScriptPunctuation` helper with merge functions, so the three RTL layouts cannot drift apart; a test asserts they expose identical actions at those four positions. Katakana derives its new tables from hiragana through the existing transform plus two hand-added deltas from the reference.

Arabic deliberately keeps no ZWNJ: the reference gives that key `÷`, and Arabic orthography does not need the half-space.

### The test gap that let all of this through CI (finding 11)

`ReturnSwipeLanguageTests` had `guard expected != swipeText else { continue }`, which made the whole return-swipe regression test a no-op for every caseless language — exactly where findings 5 to 7 live. It now walks every letter key and asserts that where uppercasing is the identity, the return action does not merely repeat its own swipe. That assertion is only possible because the factory no longer synthesizes identity return actions; dropping them is behaviour-neutral, since the resolver chain falls through to the primary binding and commits the same glyph.

New `LanguageAlphabetCoverageTests` checks one alphabet inventory per layout against the union of every `commitText`, bound compose output, sequential-combine result and accent-cycle member. Each of the 26 inventories names its source, and any deliberate gap is commented. On `develop` it fails for `he_IL ar fa_IR ur th_TH hi_IN ja_JP ja_JP_katakana`; with this PR all 26 pass.

### Notes

- The review overstates finding 6 slightly: small kana were reachable before, but only through the accent-cycle key — the undiscoverable detour it describes. The return swipes are added regardless.
- Named as out of scope in the inventory comments: Urdu `ہ`/`ھ` and Hindi `ङ` (no reference position — adding one would mean inventing it), Thai `ฅ` (obsolete), Korean tense consonants (produced by `HangulComposer`), Vietnamese tone marks (Telex).
- Not yet looked at on a simulator: the new hints change what those key faces show, and the Thai/kana circle gestures render no hint at all, because `hintGestureOrder` covers swipes only.

1093 unit tests pass; SwiftFormat and SwiftLint `--strict` are clean.

