### PR TITLE
Fix Missing Translations and Correct the Store Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,21 @@
 
 ### Fixed
 
-- Characters that could not be typed at all on the non-Latin layouts: Thai ฬ ฒ ฑ ฏ (circle gesture, matching the reference's center return) and the baht sign ฿, the Japanese 、 and 。 plus the small kana on return swipes, the Persian/Urdu half-space (ZWNJ), Arabic-script punctuation ؟ ، ؛ ٭ in place of the Latin marks, the Hindi rupee sign ₹, and the Hebrew geresh and gershayim ׳ ״ (#284)
+- Characters that could not be typed at all on the non-Latin layouts: Thai ฬ ฒ ฑ ฏ (circle gesture) and the baht sign ฿, the Japanese 、 and 。 plus the small kana on return swipes, the Persian/Urdu half-space (ZWNJ), Arabic-script punctuation ؟ ، ؛ ٭ in place of the Latin marks, the Hindi rupee sign ₹, and the Hebrew geresh and gershayim ׳ ״ (#284)
 - Forward-delete and capitalize-word with an active selection: forward-delete now removes the selection, and capitalize-word changes the case of the selection instead of eating the word in front of it (#281)
 - The double-space shortcut now requires two consecutive space presses within a short window, so a space typed into an already-finished sentence is no longer rewritten and a deliberate double space stays typable; it also inserts the script's own sentence mark (Devanagari danda, Japanese full-width stop, Urdu full stop) (#281)
 - Cut-all is bounded by the same size ceiling as a paste instead of issuing an unbounded number of delete round-trips to the host app (#281)
+- Returning to an app that was in the background now brings the keyboard back fully refreshed: settings, language, size and auto-capitalization changed in the meantime take effect before the first keystroke instead of the keyboard resurfacing on stale state (#277)
+- The app switcher no longer shows an empty gap where the keyboard was — a frozen stand-in keeps the card intact, and it neither swallows taps nor shows up in VoiceOver (#277)
+- Diagonal drags on the delete key are no longer dropped: a delete slide that drifts upwards deletes instead of doing nothing at all (#282)
+- A long press that was still armed when its key disappeared — switching mode or language mid-hold — no longer types the old key's digit into the new mode (#282)
+- Every key is operable with VoiceOver: activating the globe switches the input mode, and swipe-only actions such as copy, cut, paste and hide keyboard are offered as rotor actions (#283)
+- Key labels can no longer outgrow their key at the smallest keyboard sizes (#283)
 
 ### Changed
 
 - The `^` compose key's return swipe now types the caron dead key, so č ď ě ň ř š ť ž are reachable directly instead of only through the accent cycle (#285)
+- Leaner keyboard rendering: fewer allocations per keystroke and cached layouts released under memory pressure, leaving more headroom in the tight memory budget iOS gives keyboard extensions (#278)
 
 ## v1.4.0 — 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Want to try the latest features before they hit the App Store? Join our public T
 
 ## Features
 
-- **Multi-language support**: 15 languages including Catalan, Croatian, English, Estonian-Finnish, Finnish, French, German, Hebrew, Italian, Polish, Russian, Spanish, Swedish, Tagalog, and Vietnamese (with Telex input)
+- **Multi-language support**: 26 keyboard layouts — Arabic, Croatian, English, Estonian-Finnish, Finnish, French, German, Greek, Hebrew, Hindi, Italian, Japanese (Hiragana), Japanese (Katakana), Korean, Persian, Polish, Portuguese, Russian, Spanish, Spanish-Catalan, Swedish, Tagalog, Thai, Ukrainian, Urdu, and Vietnamese (with Telex input)
 - **MessagEase layout** with symbol and numeric layers
 - **Compose engine** that reproduces Thumb-Key's combination triggers (e.g. `' + a → á`)
 - **Return swipes** for punctuation and math symbols (`?`→`¿`, `*`→`†`, `/`→`÷`, ...)
@@ -71,6 +71,11 @@ Want to try the latest features before they hit the App Store? Join our public T
 ## FAQ
 
 Wondering why something doesn't work as expected? Check out the [Frequently Asked Questions](docs/FAQ.md) for common issues and their solutions.
+
+## Localization
+
+The app UI is localized into 23 languages. The Expert section and the imprint
+are English only — see [Localization Scope](docs/localization.md).
 
 ## Getting Started
 

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,0 +1,51 @@
+# Localization Scope
+
+The app UI ships in 23 languages: English plus the 22 in the project's
+`knownRegions` (`de fr es it ru pl sv fi hr he vi fil el pt uk ar fa ur th hi
+ja ko`). This document records where the strings live and which screens are
+deliberately left in English.
+
+## Catalogs
+
+| Catalog | Holds |
+| --- | --- |
+| `wurstfinger/Localizable.xcstrings` | Everything the host app displays: settings, onboarding, the test area — plus the keyboard's own strings, because the app renders real keyboards in its previews and showcase. |
+| `wurstfingerKeyboard/Localizable.xcstrings` | Only the strings the keyboard extension itself displays, today the VoiceOver labels of the utility keys. |
+
+Sources under `wurstfingerKeyboard/` compile into **both** products, so a
+string used there is looked up in whichever bundle is running and must exist in
+**both** catalogs. A string that only ever appears in settings therefore belongs
+in the host target — that is why `KeyboardStyle.displayName` lives in
+`StyleSettingsView.swift` and `HapticIntensityLevel.displayName` in
+`HapticSettingsView.swift`, next to the screens that show them, rather than
+next to the enums in `wurstfingerKeyboard/Settings/`.
+
+## English-only screens
+
+The Expert section is English by decision. Its vocabulary — jitter threshold,
+angular span, oriented compactness — cannot be reviewed by anyone on the team
+in 22 translations, and the whole section is a diagnostic tool for power users
+behind an acknowledgement gate:
+
+- `ExpertSettingsView`
+- `GesturePlaygroundView` (reachable only from the Expert screen)
+- `KeyboardHealthView` (reachable only from the Expert screen)
+
+Two more screens are English today, inherited rather than decided — worth
+revisiting:
+
+- `ImprintView` — legal notice, kept in a single authoritative wording. It is a
+  § 5 DDG notice for a German company, currently shown to German users in
+  English.
+- `AppStoreScreenshotView` — marketing screenshot chrome, not app UI.
+
+## What the tests guard
+
+- `LocalizationCompletenessTests` — every catalog entry is translated into all
+  22 languages, with no empty values, stale states, or stray languages.
+- `LocalizationUsageTests` — every `String(localized:)` key exists in the
+  catalog of every target that compiles the file using it.
+- `LocalizedViewLiteralTests` — every literal a view hands to a
+  `LocalizedStringKey` parameter exists in a catalog, unless its file is listed
+  in `englishOnlyViewFiles` with a reason. Adding an English-only screen means
+  adding it there and to the list above.

--- a/fastlane/metadata/de-DE/description.txt
+++ b/fastlane/metadata/de-DE/description.txt
@@ -8,10 +8,10 @@ FUNKTIONEN:
 
 • Großes 3x3-Tastenfeld - Optimiert für Daumen, nicht für Präzisionszeiger
 • Wischgesten - 8 zusätzliche Zeichen pro Taste durch Wischen
-• 14 Sprachen - Deutsch, Englisch, Spanisch, Französisch, Portugiesisch, Italienisch, Niederländisch, Schwedisch, Norwegisch, Dänisch, Finnisch, Polnisch, Tschechisch und Vietnamesisch
+• 26 Tastaturlayouts - Arabisch, Deutsch, Englisch, Estnisch-Finnisch, Finnisch, Französisch, Griechisch, Hebräisch, Hindi, Italienisch, Japanisch (Hiragana), Japanisch (Katakana), Koreanisch, Kroatisch, Persisch, Polnisch, Portugiesisch, Russisch, Schwedisch, Spanisch, Spanisch-Katalanisch, Tagalog, Thai, Ukrainisch, Urdu und Vietnamesisch (mit Telex-Eingabe)
 • Compose-Regeln - Akzente durch Kombinationen erstellen (z.B. ' + a = á)
 • Kreisbewegungen - Kreis zeichnen für Großbuchstaben
-• Cursor-Steuerung - Auf Leertaste ziehen zum Bewegen, lange drücken für Textauswahl
+• Cursor-Steuerung - Auf der Leertaste ziehen bewegt den Cursor, auf der Löschtaste ziehen löscht fortlaufend
 • Haptisches Feedback - Einstellbare Vibrationsintensität
 • Voll anpassbar - Tastaturgröße nach Wunsch skalieren
 

--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -8,10 +8,10 @@ FEATURES:
 
 • Large 3x3 Key Grid - Optimized for thumbs, not precision pointers
 • Swipe Gestures - Access 8 additional characters per key by swiping
-• 15 Languages - Catalan, Croatian, English, Estonian-Finnish, Finnish, French, German, Hebrew, Italian, Polish, Russian, Spanish, Swedish, Tagalog, and Vietnamese (with Telex input)
+• 26 Keyboard Layouts - Arabic, Croatian, English, Estonian-Finnish, Finnish, French, German, Greek, Hebrew, Hindi, Italian, Japanese (Hiragana), Japanese (Katakana), Korean, Persian, Polish, Portuguese, Russian, Spanish, Spanish-Catalan, Swedish, Tagalog, Thai, Ukrainian, Urdu, and Vietnamese (with Telex input)
 • Compose Rules - Create accents through combinations (e.g. ' + a = á)
 • Circular Gestures - Draw a circle for uppercase letters
-• Cursor Control - Drag on space bar to move cursor, long-press for text selection
+• Cursor Control - Drag on the space bar to move the cursor, drag on the delete key to erase continuously
 • Haptic Feedback - Customizable vibration intensity
 • Fully Adjustable - Scale keyboard size to your preference
 

--- a/wurstfinger/AppStoreScreenshotView.swift
+++ b/wurstfinger/AppStoreScreenshotView.swift
@@ -180,7 +180,7 @@ struct AppStoreScreenshotView: View {
         viewModel.keyAspectRatio = 1.0
         viewModel.keyboardHorizontalPosition = 0.5
         viewModel.keyboardWidth = KeyboardConstants.Calculations.squareKeyboardWidth(
-            cellSize: KeyboardConstants.Calculations.keyHeight(aspectRatio: 1.0),
+            cellSize: KeyboardConstants.Calculations.screenshotCellSize,
             columns: viewModel.currentArrangement?.columns ?? 4
         )
 

--- a/wurstfinger/ExpertSettingsView.swift
+++ b/wurstfinger/ExpertSettingsView.swift
@@ -5,6 +5,10 @@
 //  Expert settings for tuning gesture recognition parameters.
 //  Organized according to the gesture classification decision tree.
 //
+//  English only by decision: the tuning vocabulary (jitter threshold, angular
+//  span, oriented compactness) cannot be reviewed in 22 translations, and this is
+//  a diagnostic tool for power users. See docs/localization.md.
+//
 
 import SwiftUI
 
@@ -62,16 +66,7 @@ struct ExpertSettingsView: View {
     /// unclamped (no container/screen context) so the indicator reflects the
     /// device- and orientation-independent wish, matching the size slider.
     private var effectiveKeyHeight: Double {
-        // The MessagEase grid is 4 columns wide (matches the reference
-        // metrics); the height indicator is column-count independent in
-        // practice, but resolve() needs a concrete value.
-        Double(KeyboardLayoutMetrics.resolve(
-            wishWidth: keyboardWidth,
-            aspectRatio: keyAspectRatio,
-            columns: 4,
-            availableWidth: 0,
-            screenHeight: 0
-        ).cellHeight)
+        Double(SettingsLayoutMetrics.forStoredWish(width: keyboardWidth, aspectRatio: keyAspectRatio).cellHeight)
     }
 
     var body: some View {

--- a/wurstfinger/GesturePlaygroundView.swift
+++ b/wurstfinger/GesturePlaygroundView.swift
@@ -4,6 +4,8 @@
 //
 //  A visual playground for testing gesture recognition parameters.
 //
+//  English only, like the rest of the Expert section — see docs/localization.md.
+//
 
 import SwiftUI
 
@@ -18,14 +20,23 @@ struct GesturePlaygroundView: View {
     @AppStorage(SettingsKey.keyAspectRatio.rawValue, store: SharedDefaults.store)
     private var keyAspectRatio = DeviceLayoutUtils.defaultKeyAspectRatio
 
-    // Key dimensions for the input area (simulating a standard key),
-    // derived from the shared layout calculation.
+    @AppStorage(SettingsKey.keyboardWidthPoints.rawValue, store: SharedDefaults.store)
+    private var keyboardWidth = DeviceLayoutUtils.defaultKeyboardWidth
+
+    /// The cell the keyboard actually renders for the stored wish — the same
+    /// resolution the Expert screen's key-height indicator reports. Gesture
+    /// thresholds are absolute point values, so a practice key of a different
+    /// size classifies a gesture differently than a real key would.
+    private var keyCell: KeyboardLayoutMetrics {
+        SettingsLayoutMetrics.forStoredWish(width: keyboardWidth, aspectRatio: keyAspectRatio)
+    }
+
     private var keyHeight: CGFloat {
-        KeyboardConstants.Calculations.keyHeight(aspectRatio: keyAspectRatio)
+        keyCell.cellHeight
     }
 
     private var keyWidth: CGFloat {
-        keyHeight * CGFloat(keyAspectRatio)
+        keyCell.cellWidth
     }
 
     @State private var isDragging = false
@@ -356,7 +367,7 @@ struct GesturePlaygroundView: View {
 
     private func processGesture() {
         // 1. Load Config (including aspect ratio, just like the real keyboard)
-        let config = GesturePreprocessorConfig.fromUserDefaults().with(aspectRatio: keyAspectRatio)
+        let config = GesturePreprocessorConfig.fromUserDefaults().with(aspectRatio: keyCell.cellAspectRatio)
         let preprocessor = GesturePreprocessor(config: config)
 
         // 2. Preprocess

--- a/wurstfinger/HapticSettingsView.swift
+++ b/wurstfinger/HapticSettingsView.swift
@@ -171,8 +171,9 @@ struct HapticSettingsView: View {
 }
 
 extension HapticIntensityLevel {
-    /// User-facing level name. Lives in the host app target because the
-    /// keyboard extension has no string catalog.
+    /// User-facing level name. Lives in the host app target: the extension's
+    /// own catalog carries only the strings the keyboard itself displays, so a
+    /// settings-only name must not be looked up from extension code.
     var displayName: String {
         switch self {
         case .off: String(localized: "Off")

--- a/wurstfinger/KeyboardHealthView.swift
+++ b/wurstfinger/KeyboardHealthView.swift
@@ -6,6 +6,8 @@
 //  memory headroom and launch activity can be inspected on-device, without
 //  a Mac attached.
 //
+//  English only, like the rest of the Expert section — see docs/localization.md.
+//
 
 import SwiftUI
 

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -2071,144 +2071,6 @@
       },
       "comment": "Settings section header"
     },
-    "Language": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sprache"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Langue"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Idioma"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lingua"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Язык"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Język"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Språk"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kieli"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jezik"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "שפה"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ngôn ngữ"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wika"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Γλώσσα"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Idioma"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Мова"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اللغة"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "زبان"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "زبان"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ภาษา"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "भाषा"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "言語"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "언어"
-          }
-        }
-      },
-      "comment": "Settings row: keyboard layout language"
-    },
     "Utility Keys on Left": {
       "extractionState": "manual",
       "localizations": {
@@ -6763,144 +6625,6 @@
       },
       "comment": "Keyboard toolbar button to dismiss the keyboard / finish editing"
     },
-    "Keyboard Language": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tastatursprache"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Langue du clavier"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Idioma del teclado"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lingua della tastiera"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Язык клавиатуры"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Język klawiatury"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tangentbordsspråk"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Näppäimistön kieli"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jezik tipkovnice"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "שפת המקלדת"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ngôn ngữ bàn phím"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wika ng Keyboard"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Γλώσσα πληκτρολογίου"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Idioma do teclado"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Мова клавіатури"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لغة لوحة المفاتيح"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "زبان صفحه‌کلید"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ کی زبان"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ภาษาคีย์บอร์ด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड भाषा"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードの言語"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 언어"
-          }
-        }
-      },
-      "comment": "Navigation title for the language picker"
-    },
     "MessagEase Layout": {
       "extractionState": "manual",
       "localizations": {
@@ -7314,144 +7038,6 @@
         }
       },
       "comment": "Note shown on pre-iOS-26 devices; 'Liquid Glass' is a style name (keep)"
-    },
-    "Enable or disable all haptic feedback vibrations.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktiviere oder deaktiviere alle Vibrationen des haptischen Feedbacks."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activez ou désactivez toutes les vibrations de retour haptique."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Activa o desactiva todas las vibraciones de respuesta háptica."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attiva o disattiva tutte le vibrazioni del feedback aptico."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Включить или выключить вибрацию тактильного отклика."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Włącz lub wyłącz wszystkie wibracje reakcji haptycznych."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aktivera eller inaktivera alla vibrationer för taktil återkoppling."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ota käyttöön tai poista käytöstä kaikki tuntopalautteen värinät."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Uključi ili isključi sve vibracije haptičkih povratnih informacija."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "הפעל או השבת את כל רטטי המשוב המישושי."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bật hoặc tắt toàn bộ rung phản hồi xúc giác."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-enable o i-disable ang lahat ng haptic feedback na vibration."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ενεργοποιήστε ή απενεργοποιήστε όλες τις δονήσεις απτικής ανάδρασης."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ative ou desative todas as vibrações de retorno tátil."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Увімкніть або вимкніть усі вібрації тактильного відгуку."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تفعيل أو تعطيل جميع اهتزازات الاستجابة اللمسية."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "همهٔ لرزش‌های بازخورد لمسی را فعال یا غیرفعال کنید."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تمام ہیپٹک فیڈ بیک وائبریشنز فعال یا غیر فعال کریں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เปิดหรือปิดการสั่นตอบสนองแบบสัมผัสทั้งหมด"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "सभी हैप्टिक फ़ीडबैक वाइब्रेशन चालू या बंद करें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "すべての触覚フィードバックの振動を有効または無効にします。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "모든 햅틱 피드백 진동을 켜거나 끕니다."
-          }
-        }
-      },
-      "comment": "Caption under the haptic feedback toggle"
     },
     "Open the keyboard once to sync Full Access status.": {
       "extractionState": "manual",
@@ -9661,7 +9247,7 @@
       },
       "comment": "Warning with markdown bold and › separators; the path words inside ** ** are iOS Settings names — localize Settings/Keyboards/Allow Full Access, keep 'Wurstfinger', keep markdown ** and ›"
     },
-    "Keyboard Scale": {
+    "Keyboard Size": {
       "extractionState": "manual",
       "localizations": {
         "de": {
@@ -9673,37 +9259,37 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Échelle du clavier"
+            "value": "Taille du clavier"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Escala del teclado"
+            "value": "Tamaño del teclado"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scala della tastiera"
+            "value": "Dimensione della tastiera"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Масштаб клавиатуры"
+            "value": "Размер клавиатуры"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Skala klawiatury"
+            "value": "Rozmiar klawiatury"
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tangentbordets skala"
+            "value": "Tangentbordets storlek"
           }
         },
         "fi": {
@@ -9721,37 +9307,37 @@
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "קנה מידה של המקלדת"
+            "value": "גודל המקלדת"
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tỷ lệ bàn phím"
+            "value": "Kích thước bàn phím"
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scale ng Keyboard"
+            "value": "Laki ng Keyboard"
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Κλίμακα πληκτρολογίου"
+            "value": "Μέγεθος πληκτρολογίου"
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Escala do teclado"
+            "value": "Tamanho do teclado"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Масштаб клавіатури"
+            "value": "Розмір клавіатури"
           }
         },
         "ar": {
@@ -9763,13 +9349,13 @@
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "مقیاس صفحه‌کلید"
+            "value": "اندازه صفحه‌کلید"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "کی بورڈ اسکیل"
+            "value": "کی بورڈ کا سائز"
           }
         },
         "th": {
@@ -9781,7 +9367,7 @@
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "कीबोर्ड स्केल"
+            "value": "कीबोर्ड का आकार"
           }
         },
         "ja": {
@@ -9799,419 +9385,143 @@
       },
       "comment": "Slider title: overall keyboard size"
     },
-    "Compact": {
+    "Size relative to the standard keyboard. It stays the same in every orientation; if it does not fit, it shrinks to the screen.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kompakt"
+            "value": "Größe im Verhältnis zur Standardtastatur. Sie bleibt in jeder Bildschirmausrichtung gleich; passt sie nicht auf den Bildschirm, wird sie auf die Bildschirmbreite verkleinert."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Compact"
+            "value": "Taille par rapport au clavier standard. Elle reste identique dans toutes les orientations ; si le clavier ne tient pas, il est réduit à la largeur de l'écran."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Compacto"
+            "value": "Tamaño relativo al teclado estándar. Se mantiene igual en todas las orientaciones; si no cabe, se reduce al ancho de la pantalla."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Compatta"
+            "value": "Dimensione relativa alla tastiera standard. Resta invariata in ogni orientamento; se non c'è spazio sufficiente, viene ridotta alla larghezza dello schermo."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Компактно"
+            "value": "Размер относительно стандартной клавиатуры. Он одинаков в любой ориентации; если клавиатура не помещается, она уменьшается до ширины экрана."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kompaktowa"
+            "value": "Rozmiar względem klawiatury standardowej. Pozostaje taki sam w każdej orientacji; jeśli klawiatura się nie mieści, jest zmniejszana do szerokości ekranu."
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kompakt"
+            "value": "Storlek i förhållande till standardtangentbordet. Den är densamma i alla riktningar; om tangentbordet inte får plats krymps det till skärmens bredd."
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tiivis"
+            "value": "Koko suhteessa vakionäppäimistöön. Se pysyy samana kaikissa asennoissa; jos näppäimistö ei mahdu, se kutistetaan näytön leveyteen."
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kompaktno"
+            "value": "Veličina u odnosu na standardnu tipkovnicu. Ostaje ista u svakoj orijentaciji; ako tipkovnica ne stane, smanjuje se na širinu zaslona."
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "קומפקטי"
+            "value": "הגודל ביחס למקלדת הרגילה. הוא נשאר זהה בכל כיוון; אם המקלדת לא נכנסת, היא מוקטנת לרוחב המסך."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Thu gọn"
+            "value": "Kích thước so với bàn phím tiêu chuẩn. Kích thước này giữ nguyên ở mọi hướng màn hình; nếu không vừa, bàn phím sẽ thu nhỏ theo chiều rộng màn hình."
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Compact"
+            "value": "Laki kumpara sa karaniwang keyboard. Nananatili itong pareho sa lahat ng oryentasyon; kung hindi kasya, liliitan ito ayon sa lapad ng screen."
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Συμπαγές"
+            "value": "Μέγεθος σε σχέση με το τυπικό πληκτρολόγιο. Παραμένει το ίδιο σε κάθε προσανατολισμό· αν δεν χωράει, σμικρύνεται στο πλάτος της οθόνης."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Compacto"
+            "value": "Tamanho relativo ao teclado padrão. Mantém-se igual em qualquer orientação; se não couber, é reduzido à largura do ecrã."
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Компактний"
+            "value": "Розмір відносно стандартної клавіатури. Він однаковий у будь-якій орієнтації; якщо клавіатура не вміщується, вона зменшується до ширини екрана."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "مضغوط"
+            "value": "الحجم بالنسبة إلى لوحة المفاتيح القياسية. يبقى كما هو في كل الاتجاهات، وإذا لم تتسع لوحة المفاتيح فسيتم تصغيرها لتناسب عرض الشاشة."
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "فشرده"
+            "value": "اندازه نسبت به صفحه‌کلید استاندارد. در همه جهت‌ها یکسان می‌ماند؛ اگر جا نشود، به عرض صفحه کوچک می‌شود."
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "کومپیکٹ"
+            "value": "معیاری کی بورڈ کے مقابلے میں سائز۔ یہ ہر سمت میں یکساں رہتا ہے؛ اگر کی بورڈ نہ سما سکے تو اسے اسکرین کی چوڑائی کے مطابق چھوٹا کر دیا جاتا ہے۔"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "กะทัดรัด"
+            "value": "ขนาดเทียบกับคีย์บอร์ดมาตรฐาน ขนาดจะเท่าเดิมในทุกการวางแนว หากไม่พอดีจะย่อลงให้เท่าความกว้างของหน้าจอ"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "कॉम्पैक्ट"
+            "value": "मानक कीबोर्ड की तुलना में आकार। यह हर ओरिएंटेशन में एक जैसा रहता है; अगर यह नहीं समाता, तो इसे स्क्रीन की चौड़ाई तक छोटा कर दिया जाता है।"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "コンパクト"
+            "value": "標準キーボードを基準としたサイズです。どの画面の向きでも同じ大きさを保ち、収まらない場合は画面幅に合わせて縮小されます。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "축소"
+            "value": "표준 키보드를 기준으로 한 크기입니다. 화면 방향이 바뀌어도 그대로 유지되며, 들어가지 않으면 화면 너비에 맞춰 줄어듭니다."
           }
         }
       },
-      "comment": "Slider label (small size)"
-    },
-    "Full Width": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Volle Breite"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pleine largeur"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ancho completo"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Larghezza piena"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Вся ширина"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pełna szerokość"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Full bredd"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Täysi leveys"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Puna širina"
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "רוחב מלא"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Toàn chiều rộng"
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Buong Lapad"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Πλήρες πλάτος"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Largura total"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "На всю ширину"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "العرض الكامل"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "عرض کامل"
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "پوری چوڑائی"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "เต็มความกว้าง"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "पूरी चौड़ाई"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全幅"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 너비"
-          }
-        }
-      },
-      "comment": "Slider label (full width / 100%)"
-    },
-    "Scale the keyboard to make it smaller. At 100% it fills the full width, at 25% it's much more compact.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skaliere die Tastatur, um sie zu verkleinern. Bei 100 % füllt sie die volle Breite, bei 25 % ist sie deutlich kompakter."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réduisez la taille du clavier. À 100 %, il occupe toute la largeur ; à 25 %, il est beaucoup plus compact."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajusta la escala del teclado para hacerlo más pequeño. Al 100 % ocupa todo el ancho; al 25 % es mucho más compacto."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ridimensiona la tastiera per rimpicciolirla. Al 100% occupa tutta la larghezza, al 25% è molto più compatta."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Уменьшите масштаб клавиатуры. При 100 % она занимает всю ширину, при 25 % становится гораздо компактнее."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skaluj klawiaturę, aby ją zmniejszyć. Przy 100% wypełnia całą szerokość, a przy 25% jest znacznie bardziej kompaktowa."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skala tangentbordet för att göra det mindre. Vid 100 % fyller det hela bredden, vid 25 % är det mycket mer kompakt."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pienennä näppäimistöä skaalaamalla. 100 %:ssa se täyttää koko leveyden, 25 %:ssa se on huomattavasti tiiviimpi."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Smanji tipkovnicu mijenjanjem njezine veličine. Pri 100 % ispunjava punu širinu, a pri 25 % znatno je kompaktnija."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "שנה את קנה המידה של המקלדת כדי להקטין אותה. ב-100% היא ממלאת את הרוחב המלא, וב-25% היא קומפקטית בהרבה."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thu nhỏ bàn phím. Ở 100% bàn phím chiếm toàn bộ chiều rộng, ở 25% bàn phím gọn hơn nhiều."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I-scale ang keyboard para gawing mas maliit. Sa 100% pinupuno nito ang buong lapad, sa 25% mas compact ito."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Αλλάξτε την κλίμακα του πληκτρολογίου για να το κάνετε μικρότερο. Στο 100% καλύπτει όλο το πλάτος, ενώ στο 25% είναι πολύ πιο συμπαγές."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reduza a escala do teclado para o tornar mais pequeno. A 100% ocupa toda a largura, a 25% fica muito mais compacto."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Масштабуйте клавіатуру, щоб зменшити її. На 100% вона займає всю ширину, на 25% — значно компактніша."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "غيِّر حجم لوحة المفاتيح لجعلها أصغر. عند 100% تملأ العرض الكامل، وعند 25% تصبح أكثر إحكامًا."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "صفحه‌کلید را کوچک‌تر کنید. در ۱۰۰٪ تمام عرض را پر می‌کند و در ۲۵٪ بسیار فشرده‌تر است."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "کی بورڈ کو چھوٹا کرنے کے لیے اس کا اسکیل تبدیل کریں۔ 100% پر یہ پوری چوڑائی بھرتا ہے، 25% پر یہ کہیں زیادہ کومپیکٹ ہوتا ہے۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปรับขนาดคีย์บอร์ดให้เล็กลง ที่ 100% จะเต็มความกว้าง ที่ 25% จะกะทัดรัดมากขึ้น"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "कीबोर्ड को छोटा करने के लिए स्केल करें। 100% पर यह पूरी चौड़ाई भरता है, 25% पर यह काफ़ी अधिक कॉम्पैक्ट होता है।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キーボードを縮小します。100%では全幅に広がり、25%ではかなりコンパクトになります。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "키보드 크기를 조정하여 더 작게 만듭니다. 100%에서는 전체 너비를 채우고, 25%에서는 훨씬 더 작아집니다."
-          }
-        }
-      },
-      "comment": "Caption under the scale slider"
+      "comment": "Caption under the size slider"
     },
     "Horizontal Position": {
       "extractionState": "manual",
@@ -10765,277 +10075,139 @@
       },
       "comment": "Slider label: right position"
     },
-    "Position is only available when scale is below 100%.": {
+    "Adjust the horizontal position of the keyboard when it is narrower than the screen.": {
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Die Position ist nur verfügbar, wenn die Größe unter 100 % liegt."
+            "value": "Passe die horizontale Position der Tastatur an, wenn sie schmaler als der Bildschirm ist."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "La position n'est disponible que lorsque l'échelle est inférieure à 100 %."
+            "value": "Ajustez la position horizontale du clavier lorsqu'il est plus étroit que l'écran."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "La posición solo está disponible cuando la escala es inferior al 100 %."
+            "value": "Ajusta la posición horizontal del teclado cuando es más estrecho que la pantalla."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "La posizione è disponibile solo quando la scala è inferiore al 100%."
+            "value": "Regola la posizione orizzontale della tastiera quando è più stretta dello schermo."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Положение доступно только при масштабе менее 100 %."
+            "value": "Настройте положение клавиатуры по горизонтали, когда она уже экрана."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Położenie jest dostępne tylko, gdy skala jest poniżej 100%."
+            "value": "Dostosuj poziome położenie klawiatury, gdy jest węższa niż ekran."
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Positionen är endast tillgänglig när skalan är under 100 %."
+            "value": "Justera tangentbordets horisontella position när det är smalare än skärmen."
           }
         },
         "fi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sijainti on käytettävissä vain, kun koko on alle 100 %."
+            "value": "Säädä näppäimistön vaakasijaintia, kun se on näyttöä kapeampi."
           }
         },
         "hr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Položaj je dostupan samo kad je veličina ispod 100 %."
+            "value": "Prilagodi vodoravni položaj tipkovnice kad je uža od zaslona."
           }
         },
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "המיקום זמין רק כאשר קנה המידה נמוך מ-100%."
+            "value": "התאם את המיקום האופקי של המקלדת כאשר היא צרה מהמסך."
           }
         },
         "vi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Chỉ chỉnh được vị trí khi tỷ lệ dưới 100%."
+            "value": "Điều chỉnh vị trí ngang của bàn phím khi bàn phím hẹp hơn màn hình."
           }
         },
         "fil": {
           "stringUnit": {
             "state": "translated",
-            "value": "Available lang ang posisyon kapag mas mababa sa 100% ang scale."
+            "value": "Iayos ang horizontal na posisyon ng keyboard kapag mas makitid ito kaysa sa screen."
           }
         },
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Η θέση είναι διαθέσιμη μόνο όταν η κλίμακα είναι κάτω από 100%."
+            "value": "Προσαρμόστε την οριζόντια θέση του πληκτρολογίου όταν είναι στενότερο από την οθόνη."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "A posição só está disponível quando a escala é inferior a 100%."
+            "value": "Ajuste a posição horizontal do teclado quando este for mais estreito do que o ecrã."
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Положення доступне лише коли масштаб менший за 100%."
+            "value": "Регулюйте горизонтальне положення клавіатури, коли вона вужча за екран."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "لا يتوفر الموضع إلا عندما يكون الحجم أقل من 100%."
+            "value": "اضبط الموضع الأفقي للوحة المفاتيح عندما تكون أضيق من الشاشة."
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "موقعیت فقط زمانی در دسترس است که مقیاس کمتر از ۱۰۰٪ باشد."
+            "value": "وقتی صفحه‌کلید از صفحه نمایش باریک‌تر است، موقعیت افقی آن را تنظیم کنید."
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "پوزیشن صرف اس وقت دستیاب ہے جب اسکیل 100% سے کم ہو۔"
+            "value": "جب کی بورڈ اسکرین سے تنگ ہو تو اس کی افقی پوزیشن ایڈجسٹ کریں۔"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ตำแหน่งใช้ได้เฉพาะเมื่อขนาดต่ำกว่า 100% เท่านั้น"
+            "value": "ปรับตำแหน่งแนวนอนของคีย์บอร์ดเมื่อคีย์บอร์ดแคบกว่าหน้าจอ"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "स्थिति केवल तभी उपलब्ध है जब स्केल 100% से कम हो।"
+            "value": "जब कीबोर्ड स्क्रीन से सँकरा हो, तो उसकी क्षैतिज स्थिति समायोजित करें।"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "位置の調整は、サイズが100%未満のときのみ利用できます。"
+            "value": "キーボードが画面より狭いときに、水平方向の位置を調整します。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "위치는 크기가 100% 미만일 때만 사용할 수 있습니다."
-          }
-        }
-      },
-      "comment": "Note shown when scale is at 100%"
-    },
-    "Adjust the horizontal position of the keyboard when it's scaled below 100%.": {
-      "extractionState": "manual",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Passe die horizontale Position der Tastatur an, wenn sie unter 100 % skaliert ist."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajustez la position horizontale du clavier lorsque son échelle est inférieure à 100 %."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajusta la posición horizontal del teclado cuando su escala es inferior al 100 %."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Regola la posizione orizzontale della tastiera quando la scala è inferiore al 100%."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Настройте положение клавиатуры по горизонтали при масштабе менее 100 %."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dostosuj poziome położenie klawiatury, gdy jest przeskalowana poniżej 100%."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Justera tangentbordets horisontella position när det är skalat under 100 %."
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Säädä näppäimistön vaakasijaintia, kun se on skaalattu alle 100 %:iin."
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prilagodi vodoravni položaj tipkovnice kad je smanjena ispod 100 %."
-          }
-        },
-        "he": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "התאם את המיקום האופקי של המקלדת כאשר קנה המידה שלה נמוך מ-100%."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Điều chỉnh vị trí ngang của bàn phím khi tỷ lệ dưới 100%."
-          }
-        },
-        "fil": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Iayos ang horizontal na posisyon ng keyboard kapag naka-scale ito nang mas mababa sa 100%."
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Προσαρμόστε την οριζόντια θέση του πληκτρολογίου όταν η κλίμακά του είναι κάτω από 100%."
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ajuste a posição horizontal do teclado quando a escala for inferior a 100%."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Регулюйте горизонтальне положення клавіатури, коли її масштаб менший за 100%."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "اضبط الموضع الأفقي للوحة المفاتيح عندما يكون حجمها أقل من 100%."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "موقعیت افقی صفحه‌کلید را هنگامی که مقیاس آن کمتر از ۱۰۰٪ است تنظیم کنید."
-          }
-        },
-        "ur": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "جب کی بورڈ 100% سے کم اسکیل پر ہو تو اس کی افقی پوزیشن ایڈجسٹ کریں۔"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ปรับตำแหน่งแนวนอนของคีย์บอร์ดเมื่อย่อขนาดต่ำกว่า 100%"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "जब कीबोर्ड 100% से कम स्केल हो तो उसकी क्षैतिज स्थिति समायोजित करें।"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サイズが100%未満のときに、キーボードの水平方向の位置を調整します。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "크기가 100% 미만일 때 키보드의 가로 위치를 조정합니다."
+            "value": "키보드가 화면보다 좁을 때 가로 위치를 조정합니다."
           }
         }
       },
@@ -12421,6 +11593,144 @@
       },
       "comment": "ACCESSIBILITY label for the delete/backspace key (VoiceOver)"
     },
+    "Next language": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nächste Sprache"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langue suivante"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma siguiente"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lingua successiva"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Следующий язык"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Następny język"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nästa språk"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seuraava kieli"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sljedeći jezik"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "השפה הבאה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ngôn ngữ tiếp theo"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Susunod na wika"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επόμενη γλώσσα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Próximo idioma"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Наступна мова"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اللغة التالية"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زبان بعدی"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اگلی زبان"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ภาษาถัดไป"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अगली भाषा"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次の言語"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음 언어"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY action name for the switch-to-next-language gesture (VoiceOver)"
+    },
     "New line": {
       "extractionState": "manual",
       "localizations": {
@@ -12834,6 +12144,144 @@
         }
       },
       "comment": "ACCESSIBILITY label for the cut gesture (VoiceOver)"
+    },
+    "Cut all": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles ausschneiden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout couper"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar todo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taglia tutto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вырезать всё"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wytnij wszystko"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klipp ut allt"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leikkaa kaikki"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izreži sve"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "גזור הכול"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cắt tất cả"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gupitin lahat"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αποκοπή όλων"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cortar tudo"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вирізати все"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قص الكل"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "برش همه"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سب کاٹیں"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัดทั้งหมด"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सभी काटें"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて切り取り"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모두 잘라내기"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the cut-all gesture (VoiceOver)"
     },
     "Paste": {
       "extractionState": "manual",

--- a/wurstfinger/SettingsLayoutMetrics.swift
+++ b/wurstfinger/SettingsLayoutMetrics.swift
@@ -1,0 +1,29 @@
+//
+//  SettingsLayoutMetrics.swift
+//  wurstfinger
+//
+//  The keyboard geometry the settings screens report and simulate.
+//
+
+import CoreGraphics
+
+/// Resolves the stored size wish the way the settings screens present it:
+/// without a render context, so the numbers are device- and
+/// orientation-independent — exactly what the size slider edits.
+///
+/// Every arrangement the runtime selects is four columns wide (the portrait
+/// grid is kept in all orientations, see `KeyboardViewModel.currentContext`),
+/// so the cell this resolves is the cell the keyboard renders.
+enum SettingsLayoutMetrics {
+    private static let gridColumns = 4
+
+    static func forStoredWish(width: CGFloat, aspectRatio: CGFloat) -> KeyboardLayoutMetrics {
+        KeyboardLayoutMetrics.resolve(
+            wishWidth: width,
+            aspectRatio: aspectRatio,
+            columns: gridColumns,
+            availableWidth: 0,
+            screenHeight: 0
+        )
+    }
+}

--- a/wurstfinger/StyleSettingsView.swift
+++ b/wurstfinger/StyleSettingsView.swift
@@ -91,6 +91,26 @@ struct StyleSettingsView: View {
     }
 }
 
+extension KeyboardStyle {
+    /// User-facing style name. Lives in the host app target: the extension's
+    /// own catalog carries only the strings the keyboard itself displays, so a
+    /// settings-only name must not be looked up from extension code.
+    var displayName: String {
+        switch self {
+        case .classic: String(localized: "Classic")
+        case .liquidGlass: String(localized: "Liquid Glass")
+        }
+    }
+
+    /// One-line explanation shown under the style name.
+    var description: String {
+        switch self {
+        case .classic: String(localized: "Traditional opaque keys")
+        case .liquidGlass: String(localized: "Transparent glass effect (iOS 26+)")
+        }
+    }
+}
+
 #Preview {
     NavigationStack {
         StyleSettingsView()

--- a/wurstfingerKeyboard/Localizable.xcstrings
+++ b/wurstfingerKeyboard/Localizable.xcstrings
@@ -1102,7 +1102,8 @@
             "value": "모두 잘라내기"
           }
         }
-      }
+      },
+      "comment": "ACCESSIBILITY label for the cut-all gesture (VoiceOver)"
     },
     "Paste": {
       "extractionState": "manual",

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -21,8 +21,8 @@ enum KeyboardConstants {
         static let cornerRadius: CGFloat = 8
 
         /// Reference key aspect ratio (width/height) at which `height` is defined.
-        /// Used only as the baseline in `Calculations.keyHeight`; it is NOT the
-        /// user-facing default setting (that is `DeviceLayoutUtils.defaultKeyAspectRatio`).
+        /// Used only as the baseline of `Calculations.screenshotCellSize`; it is NOT
+        /// the user-facing default setting (that is `DeviceLayoutUtils.defaultKeyAspectRatio`).
         static let referenceAspectRatio: CGFloat = 1.5
 
         /// Total number of rows in the keyboard layout.
@@ -265,10 +265,10 @@ enum KeyboardConstants {
     // MARK: - Keyboard Calculations
 
     enum Calculations {
-        /// Calculates the adjusted key height based on aspect ratio
-        static func keyHeight(aspectRatio: CGFloat) -> CGFloat {
-            KeyDimensions.height * (KeyDimensions.referenceAspectRatio / aspectRatio)
-        }
+        /// Cell size the App Store screenshots render at: the reference key
+        /// height at the reference aspect ratio. A marketing constant, not a
+        /// layout value — the rendered cell comes from `KeyboardLayoutMetrics`.
+        static let screenshotCellSize: CGFloat = KeyDimensions.height * KeyDimensions.referenceAspectRatio
 
         /// Keyboard width at which the grid's cells come out exactly
         /// `cellSize` wide. Under the point-anchored metrics, square cells

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -348,22 +348,4 @@ enum CursorMovementStyle: String, CaseIterable {
 enum KeyboardStyle: String, CaseIterable {
     case classic // Traditional opaque key backgrounds
     case liquidGlass // iOS 26+ Liquid Glass effect (renders as a simplified translucent style on older iOS)
-
-    var displayName: String {
-        switch self {
-        case .classic:
-            String(localized: "Classic")
-        case .liquidGlass:
-            String(localized: "Liquid Glass")
-        }
-    }
-
-    var description: String {
-        switch self {
-        case .classic:
-            String(localized: "Traditional opaque keys")
-        case .liquidGlass:
-            String(localized: "Transparent glass effect (iOS 26+)")
-        }
-    }
 }

--- a/wurstfingerTests/LocalizationCompletenessTests.swift
+++ b/wurstfingerTests/LocalizationCompletenessTests.swift
@@ -135,14 +135,35 @@ struct LocalizationCompletenessTests {
 
 // MARK: - Usage → catalog coverage
 
-/// Source directories whose Swift files are scanned for localizable string usage.
-private let localizedSourceDirs: [String] = ["wurstfinger", "wurstfingerKeyboard"]
+/// Source directories scanned for localizable strings, mapped to the catalogs
+/// a key used there must exist in.
+///
+/// `wurstfingerKeyboard/` compiles into *both* products — the app renders the
+/// real keyboard in its previews and showcase — so a string used there is
+/// looked up in whichever bundle is running and must exist in both catalogs.
+/// A host-only string needs the host catalog only; the extension's catalog
+/// deliberately carries just the strings the keyboard itself displays.
+private let catalogsRequiredBySourceDir: [String: [String]] = [
+    "wurstfinger": ["wurstfinger/Localizable.xcstrings"],
+    "wurstfingerKeyboard": localizationCatalogs,
+]
 
-/// A `String(localized:)` usage discovered in the source tree.
+/// A localizable string usage discovered in the source tree.
 private struct LocalizedUsage: Hashable {
     let key: String
+    /// Source directory the file was scanned under, i.e. the key into
+    /// `catalogsRequiredBySourceDir`.
+    let dir: String
+    /// Path relative to the repo root, so a failure names a file that exists.
     let file: String
     let line: Int
+}
+
+/// Repo-relative path of a scanned source file.
+private func repoRelativePath(of url: URL) -> String {
+    let root = projectDir().standardizedFileURL.path + "/"
+    let path = url.standardizedFileURL.path
+    return path.hasPrefix(root) ? String(path.dropFirst(root.count)) : path
 }
 
 /// Matches `String(localized: "…")` and captures the literal, honouring escaped
@@ -202,7 +223,7 @@ private func scanLocalizedUsages() -> [LocalizedUsage] {
     var usages: [LocalizedUsage] = []
     let fileManager = FileManager.default
 
-    for dir in localizedSourceDirs {
+    for dir in catalogsRequiredBySourceDir.keys.sorted() {
         let base = root.appendingPathComponent(dir)
         guard let enumerator = fileManager.enumerator(at: base, includingPropertiesForKeys: nil) else { continue }
         for case let url as URL in enumerator where url.pathExtension == "swift" {
@@ -223,7 +244,8 @@ private func scanLocalizedUsages() -> [LocalizedUsage] {
                 usages.append(
                     LocalizedUsage(
                         key: unescapeSwiftLiteral(literal),
-                        file: "\(dir)/\(url.lastPathComponent)",
+                        dir: dir,
+                        file: repoRelativePath(of: url),
                         line: line
                     )
                 )
@@ -233,6 +255,31 @@ private func scanLocalizedUsages() -> [LocalizedUsage] {
     return usages
 }
 
+/// Catalog keys per catalog path, so a usage can be checked against exactly the
+/// catalogs its source directory ships into.
+private func catalogKeysByPath() throws -> [String: Set<String>] {
+    var keysByCatalog: [String: Set<String>] = [:]
+    for relativePath in localizationCatalogs {
+        keysByCatalog[relativePath] = try Set(loadCatalog(relativePath).strings.keys)
+    }
+    return keysByCatalog
+}
+
+/// One `file:line  "key" absent from <catalog>` line per gap, sorted by source
+/// position so the report reads like a compiler's.
+private func missingUsageReport(
+    _ usages: [LocalizedUsage],
+    keysByCatalog: [String: Set<String>]
+) -> [String] {
+    usages
+        .sorted { ($0.file, $0.line, $0.key) < ($1.file, $1.line, $1.key) }
+        .flatMap { usage in
+            (catalogsRequiredBySourceDir[usage.dir] ?? [])
+                .filter { keysByCatalog[$0]?.contains(usage.key) != true }
+                .map { "\(usage.file):\(usage.line)  \"\(usage.key)\" absent from \($0)" }
+        }
+}
+
 /// Guards the *other* direction from `LocalizationCompletenessTests`: that every
 /// string the code asks for actually exists in a catalog. The completeness tests
 /// work from the catalog outwards and cannot see a key that was never added, so a
@@ -240,28 +287,146 @@ private func scanLocalizedUsages() -> [LocalizedUsage] {
 /// language (as happened in #261) without failing any existing test.
 ///
 /// Scope: this covers the explicit `String(localized:)` API only. Bare
-/// `LocalizedStringKey` literals passed to a view initializer (e.g.
-/// `SettingsRow(title: "…")`) are not statically detectable without type
-/// information and remain outside this guard.
+/// `LocalizedStringKey` literals passed to a view initializer are covered by
+/// `LocalizedViewLiteralTests` below.
 struct LocalizationUsageTests {
-    @Test("Every String(localized:) key exists in a catalog")
+    @Test("Every String(localized:) key exists in the catalogs of the targets that compile it")
     func everyLocalizedKeyExistsInCatalog() throws {
-        var catalogKeys: Set<String> = []
-        for relativePath in localizationCatalogs {
-            try catalogKeys.formUnion(loadCatalog(relativePath).strings.keys)
-        }
+        let keysByCatalog = try catalogKeysByPath()
 
         let usages = scanLocalizedUsages()
         #expect(!usages.isEmpty, "Found no String(localized:) usages to check — has the source layout moved?")
 
-        let missing = usages.filter { !catalogKeys.contains($0.key) }
-        let detail = missing
-            .sorted { ($0.file, $0.line) < ($1.file, $1.line) }
-            .map { "\($0.file):\($0.line)  \"\($0.key)\"" }
-            .joined(separator: "\n")
+        let missing = missingUsageReport(usages, keysByCatalog: keysByCatalog)
+        let detail = missing.joined(separator: "\n")
         #expect(
             missing.isEmpty,
-            "\(missing.count) localized string(s) used in code but absent from every catalog:\n\(detail)"
+            "\(missing.count) localized string(s) used in code but absent from a catalog of a target that compiles them:\n\(detail)"
         )
+    }
+}
+
+// MARK: - View literal → catalog coverage
+
+/// Screens shipped in English only, with the reason. A file listed here is
+/// skipped below; everything else must have every user-visible literal in a
+/// catalog, so adding an English-only screen forces an entry here — and a line
+/// in `docs/localization.md`.
+private let englishOnlyViewFiles: [String: String] = [
+    "wurstfinger/ExpertSettingsView.swift":
+        "Gesture-tuning vocabulary nobody on the team can review in 22 translations; diagnostic tool behind an acknowledgement gate.",
+    "wurstfinger/GesturePlaygroundView.swift":
+        "Reachable only from the Expert screen and shares its vocabulary.",
+    "wurstfinger/KeyboardHealthView.swift":
+        "Reachable only from the Expert screen; renders raw on-device diagnostics.",
+    "wurstfinger/ImprintView.swift":
+        "Legal notice kept in a single authoritative wording.",
+    "wurstfinger/AppStoreScreenshotView.swift":
+        "Marketing screenshot chrome, not app UI.",
+]
+
+/// User-visible literals that read the same in every language.
+private let untranslatedProperNouns: Set<String> = ["GitHub", "MIT", "Wurstfinger"]
+
+/// First-argument literal of the SwiftUI initializers and modifiers whose
+/// parameter is a `LocalizedStringKey`. These are the strings
+/// `LocalizationUsageTests` cannot see: a bare literal carries no
+/// `String(localized:)` marker.
+private let viewLiteralRegex: NSRegularExpression = {
+    let inits = "Text|Button|Toggle|TextField|Section|Label|Picker|Link|Stepper|NavigationLink"
+    let modifiers = "navigationTitle|accessibilityLabel|accessibilityHint|alert|confirmationDialog"
+    let pattern = #"(?:\b(?:"# + inits + #")\(|\.(?:"# + modifiers + #")\()\s*"(?!"")((?:[^"\\]|\\.)*)""#
+    guard let regex = try? NSRegularExpression(pattern: pattern) else {
+        preconditionFailure("Invalid viewLiteralRegex pattern")
+    }
+    return regex
+}()
+
+/// `title:` / `description:` arguments of the app's own row components
+/// (`SettingsRow`, `SetupStepView`, `hapticControl`), which take
+/// `LocalizedStringKey`. Host-only on purpose: the same labels under
+/// `wurstfingerKeyboard/` name layout data (`LanguageDescriptor(title:)`),
+/// not UI strings.
+private let hostRowLabelRegex: NSRegularExpression = {
+    guard let regex = try? NSRegularExpression(
+        pattern: #"\b(?:title|description):\s*"(?!"")((?:[^"\\]|\\.)*)""#
+    ) else {
+        preconditionFailure("Invalid hostRowLabelRegex pattern")
+    }
+    return regex
+}()
+
+/// Every literal a view hands to a `LocalizedStringKey` parameter, minus the
+/// English-only screens, the proper nouns, and literals without letters
+/// (slider tick marks like "35%" or "1.62", identical in every language).
+private func scanViewLiterals() -> [LocalizedUsage] {
+    let root = projectDir()
+    var usages: [LocalizedUsage] = []
+    let fileManager = FileManager.default
+
+    for dir in catalogsRequiredBySourceDir.keys.sorted() {
+        let base = root.appendingPathComponent(dir)
+        guard let enumerator = fileManager.enumerator(at: base, includingPropertiesForKeys: nil) else { continue }
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let file = repoRelativePath(of: url)
+            guard englishOnlyViewFiles[file] == nil,
+                  let source = try? String(contentsOf: url, encoding: .utf8)
+            else { continue }
+            let ns = source as NSString
+            let fullRange = NSRange(location: 0, length: ns.length)
+            let regexes = dir == "wurstfinger" ? [viewLiteralRegex, hostRowLabelRegex] : [viewLiteralRegex]
+            for regex in regexes {
+                for match in regex.matches(in: source, range: fullRange) {
+                    let literal = ns.substring(with: match.range(at: 1))
+                    // Interpolated labels become format strings, proper nouns read
+                    // the same everywhere, and a literal without letters is not a
+                    // phrase (slider tick marks like "35%").
+                    if literal.contains("\\(") { continue }
+                    let key = unescapeSwiftLiteral(literal)
+                    if untranslatedProperNouns.contains(key) || !key.contains(where: \.isLetter) {
+                        continue
+                    }
+                    let line = ns.substring(to: match.range.location)
+                        .reduce(1) { $0 + ($1 == "\n" ? 1 : 0) }
+                    usages.append(LocalizedUsage(key: key, dir: dir, file: file, line: line))
+                }
+            }
+        }
+    }
+    return usages
+}
+
+/// Covers the blind spot `LocalizationUsageTests` documents: a bare literal
+/// passed to a `LocalizedStringKey` parameter (`Text("Keyboard Size")`) is a
+/// localizable string with no marker in the source, so a missing catalog entry
+/// renders as English in all 22 translations and no other test notices.
+struct LocalizedViewLiteralTests {
+    @Test("Every user-visible view literal exists in a catalog")
+    func everyViewLiteralExistsInCatalog() throws {
+        let keysByCatalog = try catalogKeysByPath()
+
+        let usages = scanViewLiterals()
+        #expect(!usages.isEmpty, "Found no view literals to check — has the source layout moved?")
+
+        let missing = missingUsageReport(usages, keysByCatalog: keysByCatalog)
+        let detail = missing.joined(separator: "\n")
+        let hint = "add the key to the catalog, or list the file in `englishOnlyViewFiles`"
+            + " with a reason and record it in docs/localization.md"
+        #expect(
+            missing.isEmpty,
+            "\(missing.count) view literal(s) render untranslated — \(hint):\n\(detail)"
+        )
+    }
+
+    @Test("The English-only allowlist has no stale entries")
+    func englishOnlyAllowlistIsCurrent() {
+        let root = projectDir()
+        for (file, reason) in englishOnlyViewFiles.sorted(by: { $0.key < $1.key }) {
+            #expect(
+                FileManager.default.fileExists(atPath: root.appendingPathComponent(file).path),
+                "\(file) is allowlisted as English-only but no longer exists — drop the entry"
+            )
+            #expect(!reason.isEmpty, "\(file) needs a reason for being English-only")
+        }
     }
 }

--- a/wurstfingerTests/MarketingMetadataTests.swift
+++ b/wurstfingerTests/MarketingMetadataTests.swift
@@ -1,0 +1,52 @@
+//
+//  MarketingMetadataTests.swift
+//  wurstfingerTests
+//
+//  The App Store copy and the README state the number of keyboard layouts by
+//  hand. Reads them from the repo (like LocalizationCompletenessTests) and
+//  checks the number against the registry, so a new layout cannot ship with
+//  stale marketing copy.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+private enum MarketingMetadataError: Error {
+    case unreadableFile(String)
+}
+
+/// Repo root: this file lives in `wurstfingerTests/`, so go up two levels.
+private func repoRoot(file: String = #filePath) -> URL {
+    URL(fileURLWithPath: file)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}
+
+struct MarketingMetadataTests {
+    /// Only the count is checked: the lists themselves are prose and stay a
+    /// manual review item.
+    @Test(arguments: [
+        (path: "fastlane/metadata/en-US/description.txt", noun: "Keyboard Layouts"),
+        (path: "fastlane/metadata/de-DE/description.txt", noun: "Tastaturlayouts"),
+        (path: "README.md", noun: "keyboard layouts"),
+    ])
+    func statedLayoutCountMatchesTheRegistry(file: (path: String, noun: String)) throws {
+        let url = repoRoot().appendingPathComponent(file.path)
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else {
+            throw MarketingMetadataError.unreadableFile(file.path)
+        }
+
+        let pattern = #"(\d+)\s+"# + NSRegularExpression.escapedPattern(for: file.noun)
+        let regex = try NSRegularExpression(pattern: pattern)
+        let ns = text as NSString
+        let match = try #require(
+            regex.firstMatch(in: text, range: NSRange(location: 0, length: ns.length)),
+            "\(file.path) no longer states a number of \"\(file.noun)\""
+        )
+        let stated = try #require(Int(ns.substring(with: match.range(at: 1))))
+        let shipped = KeyboardRegistry.available.count
+
+        #expect(stated == shipped, "\(file.path) claims \(stated) \(file.noun), but \(shipped) layouts ship")
+    }
+}

--- a/wurstfingerTests/SettingsLayoutMetricsTests.swift
+++ b/wurstfingerTests/SettingsLayoutMetricsTests.swift
@@ -1,0 +1,49 @@
+//
+//  SettingsLayoutMetricsTests.swift
+//  wurstfingerTests
+//
+//  The settings screens report and simulate the keyboard's geometry. Pins the
+//  seam they share to the metrics resolver, so a practice key or a key-height
+//  indicator cannot drift away from the cell the keyboard renders.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct SettingsLayoutMetricsTests {
+    @Test(arguments: [
+        (wish: CGFloat(270), aspect: CGFloat(1.0)),
+        (wish: CGFloat(392), aspect: CGFloat(1.62)),
+        (wish: CGFloat(95), aspect: CGFloat(1.0)),
+    ])
+    func reportsTheRenderedCell(config: (wish: CGFloat, aspect: CGFloat)) {
+        let settings = SettingsLayoutMetrics.forStoredWish(width: config.wish, aspectRatio: config.aspect)
+        let rendered = KeyboardLayoutMetrics.resolve(
+            wishWidth: config.wish,
+            aspectRatio: config.aspect,
+            columns: 4,
+            availableWidth: config.wish,
+            screenHeight: 0
+        )
+        #expect(abs(settings.cellWidth - rendered.cellWidth) < 0.0001)
+        #expect(abs(settings.cellHeight - rendered.cellHeight) < 0.0001)
+        #expect(abs(settings.cellAspectRatio - rendered.cellAspectRatio) < 0.0001)
+    }
+
+    /// At the default wish the keyboard renders a 57.75 pt cell, far from the
+    /// 81 pt screenshot constant. Gesture thresholds are absolute point values,
+    /// so a practice key drawn at that constant classifies gestures differently.
+    @Test func defaultWishResolvesTheRenderedCellNotTheReferenceHeight() {
+        let cellHeight = SettingsLayoutMetrics.forStoredWish(width: 270, aspectRatio: 1.0).cellHeight
+        #expect(abs(cellHeight - 57.75) < 0.0001)
+        #expect(abs(cellHeight - KeyboardConstants.Calculations.screenshotCellSize) > 20)
+    }
+
+    /// The marketing geometry is a constant of its own: moving it resizes every
+    /// App Store screenshot.
+    @Test func screenshotCellSizeIsUnchanged() {
+        #expect(KeyboardConstants.Calculations.screenshotCellSize == 81)
+    }
+}

--- a/wurstfingerUITests/wurstfingerUITests.swift
+++ b/wurstfingerUITests/wurstfingerUITests.swift
@@ -13,7 +13,7 @@ final class wurstfingerUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        // The suite queries localized display text ("Settings", "Language", …),
+        // The suite queries localized display text ("Settings", "Languages", …),
         // so pin the app to English regardless of the simulator's locale.
         app.launchArguments = [
             "-AppleLanguages", "(en)",


### PR DESCRIPTION
Findings 26 to 31 of the 2026-08-08 stabilization review.

### Size & Position was English in 21 languages (finding 26)

Three live strings were missing from the catalog while four superseded ones still carried translations nobody could see. All three are added with 22 translations each, and **nine** dead keys are removed — verified twice, and three more than the review implied (`Language`, `Compact`, and the haptic master-toggle explainer are dead too). The catalog goes from 136 to 131 keys and loses about 940 lines.

The blind spot itself is closed: `LocalizedViewLiteralTests` scans bare `LocalizedStringKey` literals in views, which `LocalizationUsageTests` never saw. It reports exactly the three known gaps on `develop` and none after.

The catalog was edited by rebuilding it from its own text blocks, never through a JSON round-trip. I proved the renderer byte-identical on three untouched entries before writing, and verified afterwards: JSON parses, the semantic diff is exactly 9 removals and 4 additions with **zero** modified existing entries, and entry order is unchanged.

### The Expert section stays English, on purpose (finding 27)

Per the decision on this PR: the Expert screen, the gesture playground and Keyboard Health stay English. Its terminology (jitter threshold, angular span, oriented compactness) cannot be reviewed by anyone here in 22 translations, and these are diagnostic tools for power users.

That is now written down rather than implied: a note at the top of each file, `docs/localization.md`, a short README section, and — so it cannot rot — a named allowlist in the test with a mandatory reason per file, plus a test that fails when an allowlist entry goes stale. `ImprintView` and `AppStoreScreenshotView` are English too and nobody ever decided that; the allowlist forces them to be named, and the doc lists them separately as inherited rather than decided.

**One thing for you to rule on:** `ImprintView` is a § 5 DDG notice for a German company, rendered in English to German users. Out of scope here, but now visible.

### The store descriptions were factually wrong (finding 28)

de-DE claimed "14 Sprachen" including Dutch, Norwegian, Danish and Czech — none of those layouts exist. There are 26, verified against `LanguageDefinitions.all`. en-US and `README.md` still said 15, which undersells 1.4.0's headline feature. All three now carry the true count and the full list, and `MarketingMetadataTests` pins the number to `KeyboardRegistry.available.count`, so the claim cannot go stale again.

**A second false claim, not in the review:** both descriptions promised long-press text selection. Keyboard extensions cannot select text — `docs/FAQ.md` cites Apple's guide on exactly this, and no such code exists. Both lines now describe the delete-key drag, which is real. Drop those two hunks if you would rather keep this PR strictly on the language count.

### Remaining items

- **Finding 29** — the Unreleased section listed only #279 although the range contains #277 and #278. Reconstructed from `git log v1.4.0..HEAD` after reading both diffs, written as user-visible effects.
- **Finding 30** — the gesture playground drew an 81 pt key while the real keyboard resolves 57.75 pt, so playground-tuned thresholds (absolute points) classified differently on the real thing, and the same Expert section showed two different key heights. Both now route through one host-side seam. `Calculations.keyHeight(aspectRatio:)` is deleted rather than bypassed, so the wrong path no longer compiles; the App Store screenshot geometry keeps its 81 pt under a name that says so, and screenshots stay pixel-identical.
- **Finding 31** — the stale "extension has no string catalog" comment is corrected. For the latent trap (`String(localized:)` in code compiled into both targets, with keys only in the host catalog) the presentation strings **moved** into the host target, which turns the trap into a compile error, rather than duplicating translations nothing displays. `LocalizationUsageTests` is now target-aware and reports exactly the five pre-existing gaps on `develop`, including `Cut all`, which the review did not name.

1080 unit tests pass; SwiftFormat and SwiftLint `--strict` are clean. The playground's new 57.75 pt key has not been looked at on a simulator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for 26 keyboard layouts and 23 localized app languages.
  * Added localized keyboard style names, size controls, positioning labels, and accessibility actions.
  * Added cursor movement by dragging on the space bar and continuous deletion by dragging on the delete key.

* **Bug Fixes**
  * Improved text input, capitalization, punctuation, selection-aware deletion, background refresh, and rendering.
  * Fixed VoiceOver support, key-label sizing, diagonal gestures, stale long-press actions, and app-switcher display.

* **Documentation**
  * Updated App Store descriptions, README content, and localization guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->