### PR TITLE
Isolate UI Tests From the Shared Store

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,3 +57,12 @@ cyclomatic_complexity:
 disabled_rules:
   - trailing_comma  # Trailing commas improve diffs
   - implicit_optional_initialization  # Removing = nil breaks memberwise initializers
+
+custom_rules:
+  ui_test_app_factory:
+    included: ".*wurstfingerUITests/.*"
+    excluded: ".*wurstfingerUITests/UITestApp\\.swift"
+    name: "UI test app factory"
+    regex: "XCUIApplication\\(\\)|\\.launchArguments\\s*="
+    message: "Build the app under test with UITestApp.make() — a bare XCUIApplication() or launchArguments assignment drops the isolated defaults suite and writes into the real app group"
+    severity: error

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ xcodebuild test -scheme Wurstfinger -destination 'platform=iOS Simulator,name=iP
 > **Note:** Some tests require an available iOS Simulator. Adjust the
 > destination to match your local simulator name if necessary.
 
+> **Note:** The screenshot-generating UI tests (`ScreenshotTests`,
+> `wurstfingerUITestsLaunchTests`) skip themselves unless the test runner sees
+> `GENERATE_SCREENSHOTS=1`. Pass `TEST_RUNNER_GENERATE_SCREENSHOTS=1` to
+> `xcodebuild` — `scripts/generate-screenshots.sh` does this for you.
+
 ### Installing the Keyboard
 
 1. Build and run the `Wurstfinger` scheme on a device or simulator.
@@ -131,7 +136,7 @@ wurstfinger/
 │  ├─ wurstfinger/             # Host app (minimal)
 │  ├─ wurstfingerKeyboard/     # Keyboard extension sources
 │  ├─ wurstfingerTests/        # Swift Testing unit tests
-│  └─ wurstfingerUITests/      # UI test target (currently empty)
+│  └─ wurstfingerUITests/      # UI + screenshot tests
 ```
 
 ## License

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,11 @@ cd wurstfinger/wurstfinger
 ./scripts/generate-screenshots.sh
 ```
 
+The `ScreenshotTests` skip themselves unless the test runner sees
+`GENERATE_SCREENSHOTS=1`, so a plain `xcodebuild test` does not pay for ~15 app
+relaunches. The script passes it as `TEST_RUNNER_GENERATE_SCREENSHOTS=1`; add
+the same setting when invoking `xcodebuild` by hand.
+
 ### What it does
 
 1. Runs UI tests (`ScreenshotTests`) that capture the keyboard in different states
@@ -27,9 +32,9 @@ cd wurstfinger/wurstfinger
 ### Requirements
 
 - Xcode 16+
-- iPhone 16 simulator installed with iOS 18.6
+- An available iPhone simulator (the script picks the first non-SE iPhone it finds)
 - `xcpretty` gem (install with `gem install xcpretty`)
-- Python 3 with Pillow library (install with `pip3 install Pillow`)
+- Python 3 with Pillow and NumPy (install with `pip3 install Pillow numpy`)
 
 ### Output
 

--- a/scripts/generate-appstore-screenshots.sh
+++ b/scripts/generate-appstore-screenshots.sh
@@ -16,7 +16,7 @@
 #
 # Usage: ./scripts/generate-appstore-screenshots.sh
 
-set -e
+set -euo pipefail
 
 # Change to project root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -131,6 +131,8 @@ for target in "${TARGETS[@]}"; do
     # randomly. `manifest_names_to_files` emits sorted `name<TAB>file` lines;
     # we take the exported file column. Use a while-read loop rather than
     # `mapfile`, which is a bash 4+ builtin absent from macOS's stock bash 3.2.
+    # The emptiness check must stay ahead of the expansion below: bash 3.2
+    # treats "${arr[@]}" on an empty array as an unbound variable under `set -u`.
     ORDERED_EXPORTS=()
     while IFS= read -r line; do
         ORDERED_EXPORTS+=("$line")

--- a/scripts/generate-screenshots.sh
+++ b/scripts/generate-screenshots.sh
@@ -5,7 +5,7 @@
 #
 # Usage: ./scripts/generate-screenshots.sh
 
-set -e
+set -euo pipefail
 
 # Change to project root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -19,8 +19,10 @@ echo ""
 
 # Configuration
 SCHEME="Wurstfinger"
