### PR TITLE
Show a Press as a Dot in the Gesture Trail

### DIFF
--- a/wurstfingerKeyboard/Runtime/Gesture/GestureTrail.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GestureTrail.swift
@@ -15,7 +15,7 @@ struct GestureTrailSample: Equatable {
     let time: TimeInterval
 }
 
-/// Rolling buffer of touch positions for the swipe trail.
+/// Rolling buffer of touch positions for the gesture trail.
 ///
 /// Two independent mechanisms shorten what is drawn:
 /// * while the finger is down, samples older than `visibleDuration` drop out

--- a/wurstfingerKeyboard/Runtime/Gesture/GestureTrail.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GestureTrail.swift
@@ -2,7 +2,7 @@
 //  GestureTrail.swift
 //  Wurstfinger
 //
-//  Time-stamped sample buffer behind the optional swipe trail, plus the
+//  Time-stamped sample buffer behind the optional gesture trail, plus the
 //  age and fade math the overlay renders from.
 //
 
@@ -32,16 +32,6 @@ struct GestureTrail: Equatable {
     /// Time the finger lifted, or nil while it is still down.
     private(set) var releaseTime: TimeInterval?
 
-    /// Touch-down position. Retained separately from `samples` so it survives
-    /// the eviction of the oldest samples and tap suppression keeps measuring
-    /// against the true origin of the gesture.
-    private(set) var origin: CGPoint?
-
-    /// Largest straight-line distance from `origin` seen so far. A running
-    /// maximum rather than a distance to the current point, so an out-and-back
-    /// return swipe still counts as movement at the moment it turns around.
-    private(set) var maxDisplacement: CGFloat = 0
-
     var isEmpty: Bool {
         samples.isEmpty
     }
@@ -49,8 +39,6 @@ struct GestureTrail: Equatable {
     /// Starts a fresh gesture, discarding anything recorded before.
     mutating func begin(at point: CGPoint, time: TimeInterval) {
         samples = [GestureTrailSample(point: point, time: time)]
-        origin = point
-        maxDisplacement = 0
         releaseTime = nil
     }
 
@@ -59,8 +47,8 @@ struct GestureTrail: Equatable {
     /// Samples closer than `minimumSpacing` to the previous one are dropped:
     /// a resting finger keeps producing positions at the display refresh rate,
     /// and storing them would evict the moving part of the path from a
-    /// capacity-bounded buffer. The dropped sample still updates
-    /// `maxDisplacement`, so tap suppression is unaffected by the decimation.
+    /// capacity-bounded buffer. A touch that never exceeds the spacing keeps
+    /// its single touch-down sample, which is what the press dot is drawn from.
     mutating func extend(
         to point: CGPoint,
         time: TimeInterval,
@@ -70,9 +58,6 @@ struct GestureTrail: Equatable {
         guard let last = samples.last else {
             begin(at: point, time: time)
             return
-        }
-        if let origin {
-            maxDisplacement = max(maxDisplacement, hypot(point.x - origin.x, point.y - origin.y))
         }
         guard hypot(point.x - last.point.x, point.y - last.point.y) >= minimumSpacing else { return }
         samples.append(GestureTrailSample(point: point, time: time))
@@ -89,8 +74,6 @@ struct GestureTrail: Equatable {
     mutating func clear() {
         samples.removeAll()
         releaseTime = nil
-        origin = nil
-        maxDisplacement = 0
     }
 
     /// Points still inside the visible age window at `now`, oldest first.
@@ -98,6 +81,13 @@ struct GestureTrail: Equatable {
     /// After release the window is anchored to the release time instead of
     /// `now`, so the lifted trail fades out as a whole rather than also
     /// shrinking away from its tail.
+    ///
+    /// Never empties a non-empty buffer: a finger that holds still stops
+    /// producing samples, so the whole path can age out while the touch is
+    /// still down. Keeping the newest sample leaves the head of the trail
+    /// where the finger is, which is what a press renders as a dot — without
+    /// it a held key would blink out mid-touch and a paused swipe would
+    /// vanish instead of shrinking back to the finger.
     func visiblePoints(
         at now: TimeInterval,
         visibleDuration: TimeInterval = KeyboardConstants.GestureTrail.visibleDuration
@@ -106,7 +96,9 @@ struct GestureTrail: Equatable {
         let cutoff = reference - visibleDuration
         // Samples are appended in time order, so the expired ones are always a
         // prefix — dropping it beats filtering the whole buffer every frame.
-        return samples.drop { $0.time < cutoff }.map(\.point)
+        let visible = samples.drop { $0.time < cutoff }
+        guard visible.isEmpty else { return visible.map(\.point) }
+        return samples.last.map { [$0.point] } ?? []
     }
 
     /// Overall opacity multiplier: 1 while the finger is down, ramping to 0

--- a/wurstfingerKeyboard/Runtime/Gesture/GestureTrailRecorder.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GestureTrailRecorder.swift
@@ -35,9 +35,10 @@ final class GestureTrailRecorder: ObservableObject {
     /// points need no offset correction to be drawn.
     static let coordinateSpace = NamedCoordinateSpace.named("wurstfinger.gestureTrail")
 
-    /// Whether the overlay should be rendering. False for taps (below the
-    /// activation distance), while the setting is off, and once the fade-out
-    /// has finished.
+    /// Whether the overlay should be rendering. True from the moment a touch
+    /// goes down with the setting on — a press that never moves is drawn as
+    /// the head of the trail standing still — and false while the setting is
+    /// off or once the fade-out has finished.
     @Published private(set) var isVisible = false
 
     /// The trail to draw. Unpublished, so drag samples cannot invalidate the
@@ -51,24 +52,6 @@ final class GestureTrailRecorder: ObservableObject {
     /// once per gesture so a toggle flipped mid-swipe cannot leave a
     /// half-recorded trail behind.
     private var isRecording = false
-
-    /// Travel at which the recognizer that owns the current touch stops
-    /// classifying it as a tap. Supplied per touch by that recognizer rather
-    /// than kept as a constant: it is the classifier's `minSwipeLength` on a
-    /// letter key, the slide activation threshold on space and delete.
-    /// `.infinity` until a touch begins, so nothing can draw unclaimed.
-    private var activationDistance: CGFloat = .infinity
-
-    /// Aspect ratio the owning recognizer classifies in. `classify` divides the
-    /// horizontal component by it before measuring travel, so its tap boundary
-    /// is an ellipse in screen space; measuring the trail the same way keeps
-    /// the two boundaries identical on non-square keys. 1 for recognizers that
-    /// classify in raw points.
-    private var aspectRatio: CGFloat = 1
-
-    /// Running maximum travel from the touch-down point, measured the way the
-    /// owning recognizer measures it.
-    private var maxNormalizedDisplacement: CGFloat = 0
 
     /// The gesture modifier whose touch sequence currently owns the trail.
     ///
@@ -90,29 +73,15 @@ final class GestureTrailRecorder: ObservableObject {
         self.now = now
     }
 
-    /// Starts recording a new touch sequence.
-    ///
-    /// `activationDistance` is the travel below which the calling recognizer
-    /// will dispatch this touch as a tap; drawing before it would advertise a
-    /// swipe that never happens. `aspectRatio` is the space that travel is
-    /// measured in. `token` identifies the recognizer.
-    func begin(
-        at location: CGPoint,
-        from token: GestureTrailToken,
-        activationDistance: CGFloat,
-        aspectRatio: CGFloat = 1
-    ) {
+    /// Starts recording a new touch sequence. `token` identifies the
+    /// recognizer it came from.
+    func begin(at location: CGPoint, from token: GestureTrailToken) {
         // First finger down wins the trail and keeps it until its sequence
         // ends. A concurrent second touch is ignored rather than drawn as
         // a second trail: one stroke matches the system keyboard, and the
         // overlay renders a single path.
         guard owner == nil else { return }
         owner = token
-        self.activationDistance = activationDistance
-        // A zero, negative or non-finite ratio would divide the horizontal
-        // component into nothing and draw under every tap.
-        self.aspectRatio = aspectRatio.isFinite && aspectRatio > 0 ? aspectRatio : 1
-        maxNormalizedDisplacement = 0
         beginTouch(at: location)
     }
 
@@ -120,21 +89,11 @@ final class GestureTrailRecorder: ObservableObject {
     func extend(to location: CGPoint, from token: GestureTrailToken) {
         guard owner === token, isRecording else { return }
         trail.extend(to: location, time: now())
-        // Suppress taps: every keystroke on this keyboard begins as a touch
-        // down, so drawing from the first sample would flash a dot under every
-        // letter typed.
-        guard !isVisible else { return }
-        if let origin = trail.origin {
-            let travel = hypot((location.x - origin.x) / aspectRatio, location.y - origin.y)
-            maxNormalizedDisplacement = max(maxNormalizedDisplacement, travel)
-        }
-        if maxNormalizedDisplacement >= activationDistance {
-            setVisible(true)
-        }
     }
 
-    /// Ends the current touch. A trail that became visible freezes and fades
-    /// out; one that stayed below the activation distance is dropped silently.
+    /// Ends the current touch: the trail freezes where the finger left it and
+    /// fades out. A tap freezes as its dot, which is the only feedback this
+    /// keyboard gives for a press — it has no key pop-up.
     func finish(from token: GestureTrailToken) {
         guard owner === token else { return }
         // Released before the `isRecording` check so a touch taken while the
@@ -142,10 +101,6 @@ final class GestureTrailRecorder: ObservableObject {
         owner = nil
         guard isRecording else { return }
         isRecording = false
-        guard isVisible else {
-            trail.clear()
-            return
-        }
         trail.release(at: now())
         scheduleFadeOut()
     }
@@ -181,6 +136,12 @@ final class GestureTrailRecorder: ObservableObject {
         isRecording = defaults.bool(forKey: SettingsKey.gestureTrailEnabled.rawValue)
         guard isRecording else { return }
         trail.begin(at: location, time: now())
+        // Drawn from the first sample rather than after a movement threshold:
+        // a press is a gesture too, and showing it as a dot is what makes the
+        // trail read as "here is your finger" instead of only "here is your
+        // swipe". Costs one publish per keystroke, which only reaches the
+        // overlay — the grid owns this object without observing it.
+        setVisible(true)
     }
 
     private func scheduleFadeOut() {

--- a/wurstfingerKeyboard/Runtime/Gesture/GestureTrailRecorder.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GestureTrailRecorder.swift
@@ -2,7 +2,7 @@
 //  GestureTrailRecorder.swift
 //  Wurstfinger
 //
-//  Collects touch positions for the swipe trail and tells the overlay when
+//  Collects touch positions for the gesture trail and tells the overlay when
 //  there is something to draw.
 //
 
@@ -18,7 +18,7 @@ import SwiftUI
 /// only for `@StateObject`'s deferred construction.
 final class GestureTrailToken: ObservableObject {}
 
-/// Per-keyboard collector for the swipe trail.
+/// Per-keyboard collector for the gesture trail.
 ///
 /// Owned by `KeyboardGridView`, fed by the gesture modifiers with positions in
 /// the shared `coordinateSpace`, and read by `GestureTrailOverlay`.
@@ -106,9 +106,9 @@ final class GestureTrailRecorder: ObservableObject {
     }
 
     /// Discards the trail immediately, without a fade. Used for the paths that
-    /// end a touch without a gesture: a system cancellation, a long press that
-    /// consumed the touch, and the teardown of a key that was mid-gesture
-    /// (which reaches neither `onEnded` nor the cancel path).
+    /// end a touch without a gesture: a system cancellation and the teardown
+    /// of a key that was mid-gesture (which reaches neither `onEnded` nor the
+    /// cancel path).
     func cancel(from token: GestureTrailToken) {
         // Also gates the recognizers' unconditional cancel paths: a key whose
         // gesture never started is not the owner and must not clear a trail
@@ -136,11 +136,6 @@ final class GestureTrailRecorder: ObservableObject {
         isRecording = defaults.bool(forKey: SettingsKey.gestureTrailEnabled.rawValue)
         guard isRecording else { return }
         trail.begin(at: location, time: now())
-        // Drawn from the first sample rather than after a movement threshold:
-        // a press is a gesture too, and showing it as a dot is what makes the
-        // trail read as "here is your finger" instead of only "here is your
-        // swipe". Costs one publish per keystroke, which only reaches the
-        // overlay — the grid owns this object without observing it.
         setVisible(true)
     }
 

--- a/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
@@ -139,11 +139,7 @@ struct KeyGestureRecognizer: ViewModifier {
                         }
                         let isTouchDown = sequence.handleChanged(translation: value.translation)
                         if isTouchDown {
-                            trail?.begin(
-                                at: value.location, from: trailToken,
-                                activationDistance: Self.tapBoundary(),
-                                aspectRatio: aspectRatio
-                            )
+                            trail?.begin(at: value.location, from: trailToken)
                         } else {
                             trail?.extend(to: value.location, from: trailToken)
                         }
@@ -240,15 +236,6 @@ struct KeyGestureRecognizer: ViewModifier {
     }
 
     // MARK: - Classification (Pure Function)
-
-    /// Travel at which `classify` stops calling a gesture a tap, measured in
-    /// the aspect-normalized space `classify` works in. The swipe trail starts
-    /// here, so a sloppy tap never flashes a streak and retuning
-    /// `minSwipeLength` in expert mode moves both together. Reads the store,
-    /// so callers evaluate it once per touch, never per drag sample.
-    static func tapBoundary(store: UserDefaults = SharedDefaults.store) -> CGFloat {
-        GestureClassificationThresholds.fromUserDefaults(store: store).minSwipeLength
-    }
 
     /// Classifies a sequence of touch positions into a `GestureType`, reading
     /// preprocessor config and thresholds from `SharedDefaults`.

--- a/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
@@ -100,7 +100,7 @@ struct KeyGestureRecognizer: ViewModifier {
     /// disables long-press detection entirely.
     var onLongPress: (() -> Bool)?
 
-    /// Collects the touch path for the swipe trail overlay. Nil disables the
+    /// Collects the touch path for the gesture trail overlay. Nil disables the
     /// feed entirely (previews and tests); when set, the recorder itself
     /// decides whether the user has the trail turned on.
     var trail: GestureTrailRecorder?
@@ -129,11 +129,10 @@ struct KeyGestureRecognizer: ViewModifier {
                     }
                     .onChanged { value in
                         // A fired long press owns the rest of this touch: the
-                        // digit is typed, the release is discarded in `onEnded`,
-                        // so neither the ring buffer nor the trail should keep
-                        // following the finger at the display rate.
+                        // digit is typed and the release is discarded in
+                        // `onEnded`, so the sequence stops following the
+                        // finger. The trail already froze when the press fired.
                         if longPress.consumedTouch {
-                            trail?.cancel(from: trailToken)
                             isActive = true
                             return
                         }
@@ -160,9 +159,6 @@ struct KeyGestureRecognizer: ViewModifier {
                             // releasing doesn't produce a second key event.
                             longPress.clearConsumed()
                             sequence.handleCancelled()
-                            // No gesture was produced, so nothing should be
-                            // left drawn: drop the trail instead of fading it.
-                            trail?.cancel(from: trailToken)
                             isActive = false
                             return
                         }
@@ -210,13 +206,16 @@ struct KeyGestureRecognizer: ViewModifier {
 
     /// Arms the shared scheduler with this recognizer's fire guard. The guard
     /// reads live `@State` (`sequence`) at fire time through the property
-    /// wrapper — identical to the previous `fireLongPress()` semantics.
+    /// wrapper. A fired press has typed its digit, so its trail freezes and
+    /// fades like any other completed keystroke.
     private func scheduleLongPress() {
         guard onLongPress != nil else { return }
         longPress.schedule {
-            sequence.isTracking
+            let fired = sequence.isTracking
                 && sequence.maxDisplacement <= KeyboardConstants.LongPress.movementTolerance
                 && onLongPress?() == true
+            if fired { trail?.finish(from: trailToken) }
+            return fired
         }
     }
 

--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -229,7 +229,7 @@ struct SlideGestureHandler: ViewModifier {
     /// on release). `nil` disables detection.
     var onLongPress: (() -> Bool)?
 
-    /// Collects the touch path for the swipe trail overlay. Nil disables the
+    /// Collects the touch path for the gesture trail overlay. Nil disables the
     /// feed entirely (previews and tests); when set, the recorder itself
     /// decides whether the user has the trail turned on.
     var trail: GestureTrailRecorder?
@@ -260,11 +260,9 @@ struct SlideGestureHandler: ViewModifier {
                     .onChanged { value in
                         // A fired long press owns the rest of this touch:
                         // don't feed the state machine, or the movement would
-                        // start a cursor slide after the digit was typed.
+                        // start a cursor slide after the digit was typed. The
+                        // trail already froze when the press fired.
                         if longPress.consumedTouch {
-                            // The digit is already typed, so stop drawing a
-                            // gesture that will never be dispatched.
-                            trail?.cancel(from: trailToken)
                             isActive = true
                             return
                         }
@@ -296,7 +294,6 @@ struct SlideGestureHandler: ViewModifier {
                             // release produces neither a tap nor a slide end.
                             longPress.clearConsumed()
                             _ = state.handleCancelled()
-                            trail?.cancel(from: trailToken)
                             isActive = false
                             return
                         }
@@ -341,30 +338,24 @@ struct SlideGestureHandler: ViewModifier {
     // MARK: - Long Press
 
     /// Arms the shared scheduler with this handler's fire guard. The guard
-    /// reads live `@State` (`state`) at fire time through the property wrapper
-    /// — identical to the previous `fireLongPress()` semantics. The
-    /// `!state.isSliding` axis is preserved: it is the one guard that
-    /// legitimately differs from `KeyGestureRecognizer` (which has no sliding
-    /// concept).
+    /// reads live `@State` (`state`) at fire time through the property
+    /// wrapper; `!state.isSliding` is the one condition `KeyGestureRecognizer`
+    /// does not share, because only slide keys can latch a slide. A fired
+    /// press has typed its digit, so its trail freezes and fades like any
+    /// other completed keystroke.
     private func scheduleLongPress() {
         guard onLongPress != nil else { return }
         longPress.schedule {
-            state.dragStarted
+            let fired = state.dragStarted
                 && !state.isSliding
                 && state.maxDisplacement <= KeyboardConstants.LongPress.movementTolerance
                 && onLongPress?() == true
+            if fired { trail?.finish(from: trailToken) }
+            return fired
         }
     }
 
     private var configuration: SlideGestureConfiguration {
         .for(slideType)
-    }
-
-    // MARK: - Activation Threshold
-
-    /// Travel below which this key's touch is dispatched as a tap. `internal`
-    /// and static so the trail-threshold guard test can pin it.
-    static func activationThreshold(for slideType: SlideType) -> CGFloat {
-        SlideGestureConfiguration.for(slideType).activationThreshold
     }
 }

--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -273,10 +273,7 @@ struct SlideGestureHandler: ViewModifier {
                             configuration: configuration
                         )
                         if update.isTouchDown {
-                            trail?.begin(
-                                at: value.location, from: trailToken,
-                                activationDistance: configuration.activationThreshold
-                            )
+                            trail?.begin(at: value.location, from: trailToken)
                             onTouchDown()
                             scheduleLongPress()
                         } else {

--- a/wurstfingerKeyboard/Runtime/View/GestureTrailGeometry.swift
+++ b/wurstfingerKeyboard/Runtime/View/GestureTrailGeometry.swift
@@ -2,8 +2,9 @@
 //  GestureTrailGeometry.swift
 //  Wurstfinger
 //
-//  Turns recorded touch positions into the tapered ribbon the swipe trail
-//  is drawn as. Pure functions, no view state.
+//  Turns recorded touch positions into the shapes the gesture trail is drawn
+//  as: a dot for a press, a tapered ribbon for a swipe. Pure functions, no
+//  view state.
 //
 
 import CoreGraphics
@@ -18,6 +19,36 @@ import SwiftUI
 /// itself, which shows up as dark blotches exactly where the finger changed
 /// direction. One filled contour has uniform alpha everywhere.
 enum GestureTrailGeometry {
+    /// The shape for one visible trail: a dot while the touch has not moved,
+    /// the tapered ribbon once it has.
+    ///
+    /// A press produces a single sample, and the ribbon needs two points to
+    /// have a direction at all, so the two cases are genuinely different
+    /// shapes rather than one degenerate case of the other.
+    static func shape(
+        through points: [CGPoint],
+        headWidth: CGFloat,
+        dotWidthFactor: CGFloat = KeyboardConstants.GestureTrail.pressDotWidthFactor
+    ) -> Path {
+        if points.count == 1 {
+            return dot(at: points[0], diameter: headWidth * dotWidthFactor)
+        }
+        return ribbon(through: smoothed(points), headWidth: headWidth)
+    }
+
+    /// Filled circle marking a stationary touch.
+    static func dot(at point: CGPoint, diameter: CGFloat) -> Path {
+        guard diameter > 0 else { return Path() }
+        return Path(
+            ellipseIn: CGRect(
+                x: point.x - diameter / 2,
+                y: point.y - diameter / 2,
+                width: diameter,
+                height: diameter
+            )
+        )
+    }
+
     /// Resamples `points` through a uniform Catmull-Rom spline.
     ///
     /// A fast flick only produces a handful of drag samples, and drawing those

--- a/wurstfingerKeyboard/Runtime/View/GestureTrailGeometry.swift
+++ b/wurstfingerKeyboard/Runtime/View/GestureTrailGeometry.swift
@@ -11,7 +11,7 @@ import CoreGraphics
 import Foundation
 import SwiftUI
 
-/// Path construction for the swipe trail.
+/// Path construction for the gesture trail.
 ///
 /// The trail is built as a single closed outline rather than as a stroked
 /// polyline: a translucent stroke made of overlapping round-capped segments
@@ -22,16 +22,12 @@ enum GestureTrailGeometry {
     /// The shape for one visible trail: a dot while the touch has not moved,
     /// the tapered ribbon once it has.
     ///
-    /// A press produces a single sample, and the ribbon needs two points to
-    /// have a direction at all, so the two cases are genuinely different
-    /// shapes rather than one degenerate case of the other.
-    static func shape(
-        through points: [CGPoint],
-        headWidth: CGFloat,
-        dotWidthFactor: CGFloat = KeyboardConstants.GestureTrail.pressDotWidthFactor
-    ) -> Path {
+    /// The ribbon needs two points to have a direction at all, so a lone
+    /// sample — a press — is drawn as a dot instead.
+    static func shape(through points: [CGPoint], headWidth: CGFloat) -> Path {
         if points.count == 1 {
-            return dot(at: points[0], diameter: headWidth * dotWidthFactor)
+            let diameter = headWidth * KeyboardConstants.GestureTrail.pressDotWidthFactor
+            return dot(at: points[0], diameter: diameter)
         }
         return ribbon(through: smoothed(points), headWidth: headWidth)
     }

--- a/wurstfingerKeyboard/Runtime/View/GestureTrailOverlay.swift
+++ b/wurstfingerKeyboard/Runtime/View/GestureTrailOverlay.swift
@@ -2,12 +2,13 @@
 //  GestureTrailOverlay.swift
 //  Wurstfinger
 //
-//  Draws the optional swipe trail on top of the key grid.
+//  Draws the optional gesture trail on top of the key grid: a dot under a
+//  press, a tapered ribbon under a swipe.
 //
 
 import SwiftUI
 
-/// Renders the swipe trail recorded by `GestureTrailRecorder`.
+/// Renders the trail recorded by `GestureTrailRecorder`.
 ///
 /// Sits in an `.overlay` on the grid layout, which is also where the recorder's
 /// coordinate space is registered — so the recorded points map onto this view's
@@ -55,12 +56,9 @@ struct GestureTrailOverlay: View {
         // opacity; bail before the geometry instead.
         guard !trail.isFinished(at: now) else { return }
         let points = trail.visiblePoints(at: now)
-        guard points.count >= 2 else { return }
+        guard !points.isEmpty else { return }
 
-        let path = GestureTrailGeometry.ribbon(
-            through: GestureTrailGeometry.smoothed(points),
-            headWidth: headWidth
-        )
+        let path = GestureTrailGeometry.shape(through: points, headWidth: headWidth)
         // One fill of one closed contour, so the alpha is uniform even where
         // the path crosses itself.
         context.opacity = KeyboardConstants.GestureTrail.opacity * trail.fadeOpacity(at: now)

--- a/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
+++ b/wurstfingerKeyboard/Runtime/View/KeyboardGridView.swift
@@ -43,7 +43,7 @@ struct KeyboardGridView: View {
     /// showcase modes with `shouldPersistSettings: false`).
     let metrics: KeyboardLayoutMetrics
 
-    /// Collects the touch path for the swipe trail. Held through a
+    /// Collects the touch path for the gesture trail. Held through a
     /// non-publishing store so the object is created once instead of on every
     /// body evaluation, and the samples arriving at up to 120 Hz still cannot
     /// re-render the grid and all of its keys. Only `GestureTrailOverlay`

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -110,7 +110,7 @@ enum KeyboardConstants {
 
     // MARK: - Gesture Trail
 
-    /// Tuning for the optional swipe trail drawn under the finger.
+    /// Tuning for the optional gesture trail drawn under the finger.
     ///
     /// A soft ribbon, widest at the finger and tapering to a point at its
     /// tail, kept short so it reads as a comet tail rather than a drawing of

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -135,7 +135,10 @@ enum KeyboardConstants {
         static let visibleDuration: TimeInterval = 0.55
 
         /// How long the frozen trail takes to fade out after the finger lifts.
-        static let fadeOutDuration: TimeInterval = 0.22
+        /// Tuned on device: 0.22 read as an abrupt blink once the press dot
+        /// made single keystrokes draw; the longer glow lets the mark register
+        /// without lagging behind fast typing.
+        static let fadeOutDuration: TimeInterval = 0.35
 
         /// Head width as a fraction of the row height, so the trail scales
         /// with the user's key size instead of overwhelming small keyboards.

--- a/wurstfingerKeyboard/Settings/KeyboardConstants.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardConstants.swift
@@ -145,6 +145,14 @@ enum KeyboardConstants {
         static let minWidth: CGFloat = 5
         static let maxWidth: CGFloat = 14
 
+        /// Diameter of the press dot, as a multiple of the head width.
+        ///
+        /// Slightly wider than the ribbon's head so both carry a comparable
+        /// amount of ink: a swipe spreads its mark along the whole path, while
+        /// a press has nothing but the dot. At 1.0 the dot reads as a smudge
+        /// next to the key label; much beyond this it starts to swamp it.
+        static let pressDotWidthFactor: CGFloat = 1.4
+
         /// Exponent of the tail taper: `width = headWidth * progress^exponent`
         /// with `progress` running 0 (tail) → 1 (finger). `headWidth` is the
         /// per-render width from `GestureTrailOverlay.headWidth(for:)`, not

--- a/wurstfingerTests/GestureTrailTests.swift
+++ b/wurstfingerTests/GestureTrailTests.swift
@@ -89,6 +89,16 @@ struct GestureTrailBufferTests {
         #expect(trail.visiblePoints(at: 103, visibleDuration: 0.55) == [CGPoint(x: 30, y: 0)])
     }
 
+    @Test func theDotSurvivesAReleaseAfterALongHold() {
+        // Lifting after a long hold anchors the window to the release time,
+        // which the lone touch-down sample predates — the fade must still
+        // have a dot to draw.
+        var trail = GestureTrail()
+        trail.begin(at: CGPoint(x: 7, y: 9), time: 100)
+        trail.release(at: 103)
+        #expect(trail.visiblePoints(at: 103.1, visibleDuration: 0.55) == [CGPoint(x: 7, y: 9)])
+    }
+
     @Test func visiblePointsStayEmptyForAnEmptyTrail() {
         #expect(GestureTrail().visiblePoints(at: 100, visibleDuration: 0.55).isEmpty)
     }
@@ -149,13 +159,16 @@ struct GestureTrailBufferTests {
 
 struct GestureTrailGeometryTests {
     @Test func aSinglePointDrawsADotAtTheTouch() {
+        // Exercises the production `pressDotWidthFactor`, so retuning the
+        // constant keeps a test pinning the rendered diameter to it.
+        let diameter = 12 * KeyboardConstants.GestureTrail.pressDotWidthFactor
         let box = GestureTrailGeometry.shape(
-            through: [CGPoint(x: 40, y: 60)], headWidth: 12, dotWidthFactor: 1.4
+            through: [CGPoint(x: 40, y: 60)], headWidth: 12
         ).boundingRect
         #expect(abs(box.midX - 40) < 0.5)
         #expect(abs(box.midY - 60) < 0.5)
-        #expect(abs(box.width - 12 * 1.4) < 0.5)
-        #expect(abs(box.height - 12 * 1.4) < 0.5)
+        #expect(abs(box.width - diameter) < 0.5)
+        #expect(abs(box.height - diameter) < 0.5)
     }
 
     @Test func theDotStaysComparableToTheRibbonHead() {

--- a/wurstfingerTests/GestureTrailTests.swift
+++ b/wurstfingerTests/GestureTrailTests.swift
@@ -2,8 +2,8 @@
 //  GestureTrailTests.swift
 //  WurstfingerTests
 //
-//  Tests for the swipe trail: sample buffer, ribbon geometry and the
-//  recorder that gates both on the user setting.
+//  Tests for the gesture trail: sample buffer, dot and ribbon geometry, and
+//  the recorder that gates both on the user setting.
 //
 
 import CoreGraphics
@@ -15,20 +15,17 @@ import Testing
 // MARK: - Sample Buffer
 
 struct GestureTrailBufferTests {
-    @Test func beginSeedsOriginAndFirstSample() {
+    @Test func beginSeedsTheFirstSample() {
         var trail = GestureTrail()
         trail.begin(at: CGPoint(x: 10, y: 20), time: 100)
-        #expect(trail.samples.count == 1)
-        #expect(trail.origin == CGPoint(x: 10, y: 20))
-        #expect(trail.maxDisplacement == 0)
+        #expect(trail.samples.map(\.point) == [CGPoint(x: 10, y: 20)])
         #expect(trail.releaseTime == nil)
     }
 
     @Test func extendBeforeBeginStartsTheTrail() {
         var trail = GestureTrail()
         trail.extend(to: CGPoint(x: 5, y: 5), time: 100)
-        #expect(trail.origin == CGPoint(x: 5, y: 5))
-        #expect(trail.samples.count == 1)
+        #expect(trail.samples.map(\.point) == [CGPoint(x: 5, y: 5)])
     }
 
     @Test func samplesCloserThanTheSpacingAreDropped() {
@@ -42,26 +39,15 @@ struct GestureTrailBufferTests {
         #expect(trail.samples.count == 2)
     }
 
-    @Test func droppedSamplesStillAdvanceMaxDisplacement() {
-        // Tap suppression must not depend on the decimation: a finger that
-        // creeps outward in sub-spacing steps has still travelled.
+    @Test func aTouchThatNeverMovesKeepsItsSingleSample() {
+        // The press dot is drawn from exactly this: a finger that creeps in
+        // sub-spacing steps must keep one sample, not zero and not a smear.
         var trail = GestureTrail()
         trail.begin(at: .zero, time: 100)
         for step in 1 ... 3 {
             trail.extend(to: CGPoint(x: CGFloat(step), y: 0), time: 100 + Double(step), minimumSpacing: 4)
         }
-        #expect(trail.samples.count == 1)
-        #expect(trail.maxDisplacement == 3)
-    }
-
-    @Test func maxDisplacementIsARunningMaximum() {
-        // An out-and-back return swipe ends near its origin but has clearly
-        // moved, so the peak — not the final distance — has to be reported.
-        var trail = GestureTrail()
-        trail.begin(at: .zero, time: 100)
-        trail.extend(to: CGPoint(x: 40, y: 0), time: 101)
-        trail.extend(to: CGPoint(x: 1, y: 0), time: 102)
-        #expect(trail.maxDisplacement == 40)
+        #expect(trail.samples.map(\.point) == [.zero])
     }
 
     @Test func capacityEvictsTheOldestSamples() {
@@ -83,6 +69,28 @@ struct GestureTrailBufferTests {
 
         let visible = trail.visiblePoints(at: 100.9, visibleDuration: 0.55)
         #expect(visible == [CGPoint(x: 10, y: 0), CGPoint(x: 20, y: 0)])
+    }
+
+    @Test func theNewestSampleSurvivesTheVisibleWindow() {
+        // A held key produces one sample and then nothing, so the window would
+        // empty under a still finger and the press dot would blink out while
+        // the touch is still down.
+        var trail = GestureTrail()
+        trail.begin(at: CGPoint(x: 7, y: 9), time: 100)
+        #expect(trail.visiblePoints(at: 103, visibleDuration: 0.55) == [CGPoint(x: 7, y: 9)])
+    }
+
+    @Test func aPausedSwipeShrinksBackToTheFinger() {
+        // Same rule seen from the other side: the tail expires as usual, but
+        // the head stays put instead of the whole trail disappearing.
+        var trail = GestureTrail()
+        trail.begin(at: .zero, time: 100)
+        trail.extend(to: CGPoint(x: 30, y: 0), time: 100.2)
+        #expect(trail.visiblePoints(at: 103, visibleDuration: 0.55) == [CGPoint(x: 30, y: 0)])
+    }
+
+    @Test func visiblePointsStayEmptyForAnEmptyTrail() {
+        #expect(GestureTrail().visiblePoints(at: 100, visibleDuration: 0.55).isEmpty)
     }
 
     @Test func releaseFreezesTheVisibleWindow() {
@@ -132,15 +140,51 @@ struct GestureTrailBufferTests {
         trail.release(at: 102)
         trail.clear()
         #expect(trail.isEmpty)
-        #expect(trail.origin == nil)
-        #expect(trail.maxDisplacement == 0)
         #expect(trail.releaseTime == nil)
+        #expect(trail.visiblePoints(at: 103).isEmpty)
     }
 }
 
 // MARK: - Ribbon Geometry
 
 struct GestureTrailGeometryTests {
+    @Test func aSinglePointDrawsADotAtTheTouch() {
+        let box = GestureTrailGeometry.shape(
+            through: [CGPoint(x: 40, y: 60)], headWidth: 12, dotWidthFactor: 1.4
+        ).boundingRect
+        #expect(abs(box.midX - 40) < 0.5)
+        #expect(abs(box.midY - 60) < 0.5)
+        #expect(abs(box.width - 12 * 1.4) < 0.5)
+        #expect(abs(box.height - 12 * 1.4) < 0.5)
+    }
+
+    @Test func theDotStaysComparableToTheRibbonHead() {
+        // A press that turns into a swipe must not jump in size when the
+        // second sample arrives, so the dot stays in the same league as the
+        // head it hands over to — a little wider, never a different order.
+        let head: CGFloat = 12
+        let dot = GestureTrailGeometry.shape(through: [CGPoint(x: 100, y: 50)], headWidth: head)
+        let ribbon = GestureTrailGeometry.shape(
+            through: [CGPoint(x: 0, y: 50), CGPoint(x: 100, y: 50)], headWidth: head
+        )
+        #expect(dot.boundingRect.height >= ribbon.boundingRect.height)
+        #expect(dot.boundingRect.height <= ribbon.boundingRect.height * 1.5)
+    }
+
+    @Test func aPathStillDrawsTheRibbon() {
+        let path = [CGPoint(x: 0, y: 50), CGPoint(x: 60, y: 50), CGPoint(x: 120, y: 50)]
+        let shape = GestureTrailGeometry.shape(through: path, headWidth: 12)
+        let ribbon = GestureTrailGeometry.ribbon(
+            through: GestureTrailGeometry.smoothed(path), headWidth: 12
+        )
+        #expect(shape.boundingRect == ribbon.boundingRect)
+    }
+
+    @Test func shapeIsEmptyForDegenerateInput() {
+        #expect(GestureTrailGeometry.shape(through: [], headWidth: 10).isEmpty)
+        #expect(GestureTrailGeometry.shape(through: [.zero], headWidth: 0).isEmpty)
+    }
+
     @Test func smoothingKeepsTheOriginalSamplesOnThePath() {
         // Catmull-Rom interpolates rather than approximates, so the trail must
         // still pass through every position the finger actually visited.
@@ -263,10 +307,6 @@ struct GestureTrailGeometryTests {
 
 // MARK: - Recorder
 
-/// Travel below which a letter key dispatches its touch as a tap — what
-/// `KeyGestureRecognizer` hands the recorder at touch down.
-private let letterKeyTapBoundary = GestureClassificationThresholds.defaultMinSwipeLength
-
 struct GestureTrailRecorderTests {
     /// Feeds a straight drag of `distance` points into the recorder, as a
     /// letter key would.
@@ -275,10 +315,9 @@ struct GestureTrailRecorderTests {
         distance: CGFloat,
         steps: Int = 8,
         from token: GestureTrailToken = GestureTrailToken(),
-        origin: CGPoint = .zero,
-        activationDistance: CGFloat = letterKeyTapBoundary
+        origin: CGPoint = .zero
     ) {
-        recorder.begin(at: origin, from: token, activationDistance: activationDistance)
+        recorder.begin(at: origin, from: token)
         for step in 1 ... steps {
             let x = origin.x + distance * CGFloat(step) / CGFloat(steps)
             recorder.extend(to: CGPoint(x: x, y: origin.y), from: token)
@@ -309,7 +348,7 @@ struct GestureTrailRecorderTests {
         var clock: TimeInterval = 0
         let recorder = makeRecorder(enabled: true, clock: { clock })
         let token = GestureTrailToken()
-        recorder.begin(at: .zero, from: token, activationDistance: letterKeyTapBoundary)
+        recorder.begin(at: .zero, from: token)
         for step in 1 ... 8 {
             clock += 0.01
             recorder.extend(to: CGPoint(x: CGFloat(step) * 15, y: 0), from: token)
@@ -318,22 +357,34 @@ struct GestureTrailRecorderTests {
         #expect(recorder.trail.samples.count > 1)
     }
 
-    @Test func tapStaysInvisible() {
-        // Every keystroke starts as a touch down, so a trail that drew from
-        // the first sample would flash under every letter typed.
+    @Test func aPressIsVisibleFromTheFirstSample() {
+        // The dot has to be there while the finger rests on the key, not only
+        // once the touch has travelled far enough to count as a swipe.
         let recorder = makeRecorder(enabled: true)
         let token = GestureTrailToken()
-        recorder.begin(at: .zero, from: token, activationDistance: letterKeyTapBoundary)
-        recorder.extend(to: CGPoint(x: 2, y: 1), from: token)
-        #expect(!recorder.isVisible)
+        recorder.begin(at: CGPoint(x: 20, y: 30), from: token)
+        #expect(recorder.isVisible)
+        #expect(recorder.trail.samples.map(\.point) == [CGPoint(x: 20, y: 30)])
+
+        recorder.extend(to: CGPoint(x: 22, y: 31), from: token)
+        #expect(recorder.isVisible)
     }
 
-    @Test func finishingATapDropsTheTrailWithoutAFade() {
-        let recorder = makeRecorder(enabled: true)
+    @Test func finishingATapFreezesTheDotForItsFade() {
+        var clock: TimeInterval = 500
+        let recorder = makeRecorder(enabled: true, clock: { clock })
         let token = GestureTrailToken()
-        recorder.begin(at: .zero, from: token, activationDistance: letterKeyTapBoundary)
-        recorder.extend(to: CGPoint(x: 2, y: 0), from: token)
+        recorder.begin(at: .zero, from: token)
+        clock = 500.1
         recorder.finish(from: token)
+        // Still drawn — the fade-out runs on a timer, not on this call.
+        #expect(recorder.isVisible)
+        #expect(recorder.trail.releaseTime == 500.1)
+    }
+
+    @Test func aPressDrawsNothingWhileTheSettingIsOff() {
+        let recorder = makeRecorder(enabled: false)
+        recorder.begin(at: .zero, from: GestureTrailToken())
         #expect(!recorder.isVisible)
         #expect(recorder.trail.isEmpty)
     }
@@ -366,8 +417,7 @@ struct GestureTrailRecorderTests {
         let first = GestureTrailToken()
         drag(recorder, distance: 120, from: first)
         recorder.finish(from: first)
-        recorder.begin(at: CGPoint(x: 300, y: 300), from: GestureTrailToken(), activationDistance: letterKeyTapBoundary)
-        #expect(!recorder.isVisible)
+        recorder.begin(at: CGPoint(x: 300, y: 300), from: GestureTrailToken())
         #expect(recorder.trail.samples.map(\.point) == [CGPoint(x: 300, y: 300)])
     }
 
@@ -386,81 +436,6 @@ struct GestureTrailRecorderTests {
         #expect(recorder.isVisible)
     }
 
-    // MARK: - Activation Distance
-
-    @Test func nothingIsDrawnBelowTheActivationDistance() {
-        let recorder = makeRecorder(enabled: true)
-        let token = GestureTrailToken()
-        recorder.begin(at: .zero, from: token, activationDistance: 20)
-        for x in stride(from: 4.0, through: 16.0, by: 4.0) {
-            recorder.extend(to: CGPoint(x: x, y: 0), from: token)
-        }
-        #expect(!recorder.isVisible)
-        recorder.extend(to: CGPoint(x: 24, y: 0), from: token)
-        #expect(recorder.isVisible)
-    }
-
-    @Test func theActivationDistanceIsPerKeyNotGlobal() {
-        // The same 12 pt drag is still a tap on a letter key (20 pt boundary)
-        // and already a cursor slide on the space bar (8 pt), so the trail has
-        // to follow the key that recorded it — a sloppy tap must not flash a
-        // streak.
-        let letterKey = makeRecorder(enabled: true)
-        let spaceBar = makeRecorder(enabled: true)
-        let left = GestureTrailToken()
-        let right = GestureTrailToken()
-        letterKey.begin(at: .zero, from: left, activationDistance: letterKeyTapBoundary)
-        spaceBar.begin(
-            at: .zero, from: right,
-            activationDistance: KeyboardConstants.SpaceGestures.dragActivationThreshold
-        )
-        for x in stride(from: 4.0, through: 12.0, by: 4.0) {
-            letterKey.extend(to: CGPoint(x: x, y: 0), from: left)
-            spaceBar.extend(to: CGPoint(x: x, y: 0), from: right)
-        }
-        #expect(!letterKey.isVisible)
-        #expect(spaceBar.isVisible)
-    }
-
-    @Test func theTapBoundaryIsMeasuredInTheClassifiersSpace() {
-        // `classify` divides the horizontal component by the key's aspect
-        // ratio, so on a wide key a sideways slip stays a tap for longer than
-        // the same travel downwards. The trail has to use the same ellipse or
-        // it draws under a touch that is about to be dispatched as a tap.
-        let aspect: CGFloat = 1.62
-        let sideways = makeRecorder(enabled: true)
-        let downwards = makeRecorder(enabled: true)
-        let left = GestureTrailToken()
-        let right = GestureTrailToken()
-        sideways.begin(at: .zero, from: left, activationDistance: 20, aspectRatio: aspect)
-        downwards.begin(at: .zero, from: right, activationDistance: 20, aspectRatio: aspect)
-        sideways.extend(to: CGPoint(x: 25, y: 0), from: left)
-        downwards.extend(to: CGPoint(x: 0, y: 25), from: right)
-        #expect(!sideways.isVisible)
-        #expect(downwards.isVisible)
-        // 20 pt normalized is 32.4 raw points across.
-        sideways.extend(to: CGPoint(x: 33, y: 0), from: left)
-        #expect(sideways.isVisible)
-    }
-
-    @Test func aDegenerateAspectRatioFallsBackToRawTravel() {
-        let recorder = makeRecorder(enabled: true)
-        let token = GestureTrailToken()
-        recorder.begin(at: .zero, from: token, activationDistance: 20, aspectRatio: 0)
-        recorder.extend(to: CGPoint(x: 24, y: 0), from: token)
-        #expect(recorder.isVisible)
-    }
-
-    @Test func theLetterKeyTrailStartsAtTheClassifiersTapBoundary() {
-        let store = InMemoryUserDefaults()
-        #expect(KeyGestureRecognizer.tapBoundary(store: store) == letterKeyTapBoundary)
-        // Expert mode retunes the classification boundary; the trail follows
-        // it instead of keeping a threshold of its own.
-        store.set(true, forKey: SettingsKey.expertModeEnabled.rawValue)
-        store.set(42.0, forKey: GestureClassificationThresholds.minSwipeLengthKey)
-        #expect(KeyGestureRecognizer.tapBoundary(store: store) == 42)
-    }
-
     // MARK: - Touch-Sequence Ownership
 
     @Test func aSecondFingerDoesNotHijackTheTrail() {
@@ -472,13 +447,13 @@ struct GestureTrailRecorderTests {
         let right = GestureTrailToken()
         drag(recorder, distance: 120, from: left)
 
-        recorder.begin(at: CGPoint(x: 300, y: 300), from: right, activationDistance: letterKeyTapBoundary)
+        recorder.begin(at: CGPoint(x: 300, y: 300), from: right)
         recorder.extend(to: CGPoint(x: 340, y: 300), from: right)
 
         #expect(recorder.isVisible)
         let points = recorder.trail.samples.map(\.point)
         #expect(points.allSatisfy { $0.y == 0 })
-        #expect(recorder.trail.origin == .zero)
+        #expect(points.first == .zero)
     }
 
     @Test func aSecondFingerLiftingDoesNotEndTheOwnersTrail() {
@@ -487,7 +462,7 @@ struct GestureTrailRecorderTests {
         let right = GestureTrailToken()
         drag(recorder, distance: 120, from: left)
 
-        recorder.begin(at: CGPoint(x: 300, y: 300), from: right, activationDistance: letterKeyTapBoundary)
+        recorder.begin(at: CGPoint(x: 300, y: 300), from: right)
         recorder.finish(from: right)
         #expect(recorder.trail.releaseTime == nil)
 
@@ -520,7 +495,7 @@ struct GestureTrailRecorderTests {
         // Only the recorder's weak `owner` refers to the token now.
         doomed = nil
 
-        recorder.begin(at: CGPoint(x: 300, y: 300), from: GestureTrailToken(), activationDistance: letterKeyTapBoundary)
+        recorder.begin(at: CGPoint(x: 300, y: 300), from: GestureTrailToken())
         #expect(recorder.trail.samples.map(\.point) == [CGPoint(x: 300, y: 300)])
     }
 

--- a/wurstfingerTests/SlideGestureStateTests.swift
+++ b/wurstfingerTests/SlideGestureStateTests.swift
@@ -450,26 +450,6 @@ struct SlideGestureStateTests {
         _ = state.handleCancelled()
         #expect(state.maxDisplacement == 0)
     }
-
-    // MARK: - Trail activation distance
-
-    /// The trail's activation distance on a slide key is the same value that
-    /// decides tap vs. slide, so a tap can never draw one.
-    @Test(arguments: [SlideType.moveCursor, .delete])
-    func theActivationThresholdIsTheTapBoundary(slideType: SlideType) {
-        let configuration = SlideGestureConfiguration.for(slideType)
-        let boundary = SlideGestureHandler.activationThreshold(for: slideType)
-
-        var short = SlideGestureState()
-        let below = CGSize(width: boundary - 1, height: 0)
-        _ = short.handleChanged(translation: below, configuration: configuration)
-        #expect(short.handleEnded(translation: below, configuration: configuration) == .tap)
-
-        var long = SlideGestureState()
-        let above = CGSize(width: boundary + 1, height: 0)
-        _ = long.handleChanged(translation: above, configuration: configuration)
-        #expect(long.handleEnded(translation: above, configuration: configuration) == .ended)
-    }
 }
 
 // MARK: - ViewModel handling of .cancelled


### PR DESCRIPTION
Follow-up to #279: the gesture trail only ever drew swipes. It waited for the touch to travel past an activation distance, so a plain keystroke left nothing behind — pressing a key was invisible even with the trail turned on.

## What changed

- **The trail draws from the first sample.** A touch that has not moved has exactly one sample and renders as a dot; the second sample turns it into the existing tapered ribbon. A press that becomes a swipe therefore grows a tail out of the dot instead of popping into existence at the threshold.
- **The dot is 1.4× the ribbon's head width.** A swipe spreads its mark along the whole path while a press has nothing but the dot, so matching the head exactly makes the dot read as a smudge next to the key label. Rendered at 1.0/1.4/1.8× to pick this; 1.8 starts to swamp the label.
- **The visible-age window always keeps the newest sample.** A finger held still stops producing samples, so the whole buffer would age out and the dot would blink away mid-touch. As a side effect a paused swipe now shrinks back to the finger instead of vanishing entirely.
- **A long press fades its dot like any other keystroke.** The recognizers finish the trail the moment a long press fires and types its digit, so the dot freezes and fades instead of snapping away without a fade when the touch is consumed.
- The activation distance and the trail's `origin`/`maxDisplacement` bookkeeping existed only to suppress taps and are gone. So are the slide keys' `activationThreshold(for:)` helper and its guard test, which only pinned that activation distance.

No new setting: this is part of `gestureTrailEnabled`, still off by default. The toggle's own strings are unchanged — "Gesture Trail" / "Draw the path your finger takes" still describes it, and a press is the zero-length case of a path.

## Verification

- Unit tests updated and extended (dot geometry, dispatch between dot and ribbon, the new window rule, press visibility in the recorder). Full `WurstfingerTests` suite green.
- Review follow-up: the dot-geometry test pins the production `pressDotWidthFactor` instead of a literal, and a new buffer test covers the dot surviving a release after a long hold.
- Offline `ImageRenderer` passes over the real overlay for the size comparison, light and dark.
- End-to-end in the simulator's interactive keyboard preview: the dot appears on touch down, is still there after a hold well past the visible window, the keystroke still dispatches, and the dot is gone after the fade.
