### PR TITLE
Complete the Kana Iteration Marks and Pin Review Follow-Up Behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Characters that could not be typed at all on the non-Latin layouts: Thai ฬ ฒ ฑ ฏ (circle gesture) and the baht sign ฿, the Japanese 、 and 。 plus the small kana on return swipes, the Persian/Urdu half-space (ZWNJ), Arabic-script punctuation ؟ ، ؛ ٭ in place of the Latin marks, the Hindi rupee sign ₹, and the Hebrew geresh and gershayim ׳ ״ (#284)
+- The voiced kana iteration marks ゞ and ヾ: they ride the return swipe of ゝ/ヽ and the ゛ key voices them too, instead of being reachable only through the accent cycle (#290)
 - Forward-delete and capitalize-word with an active selection: forward-delete now removes the selection, and capitalize-word changes the case of the selection instead of eating the word in front of it (#281)
 - The double-space shortcut now requires two consecutive space presses within a short window, so a space typed into an already-finished sentence is no longer rewritten and a deliberate double space stays typable; it also inserts the script's own sentence mark (Devanagari danda, Japanese full-width stop, Urdu full stop) (#281)
 - Cut-all is bounded by the same size ceiling as a paste instead of issuing an unbounded number of delete round-trips to the host app (#281)

--- a/wurstfingerKeyboard/Definition/Language/LanguageDefinitions+MessagEase.swift
+++ b/wurstfingerKeyboard/Definition/Language/LanguageDefinitions+MessagEase.swift
@@ -550,16 +550,17 @@ extension LanguageDefinitions {
     ]
 
     /// Small kana are the reference's *return* outputs on their full-size
-    /// counterparts (や → ゃ, あ → ぁ). A caseless script gets no auto-generated
-    /// return, so without these a return swipe just repeats the plain kana and
-    /// ゃゅょ / ぁぅぇぉ are reachable only through the accent-cycle key. Voicing
-    /// stays on the ゛ key (`hiraganaCombineRules`), as in the reference.
+    /// counterparts (や → ゃ, あ → ぁ), and the voiced iteration mark ゞ is the
+    /// return of ゝ. A caseless script gets no auto-generated return, so
+    /// without these a return swipe just repeats the plain kana and the small
+    /// and voiced forms are reachable only through the accent-cycle key.
+    /// Consonant voicing stays on the ゛ key (`hiraganaCombineRules`).
     /// `bottomCenter` keeps the Latin comma and full stop that 、 and 。 displace.
     private static let hiraganaReturnOverrides: [String: [GestureType: String]] = [
         GridSlot.topLeft: [.swipeDown: "ゃ"],
         GridSlot.center: [.swipeUp: "ぁ"],
         GridSlot.midRight: [.swipeUpLeft: "ゅ"],
-        GridSlot.bottomLeft: [.swipeRight: "ぅ"],
+        GridSlot.bottomLeft: [.swipeUpLeft: "ゞ", .swipeRight: "ぅ"],
         GridSlot.bottomCenter: [.swipeDown: ".", .swipeDownLeft: ","],
         GridSlot.bottomRight: [.swipeUp: "ぇ", .swipeLeft: "ょ", .swipeDownLeft: "ぉ"],
     ]
@@ -575,13 +576,14 @@ extension LanguageDefinitions {
     /// Dakuten voicing (kana + ゛ → voiced kana), from MessagEase hiraganaCombine.
     /// A second ゛ cascades the ha-row voiced kana to their handakuten form
     /// (ば→ぱ …) and the voiced づ to the sokuon っ, so the single ゛ key reaches
-    /// ぱぴぷぺぽ and っ (matching the global ゛ table).
+    /// ぱぴぷぺぽ and っ; the iteration mark voices like a consonant (ゝ→ゞ)
+    /// (all matching the global ゛ table).
     private static let hiraganaCombineRules = ComposeRuleSet(rules: [
         "゛": [
             "か": "が", "き": "ぎ", "く": "ぐ", "け": "げ", "こ": "ご", "さ": "ざ",
             "し": "じ", "す": "ず", "せ": "ぜ", "そ": "ぞ", "た": "だ", "ち": "ぢ",
             "つ": "づ", "て": "で", "と": "ど", "は": "ば", "ひ": "び", "ふ": "ぶ",
-            "へ": "べ", "ほ": "ぼ", "う": "ゔ",
+            "へ": "べ", "ほ": "ぼ", "う": "ゔ", "ゝ": "ゞ",
             "ば": "ぱ", "び": "ぴ", "ぶ": "ぷ", "べ": "ぺ", "ぼ": "ぽ", "づ": "っ",
         ],
     ])
@@ -656,14 +658,15 @@ extension LanguageDefinitions {
 
     /// Dakuten voicing (kana + ゛ → voiced kana), from MessagEase katakanaCombine.
     /// A second ゛ cascades the ha-row voiced kana to their handakuten form
-    /// (バ→パ …) and the voiced ヅ to the sokuon ッ.
+    /// (バ→パ …) and the voiced ヅ to the sokuon ッ; the iteration mark voices
+    /// like a consonant (ヽ→ヾ), matching the global ゛ table.
     private static let katakanaCombineRules = ComposeRuleSet(rules: [
         "゛": [
             "カ": "ガ", "キ": "ギ", "ク": "グ", "ケ": "ゲ", "コ": "ゴ", "サ": "ザ",
             "シ": "ジ", "ス": "ズ", "セ": "ゼ", "ソ": "ゾ", "タ": "ダ", "チ": "ヂ",
             "ツ": "ヅ", "テ": "デ", "ト": "ド", "ハ": "バ", "ヒ": "ビ", "フ": "ブ",
             "ヘ": "ベ", "ホ": "ボ", "ウ": "ヴ", "ワ": "ヷ", "ヰ": "ヸ", "ヱ": "ヹ",
-            "ヲ": "ヺ",
+            "ヲ": "ヺ", "ヽ": "ヾ",
             "バ": "パ", "ビ": "ピ", "ブ": "プ", "ベ": "ペ", "ボ": "ポ", "ヅ": "ッ",
         ],
     ])

--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -43,7 +43,10 @@ struct SlideGestureConfiguration: Equatable {
 
     /// Upward travel that classifies a vertical swipe, or nil for keys
     /// without an up-swipe binding — those never let the vertical axis block
-    /// the latch and never report `.swipeUp`.
+    /// the latch and never report `.swipeUp`. An up-and-return flick on such
+    /// a key ends near its origin and therefore classifies as a tap — on
+    /// delete that deletes one character. Deliberate: the alternative, a
+    /// gesture that produces nothing at all, reads as a dropped input.
     let swipeUpThreshold: CGFloat?
 
     static let moveCursor = SlideGestureConfiguration(

--- a/wurstfingerTests/KatakanaDerivationTests.swift
+++ b/wurstfingerTests/KatakanaDerivationTests.swift
@@ -70,7 +70,7 @@ struct KatakanaDerivationTests {
             GridSlot.center: [.swipeUp: "ァ"],
             GridSlot.midLeft: [.swipeDown: "ヮ"],
             GridSlot.midRight: [.swipeUpLeft: "ュ"],
-            GridSlot.bottomLeft: [.swipeRight: "ゥ"],
+            GridSlot.bottomLeft: [.swipeUpLeft: "ヾ", .swipeRight: "ゥ"],
             GridSlot.bottomCenter: [.swipeDown: ".", .swipeDownLeft: ",", .swipeDownRight: ":"],
             GridSlot.bottomRight: [.swipeUp: "ェ", .swipeLeft: "ョ", .swipeDownLeft: "ォ"],
         ]

--- a/wurstfingerTests/LanguageAlphabetCoverageTests.swift
+++ b/wurstfingerTests/LanguageAlphabetCoverageTests.swift
@@ -186,17 +186,18 @@ struct LanguageAlphabetCoverageTests {
             ]
         ),
         AlphabetInventory(
-            id: "ja_JP", source: "Hiragana gojūon, voiced and small kana, Japanese punctuation",
+            id: "ja_JP", source: "Hiragana gojūon, voiced and small kana, iteration marks, Japanese punctuation",
             groups: [
                 "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん",
-                "がぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽ", "ぁぃぅぇぉゃゅょっ", "ー、。",
+                "がぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽ", "ぁぃぅぇぉゃゅょっ", "ゝゞ", "ー、。",
             ]
         ),
         AlphabetInventory(
-            id: "ja_JP_katakana", source: "Katakana gojūon, plus small ヮ and the nakaguro separator",
+            id: "ja_JP_katakana",
+            source: "Katakana gojūon, iteration marks, plus small ヮ and the nakaguro separator",
             groups: [
                 "アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン",
-                "ガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポ", "ァィゥェォャュョッヮ", "ー、。・",
+                "ガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポ", "ァィゥェォャュョッヮ", "ヽヾ", "ー、。・",
             ]
         ),
     ]

--- a/wurstfingerTests/ScriptLayoutTests.swift
+++ b/wurstfingerTests/ScriptLayoutTests.swift
@@ -125,6 +125,51 @@ struct KanaLayoutTests {
 
         #expect(inserts(target) == ["・", ":"])
     }
+
+    /// The voiced iteration mark is the reference's return output on ゝ,
+    /// like the small kana on their full-size counterparts.
+    @Test func hiraganaIterationMarkVoicesOnTheReturnSwipe() {
+        let (vm, target) = makeViewModel(languageId: "ja_JP")
+
+        vm.handleGesture(.swipeUpLeft, keyId: GridSlot.bottomLeft, isReturn: false)
+        vm.handleGesture(.swipeUpLeft, keyId: GridSlot.bottomLeft, isReturn: true)
+
+        #expect(inserts(target) == ["ゝ", "ゞ"])
+    }
+
+    @Test func katakanaIterationMarkIsDerivedFromHiragana() {
+        let (vm, target) = makeViewModel(languageId: "ja_JP_katakana")
+
+        vm.handleGesture(.swipeUpLeft, keyId: GridSlot.bottomLeft, isReturn: false)
+        vm.handleGesture(.swipeUpLeft, keyId: GridSlot.bottomLeft, isReturn: true)
+
+        #expect(inserts(target) == ["ヽ", "ヾ"])
+    }
+
+    /// The ゛ key voices the iteration mark like a consonant, so both kana
+    /// combine tables must carry the entry the global table already has.
+    @Test(arguments: [("ja_JP", "ゝ", "ゞ"), ("ja_JP_katakana", "ヽ", "ヾ")])
+    func dakutenKeyVoicesTheIterationMark(id: String, plain: String, voiced: String) {
+        let (vm, target) = makeViewModel(languageId: id)
+
+        vm.dispatchAction(.commitText(plain))
+        vm.dispatchAction(.commitText("゛"))
+
+        #expect(target.documentContextBeforeInput == voiced)
+    }
+
+    /// The ellipsis that 。 displaced from the full stop's return swipe stays
+    /// reachable on the numeric layer, which inherits the Latin punctuation
+    /// bindings unchanged.
+    @Test(arguments: ["ja_JP", "ja_JP_katakana"])
+    func ellipsisStaysOnTheNumericLayerReturnSwipe(id: String) {
+        let (vm, target) = makeViewModel(languageId: id)
+
+        vm.handleGesture(.tap, keyId: UtilitySlot.symbols, isReturn: false)
+        vm.handleGesture(.swipeDown, keyId: GridSlot.bottomCenter, isReturn: true)
+
+        #expect(inserts(target) == ["…"])
+    }
 }
 
 // MARK: - Arabic script
@@ -160,6 +205,19 @@ struct ArabicScriptLayoutTests {
         }
 
         #expect(inserts(target) == ["?", ",", ";", "*"], "[\(id)] displaced Latin mark is unreachable")
+    }
+
+    /// The dagger that ٭ displaced from the asterisk's return swipe (the
+    /// reference keeps ٭ → † on the letter layer) stays reachable on the
+    /// numeric layer, which inherits the Latin punctuation bindings unchanged.
+    @Test(arguments: ArabicScriptLayoutTests.ids)
+    func daggerStaysOnTheNumericLayerReturnSwipe(id: String) {
+        let (vm, target) = makeViewModel(languageId: id)
+
+        vm.handleGesture(.tap, keyId: UtilitySlot.symbols, isReturn: false)
+        vm.handleGesture(.swipeRight, keyId: GridSlot.bottomLeft, isReturn: true)
+
+        #expect(inserts(target) == ["†"], "[\(id)] † lost with the letter-layer asterisk")
     }
 
     /// The three layouts share one punctuation table, so they cannot drift.

--- a/wurstfingerTests/SlideGestureStateTests.swift
+++ b/wurstfingerTests/SlideGestureStateTests.swift
@@ -341,6 +341,17 @@ struct SlideGestureStateTests {
         #expect(state.handleEnded(translation: translation, configuration: .delete) == .tap)
     }
 
+    /// An up-and-return flick on delete ends near its origin, classifies as a
+    /// tap, and deletes one character. Deliberate (decided 2026-08-09): with
+    /// no up-swipe binding on the key, the vertical peak carries no meaning,
+    /// and a gesture that produced nothing at all would read as dropped input.
+    @Test func upAndReturnFlickOnDeleteEndsAsATap() {
+        var state = SlideGestureState()
+        _ = state.handleChanged(translation: CGSize(width: 0, height: -40), configuration: .delete)
+        let ended = state.handleEnded(translation: CGSize(width: 0, height: -4), configuration: .delete)
+        #expect(ended == .tap)
+    }
+
     @Test func slideTypesResolveToTheirConfiguration() {
         #expect(SlideGestureConfiguration.for(.moveCursor) == .moveCursor)
         #expect(SlideGestureConfiguration.for(.delete) == .delete)


### PR DESCRIPTION
Follow-ups from the verification pass on the 2026-08-08 stabilization review (PRs #281–#287). Three items:

## Voiced kana iteration marks (the one undelivered part of the layout fixes)

The reference puts the voiced iteration mark on the return swipe of its plain form (`bottomLeft.upLeft`: ゝ→ゞ, ヽ→ヾ). The kana layouts had no return override on that slot, so an out-and-back swipe silently re-committed the plain mark, and the doc comment claimed the ゛ combine tables covered the voicing — they had no ゝ/ヽ entry. Now:

- ゞ rides the return swipe of ゝ; katakana derives ヾ through the existing ICU transform (pinned in `KatakanaDerivationTests`).
- Both kana combine tables voice the iteration mark on the ゛ key (ゝ+゛→ゞ, ヽ+゛→ヾ), matching the global ゛ table, and the comment now matches reality.
- ゝゞ/ヽヾ joined the alphabet inventories, and `ScriptLayoutTests` pin both paths end-to-end.

## Displaced `…` and `†` pinned on the numeric layer

The verification initially reported `…` (kana) and `†` (Arabic-script layouts) as lost when 。 and ٭ displaced the Latin `.` and `*`. That turned out wrong: `NumericLayouts.buildMode` inherits `CommonKeys.defaultSlotBindings` *including return actions*, so both marks stayed reachable on the numeric layer. What was actually missing is a test guaranteeing that — added for both (`ellipsisStaysOnTheNumericLayerReturnSwipe`, `daggerStaysOnTheNumericLayerReturnSwipe` across ar/fa_IR/ur).

## Delete up-flick decision

Since #282's per-key slide configuration, an up-and-return flick on the delete key ends near its origin and classifies as a tap that deletes one character (previously it fell through as a `.swipeUp` nobody consumed). This PR keeps that behavior deliberately — a gesture that produces nothing at all reads as dropped input — documents it in the configuration docs, and locks it with a state test.

## Test plan

- Full `WurstfingerTests` suite green locally: 1361 tests, 0 failures (10 new).