-# Detect available iPhone simulator
-DEVICE_NAME=$(xcrun simctl list devices available | grep "iPhone" | grep -v "SE" | head -n 1 | sed 's/    //g' | sed 's/ (.*//g' | xargs)
+# Detect available iPhone simulator. `head` closes the pipe early, so the
+# upstream `grep` reports SIGPIPE, and an absent simulator makes it exit 1 —
+# under `pipefail` both would abort the script instead of feeding the fallback.
+DEVICE_NAME=$(xcrun simctl list devices available | grep "iPhone" | grep -v "SE" | head -n 1 | sed 's/    //g' | sed 's/ (.*//g' | xargs || true)
 
 if [ -z "$DEVICE_NAME" ]; then
     DEVICE_NAME="iPhone 16"
@@ -270,8 +272,8 @@ else
   echo "Troubleshooting:"
   echo "  - Check if UI tests ran successfully"
   echo "  - Verify simulator is available"
-  echo "  - Verify Pillow is installed: pip3 install Pillow"
-  echo "  - Run tests manually: xcodebuild test -scheme $SCHEME -destination '$DESTINATION' -only-testing:$TEST_TARGET"
+  echo "  - Verify Pillow and numpy are installed: pip3 install Pillow numpy"
+  echo "  - Run tests manually: xcodebuild test -scheme $SCHEME -destination '$DESTINATION' -only-testing:$TEST_TARGET TEST_RUNNER_GENERATE_SCREENSHOTS=1"
 fi
 
 echo -e "${GREEN}✨ Done!${NC}"

