### PR TITLE
Remove Dead Code and Harden the Health Log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - The double-space shortcut now requires two consecutive space presses within a short window, so a space typed into an already-finished sentence is no longer rewritten and a deliberate double space stays typable; it also inserts the script's own sentence mark (Devanagari danda, Japanese full-width stop, Urdu full stop) (#281)
 - Cut-all is bounded by the same size ceiling as a paste instead of issuing an unbounded number of delete round-trips to the host app (#281)
 
+### Changed
+
+- The `^` compose key's return swipe now types the caron dead key, so č ď ě ň ř š ť ž are reachable directly instead of only through the accent cycle (#285)
+
 ## v1.4.0 — 2026-07-23
 
 ### Added

--- a/wurstfinger/OnboardingProgress.swift
+++ b/wurstfinger/OnboardingProgress.swift
@@ -1,0 +1,41 @@
+//
+//  OnboardingProgress.swift
+//  wurstfinger
+//
+//  Storage for the app-only onboarding checklist.
+//
+
+import Foundation
+
+/// UserDefaults keys owned by the host app alone — the counterpart to
+/// `SettingsKey`, which holds the keys the keyboard extension shares.
+enum AppSettingsKey: String, CaseIterable {
+    case onboardingKeyboardInstalled = "onboarding.keyboardInstalled"
+    case onboardingFullAccessEnabled = "onboarding.fullAccessEnabled"
+    case onboardingPracticed = "onboarding.practiced"
+}
+
+enum OnboardingProgress {
+    /// The app's own defaults. The checklist records what the user ticked off
+    /// in this app; the keyboard never reads it, and every write into the
+    /// shared app-group suite fires a change notification the extension pays
+    /// for on its next appearance.
+    static let store: UserDefaults = .standard
+
+    /// Moves checklist state written by earlier versions out of the shared
+    /// app-group container — without it, an updating user's ticked steps would
+    /// come back unticked. Idempotent: the shared keys are removed after the
+    /// copy, so a later run finds nothing to move.
+    static func migrateFromSharedStoreIfNeeded(
+        from shared: UserDefaults = SharedDefaults.store,
+        to local: UserDefaults = store
+    ) {
+        for key in AppSettingsKey.allCases {
+            guard let value = shared.object(forKey: key.rawValue) else { continue }
+            if local.object(forKey: key.rawValue) == nil {
+                local.set(value, forKey: key.rawValue)
+            }
+            shared.removeObject(forKey: key.rawValue)
+        }
+    }
+}

--- a/wurstfinger/OnboardingView.swift
+++ b/wurstfinger/OnboardingView.swift
@@ -22,13 +22,13 @@ import SwiftUI
     struct OnboardingContentView: View {
         @Environment(\.openURL) private var openURL
 
-        @AppStorage("onboarding.keyboardInstalled", store: SharedDefaults.store)
+        @AppStorage(AppSettingsKey.onboardingKeyboardInstalled.rawValue, store: OnboardingProgress.store)
         private var keyboardInstalled = false
 
-        @AppStorage("onboarding.fullAccessEnabled", store: SharedDefaults.store)
+        @AppStorage(AppSettingsKey.onboardingFullAccessEnabled.rawValue, store: OnboardingProgress.store)
         private var fullAccessEnabled = false
 
-        @AppStorage("onboarding.practiced", store: SharedDefaults.store)
+        @AppStorage(AppSettingsKey.onboardingPracticed.rawValue, store: OnboardingProgress.store)
         private var practiced = false
 
         private let settingsURL = URL(string: "app-settings:")!

--- a/wurstfinger/wurstfingerApp.swift
+++ b/wurstfinger/wurstfingerApp.swift
@@ -25,6 +25,11 @@ struct wurstfingerApp: App {
         // present and mask a pending migration.
         LayoutSettings.migrateLegacyScaleIfNeeded(in: SharedDefaults.store)
 
+        // The onboarding checklist is app-only state; installs from earlier
+        // versions still hold it in the shared app-group suite, so move it
+        // before the views read it.
+        OnboardingProgress.migrateFromSharedStoreIfNeeded()
+
         let defaults: [String: Any] = [
             SettingsKey.keyAspectRatio.rawValue: DeviceLayoutUtils.defaultKeyAspectRatio,
             SettingsKey.keyboardWidthPoints.rawValue: DeviceLayoutUtils.defaultKeyboardWidth,

--- a/wurstfingerKeyboard/Definition/Compose/ComposeRuleSet+Global.swift
+++ b/wurstfingerKeyboard/Definition/Compose/ComposeRuleSet+Global.swift
@@ -11,6 +11,11 @@ extension ComposeRuleSet {
     /// Global compose rules extracted from Thumb-Key compose tables.
     /// These rules are shared across all languages and can be extended
     /// with language-specific overrides via `merging(overrides:)`.
+    ///
+    /// Not every trigger is bound to a key: `˘`, `!` and `゛` are reached only
+    /// through the 🅒 accent cycle, which `ComposeEngine.buildAccentCycles`
+    /// folds out of *all* tables — dropping them as "dead" would take ğ, ł, ż
+    /// and the small kana with them.
     static let global = ComposeRuleSet(rules: [
         "¨": [
             "a": "ä", "A": "Ä", "e": "ë", "E": "Ë", "h": "ḧ", "H": "Ḧ",

--- a/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
+++ b/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
@@ -163,7 +163,7 @@ enum CommonKeys {
             ),
             .swipeUp: KeyBinding(
                 label: "^", action: .compose(trigger: "^"), category: .compose,
-                returnAction: .commitText("ˆ"), accessibilityLabel: nil
+                returnAction: .compose(trigger: "ˇ"), accessibilityLabel: nil
             ),
             .swipeUpRight: KeyBinding(
                 label: "´", action: .compose(trigger: "´"), category: .compose,

--- a/wurstfingerKeyboard/Definition/Language/LanguageConfig.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageConfig.swift
@@ -30,29 +30,28 @@ extension LanguageConfig {
         id: "en_US", name: "English", locale: Locale(identifier: "en_US")
     )
 
-    static let german = LanguageConfig(
-        id: "de_DE", name: "Deutsch", locale: Locale(identifier: "de_DE")
-    )
-
-    static let russian = LanguageConfig(
-        id: "ru_RU", name: "Русский", locale: Locale(identifier: "ru_RU")
-    )
-
     /// All supported languages, derived from `KeyboardRegistry.available` and
-    /// sorted alphabetically by name. This is the single source of truth --
+    /// sorted by display name. This is the single source of truth --
     /// adding a new `KeyboardDefinition` to `LanguageDefinitions.all`
     /// automatically surfaces it here.
     ///
     /// Computed on every access so callers always see the current registry
     /// state (important for tests that mutate `KeyboardRegistry`).
     static var allLanguages: [LanguageConfig] {
-        KeyboardRegistry.available.map { info in
+        sortedByName(KeyboardRegistry.available.map { info in
             LanguageConfig(
                 id: info.id,
                 name: info.title,
                 locale: Locale(identifier: info.localeIdentifier)
             )
-        }.sorted { $0.name < $1.name }
+        })
+    }
+
+    /// Display order for the language list: `localizedStandardCompare` puts the
+    /// names where the user's locale expects them (case- and diacritic-aware,
+    /// Finder-style), which a bare `<` — a UTF-16 code-unit comparison — does not.
+    static func sortedByName(_ languages: [LanguageConfig]) -> [LanguageConfig] {
+        languages.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
     }
 
     /// Get language config by ID.

--- a/wurstfingerKeyboard/Definition/Model/KeyConfig+Factories.swift
+++ b/wurstfingerKeyboard/Definition/Model/KeyConfig+Factories.swift
@@ -8,38 +8,6 @@
 import Foundation
 
 extension KeyConfig {
-    /// Creates a letter key. Category is automatically derived from the action.
-    static func letter(
-        _ id: String,
-        tap: String,
-        swipes: [GestureType: String] = [:],
-        returnSwipes: [GestureType: String] = [:],
-        composeSwipes: [GestureType: (trigger: String, label: String)] = [:]
-    ) -> KeyConfig {
-        var bindings: [GestureType: KeyBinding] = [:]
-        bindings[.tap] = KeyBinding(
-            label: tap, action: .commitText(tap),
-            category: nil, returnAction: nil, accessibilityLabel: nil
-        )
-        for (gesture, char) in swipes {
-            bindings[gesture] = KeyBinding(
-                label: char, action: .commitText(char), category: nil,
-                returnAction: returnSwipes[gesture].map { .commitText($0) },
-                accessibilityLabel: nil
-            )
-        }
-        for (gesture, compose) in composeSwipes {
-            bindings[gesture] = KeyBinding(
-                label: compose.label, action: .compose(trigger: compose.trigger),
-                category: .compose, returnAction: nil, accessibilityLabel: nil
-            )
-        }
-        return KeyConfig(
-            id: id, bindings: bindings, swipeMode: .eightWay,
-            slideType: .none, style: .primary, tapCycleActions: nil
-        )
-    }
-
     /// Creates a utility key (Globe, Delete, Return, etc.)
     static func utility(
         _ id: String,

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -201,17 +201,21 @@ final class KeyboardViewController: UIInputViewController {
     /// The definition caches account for only a few MB of a suspended
     /// keyboard's footprint — the bulk of it is the *SwiftUI hosting graph*,
     /// not any app data structure — so the hosting controller is torn down
-    /// here too and rebuilt in `viewWillAppear`. The health-log entry records
-    /// the footprint *after* shedding, so it measures what actually survives
-    /// to suspension.
+    /// here too and rebuilt in `viewWillAppear`. The shedding runs inside an
+    /// autorelease pool so UIKit's teardown temporaries are gone before the
+    /// health-log entry samples `phys_footprint`; the sample is still an upper
+    /// bound on what survives to suspension, since the allocator need not have
+    /// returned every freed page to the kernel by then.
     private func shedMemoryBeforeSuspension(_ event: String) {
-        KeyboardRegistry.evictAll(except: selectedLanguageId)
-        // The memoized grid layouts hold arrangement storage shared with the
-        // definitions just evicted, so dropping them is part of the same
-        // shedding step. The next appearance re-solves in microseconds.
-        GridLayoutSolver.evictAll()
-        installSuspensionPlaceholder()
-        teardownHosting()
+        autoreleasepool {
+            KeyboardRegistry.evictAll(except: selectedLanguageId)
+            // The memoized grid layouts hold arrangement storage shared with the
+            // definitions just evicted, so dropping them is part of the same
+            // shedding step. The next appearance re-solves in microseconds.
+            GridLayoutSolver.evictAll()
+            installSuspensionPlaceholder()
+            teardownHosting()
+        }
         // Flushed, not queued: the suspended process may never run again — a
         // resume-jetsam kills it on wake before an async write would get CPU
         // time — and this entry, the footprint that actually survives to
@@ -350,10 +354,6 @@ final class KeyboardViewController: UIInputViewController {
         // rotation with the keyboard open never calls viewWillAppear.
         // No-op when the height is unchanged.
         updateKeyboardHeight()
-    }
-
-    override var needsInputModeSwitchKey: Bool {
-        true
     }
 
     /// Builds the SwiftUI hosting controller and installs it as a child.

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -59,14 +59,6 @@ struct DeviceLayoutUtils {
 }
 
 final class KeyboardViewModel: ObservableObject {
-    // MARK: - Settings Keys (kept for backward compatibility)
-
-    static let hapticTapIntensityKey = SettingsKey.hapticIntensityTap.rawValue
-    static let hapticDragIntensityKey = SettingsKey.hapticIntensityDrag.rawValue
-    static let numpadStyleKey = SettingsKey.numpadStyle.rawValue
-    static let defaultTapIntensity: CGFloat = HapticSettings.defaultTapIntensity
-    static let defaultDragIntensity: CGFloat = HapticSettings.defaultDragIntensity
-
     // MARK: - State
 
     /// Current width of the keyboard's containing view.
@@ -83,8 +75,6 @@ final class KeyboardViewModel: ObservableObject {
     @Published private(set) var keyboardWidthCap: CGFloat = min(
         DeviceLayoutUtils.screenBounds.width, DeviceLayoutUtils.screenBounds.height
     )
-    /// The currently active keyboard mode.
-    @Published var currentMode: KeyboardMode?
     /// Name of the currently active mode in the data-driven definition.
     @Published var activeModeName: String = ModeNames.main
 
@@ -259,13 +249,16 @@ final class KeyboardViewModel: ObservableObject {
         layoutSettings.utilityColumnLeading ? .portraitUtilityLeft : .portrait
     }
 
-    /// The grid arrangement for `currentMode` and `currentContext`.
+    /// The grid arrangement for the active mode and `currentContext`.
     /// Returns `nil` if no definition is loaded.
     var currentArrangement: GridArrangement? {
-        currentMode?.arrangement(for: currentContext)
+        activeModeFromDefinition?.arrangement(for: currentContext)
     }
 
     /// The active mode resolved from the current definition and mode name.
+    /// The one place the mode is resolved: the grid renders from it and
+    /// `currentArrangement` sizes the keyboard from it, so a height computed
+    /// for a different layer than the one on screen cannot happen.
     var activeModeFromDefinition: KeyboardMode? {
         currentDefinition?.mode(activeModeName)
     }

--- a/wurstfingerKeyboard/Runtime/Compose/ComposeEngine.swift
+++ b/wurstfingerKeyboard/Runtime/Compose/ComposeEngine.swift
@@ -45,16 +45,6 @@ struct ComposeEngine {
         return cycle[nextIndex]
     }
 
-    // MARK: - Static API (backward compatibility)
-
-    static func compose(previous: String, trigger: String) -> String? {
-        shared.compose(previous: previous, trigger: trigger)
-    }
-
-    static func cycleAccent(for character: String) -> String? {
-        shared.cycleAccent(for: character)
-    }
-
     // MARK: - Accent Cycle Builder
 
     /// Number cycles (not language-specific).

--- a/wurstfingerKeyboard/Runtime/Pipeline/GestureResolverChain.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/GestureResolverChain.swift
@@ -25,10 +25,4 @@ struct GestureResolverChain {
         }
         return nil
     }
-
-    /// Convenience that returns the resolved `KeyAction` directly, or
-    /// `.none` if nothing matched.
-    func resolveAction(keyId: String, gesture: GestureType, in mode: KeyboardMode) -> KeyAction {
-        resolve(keyId: keyId, gesture: gesture, in: mode)?.action ?? .none
-    }
 }

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -32,7 +32,6 @@ extension KeyboardViewModel {
         )
         activeModeName = definition.defaultMode
         pipelineLocale = definition.locale
-        currentMode = definition.mode(activeModeName)
         rebuildResolverChain()
         rebuildPipeline()
     }
@@ -409,7 +408,6 @@ extension KeyboardViewModel {
               definition.mode(modeName) != nil
         else { return }
         activeModeName = modeName
-        currentMode = definition.mode(modeName)
         // Any mode change invalidates a pending auto-shift; the auto-cap
         // engage path re-sets the flag right after switching.
         shiftEngagedByAutoCapitalization = false
@@ -496,16 +494,27 @@ extension KeyboardViewModel {
         if grouped {
             let hidden = sharedDefaults.bool(forKey: SettingsKey.hideLetters.rawValue)
                 && sharedDefaults.bool(forKey: SettingsKey.hideStandardSymbols.rawValue)
-            sharedDefaults.set(!hidden, forKey: SettingsKey.hideLetters.rawValue)
-            sharedDefaults.set(!hidden, forKey: SettingsKey.hideStandardSymbols.rawValue)
+            setLabelFlag(!hidden, forKey: .hideLetters)
+            setLabelFlag(!hidden, forKey: .hideStandardSymbols)
         } else {
             let hidden = sharedDefaults.bool(forKey: SettingsKey.hideExtraSymbols.rawValue)
-            sharedDefaults.set(!hidden, forKey: SettingsKey.hideExtraSymbols.rawValue)
+            setLabelFlag(!hidden, forKey: .hideExtraSymbols)
         }
         // Confirmation tick, not a second tap impact: the touch-down already
         // fired the tap haptic, and the toggle is a state change like a
         // mode switch.
         feedbackStateChange()
+    }
+
+    /// Writes only a value the store does not already hold. Every write fires
+    /// `UserDefaults.didChangeNotification` (a full settings reload) and
+    /// invalidates the `@AppStorage` bindings the grid renders from, so
+    /// re-asserting a flag that already has the wanted value costs a keyboard
+    /// round-trip for nothing — which the grouped toggle would otherwise do
+    /// whenever the two flags start out of sync.
+    private func setLabelFlag(_ hidden: Bool, forKey key: SettingsKey) {
+        guard sharedDefaults.bool(forKey: key.rawValue) != hidden else { return }
+        sharedDefaults.set(hidden, forKey: key.rawValue)
     }
 
     /// Continuous (joystick) mode: emit one character move per `dragStep` of

--- a/wurstfingerKeyboard/Runtime/View/ViewExtensions.swift
+++ b/wurstfingerKeyboard/Runtime/View/ViewExtensions.swift
@@ -2,22 +2,10 @@
 //  ViewExtensions.swift
 //  Wurstfinger
 //
-//  Helper extensions for SwiftUI Views
+//  Helper extensions for the settings views.
 //
 
-import SwiftUI
-
-extension View {
-    /// Conditionally applies a modifier only when the optional value is non-nil.
-    @ViewBuilder
-    func ifLet<T>(_ value: T?, transform: (Self, T) -> some View) -> some View {
-        if let value {
-            transform(self, value)
-        } else {
-            self
-        }
-    }
-}
+import Foundation
 
 extension NumberFormatter {
     /// Decimal formatter bounded to `[minimum, maximum]`. Out-of-range text is

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -16,10 +16,6 @@ enum KeyboardConstants {
         /// Derived from iOS standard keyboard key height (~54pt) for comfortable touch targets.
         static let height: CGFloat = 54
 
-        /// Minimum key width for accessibility compliance.
-        /// Based on Apple's Human Interface Guidelines (44pt minimum touch target).
-        static let minWidth: CGFloat = 44
-
         /// Corner radius for modern iOS appearance.
         /// Matches iOS 15+ system keyboard style.
         static let cornerRadius: CGFloat = 8
@@ -37,20 +33,11 @@ enum KeyboardConstants {
     // MARK: - Font Sizes
 
     enum FontSizes {
-        /// Main key label size (center character).
-        static let keyLabel: CGFloat = 22
-
         /// Default label size for utility buttons.
         static let defaultLabel: CGFloat = 18
 
         /// Utility column label size (globe, delete, return).
         static let utilityLabel: CGFloat = 22
-
-        /// Emphasized hint label size (for frequently used characters).
-        static let hintEmphasis: CGFloat = 11
-
-        /// Normal hint label size (for less common characters).
-        static let hintNormal: CGFloat = 10
 
         // Main label dynamic scaling. Font sizes scale with the rendered
         // cell height relative to `KeyDimensions.height` (see
@@ -69,8 +56,6 @@ enum KeyboardConstants {
         static let hintMinSize: CGFloat = 10
         /// Maximum hint size to prevent visual clutter.
         static let hintMaxSize: CGFloat = 22
-        /// Multiplier for emphasized hints (1.1 = 10% larger).
-        static let hintEmphasisMultiplier: CGFloat = 1.1
         /// Reference font size for hint padding calculations.
         static let hintReferenceFontSize: CGFloat = 10
 
@@ -108,23 +93,11 @@ enum KeyboardConstants {
         static let verticalPaddingTop: CGFloat = 4
         /// Bottom padding - accounts for home indicator safe area on notched devices.
         static let verticalPaddingBottom: CGFloat = 10
-        /// Margin for hint labels from key edges.
-        static let hintMargin: CGFloat = 10
-        /// Larger margin for "returning" hint labels (swipe-and-return gestures).
-        static let hintMarginReturning: CGFloat = 22
     }
 
     // MARK: - Gesture Recognition
 
     enum Gesture {
-        /// Tolerance for circular gesture end-point matching.
-        /// How close the finger must return to the start point to complete a circle.
-        static let circleCompletionTolerance: CGFloat = 16
-
-        /// Multiplier for final swipe offset calculation.
-        /// 0.71 ≈ 1/√2, accounts for diagonal swipes being longer than cardinal directions.
-        static let finalOffsetMultiplier: CGFloat = 0.71
-
         /// Number of touch points to buffer for gesture analysis.
         /// SwiftUI's DragGesture delivers samples at display refresh rate, so
         /// the buffer is sized for the fastest shipping display: 120 points
@@ -220,9 +193,6 @@ enum KeyboardConstants {
         /// Minimum drag distance to activate cursor movement mode.
         static let dragActivationThreshold: CGFloat = 8
 
-        /// Minimum drag distance to activate text selection mode.
-        static let selectionActivationThreshold: CGFloat = 24
-
         /// Distance per cursor movement step (one character).
         /// Provides smooth, controlled cursor navigation.
         static let dragStep: CGFloat = 14
@@ -253,19 +223,6 @@ enum KeyboardConstants {
         /// Decoupled from `SpaceGestures.dragStep` so delete and cursor
         /// sensitivity can be tuned independently.
         static let dragStep: CGFloat = 14
-
-        /// Distance for word-at-a-time deletion gesture.
-        static let wordSwipeThreshold: CGFloat = 40
-
-        /// Vertical movement tolerance during horizontal delete swipe.
-        static let verticalTolerance: CGFloat = 28
-
-        /// Interval between repeated deletions during hold (in seconds).
-        /// 0.08s = ~12.5 characters per second.
-        static let repeatInterval: TimeInterval = 0.08
-
-        /// Initial delay before repeat-delete starts (in seconds).
-        static let repeatDelay: TimeInterval = 0.35
     }
 
     // MARK: - Text Input

--- a/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
@@ -175,8 +175,11 @@ struct KeyboardHealthLog {
             if end > 0 { payload.append(0x0A) }
             payload.append(encoded)
             try? handle.write(contentsOf: payload)
-        } else {
-            // First write / file absent.
+        } else if !FileManager.default.fileExists(atPath: fileURL.path) {
+            // First write only. A handle can also fail on an *existing* file
+            // (an unwritable container while the device is locked), and
+            // overwriting then would discard exactly the history a
+            // resume-jetsam investigation needs — drop the entry instead.
             try? encoded.write(to: fileURL, options: .atomic)
         }
         compactIfNeeded(fileURL)
@@ -188,16 +191,22 @@ struct KeyboardHealthLog {
     /// appends — O(1) amortized per event. Must only run on `ioQueue`.
     private func compactIfNeeded(_ fileURL: URL) {
         let size = (try? FileManager.default.attributesOfItem(atPath: fileURL.path))?[.size] as? Int ?? 0
-        guard size > trimThresholdBytes else { return }
-        let kept = Array(readEntries(fileURL).suffix(maxEntries))
-        write(kept, to: fileURL)
+        // A file the process cannot read is history, not garbage: rewriting it
+        // from an empty decode would replace the log with nothing.
+        guard size > trimThresholdBytes, let data = try? Data(contentsOf: fileURL) else { return }
+        write(Array(decodeEntries(from: data).suffix(maxEntries)), to: fileURL)
     }
 
-    /// Raw JSONL read; must only run on `ioQueue`. `split(separator:)` omits
-    /// empty subsequences, so leading/double newlines and undecodable legacy
-    /// segments are tolerated (corruption-discard contract preserved).
+    /// Raw JSONL read; must only run on `ioQueue`.
     private func readEntries(_ fileURL: URL) -> [Entry] {
         guard let data = try? Data(contentsOf: fileURL) else { return [] }
+        return decodeEntries(from: data)
+    }
+
+    /// `split(separator:)` omits empty subsequences, so leading/double newlines
+    /// and undecodable legacy segments are tolerated (corruption-discard
+    /// contract preserved).
+    private func decodeEntries(from data: Data) -> [Entry] {
         let decoder = JSONDecoder()
         return data.split(separator: 0x0A).compactMap { try? decoder.decode(Entry.self, from: Data($0)) }
     }

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -14,7 +14,7 @@ import Foundation
 
 /// Centralized storage for all UserDefaults keys used by the keyboard.
 /// Using an enum prevents typos and makes refactoring easier.
-enum SettingsKey: String {
+enum SettingsKey: String, CaseIterable {
     case hapticIntensityTap
     case hapticIntensityDrag
     /// Legacy master toggle — only read to migrate an explicit "off" into

--- a/wurstfingerTests/AccessibilityLabelTests.swift
+++ b/wurstfingerTests/AccessibilityLabelTests.swift
@@ -158,7 +158,7 @@ struct AccessibilityLabelTests {
     @Test func globeActivationReachesTheInputModeSwitch() throws {
         var advanced = 0
         let (viewModel, _) = makeViewModel(advanceToNextInputMode: { advanced += 1 })
-        let globe = try #require(viewModel.currentMode?.keys[UtilitySlot.globe])
+        let globe = try #require(viewModel.activeModeFromDefinition?.key(for: UtilitySlot.globe))
         let gesture = try #require(globe.accessibilityActivationOverride)
         viewModel.handleGesture(gesture, keyId: UtilitySlot.globe, isReturn: false)
         #expect(advanced == 1)

--- a/wurstfingerTests/CircularGesturePipelineTests.swift
+++ b/wurstfingerTests/CircularGesturePipelineTests.swift
@@ -118,7 +118,6 @@ struct CircularGesturePipelineTests {
             )
         )
         vm.activeModeName = ModeNames.main
-        vm.currentMode = mainMode
         vm.pipelineLocale = Locale(identifier: "de_DE")
         vm.rebuildResolverChain()
         vm.rebuildPipeline()

--- a/wurstfingerTests/ComposeEngineTests.swift
+++ b/wurstfingerTests/ComposeEngineTests.swift
@@ -171,6 +171,24 @@ struct ComposeEngineTests {
         #expect(ComposeEngine.cycleAccent(for: "xyz") == nil)
     }
 
+    /// Triggers with no `.compose` binding still reach the user through the
+    /// 🅒 accent cycle, which is built from every table in the rule set.
+    @Test(arguments: [
+        (base: "g", variant: "ğ"), // ˘
+        (base: "l", variant: "ł"), // !
+        (base: "か", variant: "が"), // ゛
+    ])
+    func unboundTriggerTablesFeedTheAccentCycle(cycle: (base: String, variant: String)) {
+        var current = cycle.base
+        var visited: [String] = []
+        for _ in 0 ..< 60 {
+            guard let next = ComposeEngine.cycleAccent(for: current), next != cycle.base else { break }
+            visited.append(next)
+            current = next
+        }
+        #expect(visited.contains(cycle.variant))
+    }
+
     // MARK: - Number Cycles
 
     @Test func numberCycleDigitToSuperscript() {

--- a/wurstfingerTests/ComposeOverrideWiringTests.swift
+++ b/wurstfingerTests/ComposeOverrideWiringTests.swift
@@ -31,7 +31,6 @@ private func makeOverrideViewModel(
     )
     vm.currentDefinition = definition
     vm.activeModeName = definition.defaultMode
-    vm.currentMode = definition.mode(definition.defaultMode)
     vm.rebuildResolverChain()
     vm.rebuildPipeline()
     return (vm, target)

--- a/wurstfingerTests/KeyboardGridRenderingTests.swift
+++ b/wurstfingerTests/KeyboardGridRenderingTests.swift
@@ -36,7 +36,7 @@ struct KeyboardViewModelContextTests {
 
     @Test func currentArrangementIsNilWithoutMode() {
         let viewModel = makeViewModel(utilityLeft: false)
-        #expect(viewModel.currentMode == nil)
+        #expect(viewModel.activeModeFromDefinition == nil)
         #expect(viewModel.currentArrangement == nil)
     }
 
@@ -76,7 +76,12 @@ struct KeyboardViewModelContextTests {
         )
 
         let viewModel = makeViewModel(utilityLeft: false)
-        viewModel.currentMode = mode
+        viewModel.currentDefinition = KeyboardDefinition(
+            title: "Fixture", id: "fixture", localeIdentifier: "de_DE",
+            modes: ["test": mode], defaultMode: "test",
+            settings: KeyboardDefinitionSettings(autoCapitalize: false, composeRuleOverrides: nil)
+        )
+        viewModel.activeModeName = "test"
         #expect(viewModel.currentArrangement?.columns == 1)
 
         viewModel.utilityColumnLeading = true

--- a/wurstfingerTests/KeyboardHealthLogTests.swift
+++ b/wurstfingerTests/KeyboardHealthLogTests.swift
@@ -81,6 +81,54 @@ struct KeyboardHealthLogTests {
         #expect(log.entries().map(\.label) == ["after-corruption"])
     }
 
+    /// A handle failure on an *existing* file must not replace the history:
+    /// the entries already on disk are the resume-jetsam forensics the log
+    /// exists for, and the container can be unwritable exactly when the
+    /// keyboard is being suspended.
+    @Test func unwritableExistingFileKeepsPriorEntries() throws {
+        let url = makeTestFileURL()
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: url.path)
+            try? FileManager.default.removeItem(at: url)
+        }
+        let log = KeyboardHealthLog(fileURL: url)
+        log.recordAndFlush("before-lock")
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o444], ofItemAtPath: url.path)
+        log.recordAndFlush("while-locked")
+
+        #expect(log.entries().map(\.label) == ["before-lock"])
+    }
+
+    /// Compaction must not rewrite a file it could not read either: an
+    /// oversized log whose read fails decodes to nothing, and writing that
+    /// back would empty the very file the append guard just protected.
+    @Test func compactionKeepsAnUnreadableFileIntact() throws {
+        let url = makeTestFileURL()
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: url.path)
+            try? FileManager.default.removeItem(at: url)
+        }
+        let encoder = JSONEncoder()
+        var seeded = Data()
+        for index in 0 ..< 40 {
+            try seeded.append(encoder.encode(KeyboardHealthLog.Entry(
+                id: UUID(), date: Date(), label: "seed-\(index)", usedMB: 1, availableMB: 1
+            )))
+            seeded.append(0x0A)
+        }
+        try seeded.write(to: url)
+        // Writable but unreadable, so the append itself still succeeds and
+        // only compaction's read-then-rewrite can destroy the seeded history.
+        try FileManager.default.setAttributes([.posixPermissions: 0o222], ofItemAtPath: url.path)
+
+        KeyboardHealthLog(fileURL: url, maxEntries: 2).recordAndFlush("while-unreadable")
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: url.path)
+        let persisted = try Data(contentsOf: url)
+        #expect(persisted.prefix(seeded.count) == seeded)
+    }
+
     @Test func nilFileURLIsANoOp() {
         let log = KeyboardHealthLog(fileURL: nil)
 

--- a/wurstfingerTests/KeyboardStateHygieneTests.swift
+++ b/wurstfingerTests/KeyboardStateHygieneTests.swift
@@ -117,7 +117,7 @@ struct ModeResetTests {
         vm.resetToDefaultMode()
 
         #expect(vm.activeModeName == ModeNames.main)
-        #expect(vm.currentMode?.name == ModeNames.main)
+        #expect(vm.activeModeFromDefinition?.name == ModeNames.main)
     }
 
     @Test func resetToDefaultModeIsPublishFreeWhenAlreadyDefault() {
@@ -140,6 +140,24 @@ struct ModeResetTests {
         )
         vm.resetToDefaultMode() // must not crash
         #expect(vm.currentDefinition == nil)
+    }
+}
+
+// MARK: - Single-sourced mode state
+
+@Suite(.serialized)
+struct ModeDerivationTests {
+    /// The layout arrangement — and with it the controller's height
+    /// constraint — must follow `activeModeName` alone.
+    @Test("The arrangement follows the active mode name")
+    func arrangementFollowsActiveModeName() {
+        let (vm, _) = makeViewModel()
+        #expect(vm.currentArrangement?.rows.last?.first?.keyId == UtilitySlot.space)
+
+        vm.activeModeName = ModeNames.numeric
+
+        #expect(vm.currentArrangement?.rows.last?.first?.keyId == GridSlot.zero)
+        #expect(vm.activeModeFromDefinition?.name == ModeNames.numeric)
     }
 }
 

--- a/wurstfingerTests/LanguageDefinitionTests.swift
+++ b/wurstfingerTests/LanguageDefinitionTests.swift
@@ -50,6 +50,19 @@ struct LanguageDefinitionValidationTests {
             )
         }
     }
+
+    @Test("Display order is the locale's alphabetical order, not codepoint order")
+    func sortedByNameUsesLocalizedOrdering() {
+        let unsorted = ["Zulu", "apfel", "Bravo"].map {
+            LanguageConfig(id: $0, name: $0, locale: Locale(identifier: "en_US"))
+        }
+        #expect(LanguageConfig.sortedByName(unsorted).map(\.name) == ["apfel", "Bravo", "Zulu"])
+    }
+
+    @Test func allLanguagesAppliesTheDisplayOrder() {
+        let listed = LanguageConfig.allLanguages
+        #expect(listed.map(\.id) == LanguageConfig.sortedByName(listed).map(\.id))
+    }
 }
 
 // MARK: - German Layout Tests

--- a/wurstfingerTests/OnboardingProgressTests.swift
+++ b/wurstfingerTests/OnboardingProgressTests.swift
@@ -1,0 +1,60 @@
+//
+//  OnboardingProgressTests.swift
+//  WurstfingerTests
+//
+//  The onboarding checklist is app-only state: it must leave the shared
+//  app-group suite without resetting an updating user's ticked steps.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct OnboardingProgressTests {
+    @Test func migrationMovesTickedStepsOutOfTheSharedStore() {
+        let shared = InMemoryUserDefaults()
+        let local = InMemoryUserDefaults()
+        shared.set(true, forKey: AppSettingsKey.onboardingKeyboardInstalled.rawValue)
+        shared.set(true, forKey: AppSettingsKey.onboardingPracticed.rawValue)
+
+        OnboardingProgress.migrateFromSharedStoreIfNeeded(from: shared, to: local)
+
+        #expect(local.bool(forKey: AppSettingsKey.onboardingKeyboardInstalled.rawValue))
+        #expect(local.bool(forKey: AppSettingsKey.onboardingPracticed.rawValue))
+        for key in AppSettingsKey.allCases {
+            #expect(shared.object(forKey: key.rawValue) == nil, "\(key.rawValue) left behind in the shared store")
+        }
+    }
+
+    @Test func migrationDoesNotOverwriteLocalState() {
+        let shared = InMemoryUserDefaults()
+        let local = InMemoryUserDefaults()
+        shared.set(false, forKey: AppSettingsKey.onboardingPracticed.rawValue)
+        local.set(true, forKey: AppSettingsKey.onboardingPracticed.rawValue)
+
+        OnboardingProgress.migrateFromSharedStoreIfNeeded(from: shared, to: local)
+
+        #expect(local.bool(forKey: AppSettingsKey.onboardingPracticed.rawValue))
+    }
+
+    @Test func migrationIsIdempotent() {
+        let shared = InMemoryUserDefaults()
+        let local = InMemoryUserDefaults()
+        shared.set(true, forKey: AppSettingsKey.onboardingFullAccessEnabled.rawValue)
+
+        OnboardingProgress.migrateFromSharedStoreIfNeeded(from: shared, to: local)
+        local.set(false, forKey: AppSettingsKey.onboardingFullAccessEnabled.rawValue)
+        OnboardingProgress.migrateFromSharedStoreIfNeeded(from: shared, to: local)
+
+        #expect(!local.bool(forKey: AppSettingsKey.onboardingFullAccessEnabled.rawValue))
+    }
+
+    /// A key owned by both enums would be written to the app's own defaults by
+    /// the host and read from the app group by the keyboard, which is the split
+    /// this store move removes.
+    @Test func appSettingsKeysDoNotCollideWithSharedKeys() {
+        let shared = Set(SettingsKey.allCases.map(\.rawValue))
+        let appOnly = Set(AppSettingsKey.allCases.map(\.rawValue))
+        #expect(appOnly.isDisjoint(with: shared), "overlapping keys: \(appOnly.intersection(shared))")
+    }
+}

--- a/wurstfingerTests/ReturnSwipePipelineTests.swift
+++ b/wurstfingerTests/ReturnSwipePipelineTests.swift
@@ -77,6 +77,30 @@ struct ReturnSwipePipelineTests {
         #expect(inserts(target).last == expected)
     }
 
+    // MARK: - Caron
+
+    /// The `^` key's return swipe is the caron dead key, matching the
+    /// MessagEase original — and the only direct entry point into the
+    /// č ď ě ľ ň ř š ť ž table.
+    @Test func returnSwipeUpOnTopCenterComposesCaron() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+        target.documentContextBeforeInput = "c"
+
+        vm.handleGesture(.swipeUp, keyId: GridSlot.topCenter, isReturn: true)
+
+        #expect(target.events == [.deleteBackward, .insertText("č")])
+    }
+
+    /// With nothing to compose it commits the modifier itself, like every
+    /// other dead key on the layout.
+    @Test func returnSwipeUpOnTopCenterCommitsBareCaron() {
+        let (vm, target) = makeViewModel(languageId: "de_DE")
+
+        vm.handleGesture(.swipeUp, keyId: GridSlot.topCenter, isReturn: true)
+
+        #expect(inserts(target).last == "ˇ")
+    }
+
     // MARK: - Newline
 
     /// The newline swipe (topRight ↗) inserts a line break.

--- a/wurstfingerTests/SlideGestureStateTests.swift
+++ b/wurstfingerTests/SlideGestureStateTests.swift
@@ -500,10 +500,44 @@ struct SlideCancellationPipelineTests {
 
 // MARK: - Space-bar label visibility toggles (.swipeUp)
 
+/// Counts writes so the label toggles can assert they never re-assert a value
+/// the store already holds.
+private final class WriteCountingDefaults: InMemoryUserDefaults {
+    private(set) var writtenKeys: [String] = []
+
+    func resetWrites() {
+        writtenKeys = []
+    }
+
+    override func set(_ value: Any?, forKey defaultName: String) {
+        writtenKeys.append(defaultName)
+        super.set(value, forKey: defaultName)
+    }
+}
+
 @Suite(.serialized)
 struct SpaceLabelTogglePipelineTests {
     private func hides(_ vm: KeyboardViewModel, _ key: SettingsKey) -> Bool {
         vm.sharedDefaults.bool(forKey: key.rawValue)
+    }
+
+    /// A grouped toggle re-asserts both flags. When one already holds the
+    /// wanted value, writing it again would fire a second change notification
+    /// — a full settings reload and grid invalidation — for a value that did
+    /// not change.
+    @Test func groupedToggleWritesOnlyTheFlagThatChanges() throws {
+        let defaults = WriteCountingDefaults()
+        let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
+        vm.loadDefinition(for: "de_DE")
+        let spaceKey = try #require(vm.activeModeFromDefinition?.key(for: UtilitySlot.space))
+        defaults.set(true, forKey: SettingsKey.hideLetters.rawValue)
+        defaults.resetWrites()
+
+        vm.handleSlide(spaceKey, phase: .swipeUp(isReturn: true))
+
+        #expect(defaults.writtenKeys == [SettingsKey.hideStandardSymbols.rawValue])
+        #expect(defaults.bool(forKey: SettingsKey.hideLetters.rawValue))
+        #expect(defaults.bool(forKey: SettingsKey.hideStandardSymbols.rawValue))
     }
 
     @Test(arguments: [CursorMovementStyle.continuous, .discrete])

--- a/wurstfingerTests/TestFixtures.swift
+++ b/wurstfingerTests/TestFixtures.swift
@@ -1,0 +1,75 @@
+//
+//  TestFixtures.swift
+//  WurstfingerTests
+//
+//  Fixture builders and call conveniences that only the test suite uses.
+//  They live here rather than in `wurstfingerKeyboard/` so they stay out of
+//  the keyboard extension's binary — and so nobody mistakes them for a
+//  supported production path (the definition layer builds `KeyConfig`s in
+//  `GridKeyboardFactory`, not through `KeyConfig.letter`).
+//
+
+import Foundation
+@testable import WurstfingerApp
+
+extension KeyConfig {
+    /// Creates a letter key. Category is automatically derived from the action.
+    static func letter(
+        _ id: String,
+        tap: String,
+        swipes: [GestureType: String] = [:],
+        returnSwipes: [GestureType: String] = [:],
+        composeSwipes: [GestureType: (trigger: String, label: String)] = [:]
+    ) -> KeyConfig {
+        var bindings: [GestureType: KeyBinding] = [:]
+        bindings[.tap] = KeyBinding(
+            label: tap, action: .commitText(tap),
+            category: nil, returnAction: nil, accessibilityLabel: nil
+        )
+        for (gesture, char) in swipes {
+            bindings[gesture] = KeyBinding(
+                label: char, action: .commitText(char), category: nil,
+                returnAction: returnSwipes[gesture].map { .commitText($0) },
+                accessibilityLabel: nil
+            )
+        }
+        for (gesture, compose) in composeSwipes {
+            bindings[gesture] = KeyBinding(
+                label: compose.label, action: .compose(trigger: compose.trigger),
+                category: .compose, returnAction: nil, accessibilityLabel: nil
+            )
+        }
+        return KeyConfig(
+            id: id, bindings: bindings, swipeMode: .eightWay,
+            slideType: .none, style: .primary, tapCycleActions: nil
+        )
+    }
+}
+
+extension LanguageConfig {
+    static let german = LanguageConfig(
+        id: "de_DE", name: "Deutsch", locale: Locale(identifier: "de_DE")
+    )
+
+    static let russian = LanguageConfig(
+        id: "ru_RU", name: "Русский", locale: Locale(identifier: "ru_RU")
+    )
+}
+
+extension GestureResolverChain {
+    /// Convenience that returns the resolved `KeyAction` directly, or
+    /// `.none` if nothing matched.
+    func resolveAction(keyId: String, gesture: GestureType, in mode: KeyboardMode) -> KeyAction {
+        resolve(keyId: keyId, gesture: gesture, in: mode)?.action ?? .none
+    }
+}
+
+extension ComposeEngine {
+    static func compose(previous: String, trigger: String) -> String? {
+        shared.compose(previous: previous, trigger: trigger)
+    }
+
+    static func cycleAccent(for character: String) -> String? {
+        shared.cycleAccent(for: character)
+    }
+}

--- a/wurstfingerTests/TestHelpers.swift
+++ b/wurstfingerTests/TestHelpers.swift
@@ -81,7 +81,7 @@ final class MockTextTarget: TextInputTarget {
 /// `KeyboardSettings` reads/writes the injected store only via
 /// `object(forKey:)` / `set(_:forKey:)` / `removeObject(forKey:)`; the typed
 /// accessors are overridden too as a safety net.
-final class InMemoryUserDefaults: UserDefaults {
+class InMemoryUserDefaults: UserDefaults {
     private var storage: [String: Any] = [:]
     private let lock = NSLock()
 

--- a/wurstfingerTests/wurstfingerTests.swift
+++ b/wurstfingerTests/wurstfingerTests.swift
@@ -124,21 +124,21 @@ struct wurstfingerTests {
         viewModel.hapticIntensityTap = 0.8
         viewModel.hapticIntensityDrag = 1.1
 
-        #expect(defaults.double(forKey: KeyboardViewModel.hapticTapIntensityKey) == 0.8)
-        let dragDefault = defaults.double(forKey: KeyboardViewModel.hapticDragIntensityKey)
+        #expect(defaults.double(forKey: SettingsKey.hapticIntensityTap.rawValue) == 0.8)
+        let dragDefault = defaults.double(forKey: SettingsKey.hapticIntensityDrag.rawValue)
         #expect(abs(dragDefault - 1.0) < 0.0001)
     }
 
     @Test @MainActor func previewViewModelDoesNotPersist() {
         let defaults = InMemoryUserDefaults()
 
-        defaults.set(0.3, forKey: KeyboardViewModel.hapticTapIntensityKey)
+        defaults.set(0.3, forKey: SettingsKey.hapticIntensityTap.rawValue)
 
         let viewModel = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
         #expect(abs(viewModel.hapticIntensityTap - 0.3) < 0.0001)
 
         viewModel.hapticIntensityTap = 0.9
-        let persistedTap = defaults.double(forKey: KeyboardViewModel.hapticTapIntensityKey)
+        let persistedTap = defaults.double(forKey: SettingsKey.hapticIntensityTap.rawValue)
         #expect(abs(persistedTap - 0.3) < 0.0001)
     }
 
@@ -152,7 +152,7 @@ struct wurstfingerTests {
 
         #expect(abs(viewModel.hapticIntensityTap - 0.0) < 0.0001)
         #expect(abs(viewModel.hapticIntensityDrag - 1.0) < 0.0001)
-        let storedDrag = defaults.double(forKey: KeyboardViewModel.hapticDragIntensityKey)
+        let storedDrag = defaults.double(forKey: SettingsKey.hapticIntensityDrag.rawValue)
         #expect(abs(storedDrag - 1.0) < 0.0001)
     }
 

--- a/wurstfingerUITests/wurstfingerUITests.swift
+++ b/wurstfingerUITests/wurstfingerUITests.swift
@@ -83,7 +83,7 @@ final class wurstfingerUITests: XCTestCase {
         let newValue = firstToggle.value as? String
         XCTAssertNotEqual(initialValue, newValue, "Toggle value should change after tap")
 
-        // The setup steps persist to the shared app-group store — restore the
+        // The setup steps persist to the app's own defaults — restore the
         // original state so the test leaves no trace on the device/simulator.
         firstToggle.tap()
         let restoredValue = firstToggle.value as? String


### PR DESCRIPTION
Findings 13, 19, 20, 21, 23 and the remaining nitpicks of finding 25 from the 2026-08-08 stabilization review.

### The health log could truncate itself (finding 13, P3)

If `FileHandle(forWritingTo:)` failed for any reason other than a missing file, the fallback atomically replaced the whole history with a single entry — destroying exactly the resume-jetsam forensics the log exists for. The destructive path now requires the file to be genuinely absent.

`compactIfNeeded` had the same "rewrite what you could not read" shape: an oversized but unreadable file decoded to `[]` and was rewritten as empty. Both guards are needed and each has its own test, so neither can silently regress behind the other.

### Dead code (findings 19, 20)

All seven dead constants are gone, including the ones documenting features that do not exist (selection mode, delete auto-repeat, word delete). Each was re-verified as unreferenced across Swift, Markdown, Python, shell, JSON and YAML before removal.

For finding 20 the treatment is split rather than blanket deletion:

- **Deleted** — `View.ifLet`, `numpadStyleKey`, the haptic default re-exports, four `FontSizes` entries, two `Layout` hint margins, `KeyDimensions.minWidth`, and the `needsInputModeSwitchKey` override.
- **Moved to the test target** (`wurstfingerTests/TestFixtures.swift`) — `KeyConfig.letter`, `LanguageConfig.german`/`.russian`, `GestureResolverChain.resolveAction`, the `ComposeEngine` statics. They are genuinely used, just only by tests; moving them keeps them out of the shipped extension binary without churning ~120 call sites.
- **Not dead** — `hapticTapIntensityKey`/`hapticDragIntensityKey` had five test users. Deleted anyway, with the tests repointed at the canonical `SettingsKey`.

### One mode instead of two (finding 21)

The grid rendered from `activeModeName` while the height constraint came from `currentMode`, synced by hand in two places. Rather than deriving one from the other — which still leaves two accessors — the stored `currentMode` is gone and `currentArrangement` reads the same accessor the grid does, so the desync is unrepresentable. Publish counts go *down* by one write in `loadDefinition` and `switchToMode`; no keystroke path touches either property.

### The caron, and a correction to the review (finding 23)

The review calls four compose tables dead. They are not: `buildAccentCycles` folds *every* table in the rule set into the accent-cycle key, so deleting them would drop `ğ ĕ ĭ ŏ ŭ`, `æ ą ç ę ł œ ß ż`, the small kana and dakuten forms, and `č ď ě ň ř š ť ž` from the cycle — and for kana it would close the only path to small kana at all. Nothing was deleted.

What was genuinely unreachable is the caron as a *direct* trigger. The `^` key's return swipe now composes `ˇ` instead of committing a bare `ˆ`, matching the reference (`germanLetters.topCenter.up == {char: '^', ret: 'ˇ'}`, same for English and French). The other three tables are documented as cycle-only. This is the one user-visible behaviour change in the PR and deserves a try on a real keyboard.

### Nitpicks (finding 25)

- The language picker claimed an alphabetical sort but did a codepoint sort; it now uses `localizedStandardCompare`.
- `toggleLabelVisibility` no longer writes a flag the store already holds. "Collapse to one round-trip" is not literally achievable — `UserDefaults` has no batch write and the grouped toggle owns two independent keys — but a redundant write is now impossible.
- The "footprint after shedding" sample is taken after an `autoreleasepool` around the teardown, so UIKit's temporaries are gone before `phys_footprint` is read. Sampling *later* is not an option: `recordAndFlush` exists because the suspended process may never get CPU again, and deferring would lose the entry in exactly the resume-jetsam case it was written for. The remaining caveat (the value is an upper bound) is documented rather than the user-visible label being renamed.
- Onboarding state moved out of the shared app-group container into the app's own defaults, behind a typed `AppSettingsKey`, with an idempotent migration in `App.init()` so nobody sees onboarding twice. `SettingsKey` became `CaseIterable` so the collision test can check all 24 cases instead of a handwritten subset.

1087 unit tests pass; SwiftFormat and SwiftLint `--strict` are clean.

One item grep cannot settle: removing the `needsInputModeSwitchKey` override tells UIKit nothing (the property is system-computed and nothing in the repo reads it), but if the globe ever misbehaves on device, that is the one-line revert.