--- a/scripts/lib/simulator-capture.sh
+++ b/scripts/lib/simulator-capture.sh
@@ -61,6 +61,8 @@ sim_status_bar_clear() {
 # Runs the screenshot UI test and returns xcodebuild's real exit code.
 # `$?` after the pipe is the formatter's exit code (always 0), so we recover
 # xcodebuild's via PIPESTATUS. Callers decide what a non-zero result means.
+# `TEST_RUNNER_`-prefixed settings reach the test runner's environment with the
+# prefix stripped; ScreenshotTests skip themselves without GENERATE_SCREENSHOTS.
 run_screenshot_tests() {
     local scheme="$1" destination="$2" test_target="$3" derived_data="$4"
     rm -rf "$derived_data"
@@ -72,6 +74,7 @@ run_screenshot_tests() {
         -only-testing:"$test_target" \
         -derivedDataPath "$derived_data" \
         CODE_SIGNING_ALLOWED=NO \
+        TEST_RUNNER_GENERATE_SCREENSHOTS=1 \
         2>&1 | if command -v xcpretty >/dev/null; then xcpretty --color; else cat; fi
     result=${PIPESTATUS[0]}
     set -e
@@ -79,9 +82,10 @@ run_screenshot_tests() {
 }
 
 # Prints the first .xcresult bundle under the given derived-data path (empty
-# if none). Callers guard against the empty case with their own message.
+# if none). Callers guard against the empty case with their own message, so a
+# missing path or the SIGPIPE from `head` must not fail them under `pipefail`.
 find_xcresult_bundle() {
-    find "$1" -name "*.xcresult" -type d | head -n 1
+    find "$1" -name "*.xcresult" -type d 2>/dev/null | head -n 1 || true
 }
 
 # Exports all attachments from an .xcresult bundle into a fresh output dir.

--- a/wurstfingerKeyboard/Settings/SharedDefaults.swift
+++ b/wurstfingerKeyboard/Settings/SharedDefaults.swift
@@ -13,13 +13,30 @@ enum SharedDefaults {
     /// The app group identifier shared between the main app and keyboard extension
     static let suiteName = "group.de.akator.wurstfinger.shared"
 
+    /// Launch argument that swaps `store` for a throwaway suite. UI tests pass
+    /// it (see `UITestApp`) so a setting they flip — or fail to flip back after
+    /// an aborted assertion — never reaches the store the user's own keyboard
+    /// reads. Keep the literal in sync with `UITestApp.isolatedDefaultsArgument`.
+    static let isolatedStoreArgument = "ISOLATED_DEFAULTS"
+
+    /// Backing suite for `isolatedStoreArgument`. Deliberately not an app group:
+    /// it lives in the launched app's own preferences, where the extension —
+    /// which never sees the host's launch arguments — cannot pick it up.
+    static let isolatedSuiteName = "de.akator.wurstfinger.isolated"
+
+    /// The suite `store` binds to for a given process argument list.
+    static func resolvedSuiteName(arguments: [String]) -> String {
+        arguments.contains(isolatedStoreArgument) ? isolatedSuiteName : suiteName
+    }
+
     /// The shared UserDefaults instance.
-    /// Falls back to standard UserDefaults if the app group is unavailable — this
+    /// Falls back to standard UserDefaults if the suite is unavailable — this
     /// must never happen in production (app and extension would stop sharing
     /// settings silently), so flag it loudly in debug builds.
     static let store: UserDefaults = {
-        guard let shared = UserDefaults(suiteName: suiteName) else {
-            assertionFailure("App group '\(suiteName)' unavailable — settings will not sync between app and keyboard extension")
+        let name = resolvedSuiteName(arguments: ProcessInfo.processInfo.arguments)
+        guard let shared = UserDefaults(suiteName: name) else {
+            assertionFailure("Defaults suite '\(name)' unavailable — settings will not sync between app and keyboard extension")
             return .standard
         }
         return shared

--- a/wurstfingerTests/SharedDefaultsIsolationTests.swift
+++ b/wurstfingerTests/SharedDefaultsIsolationTests.swift
@@ -1,0 +1,41 @@
+//
+//  SharedDefaultsIsolationTests.swift
+//  wurstfingerTests
+//
+//  Tests for the launch-argument contract between SharedDefaults and the UI tests
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct SharedDefaultsIsolationTests {
+    /// The UI test target cannot import the app module, so
+    /// `UITestApp.isolatedDefaultsArgument` repeats this literal. Renaming the
+    /// argument without updating that copy would point every UI test launch
+    /// back at the real app-group store, silently.
+    @Test func isolationArgumentLiteralIsStable() {
+        #expect(SharedDefaults.isolatedStoreArgument == "ISOLATED_DEFAULTS")
+    }
+
+    @Test func isolationArgumentSelectsThrowawaySuite() {
+        let resolved = SharedDefaults.resolvedSuiteName(
+            arguments: ["ISOLATED_DEFAULTS", "-AppleLanguages", "(en)"]
+        )
+        #expect(resolved == SharedDefaults.isolatedSuiteName)
+    }
+
+    @Test func plainLaunchKeepsTheAppGroupSuite() {
+        #expect(SharedDefaults.resolvedSuiteName(arguments: []) == SharedDefaults.suiteName)
+        #expect(SharedDefaults.resolvedSuiteName(arguments: ["SCREENSHOT_MODE"]) == SharedDefaults.suiteName)
+    }
+
+    /// The isolated suite must not be an app group (the extension would then
+    /// share it) and must not be the host bundle id, which
+    /// `UserDefaults(suiteName:)` rejects.
+    @Test func isolatedSuiteIsAppLocal() {
+        #expect(!SharedDefaults.isolatedSuiteName.hasPrefix("group."))
+        #expect(SharedDefaults.isolatedSuiteName != SharedDefaults.suiteName)
+        #expect(SharedDefaults.isolatedSuiteName != Bundle.main.bundleIdentifier)
+    }
+}

--- a/wurstfingerUITests/DeadZoneTests.swift
+++ b/wurstfingerUITests/DeadZoneTests.swift
@@ -14,12 +14,7 @@ final class DeadZoneTests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = true
-        app = XCUIApplication()
-        app.launchArguments = [
-            "SCREENSHOT_MODE",
-            "-AppleLanguages", "(en)",
-            "-AppleLocale", "en_US",
-        ]
+        app = UITestApp.make(["SCREENSHOT_MODE"] + UITestApp.englishLocaleArguments)
         app.launchEnvironment["FORCE_LAYER"] = "lower"
         app.launchEnvironment["FORCE_APPEARANCE"] = "light"
         app.launchEnvironment["DEAD_ZONE_TEST"] = "1"

--- a/wurstfingerUITests/ScreenshotTests.swift
+++ b/wurstfingerUITests/ScreenshotTests.swift
@@ -15,12 +15,16 @@ private struct ScreenshotConfig {
     var received: String = ""
 }
 
+/// Screenshot generators. They relaunch the app 15 times with hard sleeps and
+/// produce attachments rather than assertions, so they opt out of a plain
+/// `xcodebuild test` and only run when `GENERATE_SCREENSHOTS=1` reaches the
+/// test runner — see `scripts/lib/simulator-capture.sh`.
 final class ScreenshotTests: XCTestCase {
     var app: XCUIApplication!
 
     override func setUpWithError() throws {
+        try UITestApp.skipUnlessGeneratingScreenshots()
         continueAfterFailure = false
-        app = XCUIApplication()
     }
 
     // MARK: - README Screenshots (keyboard-only, cropped)
@@ -29,7 +33,7 @@ final class ScreenshotTests: XCTestCase {
     /// Uses SCREENSHOT_MODE to show KeyboardShowcaseView
     @MainActor
     func testGenerateScreenshots() {
-        app.launchArguments = ["SCREENSHOT_MODE"]
+        app = UITestApp.make(["SCREENSHOT_MODE"])
 
         // Detect the rendered keyboard via a stable key identifier (the
         // center grid slot) rather than the container element, which SwiftUI
@@ -65,15 +69,13 @@ final class ScreenshotTests: XCTestCase {
 
     /// Generate App Store screenshots showing the full app experience
     /// Does NOT use SCREENSHOT_MODE - shows normal app with TabView
-    /// Run this test on different simulators to get all required sizes:
-    /// - iPhone 15 Plus (6.7" - 1290x2796)
-    /// - iPhone 11 Pro Max (6.5" - 1242x2688)
-    /// - iPhone 8 Plus (5.5" - 1242x2208)
-    /// - iPad Pro 12.9" (2048x2732)
+    /// Not part of the shipping set: `scripts/generate-appstore-screenshots.sh`
+    /// uploads `testGenerateAppStoreKeyboardScreenshots`, rendered natively on
+    /// iPhone 17 Pro Max (1320x2868, 6.9") and iPhone 16e (1170x2532, 6.1").
     @MainActor
     func testGenerateAppStoreScreenshots() {
         // Don't use SCREENSHOT_MODE - we want the full app with tabs
-        app.launchArguments = []
+        app = UITestApp.make()
 
         // Get device identifier for naming
         let deviceName = UIDevice.current.name
@@ -142,7 +144,7 @@ final class ScreenshotTests: XCTestCase {
     /// Uses SCREENSHOT_MODE to show KeyboardShowcaseView with different layers
     @MainActor
     func testGenerateKeyboardShowcaseScreenshots() {
-        app.launchArguments = ["SCREENSHOT_MODE"]
+        app = UITestApp.make(["SCREENSHOT_MODE"])
 
         // Detect the rendered keyboard via a stable key identifier (the
         // center grid slot) rather than the container element, which SwiftUI
@@ -184,7 +186,7 @@ final class ScreenshotTests: XCTestCase {
     /// These are the primary screenshots showing the keyboard in action
     @MainActor
     func testGenerateAppStoreKeyboardScreenshots() {
-        app.launchArguments = ["APPSTORE_SCREENSHOT_MODE"]
+        app = UITestApp.make(["APPSTORE_SCREENSHOT_MODE"])
 
         let keyboard = app.buttons["center"]
 

--- a/wurstfingerUITests/TypingTests.swift
+++ b/wurstfingerUITests/TypingTests.swift
@@ -17,8 +17,7 @@ final class TypingTests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
-        app = XCUIApplication()
-        app.launchArguments = ["SCREENSHOT_MODE"]
+        app = UITestApp.make(["SCREENSHOT_MODE"])
         app.launchEnvironment["TYPING_TEST"] = "1"
         app.launchEnvironment["FORCE_LANGUAGE"] = "de_DE"
         app.launchEnvironment["FORCE_LAYER"] = "lower"

--- a/wurstfingerUITests/UITestApp.swift
+++ b/wurstfingerUITests/UITestApp.swift
@@ -1,0 +1,53 @@
+//
+//  UITestApp.swift
+//  wurstfingerUITests
+//
+//  Builds the app under test with the launch arguments every UI test needs.
+//
+
+import XCTest
+
+enum UITestApp {
+    /// Redirects the app's `SharedDefaults.store` to a throwaway suite. Every
+    /// UI launch must carry it: the settings and onboarding screens write
+    /// straight through to the app group the user's own keyboard reads, and
+    /// `continueAfterFailure = false` means a mid-test failure never reaches
+    /// whatever restore step the test had planned.
+    ///
+    /// Mirrors `SharedDefaults.isolatedStoreArgument`. The UI test target cannot
+    /// import the app module, so the literal is duplicated here and pinned by
+    /// `SharedDefaultsIsolationTests`.
+    static let isolatedDefaultsArgument = "ISOLATED_DEFAULTS"
+
+    /// Pins the app to English regardless of the simulator's locale, for suites
+    /// that query localized display text ("Settings", "Language", …).
+    static let englishLocaleArguments = ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+
+    /// Environment variable that opts a run into screenshot generation.
+    /// `scripts/lib/simulator-capture.sh` sets it via xcodebuild's
+    /// `TEST_RUNNER_` prefix, which xcodebuild forwards to the test runner
+    /// with the prefix stripped.
+    static let screenshotGenerationVariable = "GENERATE_SCREENSHOTS"
+
+    /// An unlaunched app configured with the isolated store plus `arguments`.
+    /// The isolation flag goes first so it can never land between an
+    /// `-AppleLanguages` key and its value.
+    static func make(_ arguments: [String] = []) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = [isolatedDefaultsArgument] + arguments
+        return app
+    }
+
+    /// Skips the caller unless screenshot generation was requested.
+    static func skipUnlessGeneratingScreenshots(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment[screenshotGenerationVariable] == "1",
+            "Screenshot generation is opt-in — pass TEST_RUNNER_\(screenshotGenerationVariable)=1 (see scripts/README.md)",
+            file: file,
+            line: line
+        )
+    }
+}

--- a/wurstfingerUITests/wurstfingerUITests.swift
+++ b/wurstfingerUITests/wurstfingerUITests.swift
@@ -12,13 +12,7 @@ final class wurstfingerUITests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
-        app = XCUIApplication()
-        // The suite queries localized display text ("Settings", "Languages", …),
-        // so pin the app to English regardless of the simulator's locale.
-        app.launchArguments = [
-            "-AppleLanguages", "(en)",
-            "-AppleLocale", "en_US",
-        ]
+        app = UITestApp.make(UITestApp.englishLocaleArguments)
         app.launch()
     }
 
@@ -83,11 +77,12 @@ final class wurstfingerUITests: XCTestCase {
         let newValue = firstToggle.value as? String
         XCTAssertNotEqual(initialValue, newValue, "Toggle value should change after tap")
 
-        // The setup steps persist to the app's own defaults — restore the
-        // original state so the test leaves no trace on the device/simulator.
+        // Toggling back must return the original value. Either state is safe:
+        // the app under test writes to the isolated defaults suite, not the
+        // app group the user's own keyboard reads.
         firstToggle.tap()
         let restoredValue = firstToggle.value as? String
-        XCTAssertEqual(initialValue, restoredValue, "Toggle must be restored to its original state")
+        XCTAssertEqual(initialValue, restoredValue, "Toggle must return to its original state")
     }
 
     // MARK: - Settings Tests
@@ -193,10 +188,11 @@ final class wurstfingerUITests: XCTestCase {
         let newValue = utilityToggle.value as? String
         XCTAssertNotEqual(initialValue, newValue, "Toggle should change state")
 
-        // The toggle writes to the real shared app-group store — restore it.
+        // Toggling back must return the original value; both writes land in the
+        // isolated defaults suite, not the real app-group store.
         flip()
         let restoredValue = utilityToggle.value as? String
-        XCTAssertEqual(initialValue, restoredValue, "Toggle must be restored to its original state")
+        XCTAssertEqual(initialValue, restoredValue, "Toggle must return to its original state")
     }
 
     // MARK: - Test Area Tests
@@ -235,7 +231,7 @@ final class wurstfingerUITests: XCTestCase {
     @MainActor
     func testLaunchPerformance() {
         measure(metrics: [XCTApplicationLaunchMetric()]) {
-            XCUIApplication().launch()
+            app.launch()
         }
     }
 }

--- a/wurstfingerUITests/wurstfingerUITestsLaunchTests.swift
+++ b/wurstfingerUITests/wurstfingerUITestsLaunchTests.swift
@@ -13,16 +13,14 @@ final class wurstfingerUITestsLaunchTests: XCTestCase {
     }
 
     override func setUpWithError() throws {
+        try UITestApp.skipUnlessGeneratingScreenshots()
         continueAfterFailure = false
     }
 
     @MainActor
     func testLaunch() {
-        let app = XCUIApplication()
+        let app = UITestApp.make()
         app.launch()
-
-        // Insert steps here to perform after app launch but before taking a screenshot,
-        // such as logging into a test account or navigating somewhere in the app
 
         let attachment = XCTAttachment(screenshot: app.screenshot())
         attachment.name = "Launch Screen"


### PR DESCRIPTION
Findings 32, 33 and 35 of the 2026-08-08 stabilization review.

### UI tests wrote into the real app group (finding 32)

`wurstfingerUITests` mutated `utilityColumnLeading` and the onboarding keys and restored them by tapping back. With `continueAfterFailure = false`, a mid-test failure leaked those values into the shared store — where later tests *and the developer's own keyboard* read them.

Rather than undoing the mutation, this removes it: `SharedDefaults.store` binds to a throwaway suite when the app is launched with `ISOLATED_DEFAULTS`, and every UI-test launch goes through a `UITestApp.make()` factory that passes the flag. The production path (no argument → the app group, `assertionFailure` on a nil suite) is byte-for-byte equivalent.

This also neutralizes a path a teardown block would have missed: `KeyboardViewModel.switchToNextLanguage()` writes `selectedLanguageId` unconditionally — `shouldPersistSettings: false` does not guard it — so `DeadZoneTests` and `TypingTests` could write into the app group too. That write is left alone; it belongs to another finding.

A SwiftLint custom rule scoped to the UI test target makes a bare `XCUIApplication()` launch an error, so the next test author cannot silently reopen this. Verified empirically with a temporary probe file.

### Screenshot generators ran on every full test invocation (finding 33)

About 15 app relaunches with hard sleeps and no assertions ran on every "run all tests". They now `XCTSkipUnless` on `GENERATE_SCREENSHOTS`, and `scripts/lib/simulator-capture.sh` passes `TEST_RUNNER_GENERATE_SCREENSHOTS=1` — one edit that covers both generator scripts and both screenshot workflows, so no workflow YAML changed and PR CI is unaffected. Documented in `README.md` and `scripts/README.md`.

An environment flag rather than a test plan: the repo has no `.xctestplan` and no shared scheme, so a plan- or scheme-based opt-in would not be version-controlled.

The stale device list in `ScreenshotTests` (iPhone 15 Plus, 11 Pro Max, 8 Plus, iPad Pro 12.9") is replaced with the set the scripts actually drive: iPhone 17 Pro Max and iPhone 16e.

The launch test is guarded rather than deleted — it has zero assertions and exists to produce a launch-screen attachment, i.e. it is a screenshot generator. Launch smoke coverage is not lost; `testAllTabsAreAccessible` asserts real content after launch.

### Script hardening (finding 35)

`set -e` → `set -euo pipefail` in both generators, with the two pipelines that genuinely broke fixed: simulator detection in `generate-screenshots.sh` (SIGPIPE from `head` plus a no-match exit both have to reach the fallback branch) and `find_xcresult_bundle` in the shared lib. The `|| true`s are targeted, not blanket: the two scripts have deliberately opposite error policies — one salvages and warns, the other refuses a partial set — and `pipefail` must not turn the first into a hard failure.

bash 3.2 compatibility is preserved and the one ordering constraint it imposes (`${#arr[@]}` before `"${arr[@]}"` under `set -u`) is now written down. All claims were reproduced against `/bin/bash` 3.2.57. `shellcheck` and `bash -n` are clean.

The documented Python dependencies now match the actual `import numpy` (`pip3 install Pillow numpy`), and the stale "iPhone 16 simulator with iOS 18.6" requirement is replaced with what the script does.

### Expected side effect

Screenshots become deterministic: the isolated store starts empty, so the showcase renders registered defaults and the system language instead of whatever the machine's app group held. On a fresh CI runner that is identical to today; on a developer machine with a customized keyboard the output changes, and `update-screenshots.yml` may open one "Update screenshots" PR on the next push.

1079 unit tests pass; SwiftFormat and SwiftLint `--strict` are clean.

Not verified here: that `TEST_RUNNER_GENERATE_SCREENSHOTS=1` actually reaches the runner (it is the documented mechanism, but the first `generate-screenshots.sh` run should be watched — if the screenshot tests report as *skipped*, the flag did not arrive).
