### PR TITLE
Fix Every Finding From the 2026-08-09 Review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Changed
 
-- The `^` compose key's return swipe now types the caron dead key, so č ď ě ň ř š ť ž are reachable directly instead of only through the accent cycle (#285)
+- The `^` compose key's return swipe now types the caron dead key, so č ď ě ň ř š ť ž are reachable directly instead of only through the accent cycle. The stand-alone modifier circumflex `ˆ` (U+02C6) that this return swipe used to type is deliberately gone with it; the ASCII `^` on the same key is unchanged (#285)
 - Leaner keyboard rendering: fewer allocations per keystroke and cached layouts released under memory pressure, leaving more headroom in the tight memory budget iOS gives keyboard extensions (#278)
 
 ## v1.4.0 — 2026-07-23

--- a/fastlane/metadata/de-DE/description.txt
+++ b/fastlane/metadata/de-DE/description.txt
@@ -1,6 +1,6 @@
 Wurstfinger - Die Tastatur für dicke Finger
 
-Genug von Tippfehlern? Wurstfinger ist eine datenschutzfreundliche Tastatur mit großen Tasten und Wischgesten. Basierend auf dem bewährten MessagEase-Layout ersetzt sie das enge QWERTY-Raster durch ein 3x3-Layout, das für Daumentypen optimiert ist.
+Genug von Tippfehlern? Wurstfinger ist eine datenschutzfreundliche Tastatur mit großen Tasten und Wischgesten. Basierend auf dem bewährten MessagEase-Layout ersetzt sie das enge QWERTY-Raster durch ein 3x3-Layout, das für das Tippen mit dem Daumen optimiert ist.
 
 Anders als herkömmliche Tastaturen verzichtet Wurstfinger auf invasive Wortvorhersage - stattdessen erreicht sie Genauigkeit durch ergonomisches Design. Große, gut platzierte Tasten bedeuten weniger Vertipper, und das Gestensystem ermöglicht Zugriff auf alle Zeichen ohne Suchen nach winzigen Tasten.
 

--- a/wurstfinger/KeyboardHealthView.swift
+++ b/wurstfinger/KeyboardHealthView.swift
@@ -69,7 +69,15 @@ struct KeyboardHealthView: View {
     }
 
     private var entriesSection: some View {
-        Section("Events (newest first)") {
+        Section {
+            // The legend sits above the rows, not in the section footer: the
+            // log holds up to 300 entries, and guidance printed below all of
+            // them is guidance nobody reaches. Collapsed it costs one line.
+            DisclosureGroup("How to read a cycle") {
+                Text(Self.cycleLegend)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
             ForEach(entries.reversed()) { entry in
                 VStack(alignment: .leading, spacing: 2) {
                     HStack {
@@ -86,10 +94,34 @@ struct KeyboardHealthView: View {
                         .foregroundColor(.secondary)
                 }
             }
+        } header: {
+            Text("Events (newest first)")
         }
     }
 
     // MARK: - Helpers
+
+    /// What a reader needs to know before drawing conclusions from a cycle.
+    /// Every claim here is one the code or a measurement backs; where a
+    /// question is open (host-lifecycle entries on real hardware, see
+    /// `KeyboardViewController.observeHostLifecycle`) it says so rather than
+    /// inviting an inference from silence.
+    private static let cycleLegend = """
+    viewDidDisappear is measured while the freed memory is still being \
+    reclaimed and reads a little high. A postShedSettled entry about two \
+    seconds later is the honest figure for what the keyboard carries into \
+    suspension — but it is deliberately dropped when the keyboard comes back \
+    before it fires, or when the process was frozen and the sample would only \
+    have been taken long after the fact. A cycle without one is normal.
+
+    A viewDidAppear followed straight by a fresh viewDidLoad.start means the \
+    host app was killed while the keyboard was up — iOS reports nothing back \
+    on that path, so no cleanup ran.
+
+    hostDidEnterBackground and hostWillEnterForeground did not appear in any \
+    measured cycle on the iOS 26 Simulator; whether a real device delivers \
+    them at all is unverified. Their absence says nothing either way.
+    """
 
     private func reload() {
         entries = KeyboardHealthLog.shared.entries()

--- a/wurstfinger/KeyboardSizePositionSettingsView.swift
+++ b/wurstfinger/KeyboardSizePositionSettingsView.swift
@@ -36,90 +36,22 @@ struct KeyboardSizePositionSettingsView: View {
             InteractiveKeyboardPreview(aspectRatio: $keyAspectRatio, width: $width, position: $position)
                 .padding(.horizontal, 16)
 
-            // Size Slider
-            VStack(spacing: 16) {
-                HStack {
-                    Text("Keyboard Size")
-                        .font(.headline)
-                    Spacer()
-                    Spacer()
-                    TextField(
-                        "Value",
-                        value: sizePercent,
-                        formatter: NumberFormatter.decimalFormatter(
-                            minimum: Self.minPercent, maximum: Self.maxPercent
-                        )
-                    )
-                    .keyboardType(.decimalPad)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(width: 80)
-                    .multilineTextAlignment(.trailing)
+            // The controls scroll below the pinned preview, like the other
+            // preview screens (Style, Haptics). The preview's height follows the
+            // configured keyboard size, so with a large keyboard, a wordy
+            // translation or a large Dynamic Type size the sliders and their
+            // explanations stop fitting: in a plain VStack SwiftUI compressed
+            // them instead, and the size explainer below was silently cut to a
+            // single truncated line in every language. Keeping the preview
+            // *outside* the ScrollView also keeps its typing gestures from
+            // competing with the scroll gesture.
+            ScrollView {
+                VStack(spacing: 20) {
+                    sizeControls
+                    positionControls
                 }
-
-                VStack(spacing: 8) {
-                    Slider(value: sizePercent, in: Self.minPercent ... Self.maxPercent, step: 1)
-
-                    HStack {
-                        Text("35%")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Spacer()
-                        Text("100%")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Spacer()
-                        Text("145%")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-
-                Text("Size relative to the standard keyboard. It stays the same in every orientation; if it does not fit, it shrinks to the screen.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 8)
             }
-            .padding(.horizontal, 16)
-
-            // Position Slider
-            VStack(spacing: 16) {
-                HStack {
-                    Text("Horizontal Position")
-                        .font(.headline)
-                    Spacer()
-                    TextField("Value", value: $position, formatter: NumberFormatter.decimalFormatter(minimum: 0.0, maximum: 1.0))
-                        .keyboardType(.decimalPad)
-                        .textFieldStyle(.roundedBorder)
-                        .frame(width: 80)
-                        .multilineTextAlignment(.trailing)
-                }
-
-                VStack(spacing: 8) {
-                    Slider(value: $position, in: 0.0 ... 1.0, step: 0.01)
-
-                    HStack {
-                        Text("Left")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Spacer()
-                        Text("Center")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Spacer()
-                        Text("Right")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                }
-
-                Text("Adjust the horizontal position of the keyboard when it is narrower than the screen.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .padding(.horizontal, 16)
-
-            Spacer()
         }
         .padding(.vertical, 20)
         .navigationTitle("Size & Position")
@@ -132,6 +64,100 @@ struct KeyboardSizePositionSettingsView: View {
                 }
             }
         }
+    }
+
+    // MARK: - Controls
+
+    private var sizeControls: some View {
+        VStack(spacing: 16) {
+            HStack {
+                Text("Keyboard Size")
+                    .font(.headline)
+                Spacer()
+                Spacer()
+                TextField(
+                    "Value",
+                    value: sizePercent,
+                    formatter: NumberFormatter.decimalFormatter(
+                        minimum: Self.minPercent, maximum: Self.maxPercent
+                    )
+                )
+                .keyboardType(.decimalPad)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 80)
+                .multilineTextAlignment(.trailing)
+            }
+
+            VStack(spacing: 8) {
+                Slider(value: sizePercent, in: Self.minPercent ... Self.maxPercent, step: 1)
+
+                HStack {
+                    Text("35%")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    Text("100%")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    Text("145%")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            Text("Size relative to the standard keyboard. It stays the same in every orientation; if it does not fit, it shrinks to the screen.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                // Take the full wrapped height even when the proposal is
+                // tight, so the sentence can never be cut to one line again.
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 16)
+    }
+
+    private var positionControls: some View {
+        VStack(spacing: 16) {
+            HStack {
+                Text("Horizontal Position")
+                    .font(.headline)
+                Spacer()
+                TextField("Value", value: $position, formatter: NumberFormatter.decimalFormatter(minimum: 0.0, maximum: 1.0))
+                    .keyboardType(.decimalPad)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 80)
+                    .multilineTextAlignment(.trailing)
+            }
+
+            VStack(spacing: 8) {
+                Slider(value: $position, in: 0.0 ... 1.0, step: 0.01)
+
+                HStack {
+                    Text("Left")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    Text("Center")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    Text("Right")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            Text("Adjust the horizontal position of the keyboard when it is narrower than the screen.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                // Shorter than the size explainer, so it still fitted — but
+                // it wraps to two lines in the longer languages and sits in
+                // the same tight stack, so it gets the same guarantee.
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 16)
     }
 }
 

--- a/wurstfinger/Localizable.xcstrings
+++ b/wurstfinger/Localizable.xcstrings
@@ -667,7 +667,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "คีย์บอร์ดสำหรับนิ้วอวบ"
+            "value": "แป้นพิมพ์สำหรับนิ้วอวบ"
           }
         },
         "hi": {
@@ -961,7 +961,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "문제 해결"
+            "value": "문제 신고"
           }
         }
       },
@@ -1081,7 +1081,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "เปิดใช้คีย์บอร์ด"
+            "value": "เปิดใช้แป้นพิมพ์"
           }
         },
         "hi": {
@@ -1165,7 +1165,7 @@
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "פתח את הגדרות iOS → כללי → מקלדת → מקלדות והוסף את Wurstfinger."
+            "value": "פתח את הגדרות iOS ← כללי ← מקלדת ← מקלדות והוסף את Wurstfinger."
           }
         },
         "vi": {
@@ -1633,7 +1633,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "เปิดใช้ \"อนุญาตการเข้าถึงเต็มรูปแบบ\" เพื่อให้การควบคุมเคอร์เซอร์และเจสเจอร์ลบข้อความทำงานได้"
+            "value": "เปิดใช้ \"อนุญาตการเข้าถึงเต็มรูปแบบ\" เพื่อให้การควบคุมเคอร์เซอร์และท่าทางลบข้อความทำงานได้"
           }
         },
         "hi": {
@@ -1771,7 +1771,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ลองใช้คีย์บอร์ด"
+            "value": "ลองใช้แป้นพิมพ์"
           }
         },
         "hi": {
@@ -1909,7 +1909,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "สลับไปที่แท็บทดสอบและลองใช้เจสเจอร์ต่างๆ"
+            "value": "สลับไปที่แท็บทดสอบและลองใช้ท่าทางต่างๆ"
           }
         },
         "hi": {
@@ -2131,7 +2131,7 @@
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "מקשי שירות מימין"
+            "value": "מקשי שירות משמאל"
           }
         },
         "vi": {
@@ -2191,7 +2191,7 @@
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "यूटिलिटी कीज़ बाईं ओर"
+            "value": "यूटिलिटी कुंजियाँ बाईं ओर"
           }
         },
         "ja": {
@@ -3091,7 +3091,7 @@
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "החזיקו מקש אות כדי להקליד את הספרה שלו"
+            "value": "החזק מקש אות כדי להקליד את הספרה שלו"
           }
         },
         "hi": {
@@ -3841,7 +3841,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ปรับแต่งหน้าตาและสัมผัสของคีย์บอร์ดของคุณ"
+            "value": "ปรับแต่งหน้าตาและสัมผัสของแป้นพิมพ์ของคุณ"
           }
         },
         "hi": {
@@ -4123,7 +4123,7 @@
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "की आस्पेक्ट रेशियो"
+            "value": "कुंजी का आस्पेक्ट रेशियो"
           }
         },
         "ja": {
@@ -4513,19 +4513,19 @@
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "كلاسيكي (7-8-9)"
+            "value": "كلاسيكي (⁦7-8-9⁩)"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "کلاسیک (۷-۸-۹)"
+            "value": "کلاسیک (⁦۷-۸-۹⁩)"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "کلاسک (7-8-9)"
+            "value": "کلاسک (⁦7-8-9⁩)"
           }
         },
         "th": {
@@ -4651,19 +4651,19 @@
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "الهاتف (1-2-3)"
+            "value": "الهاتف (⁦1-2-3⁩)"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "تلفن (۱-۲-۳)"
+            "value": "تلفن (⁦۱-۲-۳⁩)"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "فون (1-2-3)"
+            "value": "فون (⁦1-2-3⁩)"
           }
         },
         "th": {
@@ -5911,7 +5911,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "สลับคีย์บอร์ด"
+            "value": "สลับแป้นพิมพ์"
           }
         },
         "hi": {
@@ -6049,7 +6049,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "แตะไอคอนลูกโลกบนคีย์บอร์ดเพื่อสลับระหว่างคีย์บอร์ดที่ติดตั้งไว้"
+            "value": "แตะไอคอนลูกโลกบนแป้นพิมพ์เพื่อสลับระหว่างแป้นพิมพ์ที่ติดตั้งไว้"
           }
         },
         "hi": {
@@ -6325,7 +6325,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "แตะที่นี่เพื่อเปิดคีย์บอร์ด..."
+            "value": "แตะที่นี่เพื่อเปิดแป้นพิมพ์..."
           }
         },
         "hi": {
@@ -6979,61 +6979,61 @@
         "el": {
           "stringUnit": {
             "state": "translated",
-            "value": "Το Liquid Glass απαιτεί iOS 26 ή νεότερη έκδοση. Σε αυτή τη συσκευή θα χρησιμοποιηθεί το κλασικό στιλ."
+            "value": "Το Liquid Glass έχει σχεδιαστεί για iOS 26 και νεότερες εκδόσεις. Σε παλαιότερες εκδόσεις χρησιμοποιείται ένα απλοποιημένο ημιδιαφανές στιλ."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Liquid Glass requer o iOS 26 ou posterior. Neste dispositivo será usado o estilo clássico."
+            "value": "O Liquid Glass foi concebido para o iOS 26 ou posterior. Em versões anteriores, é usado um estilo translúcido simplificado."
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass потребує iOS 26 або новішої версії. На цьому пристрої використовуватиметься класичний стиль."
+            "value": "Liquid Glass розроблено для iOS 26 і новіших версій. У старіших версіях використовується спрощений напівпрозорий стиль."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "يتطلب Liquid Glass نظام iOS 26 أو أحدث. سيُستخدم النمط الكلاسيكي على هذا الجهاز."
+            "value": "تم تصميم Liquid Glass لنظام iOS 26 والإصدارات الأحدث. في الإصدارات الأقدم، يُستخدم نمط مبسّط شبه شفاف."
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass به iOS 26 یا جدیدتر نیاز دارد. در این دستگاه از سبک کلاسیک استفاده می‌شود."
+            "value": "Liquid Glass برای iOS 26 و نسخه‌های جدیدتر طراحی شده است. در نسخه‌های قدیمی‌تر، از یک سبک نیمه‌شفاف ساده‌شده استفاده می‌شود."
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass کے لیے iOS 26 یا بعد کا ورژن درکار ہے۔ اس ڈیوائس پر کلاسک انداز استعمال ہوگا۔"
+            "value": "Liquid Glass کو iOS 26 اور بعد کے ورژنز کے لیے ڈیزائن کیا گیا ہے۔ پرانے ورژنز پر ایک سادہ نیم شفاف انداز استعمال ہوتا ہے۔"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass ต้องใช้ iOS 26 ขึ้นไป อุปกรณ์นี้จะใช้สไตล์คลาสสิกแทน"
+            "value": "Liquid Glass ออกแบบมาสำหรับ iOS 26 ขึ้นไป ในเวอร์ชันก่อนหน้าจะใช้สไตล์โปร่งแสงแบบเรียบง่าย"
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass के लिए iOS 26 या बाद का वर्शन ज़रूरी है। इस डिवाइस पर क्लासिक स्टाइल इस्तेमाल होगी।"
+            "value": "Liquid Glass को iOS 26 और उसके बाद के वर्शन के लिए डिज़ाइन किया गया है। पुराने वर्शन पर सरलीकृत पारभासी स्टाइल इस्तेमाल होती है।"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid GlassにはiOS 26以降が必要です。このデバイスではクラシックスタイルが使用されます。"
+            "value": "Liquid GlassはiOS 26以降向けに設計されています。それ以前のバージョンでは、簡素化された半透明のスタイルが使用されます。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Liquid Glass는 iOS 26 이상이 필요합니다. 이 기기에서는 클래식 스타일이 사용됩니다."
+            "value": "Liquid Glass는 iOS 26 이상에 맞게 설계되었습니다. 이전 버전에서는 단순화된 반투명 스타일이 사용됩니다."
           }
         }
       },
@@ -7153,7 +7153,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "เปิดคีย์บอร์ดหนึ่งครั้งเพื่อซิงค์สถานะการเข้าถึงเต็มรูปแบบ"
+            "value": "เปิดแป้นพิมพ์หนึ่งครั้งเพื่อซิงค์สถานะการเข้าถึงเต็มรูปแบบ"
           }
         },
         "hi": {
@@ -7435,7 +7435,7 @@
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "किसी भी की को छूने पर लागू होता है।"
+            "value": "किसी भी कुंजी को छूने पर लागू होता है।"
           }
         },
         "ja": {
@@ -7483,7 +7483,7 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Отклик при перетягивании"
+            "value": "Отклик при перетаскивании"
           }
         },
         "pl": {
@@ -7621,7 +7621,7 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Применяется при перетягивании клавиши пробела или удаления для перемещения курсора или удаления текста."
+            "value": "Применяется при перетаскивании клавиши пробела или удаления для перемещения курсора или удаления текста."
           }
         },
         "pl": {
@@ -7711,7 +7711,7 @@
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "कर्सर हिलाने या टेक्स्ट डिलीट करने के लिए स्पेस या डिलीट की को ड्रैग करने पर लागू होता है।"
+            "value": "कर्सर हिलाने या टेक्स्ट डिलीट करने के लिए स्पेस या डिलीट कुंजी को ड्रैग करने पर लागू होता है।"
           }
         },
         "ja": {
@@ -9361,7 +9361,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ขนาดคีย์บอร์ด"
+            "value": "ขนาดแป้นพิมพ์"
           }
         },
         "hi": {
@@ -9499,7 +9499,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ขนาดเทียบกับคีย์บอร์ดมาตรฐาน ขนาดจะเท่าเดิมในทุกการวางแนว หากไม่พอดีจะย่อลงให้เท่าความกว้างของหน้าจอ"
+            "value": "ขนาดเทียบกับแป้นพิมพ์มาตรฐาน ขนาดจะเท่าเดิมในทุกการวางแนว หากไม่พอดีจะย่อลงให้เท่าความกว้างของหน้าจอ"
           }
         },
         "hi": {
@@ -10189,7 +10189,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ปรับตำแหน่งแนวนอนของคีย์บอร์ดเมื่อคีย์บอร์ดแคบกว่าหน้าจอ"
+            "value": "ปรับตำแหน่งแนวนอนของแป้นพิมพ์เมื่อแป้นพิมพ์แคบกว่าหน้าจอ"
           }
         },
         "hi": {
@@ -10639,7 +10639,7 @@
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Doré"
+            "value": "Nombre d'or"
           }
         },
         "es": {
@@ -10711,7 +10711,7 @@
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Dourado"
+            "value": "Áureo"
           }
         },
         "uk": {
@@ -10885,7 +10885,7 @@
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "कीज़ के चौड़ाई-से-ऊँचाई अनुपात को समायोजित करें। 1.0 वर्गाकार कीज़ बनाता है (डिफ़ॉल्ट), और 1.62 गोल्डन रेशियो है (सबसे चौड़ा)।"
+            "value": "कुंजियों के चौड़ाई-से-ऊँचाई अनुपात को समायोजित करें। 1.0 वर्गाकार कुंजियाँ बनाता है (डिफ़ॉल्ट), और 1.62 गोल्डन रेशियो है (सबसे चौड़ा)।"
           }
         },
         "ja": {
@@ -11155,7 +11155,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "พิมพ์บนคีย์บอร์ดด้านล่าง"
+            "value": "พิมพ์บนแป้นพิมพ์ด้านล่าง"
           }
         },
         "hi": {
@@ -11293,7 +11293,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "สลับคีย์บอร์ด"
+            "value": "สลับแป้นพิมพ์"
           }
         },
         "hi": {
@@ -11431,7 +11431,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ซ่อนคีย์บอร์ด"
+            "value": "ซ่อนแป้นพิมพ์"
           }
         },
         "hi": {
@@ -12277,7 +12277,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "모두 잘라내기"
+            "value": "모두 오려두기"
           }
         }
       },
@@ -12937,7 +12937,7 @@
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "فعلی: %@:۱"
+            "value": "فعلی: %@:1"
           }
         },
         "ur": {
@@ -13141,7 +13141,7 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Нажатие: %@ • Перетягивание: %@"
+            "value": "Нажатие: %@ • Перетаскивание: %@"
           }
         },
         "pl": {
@@ -13363,7 +13363,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "เปิดใช้การปรับแต่งเจสเจอร์"
+            "value": "เปิดใช้การปรับแต่งท่าทาง"
           }
         },
         "hi": {
@@ -13501,7 +13501,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "การตั้งค่าเจสเจอร์ขั้นสูง"
+            "value": "การตั้งค่าท่าทางขั้นสูง"
           }
         },
         "hi": {
@@ -13555,7 +13555,7 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Перетягивание перемещает курсор"
+            "value": "Перетаскивание перемещает курсор"
           }
         },
         "pl": {
@@ -13897,19 +13897,19 @@
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "تخطيط الهاتف (1-2-3)"
+            "value": "تخطيط الهاتف (⁦1-2-3⁩)"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "چیدمان تلفن (۱-۲-۳)"
+            "value": "چیدمان تلفن (⁦۱-۲-۳⁩)"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "فون لے آؤٹ (1-2-3)"
+            "value": "فون لے آؤٹ (⁦1-2-3⁩)"
           }
         },
         "th": {
@@ -14035,19 +14035,19 @@
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "التخطيط الكلاسيكي (7-8-9)"
+            "value": "التخطيط الكلاسيكي (⁦7-8-9⁩)"
           }
         },
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "چیدمان کلاسیک (۷-۸-۹)"
+            "value": "چیدمان کلاسیک (⁦۷-۸-۹⁩)"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "کلاسک لے آؤٹ (7-8-9)"
+            "value": "کلاسک لے آؤٹ (⁦7-8-9⁩)"
           }
         },
         "th": {
@@ -14485,7 +14485,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "문자"
+            "value": "글자"
           }
         }
       },
@@ -14623,7 +14623,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "기본 기호"
+            "value": "표준 기호"
           }
         }
       },
@@ -15025,7 +15025,7 @@
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "मानक चिह्न दिखाएँ"
+            "value": "मानक सिंबल दिखाएँ"
           }
         },
         "ja": {
@@ -15163,7 +15163,7 @@
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "अतिरिक्त चिह्न दिखाएँ"
+            "value": "अतिरिक्त सिंबल दिखाएँ"
           }
         },
         "ja": {
@@ -15265,7 +15265,7 @@
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Oculte os rótulos para praticar o layout de memória. Números e teclas de controle estão sempre visíveis."
+            "value": "Oculte as etiquetas para praticar o esquema de memória. Os números e as teclas de controlo estão sempre visíveis."
           }
         },
         "uk": {
@@ -15313,7 +15313,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "레이아웃을 외워서 연습하려면 라벨을 숨기세요. 숫자와 컨트롤 키는 항상 표시됩니다."
+            "value": "레이아웃을 외워서 연습하려면 레이블을 숨기세요. 숫자와 컨트롤 키는 항상 표시됩니다."
           }
         }
       },
@@ -15715,7 +15715,7 @@
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "पारंपरिक अपारदर्शी कीज़"
+            "value": "पारंपरिक अपारदर्शी कुंजियाँ"
           }
         },
         "ja": {
@@ -15793,7 +15793,7 @@
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "אפקט זכוכית שקופה (iOS 26+)"
+            "value": "אפקט זכוכית שקופה (iOS 26 ואילך)"
           }
         },
         "vi": {
@@ -15835,13 +15835,13 @@
         "fa": {
           "stringUnit": {
             "state": "translated",
-            "value": "افکت شیشه‌ای شفاف (iOS 26+)"
+            "value": "افکت شیشه‌ای شفاف (iOS 26 و جدیدتر)"
           }
         },
         "ur": {
           "stringUnit": {
             "state": "translated",
-            "value": "شفاف گلاس ایفیکٹ (iOS 26+)"
+            "value": "شفاف گلاس ایفیکٹ (iOS 26 اور بعد کے ورژنز)"
           }
         },
         "th": {
@@ -17371,7 +17371,7 @@
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "भाषाएँ बदलने के लिए ग्लोब की पर दाईं ओर स्वाइप करें। किसी भाषा को डिफ़ॉल्ट स्टार्टअप भाषा बनाने के लिए उस पर टैप करें।"
+            "value": "भाषाएँ बदलने के लिए ग्लोब कुंजी पर दाईं ओर स्वाइप करें। किसी भाषा को डिफ़ॉल्ट स्टार्टअप भाषा बनाने के लिए उस पर टैप करें।"
           }
         },
         "ja": {
@@ -17449,7 +17449,7 @@
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "इशारे का निशान"
+            "value": "जेस्चर का निशान"
           }
         },
         "hr": {
@@ -17749,7 +17749,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "원을 그려 전체 잘라내기"
+            "value": "원을 그려 모두 오려두기"
           }
         },
         "pl": {
@@ -17886,7 +17886,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "클립보드로 잘라내려면 전체 접근이 필요합니다"
+            "value": "클립보드로 오려두려면 전체 접근이 필요합니다"
           }
         },
         "pl": {
@@ -17993,13 +17993,13 @@
         "he": {
           "stringUnit": {
             "state": "translated",
-            "value": "שרטטו מעגל על מקש 123 כדי לגזור את הטקסט סביב הסמן. החליקו מטה על אותו מקש כדי להדביק אותו בחזרה. שתי המחוות נשארות על המקש גם אחרי שהוא מחליף את המקלדת למספרים."
+            "value": "שרטט מעגל על מקש 123 כדי לגזור את הטקסט סביב הסמן. החלק מטה על אותו מקש כדי להדביק אותו בחזרה. שתי המחוות נשארות על המקש גם אחרי שהוא מחליף את המקלדת למספרים."
           }
         },
         "hi": {
           "stringUnit": {
             "state": "translated",
-            "value": "कर्सर के आसपास का टेक्स्ट काटने के लिए 123 कुंजी पर गोला बनाएँ। उसे वापस चिपकाने के लिए उसी कुंजी पर नीचे स्वाइप करें। कुंजी द्वारा कीबोर्ड को अंकों पर बदलने के बाद भी दोनों हावभाव उसी कुंजी पर बने रहते हैं।"
+            "value": "कर्सर के आसपास का टेक्स्ट काटने के लिए 123 कुंजी पर गोला बनाएँ। उसे वापस चिपकाने के लिए उसी कुंजी पर नीचे स्वाइप करें। कुंजी द्वारा कीबोर्ड को अंकों पर बदलने के बाद भी दोनों जेस्चर उसी कुंजी पर बने रहते हैं।"
           }
         },
         "hr": {
@@ -18023,7 +18023,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "123 키에서 원을 그리면 커서 주변 텍스트를 잘라냅니다. 같은 키를 아래로 쓸어내리면 다시 붙여넣습니다. 이 키가 키보드를 숫자로 전환한 뒤에도 두 제스처는 그대로 유지됩니다."
+            "value": "123 키에서 원을 그리면 커서 주변 텍스트를 오려둡니다. 같은 키를 아래로 쓸어내리면 다시 붙여넣습니다. 이 키가 키보드를 숫자로 전환한 뒤에도 두 제스처는 그대로 유지됩니다."
           }
         },
         "pl": {
@@ -18212,6 +18212,972 @@
           }
         }
       }
+    },
+    "Numbers": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zahlen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiffres"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Números"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Numeri"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цифры"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cyfry"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siffror"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Numerot"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brojevi"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מספרים"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Số"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga numero"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αριθμοί"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Números"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цифри"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أرقام"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اعداد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اعداد"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวเลข"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अंक"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "数字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "숫자"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the 123 key that switches to the numeric mode (VoiceOver)"
+    },
+    "Letters": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buchstaben"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettres"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letras"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettere"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Буквы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Litery"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bokstäver"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kirjaimet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slova"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אותיות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chữ cái"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga letra"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Γράμματα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letras"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Літери"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أحرف"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حروف"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حروف"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวอักษร"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अक्षर"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글자"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the abc key that switches back to the alphabetic mode (VoiceOver)"
+    },
+    "Shift": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Großbuchstaben"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Majuscules"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mayúsculas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maiuscole"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Верхний регистр"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wielkie litery"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versaler"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isot kirjaimet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velika slova"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אותיות רישיות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chữ hoa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Malaking titik"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κεφαλαία"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maiúsculas"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Верхній регістр"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أحرف كبيرة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حروف بزرگ"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بڑے حروف"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวพิมพ์ใหญ่"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बड़े अक्षर"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "大文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대문자"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY action name for the shift swipe that switches to the uppercase mode (VoiceOver)"
+    },
+    "Lowercase": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kleinbuchstaben"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minuscules"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minúsculas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minuscole"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нижний регистр"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Małe litery"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gemener"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pienet kirjaimet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mala slova"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אותיות קטנות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chữ thường"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maliit na titik"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πεζά"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minúsculas"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нижній регістр"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أحرف صغيرة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حروف کوچک"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چھوٹے حروف"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวพิมพ์เล็ก"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "छोटे अक्षर"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소문자"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY action name for the swipe that leaves the uppercase/caps-lock mode (VoiceOver)"
+    },
+    "Comma": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Komma"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Virgule"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coma"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Virgola"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запятая"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przecinek"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Komma"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pilkku"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zarez"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פסיק"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dấu phẩy"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kuwit"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κόμμα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vírgula"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кома"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فاصلة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ویرگول"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کوما"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "จุลภาค"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अल्पविराम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カンマ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "쉼표"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY action name for the comma swipe; scripts with their own mark (Arabic ، Japanese 、) inherit it (VoiceOver)"
+    },
+    "Period": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punkt"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Point"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punto"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Точка"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kropka"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punkt"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piste"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Točka"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "נקודה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dấu chấm"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tuldok"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τελεία"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ponto"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Крапка"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقطة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقطه"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقطہ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "มหัพภาค"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पूर्ण विराम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ピリオド"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마침표"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY action name for the full-stop swipe; scripts with their own mark (Japanese 。) inherit it (VoiceOver)"
+    },
+    "Question mark": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fragezeichen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Point d’interrogation"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signo de interrogación"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punto interrogativo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вопросительный знак"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Znak zapytania"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frågetecken"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kysymysmerkki"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upitnik"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סימן שאלה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dấu chấm hỏi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tandang pananong"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ερωτηματικό"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ponto de interrogação"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Знак питання"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "علامة استفهام"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "علامت سؤال"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سوالیہ نشان"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เครื่องหมายคำถาม"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "प्रश्नवाचक चिह्न"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "疑問符"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "물음표"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY action name for the question-mark swipe; the Arabic script substitutes ؟ (VoiceOver)"
     }
   },
   "version": "1.0"

--- a/wurstfinger/OnboardingProgress.swift
+++ b/wurstfinger/OnboardingProgress.swift
@@ -16,20 +16,48 @@ enum AppSettingsKey: String, CaseIterable {
 }
 
 enum OnboardingProgress {
-    /// The app's own defaults. The checklist records what the user ticked off
-    /// in this app; the keyboard never reads it, and every write into the
-    /// shared app-group suite fires a change notification the extension pays
-    /// for on its next appearance.
-    static let store: UserDefaults = .standard
+    /// The store the checklist binds to for a given process argument list.
+    ///
+    /// An ordinary launch keeps it in the app's own defaults: the checklist
+    /// records what the user ticked off in this app, the keyboard never reads
+    /// it, and every write into the shared app-group suite would cost the
+    /// extension a change notification on its next appearance.
+    ///
+    /// Under the UI-test isolation argument it follows `SharedDefaults.store`
+    /// into the throwaway suite instead. The checklist is the one screen a UI
+    /// test drives by tapping persisted state (`OnboardingView` binds the three
+    /// steps straight to these keys), and `continueAfterFailure = false` means
+    /// a failure between the tick and the untick never reaches a restore step —
+    /// so without the redirect the tester keeps a ticked checkbox in their real
+    /// app defaults.
+    static func resolvedStore(arguments: [String]) -> UserDefaults {
+        arguments.contains(SharedDefaults.isolatedStoreArgument) ? SharedDefaults.store : .standard
+    }
+
+    /// The app's own defaults, or the isolated suite under a UI test.
+    static let store: UserDefaults = resolvedStore(arguments: ProcessInfo.processInfo.arguments)
 
     /// Moves checklist state written by earlier versions out of the shared
     /// app-group container — without it, an updating user's ticked steps would
     /// come back unticked. Idempotent: the shared keys are removed after the
     /// copy, so a later run finds nothing to move.
+    ///
+    /// The identity guard is what stops the migration destroying the state it
+    /// exists to rescue when both parameters are the same store: the copy would
+    /// be skipped (the value is already under that key) and `removeObject` would
+    /// then delete the only copy there is. That is not hypothetical — an
+    /// isolated UI-test launch resolves `store` to `SharedDefaults.store`, so
+    /// the two really are one object.
+    ///
+    /// It compares instance identity, not domain identity, and
+    /// `UserDefaults(suiteName:)` hands out a fresh object per call: two objects
+    /// addressing one domain would slip past it. If either store ever becomes
+    /// such an instance, re-derive the argument rather than trusting the guard.
     static func migrateFromSharedStoreIfNeeded(
         from shared: UserDefaults = SharedDefaults.store,
         to local: UserDefaults = store
     ) {
+        guard shared !== local else { return }
         for key in AppSettingsKey.allCases {
             guard let value = shared.object(forKey: key.rawValue) else { continue }
             if local.object(forKey: key.rawValue) == nil {

--- a/wurstfinger/PrivacyInfo.xcprivacy
+++ b/wurstfinger/PrivacyInfo.xcprivacy
@@ -13,7 +13,8 @@
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-			<!-- Both reasons apply here, and both are exercised on every launch:
+			<!-- Both reasons apply here, and an ordinary launch exercises both
+			     (a UI test redirects them to a throwaway suite instead):
 			     1C8F.1 for the app group suite the settings screens write and the
 			     keyboard extension reads back (SharedDefaults.suiteName), CA92.1
 			     for the app's own defaults, where the onboarding checklist lives

--- a/wurstfinger/PrivacyInfo.xcprivacy
+++ b/wurstfinger/PrivacyInfo.xcprivacy
@@ -13,8 +13,15 @@
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<!-- Both reasons apply here, and both are exercised on every launch:
+			     1C8F.1 for the app group suite the settings screens write and the
+			     keyboard extension reads back (SharedDefaults.suiteName), CA92.1
+			     for the app's own defaults, where the onboarding checklist lives
+			     (OnboardingProgress.store) precisely because the extension has no
+			     business seeing it. -->
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
+				<string>1C8F.1</string>
 				<string>CA92.1</string>
 			</array>
 		</dict>

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -186,7 +186,7 @@ struct SettingsView: View {
                 SettingsRow(
                     icon: "square.resize", color: .orange,
                     title: "Key Aspect Ratio",
-                    subtitle: String(localized: "Current: \(String(format: "%.2f", keyAspectRatio)):1")
+                    subtitle: Self.keyAspectRatioSubtitle(for: keyAspectRatio)
                 )
             }
 
@@ -296,6 +296,33 @@ struct SettingsView: View {
             return String(localized: "\(list) (default: \(pinned.name))")
         }
         return list
+    }
+
+    /// The key aspect ratio subtitle, e.g. `Current: 1.00:1`.
+    ///
+    /// The ratio is substituted with `String(format:)` instead of the localized
+    /// string interpolation used everywhere else, on purpose: Foundation wraps
+    /// every interpolated argument in a bidi isolate (U+2068 … U+2069) as soon as
+    /// the resolved localization is right-to-left. That isolate covered only the
+    /// number, so the `:1` that lives at the end of the translated template fell
+    /// back to the Arabic/Hebrew paragraph direction and reordered — the subtitle
+    /// read `1:1.00`. Substituted plainly, the digits, the decimal point and the
+    /// colon form a single uninterrupted number run (UAX#9 rule W4 folds a lone
+    /// common separator between two numbers into the number type), which stays
+    /// left-to-right in every script.
+    ///
+    /// This is why the translated values must keep `:1` directly behind `%@`: a
+    /// space in between splits the run and the reordering returns.
+    /// `AspectRatioSubtitleTests` pins both halves of that contract.
+    ///
+    /// - Parameter bundle: Where the template is resolved from; `nil` is the
+    ///   main bundle. Only the tests pass one. Foundation inserts the isolate
+    ///   solely when the *resolved* localization is right-to-left, so under the
+    ///   English test localization this body and the interpolating one it
+    ///   replaced return byte-identical strings — resolving against the app's
+    ///   `ar.lproj` is the only way a test can fail on a revert.
+    static func keyAspectRatioSubtitle(for ratio: Double, bundle: Bundle? = nil) -> String {
+        String(format: String(localized: "Current: %@:1", bundle: bundle), String(format: "%.2f", ratio))
     }
 
     private var sizePositionDescription: String {

--- a/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
+++ b/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
@@ -88,10 +88,15 @@ enum CommonKeys {
         .circularCounterclockwise: cutAll,
     ]
 
+    /// Switches to the numeric mode. The label is the glyph sequence "123",
+    /// which VoiceOver reads as the *number* one hundred twenty-three, so the
+    /// tap carries a semantic name — as every neighbouring utility key does.
+    /// Its counterpart is `NumericLayouts.backToMain`, named "Letters".
     static let symbols = KeyConfig.utility(
         UtilitySlot.symbols, label: "123", action: .switchMode(ModeNames.numeric),
         swipeMode: .eightWay,
-        swipes: clipboardBindings
+        swipes: clipboardBindings,
+        accessibilityLabel: String(localized: "Numbers")
     )
 
     /// Space bar. The `zeroDigit` parameterizes the hold-for-digit output so
@@ -136,6 +141,30 @@ enum CommonKeys {
     /// Shared punctuation, symbol, compose, and action bindings for each grid slot.
     /// The factory merges these with language-specific center characters.
     /// Each KeyBinding includes both the primary action and an optional return-swipe action.
+    ///
+    /// **Which of these carry an `accessibilityLabel`, and why so few.** A label
+    /// is the opt-in for a VoiceOver custom action (`KeyConfig.accessibilityActions`)
+    /// and every named binding becomes a rotor entry on that key, so naming all
+    /// eight directions would put eight to sixteen entries on every letter key —
+    /// exactly what the opt-in exists to prevent. Until swipe outputs can be
+    /// offered as generated, spoken-glyph actions (follow-up design work), only
+    /// bindings that are unreachable without gestures *and* have no workaround
+    /// are named:
+    ///
+    /// - `,` `.` `?` — sentence punctuation. Auto-capitalization and the
+    ///   double-space shortcut can stand in for a period; nothing stands in for
+    ///   comma and question mark, and a keyboard that cannot end a question is
+    ///   not usable without gestures.
+    /// - `⇧` / `⇩` — deliberate capitalization. Auto-capitalization only produces
+    ///   sentence-initial capitals, so names and acronyms need the modifier. Both
+    ///   directions are named so that caps lock is not a one-way door: `⇧` in the
+    ///   caps-lock mode is a no-op, and `⇩` is the only way back.
+    ///
+    /// Letter bindings stay unnamed on purpose: a key's own center letter is
+    /// already reachable by activating it, and naming its other eight directions
+    /// is the flooding case above. Names state the *function*, not the glyph, so
+    /// `GridKeyboardFactory` hands them down when a layout substitutes its own
+    /// script's mark (Arabic `،`, Japanese `。`).
     static let defaultSlotBindings: [String: [GestureType: KeyBinding]] = [
         // MARK: topLeft
 
@@ -204,7 +233,8 @@ enum CommonKeys {
             ),
             .swipeLeft: KeyBinding(
                 label: "?", action: .commitText("?"), category: nil,
-                returnAction: .commitText("¿"), accessibilityLabel: nil
+                returnAction: .commitText("¿"),
+                accessibilityLabel: String(localized: "Question mark")
             ),
         ],
 
@@ -242,9 +272,16 @@ enum CommonKeys {
                 label: "|", action: .commitText("|"), category: nil,
                 returnAction: .commitText("¶"), accessibilityLabel: nil
             ),
+            // The name is the same in every mode this binding survives into:
+            // `KeyboardMode.replacingShiftUpBinding` repoints it to caps lock in
+            // the shifted mode and to a no-op in caps lock itself, which matches
+            // how a single shift key behaves everywhere else. The return swipe
+            // (`capitalizeWord`) cannot be named separately — a binding carries
+            // one label, and a custom action always dispatches `isReturn: false`.
             .swipeUp: KeyBinding(
                 label: "⇧", action: .switchMode(ModeNames.shifted), category: .modifier,
-                returnAction: .capitalizeWord(uppercased: true), accessibilityLabel: nil
+                returnAction: .capitalizeWord(uppercased: true),
+                accessibilityLabel: String(localized: "Shift")
             ),
             .swipeUpRight: KeyBinding(
                 label: "}", action: .commitText("}"), category: nil,
@@ -254,9 +291,12 @@ enum CommonKeys {
                 label: ")", action: .commitText(")"), category: nil,
                 returnAction: .commitText("("), accessibilityLabel: nil
             ),
+            // Only present in the shifted and caps-lock modes (the factory strips
+            // it from main). Named because it is the only way out of caps lock,
+            // where the ⇧ above switches to the mode it is already in.
             .swipeDown: KeyBinding(
                 label: "⇩", action: .switchMode(ModeNames.main), category: .modifier,
-                returnAction: nil, accessibilityLabel: nil
+                returnAction: nil, accessibilityLabel: String(localized: "Lowercase")
             ),
             .swipeDownRight: KeyBinding(
                 label: "]", action: .commitText("]"), category: nil,
@@ -310,11 +350,13 @@ enum CommonKeys {
             ),
             .swipeDown: KeyBinding(
                 label: ".", action: .commitText("."), category: nil,
-                returnAction: .commitText("…"), accessibilityLabel: nil
+                returnAction: .commitText("…"),
+                accessibilityLabel: String(localized: "Period")
             ),
             .swipeDownLeft: KeyBinding(
                 label: ",", action: .commitText(","), category: nil,
-                returnAction: .commitText(","), accessibilityLabel: nil
+                returnAction: .commitText(","),
+                accessibilityLabel: String(localized: "Comma")
             ),
         ],
 

--- a/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
+++ b/wurstfingerKeyboard/Definition/Language/CommonKeys.swift
@@ -272,12 +272,13 @@ enum CommonKeys {
                 label: "|", action: .commitText("|"), category: nil,
                 returnAction: .commitText("¶"), accessibilityLabel: nil
             ),
-            // The name is the same in every mode this binding survives into:
-            // `KeyboardMode.replacingShiftUpBinding` repoints it to caps lock in
-            // the shifted mode and to a no-op in caps lock itself, which matches
-            // how a single shift key behaves everywhere else. The return swipe
-            // (`capitalizeWord`) cannot be named separately — a binding carries
-            // one label, and a custom action always dispatches `isReturn: false`.
+            // `KeyboardMode.replacingShiftUpBinding` repoints this to caps lock
+            // in the shifted mode and to a no-op in caps lock itself, which
+            // matches how a single shift key behaves everywhere else — and it
+            // decides the name per mode, because the caps-lock no-op must not
+            // become a rotor action. The return swipe (`capitalizeWord`) cannot
+            // be named separately: a binding carries one label, and a custom
+            // action always dispatches `isReturn: false`.
             .swipeUp: KeyBinding(
                 label: "⇧", action: .switchMode(ModeNames.shifted), category: .modifier,
                 returnAction: .capitalizeWord(uppercased: true),

--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -94,7 +94,10 @@ enum GridKeyboardFactory {
                             : nil
                         bindings[gesture] = KeyBinding(
                             label: text, action: .commitText(text),
-                            category: nil, returnAction: returnAction, accessibilityLabel: nil
+                            category: nil, returnAction: returnAction,
+                            accessibilityLabel: inheritedAccessibilityName(
+                                replacing: bindings[gesture], isLetter: isLetter
+                            )
                         )
                     }
                 }
@@ -226,5 +229,27 @@ enum GridKeyboardFactory {
             numericBackToAlphaLabel: numericBackToAlphaLabel,
             numericDigits: numericDigits
         )
+    }
+
+    /// VoiceOver name a directional override inherits from the shared binding it
+    /// displaces, or nil when it must not inherit one.
+    ///
+    /// `CommonKeys.defaultSlotBindings` names `, . ?` after their *function*, not
+    /// their glyph, so a layout that puts its own script's mark on the same
+    /// gesture is still the comma (Arabic `،`), the full stop (Japanese `。`) or
+    /// the question mark (Arabic `؟`) — and dropping the name there would leave
+    /// exactly the RTL and CJK users the labelling was for with an unnamed key.
+    /// Two guards keep the inheritance honest:
+    ///
+    /// - a letter never inherits: "Comma" would be a lie on Japanese `ね`, and
+    ///   letters are deliberately unnamed (see `CommonKeys.defaultSlotBindings`);
+    /// - only a text-committing default hands its name down, so Hindi's danda on
+    ///   the midRight `⇩` gesture does not inherit the shift affordance's name.
+    private static func inheritedAccessibilityName(
+        replacing displaced: KeyBinding?,
+        isLetter: Bool
+    ) -> String? {
+        guard !isLetter, let displaced, case .commitText = displaced.action else { return nil }
+        return displaced.accessibilityLabel
     }
 }

--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -184,6 +184,11 @@ enum GridKeyboardFactory {
             let shiftedBase = baseMode.generateShifted(locale: locale)
 
             // 4. Shifted — shift-up points directly to capsLock (label stays ⇧).
+            // The VoiceOver name stays "Shift" too, although this step enters
+            // caps lock: it is one affordance progressing through its states,
+            // exactly like the visual ⇧ it mirrors, and announcing the middle
+            // step as "Caps Lock" would promise a mode the first activation
+            // does not enter. Deliberate, not an oversight.
             modes[ModeNames.shifted] = shiftedBase
                 .with(autoTransitions: [.letter: ModeNames.main])
                 .replacingShiftUpBinding(

--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -186,12 +186,21 @@ enum GridKeyboardFactory {
             // 4. Shifted — shift-up points directly to capsLock (label stays ⇧).
             modes[ModeNames.shifted] = shiftedBase
                 .with(autoTransitions: [.letter: ModeNames.main])
-                .replacingShiftUpBinding(label: "⇧", action: .switchMode(ModeNames.capsLock))
+                .replacingShiftUpBinding(
+                    label: "⇧", action: .switchMode(ModeNames.capsLock),
+                    accessibilityLabel: String(localized: "Shift")
+                )
 
             // 5. Caps lock — shift-up is no-op (stays in capsLock), label shows ⇪.
+            // Unnamed on purpose: a named binding becomes a VoiceOver rotor
+            // action, and this one would lead back to the mode it was invoked
+            // from. The ⇩ below is the labelled way out.
             modes[ModeNames.capsLock] = shiftedBase
                 .with(name: ModeNames.capsLock)
-                .replacingShiftUpBinding(label: "⇪", action: .switchMode(ModeNames.capsLock))
+                .replacingShiftUpBinding(
+                    label: "⇪", action: .switchMode(ModeNames.capsLock),
+                    accessibilityLabel: nil
+                )
 
             // 6. Main mode — remove shift-down hint from midRight (only shown in shifted/capsLock).
             modes[ModeNames.main] = baseMode

--- a/wurstfingerKeyboard/Definition/Language/KeyboardMode.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardMode.swift
@@ -83,14 +83,24 @@ struct KeyboardMode: Codable, Equatable {
 
     /// Returns a copy where the shift-up binding on midRight is replaced.
     /// Used to point shifted → capsLock and capsLock → capsLock (no-op).
-    func replacingShiftUpBinding(label: String, action: KeyAction) -> KeyboardMode {
+    ///
+    /// `accessibilityLabel` is passed rather than inherited because the two
+    /// uses disagree about it: the shifted mode's binding still does
+    /// something and deserves a name, the caps-lock one switches to the mode
+    /// it is already in and must stay unnamed, or `KeyConfig.accessibilityActions`
+    /// would offer VoiceOver a rotor entry that does nothing.
+    func replacingShiftUpBinding(
+        label: String,
+        action: KeyAction,
+        accessibilityLabel: String?
+    ) -> KeyboardMode {
         guard var midRight = keys[GridSlot.midRight],
               let existing = midRight.bindings[.swipeUp]
         else { return self }
         midRight.bindings[.swipeUp] = KeyBinding(
             label: label, action: action,
             category: existing.category, returnAction: existing.returnAction,
-            accessibilityLabel: existing.accessibilityLabel
+            accessibilityLabel: accessibilityLabel
         )
         var updatedKeys = keys
         updatedKeys[GridSlot.midRight] = midRight

--- a/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
+++ b/wurstfingerKeyboard/Definition/Language/NumericLayouts.swift
@@ -76,11 +76,16 @@ enum NumericLayouts {
 
     // MARK: - Numeric Utility Keys
 
+    /// Switches back to the main (alphabetic) mode. The label is the script's
+    /// first letters ("abc", "абв", "कखग"), which VoiceOver spells out or reads
+    /// as a nonsense word, so the tap carries a semantic name that is the same in
+    /// every layout — the counterpart to `CommonKeys.symbols`, named "Numbers".
     private static func backToMain(label: String) -> KeyConfig {
         KeyConfig.utility(
             UtilitySlot.symbols, label: label, action: .switchMode(ModeNames.main),
             swipeMode: .eightWay,
-            swipes: CommonKeys.clipboardBindings
+            swipes: CommonKeys.clipboardBindings,
+            accessibilityLabel: String(localized: "Letters")
         )
     }
 

--- a/wurstfingerKeyboard/Definition/Model/KeyConfig+Accessibility.swift
+++ b/wurstfingerKeyboard/Definition/Model/KeyConfig+Accessibility.swift
@@ -42,7 +42,10 @@ extension KeyConfig {
     ///
     /// A binding qualifies by carrying an `accessibilityLabel`: that label is
     /// what a VoiceOver user hears, and it doubles as the opt-in, so a letter
-    /// or punctuation swipe does not add eight unnamed entries to every key.
+    /// swipe does not add eight unnamed entries to every key. Which bindings
+    /// take the opt-in is a deliberate, narrow choice — the utility keys plus
+    /// `, . ?` and the shift affordance; `CommonKeys.defaultSlotBindings`
+    /// documents the reasoning and `AccessibilityLabelTests` pins the set.
     /// Names are deduplicated — cut-all is bound to both circle directions
     /// with one label, and two identical rotor entries read as a bug.
     var accessibilityActions: [KeyAccessibilityAction] {

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -205,7 +205,8 @@ final class KeyboardViewController: UIInputViewController {
     /// autorelease pool so UIKit's teardown temporaries are gone before the
     /// health-log entry samples `phys_footprint`; the sample is still an upper
     /// bound on what survives to suspension, since the allocator need not have
-    /// returned every freed page to the kernel by then.
+    /// returned every freed page to the kernel by then — which is why the
+    /// guaranteed entry is paired with a deferred second one below.
     private func shedMemoryBeforeSuspension(_ event: String) {
         autoreleasepool {
             KeyboardRegistry.evictAll(except: selectedLanguageId)
@@ -218,11 +219,56 @@ final class KeyboardViewController: UIInputViewController {
         }
         // Flushed, not queued: the suspended process may never run again — a
         // resume-jetsam kills it on wake before an async write would get CPU
-        // time — and this entry, the footprint that actually survives to
-        // suspension, is the one those incidents need. Unlike launch, this
-        // path is not latency-critical.
+        // time — and this entry is the closest guaranteed record of the
+        // footprint that survives to suspension. Unlike launch, this path is
+        // not latency-critical.
         KeyboardHealthLog.shared.recordAndFlush(event)
+        // The guaranteed entry is measurably too pessimistic, though: reclaim
+        // of the torn-down hosting graph only completes 1–2 s after
+        // `teardownHosting()`, so it read 1.3–3.3 MB (2.8–7.3 %) above the
+        // externally sampled floor in every measured dismissal — exactly the
+        // direction that misleads a resume-jetsam post-mortem into
+        // over-crediting headroom near the per-process limit. Hence a second,
+        // late sample of the same event. It is best effort by construction:
+        // queued and never awaited, so it cannot delay suspension, and
+        // captured on the shared log alone, so the graph just released stays
+        // released.
+        //
+        // Best effort is not the same as harmless, though: a frozen process
+        // does not drop the pending block — libdispatch runs an overdue timer
+        // as soon as the process is scheduled again, which for a reused
+        // extension can be a host cycle later, against a keyboard rebuilt in
+        // the meantime. Two guards keep the label honest: the item is
+        // cancelled once a hosting graph exists again (`configureHosting`),
+        // and `recordDeferred` discards a sample that starts more than its own
+        // delay late. A second shed supersedes a still-pending one here for
+        // the same reason — the token holds one item, and one it no longer
+        // points to is one nothing can cancel. Either way the pessimistic
+        // entry above stands, and the next launch's `viewDidLoad.start`
+        // remains the fallback truth — the one sample a frozen process cannot
+        // miss.
+        Self.pendingSettledSample?.cancel()
+        Self.pendingSettledSample = KeyboardHealthLog.shared.recordDeferred(
+            "postShedSettled",
+            after: Self.postShedSettleDelay
+        )
     }
+
+    /// How long the deferred post-shedding sample waits before reading the
+    /// footprint again: long enough to be past the measured 1–2 s reclaim of
+    /// the hosting graph, short enough to stay inside the window in which a
+    /// just-backgrounded extension still gets CPU (measured: it lands).
+    private static let postShedSettleDelay: TimeInterval = 2
+
+    /// The post-shedding sample still waiting to fire, if any.
+    ///
+    /// Static, not per instance: a host foreground return builds a *new*
+    /// controller in the same extension process (see `observeHostLifecycle`),
+    /// so the instance that queued the sample is usually gone by the time the
+    /// keyboard that invalidates it is rebuilt. The token has to outlive it to
+    /// be reachable from there at all. Only ever touched from the shedding and
+    /// hosting paths, both of which are main-thread-only.
+    private static var pendingSettledSample: DispatchWorkItem?
 
     /// Covers the hole the hosting teardown would leave in the host app's
     /// app-switcher card: iOS takes that snapshot *after* the host
@@ -263,12 +309,39 @@ final class KeyboardViewController: UIInputViewController {
         hostingController = nil
     }
 
-    /// The keyboard can be suspended without `viewDidDisappear` ever firing:
-    /// when the host app itself backgrounds while the keyboard is on screen
-    /// (home gesture, app switch, tapping a Spotlight result), the view stays
-    /// in the hierarchy and only the host lifecycle notifications fire — so
-    /// the pre-suspension shedding must hook them too. The foreground record
-    /// documents survived resumes in the health log.
+    /// Covers the case where the host app itself backgrounds while the
+    /// keyboard is on screen (home gesture, app switch, tapping a Spotlight
+    /// result): the view is expected to stay in the hierarchy, so
+    /// `viewDidDisappear` would never fire and only these notifications would
+    /// announce the coming suspension — the pre-suspension shedding has to
+    /// hook them too. The foreground record documents survived resumes in the
+    /// health log.
+    ///
+    /// Measured on the iOS 26 *simulator*, the opposite happens, and the
+    /// observers are kept anyway. In 3/3 host-background cycles with the
+    /// keyboard up, iOS delivered `viewDidDisappear` and no `NSExtensionHost*`
+    /// notification at all (zero entries in the health log and in the unified
+    /// log, while every view-lifecycle event appeared in both), and every
+    /// foreground return rebuilt the entire controller — `viewDidLoad` →
+    /// `viewWillAppear` → `viewDidAppear`, a new instance in the same
+    /// extension process. Three consequences worth knowing before reading a
+    /// log or changing this code:
+    ///
+    /// - Shedding is covered either way; there the `viewDidDisappear` path
+    ///   does it, so nothing leaks by these blocks not running.
+    /// - The one deliberate difference of the foreground path — keeping the
+    ///   active mode (`resettingLayer: false`) because the user comes back to
+    ///   the same field mid-typing — never takes effect there: the rebuild
+    ///   goes through `viewWillAppear` and reopens on the default mode.
+    /// - No `hostDidEnterBackground`/`hostWillEnterForeground` entry appeared
+    ///   in any measured simulator cycle, so their absence from a simulator
+    ///   log is the expected reading and proves nothing about this code. The
+    ///   same absence on a device would be evidence — see below.
+    ///
+    /// Whether a physical device delivers the notifications, and whether the
+    /// keep-the-mode path therefore engages at all, is unverified (open
+    /// on-device item from #277) — which is precisely why these observers stay
+    /// until someone has measured it on real hardware.
     private func observeHostLifecycle() {
         let center = NotificationCenter.default
         hostLifecycleObservers.append(center.addObserver(
@@ -365,6 +438,14 @@ final class KeyboardViewController: UIInputViewController {
     /// AttributeGraph overhead — every byte matters under the extension's
     /// jetsam budget.
     private func configureHosting() {
+        // A live hosting graph voids a pending post-shedding sample: it would
+        // weigh the rebuilt keyboard under a label forensics reads as the
+        // suspension floor. Cancelling an item that has not started keeps it
+        // from ever running; the residual window — the rebuild landing while
+        // the sample is already executing on the log's queue — is microseconds
+        // wide and costs one over-reported diagnostics entry.
+        Self.pendingSettledSample?.cancel()
+        Self.pendingSettledSample = nil
         guard hostingController == nil else { return }
         let rootView = DataDrivenKeyboardRootView(viewModel: viewModel)
         let controller = UIHostingController(rootView: rootView)

--- a/wurstfingerKeyboard/Localizable.xcstrings
+++ b/wurstfingerKeyboard/Localizable.xcstrings
@@ -115,7 +115,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "สลับคีย์บอร์ด"
+            "value": "สลับแป้นพิมพ์"
           }
         },
         "hi": {
@@ -253,7 +253,7 @@
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "ซ่อนคีย์บอร์ด"
+            "value": "ซ่อนแป้นพิมพ์"
           }
         },
         "hi": {
@@ -1099,7 +1099,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "모두 잘라내기"
+            "value": "모두 오려두기"
           }
         }
       },
@@ -1380,6 +1380,972 @@
         }
       },
       "comment": "ACCESSIBILITY label for the space bar (VoiceOver)"
+    },
+    "Numbers": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zahlen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiffres"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Números"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Numeri"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цифры"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cyfry"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siffror"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Numerot"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brojevi"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "מספרים"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Số"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga numero"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Αριθμοί"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Números"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цифри"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أرقام"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اعداد"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اعداد"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวเลข"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अंक"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "数字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "숫자"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the 123 key that switches to the numeric mode (VoiceOver)"
+    },
+    "Letters": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buchstaben"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettres"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letras"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lettere"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Буквы"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Litery"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bokstäver"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kirjaimet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slova"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אותיות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chữ cái"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mga letra"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Γράμματα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letras"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Літери"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أحرف"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حروف"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حروف"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวอักษร"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अक्षर"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글자"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY label for the abc key that switches back to the alphabetic mode (VoiceOver)"
+    },
+    "Shift": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Großbuchstaben"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Majuscules"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mayúsculas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maiuscole"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Верхний регистр"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wielkie litery"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versaler"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isot kirjaimet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velika slova"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אותיות רישיות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chữ hoa"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Malaking titik"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κεφαλαία"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maiúsculas"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Верхній регістр"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أحرف كبيرة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حروف بزرگ"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بڑے حروف"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวพิมพ์ใหญ่"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "बड़े अक्षर"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "大文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대문자"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY action name for the shift swipe that switches to the uppercase mode (VoiceOver)"
+    },
+    "Lowercase": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kleinbuchstaben"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minuscules"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minúsculas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minuscole"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нижний регистр"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Małe litery"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gemener"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pienet kirjaimet"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mala slova"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אותיות קטנות"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chữ thường"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maliit na titik"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Πεζά"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minúsculas"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нижній регістр"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أحرف صغيرة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حروف کوچک"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چھوٹے حروف"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวพิมพ์เล็ก"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "छोटे अक्षर"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小文字"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소문자"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY action name for the swipe that leaves the uppercase/caps-lock mode (VoiceOver)"
+    },
+    "Comma": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Komma"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Virgule"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coma"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Virgola"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запятая"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przecinek"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Komma"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pilkku"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zarez"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "פסיק"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dấu phẩy"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kuwit"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κόμμα"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vírgula"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кома"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فاصلة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ویرگول"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "کوما"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "จุลภาค"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "अल्पविराम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カンマ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "쉼표"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY action name for the comma swipe; scripts with their own mark (Arabic ، Japanese 、) inherit it (VoiceOver)"
+    },
+    "Period": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punkt"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Point"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punto"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Точка"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kropka"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punkt"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Piste"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Točka"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "נקודה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dấu chấm"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tuldok"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Τελεία"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ponto"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Крапка"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقطة"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقطه"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نقطہ"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "มหัพภาค"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पूर्ण विराम"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ピリオド"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마침표"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY action name for the full-stop swipe; scripts with their own mark (Japanese 。) inherit it (VoiceOver)"
+    },
+    "Question mark": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fragezeichen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Point d’interrogation"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signo de interrogación"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Punto interrogativo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вопросительный знак"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Znak zapytania"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frågetecken"
+          }
+        },
+        "fi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kysymysmerkki"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upitnik"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סימן שאלה"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dấu chấm hỏi"
+          }
+        },
+        "fil": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tandang pananong"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ερωτηματικό"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ponto de interrogação"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Знак питання"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "علامة استفهام"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "علامت سؤال"
+          }
+        },
+        "ur": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سوالیہ نشان"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เครื่องหมายคำถาม"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "प्रश्नवाचक चिह्न"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "疑問符"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "물음표"
+          }
+        }
+      },
+      "comment": "ACCESSIBILITY action name for the question-mark swipe; the Arabic script substitutes ؟ (VoiceOver)"
     }
   },
   "version": "1.0"

--- a/wurstfingerKeyboard/PrivacyInfo.xcprivacy
+++ b/wurstfingerKeyboard/PrivacyInfo.xcprivacy
@@ -13,8 +13,16 @@
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<!-- 1C8F.1 is the whole story in practice: every setting the keyboard
+			     reads lives in the app group suite it shares with the host app
+			     (SharedDefaults.suiteName), which is verbatim the app-group case.
+			     CA92.1 covers the one other store this target can end up on: if
+			     UserDefaults(suiteName:) ever returned nil, SharedDefaults falls
+			     back to .standard — a debug assertion in development, but in a
+			     release build a silent fallback to this process' own defaults. -->
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
+				<string>1C8F.1</string>
 				<string>CA92.1</string>
 			</array>
 		</dict>

--- a/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
@@ -45,6 +45,11 @@
 //     - Handles touch glitches and multitouch interference
 //     - Keeps points consistent with a raw neighbor, so a single dropped-frame
 //       gap cannot cascade and discard the rest of a genuine fast swipe
+//     - Velocity-aware: a jump that continues the movement the finger was
+//       already making — same direction to within 45°, at most three times
+//       the established step and never beyond 3x maxJumpDistance — is kept,
+//       so a flick covering more than maxJumpDistance per sample is not read
+//       as a teleport
 //
 //  3. **Aspect Ratio Normalization**: Divides X by aspect ratio
 //     - Makes horizontal and vertical movements comparable on non-square keys
@@ -258,18 +263,50 @@ struct GesturePreprocessor {
     /// dropped-frame gap leaves the anchor stuck before the gap, so every
     /// later sample of a genuine fast swipe (or of a re-anchored long drag
     /// whose retained window sits far from the origin) would be discarded
-    /// too. Consistency with a raw neighbor proves real motion, so only
-    /// isolated glitch points are removed.
+    /// too. Consistency with a raw neighbor proves real motion; the ceiling
+    /// below is what stops a ghost cluster from vouching for itself.
+    ///
+    /// Those criteria all measure *where* a sample landed. The last one
+    /// measures *how the finger got there*, and it is the only evidence that
+    /// separates the two cases this filter has to tell apart — a touch glitch
+    /// and a violent flick land in the same place, but the glitch appears out
+    /// of a near-stationary path while the flick is preceded by a finger
+    /// already covering that ground every sample. Without it a fling faster
+    /// than `maxJumpDistance` per sample had *every* sample discarded and
+    /// committed the key's center letter, while the gesture trail — which
+    /// draws the raw path — showed the full swipe (review 2026-08-09,
+    /// finding 3).
+    ///
+    /// Accepting a point moves the anchor onto it, so a glitch let in here is
+    /// paid for twice: the genuine sample after it is then measured from the
+    /// glitch and can fail every criterion. That is why `isSameMovement` is
+    /// deliberately narrow — a jump has to continue the established direction
+    /// to within 45° and stay inside three times the established step.
+    ///
+    /// The one shape it cannot resolve is a jump straight out of the origin.
+    /// How long the finger rested there would separate a tap from a launch,
+    /// but the jitter filter has already collapsed that dwell by the time this
+    /// filter runs, so a tap followed by two consistently-moving interference
+    /// samples arrives byte-identical to a finger that landed already flying.
+    /// Both are accepted; what bounds the damage is the magnitude ceiling in
+    /// `isSameMovement`, not the shape. Separating them needs the pipeline
+    /// order changed (or the trail clamped to post-filter samples), which is
+    /// the structural half of finding 3 and is not attempted here.
     func filterOutliers(_ points: [CGPoint]) -> [CGPoint] {
         guard points.count >= 2 else { return points }
 
         var filtered: [CGPoint] = [points[0]]
+        // Step between the two most recently accepted samples — the velocity
+        // the accepted path has established so far. Nil while the origin is
+        // the entire accepted path.
+        var acceptedStep: CGVector?
 
         for i in 1 ..< points.count {
             // Safe: filtered always has at least one element (initialized with points[0])
             guard let lastAccepted = filtered.last else { continue }
             let current = points[i]
 
+            let step = CGVector(dx: current.x - lastAccepted.x, dy: current.y - lastAccepted.y)
             let distanceToAccepted = current.distance(to: lastAccepted)
             let nearAccepted = distanceToAccepted <= config.maxJumpDistance
             let nearRawPrevious = current.distance(to: points[i - 1]) <= config.maxJumpDistance
@@ -287,10 +324,16 @@ struct GesturePreprocessor {
             let supportIsPlausible = distanceToAccepted <= ceiling
                 || consistentRunLength(in: points, at: i) >= Self.sustainedRunMinimumLength
 
-            if nearAccepted || ((nearRawPrevious || nearRawNext) && supportIsPlausible) {
+            if nearAccepted
+                || ((nearRawPrevious || nearRawNext) && supportIsPlausible)
+                || continuesEstablishedMotion(step, after: acceptedStep, in: points, at: i) {
                 filtered.append(current)
+                acceptedStep = step
             }
-            // Isolated or clustered outlier: skip
+            // Isolated or clustered outlier: skip — and leave `acceptedStep`
+            // alone, so a rejected glitch never raises the velocity that would
+            // admit the next one. An *accepted* one cannot either: the
+            // reference is capped in `isSameMovement`.
         }
 
         return filtered
@@ -322,6 +365,96 @@ struct GesturePreprocessor {
             forward += 1
         }
         return length
+    }
+
+    /// A jump may be this multiple of the step the finger was already
+    /// covering — itself capped at `maxJumpDistance`, see `isSameMovement` —
+    /// and still count as the same movement.
+    ///
+    /// Sized against the two regimes it separates. The rule only ever runs for
+    /// jumps beyond `maxJumpDistance`, so the reference step is already a
+    /// third of that (≈17 pt per sample at the default — a finger crossing two
+    /// key heights in about six frames) before anything can be accepted at
+    /// all. The cap is what keeps the number meaning something: an accepted
+    /// jump becomes the next sample's reference, so without it every
+    /// admission would triple the allowance for the one after it and a chain
+    /// of ever-longer jumps would walk itself off the key. With it the rule
+    /// can never admit more than 3 × `maxJumpDistance` — 150 pt per sample at
+    /// the default, ≈1.4 m/s at 60 Hz, about three times the fling it exists
+    /// for.
+    private static let velocityToleranceFactor: CGFloat = 3
+
+    /// How far a jump may turn away from the established direction and still
+    /// count as the same movement, as a cosine: one swipe sector (45°).
+    ///
+    /// A finger that crosses a key in a single frame does not also change
+    /// direction in it. The half-plane this replaced — any angle short of a
+    /// right angle — admitted a near-perpendicular jump at three times the
+    /// established step, which flipped the committed direction of ordinary
+    /// fast swipes carrying one trailing glitch sample (review 2026-08-09).
+    private static let minimumDirectionCosine = CGFloat(cos(Double.pi / 4))
+
+    /// Whether the jump onto `points[i]` continues the movement the finger was
+    /// already making.
+    ///
+    /// `previousStep` is the velocity the accepted path established, and it
+    /// wins whenever there is one. Before that — the first sample after
+    /// touch-down, where the whole accepted path is the origin — the only
+    /// available evidence is the step that *follows*: a finger that lands
+    /// already moving keeps moving at a comparable rate, whereas a glitch
+    /// lands once and stops. That premise is an assumption, and a glitch that
+    /// moves consistently for two samples defeats it — see `filterOutliers`
+    /// for why nothing available here can tell that case from a real launch,
+    /// and what bounds it instead.
+    ///
+    /// A trailing jump has no following step, so it is judged against
+    /// `previousStep` alone, and only when the accepted path is still just the
+    /// origin does it have no evidence at all and stay an outlier. What keeps
+    /// a glitch at the end of a tap out is therefore how far it jumped, not
+    /// where it sits in the path: a tap establishes a step of a few points and
+    /// `isSameMovement` allows three times that, while the glitch is beyond
+    /// `maxJumpDistance`. A finger already travelling `maxJumpDistance`/3 per
+    /// sample does carry a trailing jump in — deliberately, since the last
+    /// sample of a genuine flick is itself one.
+    private func continuesEstablishedMotion(
+        _ step: CGVector,
+        after previousStep: CGVector?,
+        in points: [CGPoint],
+        at i: Int
+    ) -> Bool {
+        guard let reference = previousStep ?? followingRawStep(in: points, at: i) else { return false }
+        return isSameMovement(reference, step)
+    }
+
+    /// The raw step leading away from `points[i]`, or nil when it is the last
+    /// sample.
+    private func followingRawStep(in points: [CGPoint], at i: Int) -> CGVector? {
+        guard i + 1 < points.count else { return nil }
+        return CGVector(dx: points[i + 1].x - points[i].x, dy: points[i + 1].y - points[i].y)
+    }
+
+    /// Two steps belong to one movement when they point the same way to within
+    /// `minimumDirectionCosine` and the second does not explode in length.
+    ///
+    /// The direction test is what rejects an out-and-back teleport, whose two
+    /// steps are both long but opposed — a shape that a magnitude comparison
+    /// alone would happily accept — and, as a cone rather than a half-plane,
+    /// the sideways glitch: past a 45° turn the accepted sample pulls the
+    /// max-displacement angle far enough that the swipe can commit out of the
+    /// sector the finger was travelling towards.
+    ///
+    /// The reference is capped at `maxJumpDistance` so that a jump this rule
+    /// admits cannot raise the allowance for the next one. A zero-length
+    /// reference establishes no direction; the guard says so rather than
+    /// leaning on the magnitude test, which happens to reject it too because a
+    /// zero budget admits no step.
+    private func isSameMovement(_ reference: CGVector, _ step: CGVector) -> Bool {
+        let referenceLength = hypot(reference.dx, reference.dy)
+        let stepLength = hypot(step.dx, step.dy)
+        let budget = min(referenceLength, config.maxJumpDistance)
+        guard budget > 0, stepLength <= budget * Self.velocityToleranceFactor else { return false }
+        return reference.dx * step.dx + reference.dy * step.dy
+            >= Self.minimumDirectionCosine * referenceLength * stepLength
     }
 
     // MARK: - Step 3: Aspect Ratio Normalization

--- a/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/KeyGestureRecognizer.swift
@@ -106,7 +106,7 @@ struct KeyGestureRecognizer: ViewModifier {
     var trail: GestureTrailRecorder?
 
     @State private var sequence = KeyGestureSequence()
-    @State private var longPress = LongPressScheduler()
+    @State private var longPress: LongPressScheduler
     /// Identifies this key's touch sequence to the shared trail recorder.
     @StateObject private var trailToken = GestureTrailToken()
     @Binding var isActive: Bool
@@ -116,6 +116,32 @@ struct KeyGestureRecognizer: ViewModifier {
     /// touches (incoming call, edge swipe, keyboard dismissal), where
     /// `onEnded` is never called — the reset is our cancellation signal.
     @GestureState private var sequenceInFlight = false
+
+    /// - Parameter longPress: The scheduler this recognizer arms. Held in
+    ///   `@State` so it survives body re-evaluations, and injectable so a test
+    ///   can arm it from the outside and then observe what teardown does to
+    ///   it. Without that seam the `onDisappear` → `abandonSequence()` wiring
+    ///   is unobservable from a unit test: arming it through the real gesture
+    ///   needs touch events the test target cannot synthesize. Mutation
+    ///   testing found the wiring unpinned for exactly that reason (review
+    ///   2026-08-09, finding 15).
+    init(
+        onGestureRecognized: @escaping (GestureClassification) -> Void,
+        onTouchDown: @escaping () -> Void,
+        aspectRatio: CGFloat,
+        onLongPress: (() -> Bool)? = nil,
+        trail: GestureTrailRecorder? = nil,
+        isActive: Binding<Bool>,
+        longPress: LongPressScheduler = LongPressScheduler()
+    ) {
+        self.onGestureRecognized = onGestureRecognized
+        self.onTouchDown = onTouchDown
+        self.aspectRatio = aspectRatio
+        self.onLongPress = onLongPress
+        self.trail = trail
+        _isActive = isActive
+        _longPress = State(initialValue: longPress)
+    }
 
     func body(content: Content) -> some View {
         content
@@ -208,6 +234,27 @@ struct KeyGestureRecognizer: ViewModifier {
     /// reads live `@State` (`sequence`) at fire time through the property
     /// wrapper. A fired press has typed its digit, so its trail freezes and
     /// fades like any other completed keystroke.
+    ///
+    /// The armed timer deliberately survives a mode switch that keeps this key
+    /// alive — an accepted tradeoff, re-derived exhaustively in the
+    /// 2026-08-09 review (finding 14) and recorded here so it does not get
+    /// re-litigated:
+    ///
+    /// * A `.longPress` resolves to exactly two things: the space bar's zero
+    ///   binding and the `GhostKeyResolver`'s digit-category tap fallback.
+    ///   Everything else leaves the touch unconsumed and classifies normally
+    ///   on release, so nothing else can fire late.
+    /// * A key that is *removed* by the switch tears the hold down through
+    ///   `onDisappear` → `abandonSequence()`. The portrait letters ↔ numeric
+    ///   switch moves the space and return cells structurally, so a space hold
+    ///   is torn down rather than surviving it.
+    /// * For a pure mode switch that keeps the slot, the digit that fires is
+    ///   the same one the uninterrupted hold would have typed — the numeric
+    ///   fallback is shared. The only observable deviation is a mid-hold
+    ///   *language* switch, i.e. a 0.7 s two-thumb race on an opt-in feature.
+    ///
+    /// Closing it would mean cancelling the timer from an `onChange` of the
+    /// active mode; it is not worth the extra state for that window.
     private func scheduleLongPress() {
         guard onLongPress != nil else { return }
         longPress.schedule {

--- a/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/SlideGestureHandler.swift
@@ -240,7 +240,7 @@ struct SlideGestureHandler: ViewModifier {
     @Binding var isActive: Bool
 
     @State private var state = SlideGestureState()
-    @State private var longPress = LongPressScheduler()
+    @State private var longPress: LongPressScheduler
     /// Identifies this key's touch sequence to the shared trail recorder.
     @StateObject private var trailToken = GestureTrailToken()
 
@@ -249,6 +249,29 @@ struct SlideGestureHandler: ViewModifier {
     /// touches (incoming call, edge swipe, keyboard dismissal), where
     /// `onEnded` is never called — the reset is our cancellation signal.
     @GestureState private var sequenceInFlight = false
+
+    /// - Parameter longPress: The scheduler this handler arms. Same contract
+    ///   and same reason for being injectable as
+    ///   `KeyGestureRecognizer.init(…)`: it is the only handle a unit test has
+    ///   on the `onDisappear` → `abandonSequence()` teardown, which mutation
+    ///   testing found unpinned (review 2026-08-09, finding 15).
+    init(
+        slideType: SlideType,
+        onSlide: @escaping (SlidePhase) -> Void,
+        onTouchDown: @escaping () -> Void,
+        onLongPress: (() -> Bool)? = nil,
+        trail: GestureTrailRecorder? = nil,
+        isActive: Binding<Bool>,
+        longPress: LongPressScheduler = LongPressScheduler()
+    ) {
+        self.slideType = slideType
+        self.onSlide = onSlide
+        self.onTouchDown = onTouchDown
+        self.onLongPress = onLongPress
+        self.trail = trail
+        _isActive = isActive
+        _longPress = State(initialValue: longPress)
+    }
 
     func body(content: Content) -> some View {
         content
@@ -346,6 +369,11 @@ struct SlideGestureHandler: ViewModifier {
     /// does not share, because only slide keys can latch a slide. A fired
     /// press has typed its digit, so its trail freezes and fades like any
     /// other completed keystroke.
+    ///
+    /// What an armed timer may still do across a mode switch that keeps this
+    /// key alive is bounded in `KeyGestureRecognizer.scheduleLongPress()` —
+    /// the space bar's zero binding is one of the two actions that bound
+    /// reaches.
     private func scheduleLongPress() {
         guard onLongPress != nil else { return }
         longPress.schedule {

--- a/wurstfingerKeyboard/Runtime/Pipeline/AdvancedTextMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/AdvancedTextMiddleware.swift
@@ -134,6 +134,24 @@ struct AdvancedTextMiddleware: ActionMiddleware {
 
     private func handlePaste(target: TextInputTarget) {
         guard target.hasFullAccess else { return }
+        // The pasteboard is the gesture path's only external I/O — the writes in
+        // handleCopy/handleCut/handleCutAll cross to pasteboardd on this same
+        // thread — but this read is the one that can end up waiting on something
+        // other than the daemon, and that is an accepted tradeoff: a Universal
+        // Clipboard item makes the getter wait for the transfer from the other
+        // device, and under the "Ask" paste permission it waits for the system
+        // alert — the keyboard's main thread sits inside this line for as long
+        // as that takes. What makes it acceptable rather than a hang: both are
+        // user-initiated (this is a paste swipe), the system narrates them with
+        // its own HUD or alert, the host app stays responsive throughout, and
+        // UIKit's own paste blocks exactly the same way. `hasStrings` is no
+        // escape — the fetch is what blocks, not the emptiness check.
+        //
+        // If it ever has to become non-blocking: read asynchronously through
+        // `itemProviders`/`loadObject`, hop back to the main thread to insert,
+        // and drop the result if the gesture that asked for it is no longer the
+        // current one — by then the cursor may have moved or the keyboard may
+        // have been torn down.
         if let text = UIPasteboard.general.string, !text.isEmpty {
             // Cap pasted text so a multi-MB pasteboard cannot blow the
             // keyboard extension's jetsam memory budget. Truncates silently.

--- a/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
@@ -29,9 +29,13 @@ import os
 /// measurement is attributed to the right lifecycle point) but persists on a
 /// serial utility queue — file I/O must not sit in the keyboard's launch
 /// path. The suspension path uses `recordAndFlush` instead: there the write
-/// must land before the process is frozen, and latency does not matter. A
-/// host-app clear racing an extension write can lose one side — acceptable
-/// for diagnostics, and the file stays bounded by `maxEntries` either way.
+/// must land before the process is frozen, and latency does not matter.
+/// `recordDeferred` covers the one case neither serves — a figure that is
+/// only correct some time *after* the call site — and is allowed to go
+/// missing: the caller can cancel it, and a sample that arrives long after
+/// its deadline is discarded rather than logged (see there). A host-app clear
+/// racing an extension write can lose one side — acceptable for diagnostics,
+/// and the file stays bounded by `maxEntries` either way.
 struct KeyboardHealthLog {
     struct Entry: Codable, Equatable, Identifiable {
         let id: UUID
@@ -47,10 +51,20 @@ struct KeyboardHealthLog {
         let availableMB: Double
     }
 
-    /// Bounds the log file (~50 KB). A cold start records four entries, and
-    /// every open→close cycle three — `viewWillAppear`, `viewDidAppear`, and
-    /// the suspension entry that closes it — so this holds roughly a hundred
-    /// cycles: still days of typical usage.
+    /// Bounds the log file (~50 KB). A cold start records four entries, and a
+    /// cleanly closed open→close cycle up to four — `viewWillAppear`,
+    /// `viewDidAppear`, the suspension entry that closes it, and the deferred
+    /// `postShedSettled` sample that follows it (see
+    /// `KeyboardViewController.shedMemoryBeforeSuspension`) — so this holds
+    /// roughly seventy cycles: still days of typical usage.
+    ///
+    /// "Cleanly closed" is not guaranteed. When the host app is killed
+    /// outright while the keyboard is on screen, iOS calls nothing back: no
+    /// closing entry is written and no shedding runs, so the log jumps from
+    /// `viewDidAppear` straight to the next launch's `viewDidLoad.start`. That
+    /// gap is a legible signature, not a defect of the log — it is the one
+    /// path on which the extension idles at its full pre-shed weight until the
+    /// system reaps it. No callback exists to close the cycle at the source.
     static let defaultMaxEntries = 300
 
     static let fileName = "keyboard-health-log.json"
@@ -116,6 +130,43 @@ struct KeyboardHealthLog {
     func recordAndFlush(_ label: String) {
         let entry = makeEntry(label)
         Self.ioQueue.sync { appendEntry(entry) }
+    }
+
+    /// Records an entry whose footprint is sampled `delay` seconds from now,
+    /// on a strictly best-effort basis, and hands back the pending work item
+    /// so the caller can void it once the premise it was queued under stops
+    /// holding.
+    ///
+    /// The inverse of the other two: they sample at the call site precisely so
+    /// the figure belongs to that lifecycle point, while this one deliberately
+    /// samples *late*, for the case where the interesting number only becomes
+    /// true after something the call site cannot wait for has settled (the
+    /// kernel reclaiming a torn-down view graph takes another 1–2 s). Queued,
+    /// never awaited, so it cannot delay the caller.
+    ///
+    /// Nothing is promised, and the two ways the entry can go missing are both
+    /// deliberate. A process that dies before the timer fires loses it — hence
+    /// callers must treat this as a refinement of an already-recorded
+    /// guaranteed entry, never as the record itself. A process that is merely
+    /// *frozen* does not lose it: libdispatch has no drop-on-overdue policy,
+    /// so the block runs as soon as the process is scheduled again — possibly
+    /// minutes later and inside the next host cycle, since the extension
+    /// process is reused. That sample would describe the resumed process while
+    /// carrying the label of the earlier one, so a block that starts more than
+    /// its own delay late writes nothing.
+    @discardableResult
+    func recordDeferred(_ label: String, after delay: TimeInterval) -> DispatchWorkItem {
+        let deadline = DispatchTime.now() + delay
+        // Overdue by more than the wait itself: no process that kept running
+        // is that far behind, so whatever the sample would read now belongs to
+        // a different situation than the label names.
+        let discardAfter = deadline + delay
+        let item = DispatchWorkItem {
+            guard DispatchTime.now() < discardAfter else { return }
+            appendEntry(makeEntry(label))
+        }
+        Self.ioQueue.asyncAfter(deadline: deadline, execute: item)
+        return item
     }
 
     /// Captures the footprint synchronously at the call site, so the

--- a/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
@@ -154,6 +154,14 @@ struct KeyboardHealthLog {
     /// process is reused. That sample would describe the resumed process while
     /// carrying the label of the earlier one, so a block that starts more than
     /// its own delay late writes nothing.
+    ///
+    /// One clock caveat bounds that guard rather than breaking it: the
+    /// comparison reads `DispatchTime` — mach time, which pauses while the
+    /// *device* sleeps — so a sample delayed across a sleep window can look
+    /// punctual and slip through. The caller's cancellation covers the case
+    /// that matters (a rebuilt keyboard voids the pending sample); what the
+    /// clock caveat can cost is a single stale-but-plausible diagnostics
+    /// entry, which the log's consumers tolerate by design.
     @discardableResult
     func recordDeferred(_ label: String, after delay: TimeInterval) -> DispatchWorkItem {
         let deadline = DispatchTime.now() + delay

--- a/wurstfingerKeyboard/Settings/SharedDefaults.swift
+++ b/wurstfingerKeyboard/Settings/SharedDefaults.swift
@@ -22,11 +22,27 @@ enum SharedDefaults {
     /// Backing suite for `isolatedStoreArgument`. Deliberately not an app group:
     /// it lives in the launched app's own preferences, where the extension —
     /// which never sees the host's launch arguments — cannot pick it up.
+    ///
+    /// Debug builds wipe it on every isolated launch (see `store`), so each UI
+    /// test starts from factory defaults instead of inheriting whatever the
+    /// previous run left behind.
     static let isolatedSuiteName = "de.akator.wurstfinger.isolated"
 
     /// The suite `store` binds to for a given process argument list.
     static func resolvedSuiteName(arguments: [String]) -> String {
         arguments.contains(isolatedStoreArgument) ? isolatedSuiteName : suiteName
+    }
+
+    /// Whether the suite bound at launch is the throwaway one and may therefore
+    /// be emptied. The second conjunct is a structural stop, not a redundant
+    /// one: `removePersistentDomain` has no undo, and were the two constants
+    /// above ever to converge, an ordinary launch of app *and* extension would
+    /// resolve to that name and delete the user's settings. Written this way,
+    /// convergence switches the wipe off instead of aiming it at the app group.
+    static func isWipeableSuite(
+        _ name: String, appGroup: String = suiteName, isolated: String = isolatedSuiteName
+    ) -> Bool {
+        name == isolated && name != appGroup
     }
 
     /// The shared UserDefaults instance.
@@ -39,6 +55,21 @@ enum SharedDefaults {
             assertionFailure("Defaults suite '\(name)' unavailable — settings will not sync between app and keyboard extension")
             return .standard
         }
+        #if DEBUG
+            // Start every isolated launch from an empty suite. The wipe has to
+            // happen here, in the app under test: the UI test runner is its own
+            // sandboxed process, so a `removePersistentDomain` on its side would
+            // clear its own copy of the suite and leave the app's untouched.
+            // Wiping before the first read also means it can never race a
+            // `@AppStorage` view — `store` is resolved lazily, exactly once.
+            // Debug-only so that no shipped binary carries a destructive call at
+            // all; a UI-test run built for Release keeps the redirect but loses
+            // the wipe, and says so through
+            // `testLaunchArgumentIsolatesDefaultsFromTheRealStore`.
+            if isWipeableSuite(name) {
+                shared.removePersistentDomain(forName: name)
+            }
+        #endif
         return shared
     }()
 }

--- a/wurstfingerTests/AccessibilityLabelTests.swift
+++ b/wurstfingerTests/AccessibilityLabelTests.swift
@@ -9,6 +9,11 @@
 //  Complements LayoutValidationTests.allGridKeyTapBindingsAreNonEmpty, which
 //  only checks grid keys in the main mode.
 //
+//  NamedAccessibilityBindingTests below covers the other half: which *non-tap*
+//  bindings carry a VoiceOver name. Those names are the opt-in for custom rotor
+//  actions, so a suite that only inspects named bindings cannot see the ones
+//  that are missing — the set itself has to be pinned.
+//
 
 import Foundation
 import Testing
@@ -162,5 +167,201 @@ struct AccessibilityLabelTests {
         let gesture = try #require(globe.accessibilityActivationOverride)
         viewModel.handleGesture(gesture, keyId: UtilitySlot.globe, isReturn: false)
         #expect(advanced == 1)
+    }
+}
+
+// MARK: - Which bindings are named
+
+/// Pins the *set* of named bindings, not just the ones that happen to be named.
+///
+/// A VoiceOver name is the opt-in for a custom action, so the suite could only
+/// ever see bindings that already had one — the swipe-only punctuation and shift
+/// gap was therefore structurally invisible to it. The table below writes the
+/// policy out, and both directions of a regression now fail: a name silently
+/// dropped, and a name silently added (the rotor flooding the opt-in exists to
+/// prevent). The reasoning behind the selection lives on
+/// `CommonKeys.defaultSlotBindings`.
+struct NamedAccessibilityBindingTests {
+    private var definitions: [KeyboardDefinition] {
+        KeyboardRegistry.available.compactMap { KeyboardRegistry.load(id: $0.id) }
+    }
+
+    /// Every grid-key gesture allowed to carry a name. Letter gestures are
+    /// absent on purpose: a key's own center letter is reachable by activating
+    /// it, and naming the other eight on all nine keys is the flooding case.
+    private static let namedGridGestures: [String: Set<GestureType>] = [
+        GridSlot.topRight: [.swipeLeft], // ?
+        GridSlot.bottomCenter: [.swipeDown, .swipeDownLeft], // . and ,
+        GridSlot.midRight: [.swipeUp, .swipeDown], // ⇧ and ⇩
+    ]
+
+    /// The three sentence-punctuation gestures. A layout may substitute its own
+    /// script's mark here (Arabic ؟ ،, Japanese 。 、) and the name follows,
+    /// because it states the function rather than the glyph.
+    private static let sentencePunctuation: [(slot: String, gesture: GestureType)] = [
+        (GridSlot.topRight, .swipeLeft),
+        (GridSlot.bottomCenter, .swipeDown),
+        (GridSlot.bottomCenter, .swipeDownLeft),
+    ]
+
+    private static let gridSlotIds = Set(GridSlot.allSlots.flatMap(\.self))
+
+    /// Non-tap gestures of a key that carry a non-empty name. The tap is the
+    /// element's own label, not a custom action, so it is never in here.
+    private func namedGestures(of key: KeyConfig) -> Set<GestureType> {
+        Set(
+            key.bindings
+                .filter { $0.key != .tap && !($0.value.accessibilityLabel ?? "").isEmpty }
+                .keys
+        )
+    }
+
+    private func requireBinding(
+        _ languageId: String, _ modeName: String, _ keyId: String, _ gesture: GestureType
+    ) throws -> KeyBinding {
+        let definition = try #require(
+            KeyboardRegistry.load(id: languageId), "\(languageId) does not load"
+        )
+        let mode = try #require(definition.modes[modeName], "\(languageId) has no \(modeName) mode")
+        let key = try #require(mode.keys[keyId], "\(languageId)/\(modeName) has no \(keyId) key")
+        return try #require(
+            key.bindings[gesture], "\(languageId)/\(modeName)/\(keyId) has no \(gesture) binding"
+        )
+    }
+
+    @Test func noGridBindingIsNamedOutsideThePolicySet() {
+        for def in definitions {
+            for (modeName, mode) in def.modes {
+                for (keyId, key) in mode.keys where Self.gridSlotIds.contains(keyId) {
+                    let unexpected = namedGestures(of: key)
+                        .subtracting(Self.namedGridGestures[keyId] ?? [])
+                    let listed = unexpected.map { "\($0)" }.sorted().joined(separator: ", ")
+                    #expect(
+                        unexpected.isEmpty,
+                        """
+                        \(def.id)/\(modeName)/\(keyId) names [\(listed)] — every name is a rotor entry, \
+                        so extend namedGridGestures deliberately or drop the label
+                        """
+                    )
+                }
+            }
+        }
+    }
+
+    /// The gap the review found: `, . ?` were swipe-only and had no name, so a
+    /// VoiceOver user could not end a sentence at all.
+    @Test func sentencePunctuationIsNamedInEveryModeOfEveryLayout() {
+        for def in definitions {
+            for (modeName, mode) in def.modes {
+                for (slot, gesture) in Self.sentencePunctuation {
+                    // A layout is free to place a letter here instead; only the
+                    // punctuation this slot normally carries has to be named.
+                    guard let binding = mode.keys[slot]?.bindings[gesture],
+                          binding.resolvedCategory == .symbol
+                    else { continue }
+                    #expect(
+                        !(binding.accessibilityLabel ?? "").isEmpty,
+                        "\(def.id)/\(modeName)/\(slot) \(gesture) commits \"\(binding.label)\" unnamed"
+                    )
+                }
+            }
+        }
+    }
+
+    /// Deliberate capitalization: auto-capitalization only produces
+    /// sentence-initial capitals, so without a name the modifier is unreachable.
+    @Test func theShiftAffordanceIsNamedWhereverItExists() {
+        for def in definitions {
+            for (modeName, mode) in def.modes {
+                for gesture in [GestureType.swipeUp, .swipeDown] {
+                    guard let binding = mode.keys[GridSlot.midRight]?.bindings[gesture],
+                          case .switchMode = binding.action
+                    else { continue }
+                    #expect(
+                        !(binding.accessibilityLabel ?? "").isEmpty,
+                        "\(def.id)/\(modeName) midRight \(gesture) switches mode unnamed"
+                    )
+                }
+            }
+        }
+    }
+
+    /// Why `⇩` is named alongside `⇧`: in the caps-lock mode the `⇧` gesture
+    /// switches to the mode it is already in, so `⇩` is the only way out. Naming
+    /// only `⇧` would hand VoiceOver users a one-way door into caps lock.
+    @Test func capsLockIsNotAOneWayDoorForVoiceOver() throws {
+        for def in definitions {
+            guard let capsLock = def.modes[ModeNames.capsLock] else { continue }
+            let midRight = try #require(
+                capsLock.keys[GridSlot.midRight], "\(def.id) caps lock has no midRight key"
+            )
+            let exits = midRight.accessibilityActions.filter { action in
+                midRight.bindings[action.gesture]?.action == .switchMode(ModeNames.main)
+            }
+            #expect(
+                !exits.isEmpty,
+                "\(def.id) caps lock offers no named action back to the main mode"
+            )
+        }
+    }
+
+    /// Finding 11: VoiceOver read "123" as the number one hundred twenty-three
+    /// and "abc"/"абв"/"कखग" as a word, instead of naming what the key does.
+    @Test func theModeSwitchKeysAreNamedSemantically() throws {
+        for def in definitions {
+            let toNumeric = try requireBinding(def.id, ModeNames.main, UtilitySlot.symbols, .tap)
+            let toLetters = try requireBinding(def.id, ModeNames.numeric, UtilitySlot.symbols, .tap)
+            for (key, mode) in [(toNumeric, ModeNames.main), (toLetters, ModeNames.numeric)] {
+                let name = key.accessibilityLabel ?? ""
+                #expect(!name.isEmpty, "\(def.id)/\(mode) symbols key falls back to its glyph label")
+                #expect(
+                    name != key.label,
+                    "\(def.id)/\(mode) symbols key names itself \"\(name)\" — that is the glyph, not the function"
+                )
+            }
+            #expect(
+                toNumeric.accessibilityLabel != toLetters.accessibilityLabel,
+                "\(def.id) uses one name for both directions of the numeric mode switch"
+            )
+        }
+    }
+
+    /// The names state the function, so a layout substituting its own script's
+    /// mark inherits them — otherwise exactly the RTL and CJK users the labelling
+    /// was for would be left with unnamed keys.
+    @Test func aScriptsOwnMarkInheritsTheSharedPunctuationName() throws {
+        let questionMark = try requireBinding("de_DE", ModeNames.main, GridSlot.topRight, .swipeLeft)
+        let period = try requireBinding("de_DE", ModeNames.main, GridSlot.bottomCenter, .swipeDown)
+        let comma = try requireBinding("de_DE", ModeNames.main, GridSlot.bottomCenter, .swipeDownLeft)
+
+        let arabicQuestionMark = try requireBinding("ar", ModeNames.main, GridSlot.topRight, .swipeLeft)
+        #expect(arabicQuestionMark.label == "؟")
+        #expect(arabicQuestionMark.accessibilityLabel == questionMark.accessibilityLabel)
+
+        let arabicComma = try requireBinding("ar", ModeNames.main, GridSlot.bottomCenter, .swipeDownLeft)
+        #expect(arabicComma.label == "،")
+        #expect(arabicComma.accessibilityLabel == comma.accessibilityLabel)
+
+        let japanesePeriod = try requireBinding("ja_JP", ModeNames.main, GridSlot.bottomCenter, .swipeDown)
+        #expect(japanesePeriod.label == "。")
+        #expect(japanesePeriod.accessibilityLabel == period.accessibilityLabel)
+
+        let japaneseComma = try requireBinding("ja_JP", ModeNames.main, GridSlot.bottomCenter, .swipeDownLeft)
+        #expect(japaneseComma.label == "、")
+        #expect(japaneseComma.accessibilityLabel == comma.accessibilityLabel)
+    }
+
+    /// The two guards on that inheritance. A letter must not inherit a
+    /// punctuation name ("Comma" would be a lie on て), and a mark that displaces
+    /// a *mode switch* must not inherit its name — Hindi's danda sits on the
+    /// midRight `⇩` gesture and is a full stop, not the way out of caps lock.
+    @Test func inheritedNamesStopAtLettersAndAtModeSwitches() throws {
+        let japaneseLetter = try requireBinding("ja_JP", ModeNames.main, GridSlot.bottomCenter, .swipeUp)
+        #expect(japaneseLetter.label == "て")
+        #expect(japaneseLetter.accessibilityLabel == nil)
+
+        let danda = try requireBinding("hi_IN", ModeNames.main, GridSlot.midRight, .swipeDown)
+        #expect(danda.label == "।")
+        #expect(danda.accessibilityLabel == nil)
     }
 }

--- a/wurstfingerTests/AccessibilityLabelTests.swift
+++ b/wurstfingerTests/AccessibilityLabelTests.swift
@@ -270,16 +270,39 @@ struct NamedAccessibilityBindingTests {
 
     /// Deliberate capitalization: auto-capitalization only produces
     /// sentence-initial capitals, so without a name the modifier is unreachable.
+    ///
+    /// A binding that switches to the mode it already lives in is the one
+    /// exception, pinned separately below.
     @Test func theShiftAffordanceIsNamedWhereverItExists() {
         for def in definitions {
             for (modeName, mode) in def.modes {
                 for gesture in [GestureType.swipeUp, .swipeDown] {
                     guard let binding = mode.keys[GridSlot.midRight]?.bindings[gesture],
-                          case .switchMode = binding.action
+                          case let .switchMode(target) = binding.action,
+                          target != modeName
                     else { continue }
                     #expect(
                         !(binding.accessibilityLabel ?? "").isEmpty,
                         "\(def.id)/\(modeName) midRight \(gesture) switches mode unnamed"
+                    )
+                }
+            }
+        }
+    }
+
+    /// The counterpart: naming a binding is what puts it in the rotor, so a
+    /// binding that switches to the mode it is invoked from must stay unnamed.
+    /// The caps-lock `⇪` is the only one — activating it would return the
+    /// VoiceOver user exactly where they were.
+    @Test func aModeSwitchOntoItsOwnModeOffersNoAction() {
+        for def in definitions {
+            for (modeName, mode) in def.modes {
+                for (gesture, binding) in mode.keys[GridSlot.midRight]?.bindings ?? [:] {
+                    guard case let .switchMode(target) = binding.action, target == modeName
+                    else { continue }
+                    #expect(
+                        binding.accessibilityLabel == nil,
+                        "\(def.id)/\(modeName) midRight \(gesture) names a switch onto its own mode"
                     )
                 }
             }

--- a/wurstfingerTests/AdvancedTextMiddlewareTests.swift
+++ b/wurstfingerTests/AdvancedTextMiddlewareTests.swift
@@ -344,10 +344,13 @@ private enum PasteboardWarmUp {
         // it holds no lock the suite needs, and a skipped suite touches the
         // pasteboard no further.
         DispatchQueue.global().async {
-            let original = UIPasteboard.general.string
+            // `items`, not `string`: assigning `string` replaces every item, so
+            // capturing only the string would drop an image or a URL a
+            // developer had on their clipboard when the suite ran.
+            let original = UIPasteboard.general.items
             UIPasteboard.general.string = "warm-up-\(UUID().uuidString)"
             _ = UIPasteboard.general.string
-            UIPasteboard.general.string = original
+            UIPasteboard.general.items = original
             answered.signal()
         }
         return answered.wait(timeout: .now() + deadline) == .success
@@ -388,16 +391,19 @@ struct PasteboardEnvironmentTests {
     )
 )
 final class AdvancedTextMiddlewareClipboardTests {
-    private let originalPasteboard: String?
+    /// The whole pasteboard, not just its string: the tests below assign
+    /// `string`, which replaces every item, so restoring a `String?` would
+    /// leave a developer's image or URL destroyed by a test run.
+    private let originalPasteboard: [[String: Any]]
 
     init() {
         // Free once the suite trait resolved it; keeps the capture below from
         // becoming the blocking call should trait evaluation ever move.
         _ = PasteboardWarmUp.didAnswer
-        originalPasteboard = UIPasteboard.general.string
+        originalPasteboard = UIPasteboard.general.items
     }
 
-    deinit { UIPasteboard.general.string = originalPasteboard }
+    deinit { UIPasteboard.general.items = originalPasteboard }
 
     @Test func copyWritesSelectionToPasteboardWithFullAccess() {
         let target = MockTextTarget()

--- a/wurstfingerTests/AdvancedTextMiddlewareTests.swift
+++ b/wurstfingerTests/AdvancedTextMiddlewareTests.swift
@@ -294,16 +294,106 @@ struct AdvancedTextCapitalizeWordTests {
 
 // MARK: - Clipboard
 
+/// One-time probe for the process-global pasteboard, so a wedged daemon costs
+/// this suite a bounded wait instead of the whole run.
+///
+/// `UIPasteboard.general` talks to a system service, and on a cold simulator the
+/// first call can block for a very long time before returning perfectly normal
+/// data: one review run measured `copyWritesSelectionToPasteboardWithFullAccess`
+/// at 2268 s (~38 min) — and then green — where a healthy run takes 1.4 s. The
+/// call is not cancellable, so the probe hands it to a background thread and
+/// waits with a deadline; the answer decides whether the suite runs at all.
+///
+/// The environment-dependent tests in this target, worth knowing before chasing
+/// a slow or oddly-failing run:
+///
+/// - `LongPressSchedulerTests` — the only wall-clock unit tests: 20–50 ms timers
+///   awaited with 200–300 ms sleeps. Tightest budget in the suite; its negative
+///   tests can false-pass under load, not flake.
+/// - This suite — process-global pasteboard, serialized and capture/restore-ed;
+///   cross-suite safety rests on nothing else touching `UIPasteboard.general`.
+/// - `KeyboardHealthLogTests` — permission-dependent cases; false-fail as root.
+/// - `SettingsReloadObserverTests` — drains the runloop against wall-clock time.
+private enum PasteboardWarmUp {
+    /// Far above a healthy cold start (single-digit seconds), far below the
+    /// pathology (tens of minutes). Nothing legitimate lives in between.
+    static let deadline: TimeInterval = 30
+
+    /// Whether a full write/read/restore round-trip came back inside
+    /// `deadline`. Resolved once per process — later reads are free, so every
+    /// test can ask.
+    ///
+    /// The probe **writes**, and that is the whole point. A read of an empty
+    /// pasteboard can answer instantly on a host whose write path is wedged:
+    /// measured on one such machine, a read-only probe passed while
+    /// `copyWritesSelectionToPasteboardWithFullAccess` — the first test to
+    /// *assign* `UIPasteboard.general.string` — then took 59 minutes and
+    /// passed. A read-only probe therefore certifies an environment it never
+    /// exercised. Since `xcodebuild` runs the target in parallel clones and
+    /// each clone is its own process resolving this on its own, one clone
+    /// gating correctly does nothing for the next one; the probe has to test
+    /// the operation that actually stalls.
+    ///
+    /// The restore is inside the probe because nothing else can do it: the
+    /// suite's own capture/restore only runs once this has resolved.
+    static let didAnswer: Bool = {
+        let answered = DispatchSemaphore(value: 0)
+        // Detached on purpose: a stuck call owns its thread until the service
+        // replies, and that must not be the thread the suite waits on. The
+        // thread stays stuck for the rest of the run, which is survivable —
+        // it holds no lock the suite needs, and a skipped suite touches the
+        // pasteboard no further.
+        DispatchQueue.global().async {
+            let original = UIPasteboard.general.string
+            UIPasteboard.general.string = "warm-up-\(UUID().uuidString)"
+            _ = UIPasteboard.general.string
+            UIPasteboard.general.string = original
+            answered.signal()
+        }
+        return answered.wait(timeout: .now() + deadline) == .success
+    }()
+}
+
+/// Reports the wedged daemon as a failure of its own. Skipping the clipboard
+/// suite keeps the run bounded, and this keeps the run *loud*: without it, a
+/// stuck pasteboard would read as a green build with twenty quietly skipped
+/// tests.
+struct PasteboardEnvironmentTests {
+    @Test func pasteboardAnswersWithinTheWarmUpDeadline() {
+        #expect(
+            PasteboardWarmUp.didAnswer,
+            """
+            UIPasteboard.general did not answer within \(Int(PasteboardWarmUp.deadline)) s — the known \
+            cold-simulator pasteboard stall. AdvancedTextMiddlewareClipboardTests was skipped for this \
+            run, so clipboard behaviour is unverified; re-run against a warm simulator (or reboot it).
+            """
+        )
+    }
+}
+
 // Serialized: these tests share the process-wide `UIPasteboard.general`
 // singleton, so they must not run concurrently with one another. A fresh
 // instance is created per test, so capturing the pasteboard in `init` and
 // restoring it in `deinit` reverts any clipboard writes and prevents leaking
 // process-global state into later tests.
-@Suite(.serialized)
+//
+// Gated on the warm-up rather than warmed up inside `init`, because a condition
+// trait is the only hook that can still *decline* to run: once the daemon has
+// gone quiet, every test body would otherwise pay the same unbounded block.
+@Suite(
+    .serialized,
+    .enabled(
+        if: PasteboardWarmUp.didAnswer,
+        "The pasteboard did not answer within the warm-up deadline — see PasteboardEnvironmentTests"
+    )
+)
 final class AdvancedTextMiddlewareClipboardTests {
     private let originalPasteboard: String?
 
     init() {
+        // Free once the suite trait resolved it; keeps the capture below from
+        // becoming the blocking call should trait evaluation ever move.
+        _ = PasteboardWarmUp.didAnswer
         originalPasteboard = UIPasteboard.general.string
     }
 

--- a/wurstfingerTests/AspectRatioSubtitleTests.swift
+++ b/wurstfingerTests/AspectRatioSubtitleTests.swift
@@ -1,0 +1,127 @@
+//
+//  AspectRatioSubtitleTests.swift
+//  wurstfingerTests
+//
+//  The key-aspect-ratio subtitle is the one place in the app where a value and
+//  a literal have to stay glued together across scripts: `Current: 1.00:1`. It
+//  used to interpolate only the number into the localized string, and because
+//  Foundation isolates interpolated arguments in right-to-left localizations,
+//  the trailing `:1` reordered — Arabic and Hebrew showed `1:1.00`. These tests
+//  pin both halves of the fix: the composed value, and the contract the fix
+//  places on the translations.
+//
+//  The composed value has to be checked against a right-to-left bundle. Under
+//  the English test localization Foundation inserts no isolate, so the old and
+//  the new implementation return the same bytes there and an English-only check
+//  would pass either way.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+/// The catalog key the subtitle is looked up under. Changing the format string
+/// in `SettingsView` means renaming this key in the String Catalog and adapting
+/// all translations. `sourceStringGluesTheRatioTogether` ties this constant to
+/// the lookup in `SettingsView` so that a rename fails here: String Catalog
+/// entries are `manual`, so Xcode never prunes the old one, and the translation
+/// guard below would otherwise keep validating an entry nothing renders.
+private let aspectRatioKey = "Current: %@:1"
+
+/// Repo root: this file lives in `wurstfingerTests/`, so go up two levels.
+private func projectDir(file: String = #filePath) -> URL {
+    URL(fileURLWithPath: file)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}
+
+/// Every localized value of `aspectRatioKey`, keyed by language.
+private func aspectRatioTranslations() throws -> [String: String] {
+    let url = projectDir().appendingPathComponent("wurstfinger/Localizable.xcstrings")
+    let data = try Data(contentsOf: url)
+    let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    let strings = json?["strings"] as? [String: Any]
+    let entry = strings?[aspectRatioKey] as? [String: Any]
+    let localizations = entry?["localizations"] as? [String: Any] ?? [:]
+    var values: [String: String] = [:]
+    for (language, localization) in localizations {
+        guard
+            let unit = (localization as? [String: Any])?["stringUnit"] as? [String: Any],
+            let value = unit["value"] as? String
+        else {
+            continue
+        }
+        values[language] = value
+    }
+    return values
+}
+
+struct AspectRatioSubtitleTests {
+    /// The ratio ends the subtitle and its decimals are fixed at two places (it
+    /// is a display value, not a measurement). This resolves in whatever
+    /// localization the test host runs under — English by default, where no
+    /// isolate is inserted, so the bidi half is pinned in the test below.
+    @Test(arguments: [
+        (ratio: 1.0, expected: "1.00:1"),
+        (ratio: 1.62, expected: "1.62:1"),
+        (ratio: 0.7, expected: "0.70:1"),
+    ])
+    func composesTheRatioWithTwoDecimals(config: (ratio: Double, expected: String)) {
+        let subtitle = SettingsView.keyAspectRatioSubtitle(for: config.ratio)
+        #expect(subtitle.hasSuffix(config.expected), "subtitle was \(subtitle)")
+    }
+
+    /// The reordering exists only once the resolved localization is right-to-left,
+    /// so resolve the template against the app's Arabic bundle rather than the
+    /// test locale. Reverting to `String(localized: "Current: \(number):1")` puts
+    /// U+2068/U+2069 around the number here and fails both expectations.
+    @Test func keepsTheRatioAsOneRunInRightToLeftLocalizations() throws {
+        let path = try #require(
+            Bundle.main.path(forResource: "ar", ofType: "lproj"),
+            "the app bundle no longer ships Arabic — resolve against another right-to-left localization"
+        )
+        let arabic = try #require(Bundle(path: path))
+        let subtitle = SettingsView.keyAspectRatioSubtitle(for: 1.0, bundle: arabic)
+        #expect(subtitle.hasSuffix("1.00:1"), "subtitle was \(subtitle.debugDescription)")
+
+        let isolates: Set<Unicode.Scalar> = ["\u{2066}", "\u{2067}", "\u{2068}", "\u{2069}"]
+        let hasIsolate = subtitle.unicodeScalars.contains { isolates.contains($0) }
+        #expect(!hasIsolate, "the ratio must not be split by a bidi isolate: \(subtitle.debugDescription)")
+    }
+
+    /// The English source string is the fallback whenever a language is missing,
+    /// so it has to satisfy the same contract as the translations. The first
+    /// expectation is what makes the second one more than a literal compared
+    /// against a substring of itself: it pins `aspectRatioKey` to the key
+    /// `SettingsView` actually looks the subtitle up under.
+    @Test func sourceStringGluesTheRatioTogether() throws {
+        let url = projectDir().appendingPathComponent("wurstfinger/SettingsView.swift")
+        let source = try String(contentsOf: url, encoding: .utf8)
+        #expect(
+            source.contains("String(localized: \"\(aspectRatioKey)\""),
+            "SettingsView no longer looks the subtitle up under '\(aspectRatioKey)' — update the key here and in the catalog"
+        )
+        #expect(aspectRatioKey.hasSuffix("%@:1"))
+    }
+
+    /// In every translation the `:1` must follow the placeholder directly. A
+    /// separator (a space, a right-to-left mark, a reordered suffix) would break
+    /// the number run apart and bring the `1:1.00` rendering back in Arabic,
+    /// Hebrew, Persian and Urdu.
+    @Test func everyTranslationGluesTheRatioToThePlaceholder() throws {
+        let translations = try aspectRatioTranslations()
+        #expect(!translations.isEmpty, "\(aspectRatioKey) is missing from wurstfinger/Localizable.xcstrings")
+
+        for (language, value) in translations.sorted(by: { $0.key < $1.key }) {
+            guard let placeholder = value.range(of: "%@") else {
+                Issue.record("\(language): '\(value)' has no %@ placeholder")
+                continue
+            }
+            let suffix = Array(value[placeholder.upperBound...])
+            #expect(suffix.first == ":", "\(language): '\(value)' must continue with ':' right after %@")
+            // The `1` of the ratio may be written in the local digit shapes
+            // (Persian uses ۱), which resolve as a number just like ASCII.
+            #expect(suffix.dropFirst().first?.isNumber == true, "\(language): '\(value)' must end in ':<digit>'")
+        }
+    }
+}

--- a/wurstfingerTests/DeliberatelyUnboundCharacterTests.swift
+++ b/wurstfingerTests/DeliberatelyUnboundCharacterTests.swift
@@ -1,0 +1,142 @@
+//
+//  DeliberatelyUnboundCharacterTests.swift
+//  WurstfingerTests
+//
+//  The mirror image of `LanguageAlphabetCoverageTests`: that file pins the
+//  characters every layout must be able to produce, this one pins the handful
+//  that no layout is supposed to produce any more. A character that was dropped
+//  on purpose looks exactly like one that was lost by accident when somebody
+//  reads the layout tables a year later, so the reason is written down here and
+//  the decision is held in place until someone deliberately revisits it.
+//
+
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+/// A character deliberately left unbound, with the reason it went away.
+private struct UnboundCharacter {
+    let scalar: Unicode.Scalar
+    let name: String
+    let reason: String
+
+    var codePoint: String {
+        String(format: "U+%04X", scalar.value)
+    }
+}
+
+struct DeliberatelyUnboundCharacterTests {
+    /// One entry so far. Until #285 the `^` key's return swipe committed the
+    /// stand-alone modifier circumflex; that was Wurstfinger's own addition,
+    /// which the layout Wurstfinger is modelled on never had, and #285 gave the
+    /// return swipe to the caron dead key instead — one gesture to č ď ě ň ř š ť ž
+    /// where before there was only the accent cycle. The ASCII `^` stayed on the
+    /// same key, so nothing a keyboard is normally asked for was lost.
+    ///
+    /// This is a record, not a ban: if a layout ever wants the character back,
+    /// bind it, drop the entry here, and say so in the CHANGELOG — the only
+    /// thing being ruled out is losing it a second time without noticing.
+    private static let cuts = [
+        UnboundCharacter(
+            scalar: "\u{02C6}",
+            name: "modifier circumflex",
+            reason: "given up by the ^ key's return swipe in favour of the caron dead key (#285)"
+        ),
+    ]
+
+    @Test(arguments: LanguageDefinitions.all)
+    func noLayoutProducesADeliberatelyUnboundCharacter(descriptor: LanguageDescriptor) {
+        let producible = Self.producibleText(of: descriptor.makeDefinition())
+        for cut in Self.cuts {
+            #expect(
+                !producible.contains(String(cut.scalar)),
+                """
+                [\(descriptor.id)] can produce the \(cut.name) \(cut.codePoint) again — \
+                it was \(cut.reason). If that is intended, remove it from `cuts` and \
+                record the change in the CHANGELOG.
+                """
+            )
+        }
+    }
+
+    /// The routes by which this definition puts text into the document: every
+    /// `commitText` (primary and return swipe, all modes), the space and newline
+    /// actions, every compose trigger a key binds — `ComposeMiddleware` commits
+    /// an unmatched trigger verbatim, which is the only way ASCII `^` reaches
+    /// the document at all — every output of a bound trigger's rules, every
+    /// sequential-combine result, and the accent-cycle closure over all of
+    /// those. Not modelled, because the characters do not come from the
+    /// definition's own tables: a paste, case mapping of text already in the
+    /// document, and the algorithmic input methods (Hangul, Telex).
+    ///
+    /// Derived the same way `LanguageAlphabetCoverageTests` derives it but
+    /// deliberately duplicated rather than shared. The coverage test asks "is
+    /// this reachable?", this one asks "is this unreachable?", which flips which
+    /// way an incomplete model is safe: a route it misses costs the coverage
+    /// test a false alarm and costs this one the finding. So the two have to be
+    /// free to diverge here — and a cut that one of the unmodelled routes could
+    /// reinstate needs a pin of its own rather than this one.
+    private static func producibleText(of definition: KeyboardDefinition) -> Set<String> {
+        var direct: Set<String> = []
+        var composeTriggers: Set<String> = []
+        for mode in definition.modes.values {
+            for key in mode.keys.values {
+                for binding in key.bindings.values {
+                    collect(binding.action, into: &direct, triggers: &composeTriggers)
+                    if let returnAction = binding.returnAction {
+                        collect(returnAction, into: &direct, triggers: &composeTriggers)
+                    }
+                }
+            }
+        }
+
+        let engine = definition.settings.composeRuleOverrides
+            .map { ComposeEngine.withGlobalRules(overrides: $0) } ?? ComposeEngine.shared
+        for trigger in composeTriggers {
+            if let outputs = engine.ruleSet.rules[trigger]?.values {
+                direct.formUnion(outputs)
+            }
+        }
+        if let combine = definition.settings.combineRuleSet {
+            for map in combine.rules.values {
+                direct.formUnion(map.values)
+            }
+        }
+        return cycleClosure(of: direct, engine: engine)
+    }
+
+    private static func collect(
+        _ action: KeyAction, into direct: inout Set<String>, triggers: inout Set<String>
+    ) {
+        switch action {
+        case let .commitText(text): direct.insert(text)
+        case let .compose(trigger):
+            // A bound trigger is producible text in its own right, not just a
+            // key into the rule table: `ComposeMiddleware` commits it verbatim
+            // whenever no rule matches the preceding character. Without this,
+            // reinstating a cut character as a dead key would leave the test
+            // green — and ASCII `^`, which reaches the document by no other
+            // route, would be reported as unproducible.
+            triggers.insert(trigger)
+            direct.insert(trigger)
+        case .space: direct.insert(" ")
+        case .newline: direct.insert("\n")
+        default: break
+        }
+    }
+
+    /// The 🅒 key cycles the character before the cursor through its accent
+    /// variants, so everything on a reachable character's cycle is reachable too
+    /// — and a cut character sitting on such a cycle would not be cut at all.
+    private static func cycleClosure(of seeds: Set<String>, engine: ComposeEngine) -> Set<String> {
+        var result = seeds
+        var pending = Array(seeds)
+        while let character = pending.popLast() {
+            guard let next = engine.cycleAccent(for: character),
+                  result.insert(next).inserted
+            else { continue }
+            pending.append(next)
+        }
+        return result
+    }
+}

--- a/wurstfingerTests/GesturePreprocessorRobustnessTests.swift
+++ b/wurstfingerTests/GesturePreprocessorRobustnessTests.swift
@@ -67,6 +67,39 @@ struct GesturePreprocessorRobustnessTests {
         #expect(classify(points) == .swipeRight)
     }
 
+    /// A fling fast enough that no two consecutive samples are within
+    /// maxJumpDistance of each other used to have every sample dropped as a
+    /// teleport, leaving a single-point path that classifies as a tap — so the
+    /// key committed its center letter for an unmistakable swipe.
+    @Test func flickFasterThanTheJumpThresholdStaysASwipe() {
+        // ~0.5 m/s delivered at 60 Hz ≈ 53pt between samples (the threshold is
+        // 50pt), straight down the key.
+        let points = (0 ... 4).map { CGPoint(x: 0, y: CGFloat($0) * 53) }
+        #expect(classify(points) == .swipeDown)
+    }
+
+    /// The gesture trail draws the *raw* touch path while the classifier
+    /// consumes the filtered one. When they disagree the user watches a full
+    /// swipe comet and gets the center letter — the divergence that made this
+    /// failure mode invisible in the first place. Pinned for the flick that
+    /// used to diverge, through a real `GestureTrail` at the production
+    /// spacing and capacity rather than a copy of its retention rule: what the
+    /// overlay keeps is what the classifier has to agree with.
+    @Test func aFlickTheTrailDrawsInFullIsNotClassifiedAsATap() {
+        let points = (0 ... 4).map { CGPoint(x: CGFloat($0) * 53, y: 0) }
+
+        var trail = GestureTrail()
+        trail.begin(at: points[0], time: 0)
+        for (index, point) in points.enumerated().dropFirst() {
+            trail.extend(to: point, time: TimeInterval(index) / 60)
+        }
+
+        // The overlay draws the whole stroke…
+        #expect(trail.samples.map(\.point) == points)
+        // …so the classification must be the swipe the user saw.
+        #expect(classify(points) == .swipeRight)
+    }
+
     @Test func pathLongerThanPositionBufferStaysClassifiable() {
         // More samples than KeyboardConstants.Gesture.positionBufferSize
         // (120), a straight rightward drag — must still classify as a right

--- a/wurstfingerTests/GesturePreprocessorSweepTests.swift
+++ b/wurstfingerTests/GesturePreprocessorSweepTests.swift
@@ -1,0 +1,193 @@
+//
+//  GesturePreprocessorSweepTests.swift
+//  WurstfingerTests
+//
+//  Property sweep over generated touch paths, pinning the two guarantees the
+//  velocity-aware outlier filter has to keep in balance: a genuine gesture is
+//  never demoted (a fast flick stays a swipe, an ordinary swipe keeps its
+//  sector), and a glitch is never promoted (a teleport sample changes no
+//  classification, in whatever direction it points).
+//
+//  The parameters of the velocity rule were originally chosen against an
+//  ad-hoc sweep of ~600k synthetic paths that compared three compiled
+//  variants of the filter; that harness was never part of the repo, so its
+//  "zero regressions" figure could not be re-checked. This file is the
+//  repo-resident replacement: a few thousand deterministic paths spanning the
+//  same regimes, asserted as properties on every CI run. The individually
+//  interesting boundary cases keep their own named tests in
+//  `GesturePreprocessorTests` / `GesturePreprocessorRobustnessTests`; this
+//  sweep is about the space between them.
+//
+//  Every family stays deliberately clear of the documented ambiguity bands
+//  (steps at jitter scale count as dwell, glitches start beyond
+//  maxJumpDistance, flick steps stay under 3x maxJumpDistance): inside those
+//  bands the filter's choice is a judgement call the named tests own, and a
+//  sweep asserting exact outcomes there would pin coincidences, not intent.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import WurstfingerApp
+
+struct GesturePreprocessorSweepTests {
+    /// Sector-center angles plus offsets safely inside each 45° sector, in
+    /// degrees (`atan2` convention: 0 = right, 90 = down). Boundary angles are
+    /// pinned exactly by `AngleToGestureTypeTests`; the sweep keeps 12.5° of
+    /// margin so it can never flake on the half-open boundaries.
+    private static let sectorSafeAngles: [CGFloat] = {
+        let centers: [CGFloat] = [0, 45, 90, 135, 180, 225, 270, 315]
+        var angles: [CGFloat] = []
+        for center in centers {
+            let low: CGFloat = center - 10
+            angles.append(low < 0 ? low + 360 : low)
+            angles.append(center)
+            angles.append(center + 10)
+        }
+        return angles
+    }()
+
+    private func classify(_ points: [CGPoint]) -> GestureType {
+        KeyGestureRecognizer.classify(positions: points, config: .default, thresholds: .default).gesture
+    }
+
+    private func unit(_ degrees: CGFloat) -> CGVector {
+        let radians = degrees * .pi / 180
+        return CGVector(dx: cos(radians), dy: sin(radians))
+    }
+
+    private func straightPath(
+        from origin: CGPoint = .zero,
+        degrees: CGFloat,
+        step: CGFloat,
+        samples: Int
+    ) -> [CGPoint] {
+        let direction = unit(degrees)
+        return (0 ..< samples).map {
+            CGPoint(
+                x: origin.x + direction.dx * step * CGFloat($0),
+                y: origin.y + direction.dy * step * CGFloat($0)
+            )
+        }
+    }
+
+    /// A fling whose every inter-sample distance exceeds `maxJumpDistance`
+    /// (50pt) must classify as a swipe in the direction it travelled — the
+    /// review-2026-08-09 finding-3 regime, across speeds up to just under the
+    /// 3x admission ceiling and around the full circle. Three samples is the
+    /// floor: a two-point path is the documented origin-jump ambiguity and
+    /// deliberately stays a tap.
+    @Test func everyStraightFlickAboveTheJumpThresholdKeepsItsSector() {
+        var mismatches: [String] = []
+        for degrees in Self.sectorSafeAngles {
+            let expected = KeyGestureRecognizer.gestureType(forDegrees: degrees)
+            for step: CGFloat in [51, 60, 75, 90, 110, 130, 145] {
+                for samples in 3 ... 6 {
+                    let points = straightPath(degrees: degrees, step: step, samples: samples)
+                    let actual = classify(points)
+                    if actual != expected {
+                        mismatches.append("\(Int(degrees))° step \(Int(step)) n\(samples): \(actual) ≠ \(expected)")
+                    }
+                }
+            }
+        }
+        #expect(mismatches.isEmpty, "\(mismatches.count) of 672 flicks misclassified: \(mismatches.prefix(5))")
+    }
+
+    /// An ordinary swipe (steps well under `maxJumpDistance`) must keep its
+    /// sector — the regime every real gesture lives in, and the one the first
+    /// attempt at the velocity rule regressed. The outlier filter should be a
+    /// spectator here; this pins that adding the rescue did not change it.
+    @Test func everyOrdinarySwipeKeepsItsSector() {
+        var mismatches: [String] = []
+        for degrees in Self.sectorSafeAngles {
+            let expected = KeyGestureRecognizer.gestureType(forDegrees: degrees)
+            for step: CGFloat in [8, 14, 20] {
+                for samples in [5, 9] {
+                    let points = straightPath(degrees: degrees, step: step, samples: samples)
+                    let actual = classify(points)
+                    if actual != expected {
+                        mismatches.append("\(Int(degrees))° step \(Int(step)) n\(samples): \(actual) ≠ \(expected)")
+                    }
+                }
+            }
+        }
+        #expect(mismatches.isEmpty, "\(mismatches.count) of 144 swipes misclassified: \(mismatches.prefix(5))")
+    }
+
+    /// A trailing glitch beyond `maxJumpDistance` must never change what a
+    /// path classifies as — neither a dwell (which must stay a tap, whatever
+    /// direction the glitch points) nor an ordinary swipe (which must keep its
+    /// sector, the shape that flipped under the first, half-plane version of
+    /// the velocity rule). The established steps stay at jitter/swipe scale so
+    /// the glitch is always outside the 3x-step admission budget; a jump
+    /// *inside* that budget is treated as acceleration by design and belongs
+    /// to the flick family above.
+    @Test func aTrailingGlitchNeverChangesTheClassification() {
+        var mismatches: [String] = []
+        var count = 0
+        // Dwell prefixes along +x (0, 1 or 2 sub-swipe steps), then a glitch.
+        for prefixStep: CGFloat in [0, 4, 8] {
+            for prefixMoves in 0 ... 2 {
+                let prefix = [CGPoint.zero] + straightPath(
+                    degrees: 0, step: prefixStep, samples: prefixMoves + 1
+                ).dropFirst()
+                // Swipe prefixes: a clean rightward swipe before the glitch.
+                let bases = [prefix, straightPath(degrees: 0, step: 14, samples: 6)]
+                for base in bases {
+                    let expected = classify(base)
+                    guard let last = base.last else { continue }
+                    for glitchDistance: CGFloat in [55, 80, 120, 200] {
+                        for degrees in stride(from: CGFloat(0), to: 360, by: 45) {
+                            let glitch = CGPoint(
+                                x: last.x + unit(degrees).dx * glitchDistance,
+                                y: last.y + unit(degrees).dy * glitchDistance
+                            )
+                            count += 1
+                            let actual = classify(base + [glitch])
+                            if actual != expected {
+                                let shape = "prefixStep \(Int(prefixStep)) moves \(prefixMoves)"
+                                let jump = "glitch \(Int(glitchDistance))@\(Int(degrees))°"
+                                mismatches.append("\(shape) \(jump): \(actual) ≠ \(expected)")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        #expect(mismatches.isEmpty, "\(mismatches.count) of \(count) glitched paths reclassified: \(mismatches.prefix(5))")
+    }
+
+    /// A teleport sample in the middle of an ordinary swipe — interference
+    /// landing far off the path for one frame — must not change the sector the
+    /// swipe classifies into. The teleport is rejected on distance (beyond the
+    /// 3x-step budget of a 12pt gait) and the path continues from the sample
+    /// before it.
+    @Test func aMidPathTeleportNeverChangesTheSector() {
+        var mismatches: [String] = []
+        var count = 0
+        for degrees in stride(from: CGFloat(0), to: 360, by: 45) {
+            let base = straightPath(degrees: degrees, step: 12, samples: 8)
+            let expected = classify(base)
+            for teleportDistance: CGFloat in [60, 120] {
+                for relativeDegrees: CGFloat in [90, 180, 315] {
+                    let anchor = base[3]
+                    let teleport = CGPoint(
+                        x: anchor.x + unit(degrees + relativeDegrees).dx * teleportDistance,
+                        y: anchor.y + unit(degrees + relativeDegrees).dy * teleportDistance
+                    )
+                    var points = base
+                    points.insert(teleport, at: 4)
+                    count += 1
+                    let actual = classify(points)
+                    if actual != expected {
+                        mismatches.append(
+                            "\(Int(degrees))° teleport \(Int(teleportDistance))@+\(Int(relativeDegrees))°: \(actual) ≠ \(expected)"
+                        )
+                    }
+                }
+            }
+        }
+        #expect(mismatches.isEmpty, "\(mismatches.count) of \(count) teleported swipes reclassified: \(mismatches.prefix(5))")
+    }
+}

--- a/wurstfingerTests/GesturePreprocessorTests.swift
+++ b/wurstfingerTests/GesturePreprocessorTests.swift
@@ -93,7 +93,9 @@ struct GesturePreprocessorTests {
         let preprocessor = GesturePreprocessor(config: config)
 
         // A glitch as the final sample has no raw successor and must
-        // still be removed.
+        // still be removed. What removes it is its size, not its position:
+        // the established step is 10pt and the jump is 130, thirteen times
+        // what the finger was covering per sample.
         let points: [CGPoint] = [
             CGPoint(x: 0, y: 0),
             CGPoint(x: 10, y: 0),
@@ -145,6 +147,177 @@ struct GesturePreprocessorTests {
         let filtered = preprocessor.filterOutliers(points)
 
         #expect(filtered == [points[0], points[1], points[4], points[5]])
+    }
+
+    @Test func outlierFilterKeepsAFlickFasterThanTheJumpThreshold() {
+        let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // A fling at ~0.5 m/s delivered at 60 Hz puts ~53pt between
+        // consecutive samples, so *every* step exceeds maxJumpDistance and no
+        // sample has a raw neighbor within it. Only the fact that the steps
+        // continue one another marks this as real motion rather than a run of
+        // teleports — without that criterion the whole gesture was discarded
+        // and the key committed its center letter.
+        let points = (0 ... 4).map { CGPoint(x: CGFloat($0) * 53, y: 0) }
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(filtered == points)
+    }
+
+    @Test func outlierFilterRejectsAJumpTheFingerWasTooSlowFor() {
+        let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // Same direction as the established motion, but ~15x its per-sample
+        // travel: a finger moving 12pt per sample cannot cover 176 in the
+        // next one. The glitch has a dwell partner after it, so the
+        // trailing-glitch rule does not apply — this pins that the velocity
+        // criterion refuses to admit it either.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 12, y: 0),
+            CGPoint(x: 24, y: 0),
+            CGPoint(x: 200, y: 0), // glitch: 176pt in one sample
+            CGPoint(x: 201, y: 0)
+        ]
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(!filtered.contains(CGPoint(x: 200, y: 0)))
+    }
+
+    @Test func outlierFilterRejectsATeleportThatReturnsToThePath() {
+        let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // A glitch on the first sample after touch-down, where the accepted
+        // path has no step of its own yet and the following raw step is the
+        // only velocity evidence there is. Both steps around the ghost are
+        // long, so magnitude alone reads as fast motion — they point opposite
+        // ways, which no finger does between two samples.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 150, y: 0), // out…
+            CGPoint(x: 5, y: 0), // …and straight back to the finger
+            CGPoint(x: 10, y: 0)
+        ]
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(filtered == [points[0], points[2], points[3]])
+    }
+
+    @Test func outlierFilterRemovesATrailingGlitchOnAFastSwipe() {
+        let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // An ordinary fast right swipe with one glitch sample on the end. The
+        // glitch is 119pt from the path — just inside 3x the 40pt established
+        // step — but nearly perpendicular to it. Admitting it moved the
+        // committed direction from right to down-right, i.e. a different
+        // letter, on a gesture the filter used to read correctly.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 40, y: 0),
+            CGPoint(x: 80, y: 0),
+            CGPoint(x: 120, y: 0),
+            CGPoint(x: 125, y: 119) // glitch: 88° off the established motion
+        ]
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(filtered == Array(points.prefix(4)))
+    }
+
+    @Test func outlierFilterKeepsTheGenuineTailAfterRejectingAGlitch() {
+        let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // The same glitch with the swipe continuing past it. Accepting a
+        // glitch costs twice: the anchor moves onto it, and the genuine
+        // sample after it is then measured from the glitch instead of from
+        // the path — so it fails every criterion and the swipe loses its tail.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 40, y: 0),
+            CGPoint(x: 80, y: 0),
+            CGPoint(x: 120, y: 0),
+            CGPoint(x: 125, y: 119), // glitch
+            CGPoint(x: 160, y: 0) // real motion continues
+        ]
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(filtered == [points[0], points[1], points[2], points[3], points[5]])
+    }
+
+    @Test func outlierFilterRejectsAJumpAcrossTheEstablishedDirection() {
+        let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // A 3-4-5 step: 100pt long, 53° off the established direction. The
+        // length is inside the 3x tolerance the 40pt established step buys, so
+        // only the direction cone rejects it — 53° is wider than the 45° a
+        // swipe sector spans, which is exactly when admitting a sample can
+        // change the committed letter.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 40, y: 0),
+            CGPoint(x: 80, y: 0),
+            CGPoint(x: 120, y: 0),
+            CGPoint(x: 180, y: 80) // step (60, 80): |100| at 53°
+        ]
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(filtered == Array(points.prefix(4)))
+    }
+
+    @Test func outlierFilterCannotRaiseItsOwnJumpBudget() {
+        let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // A 53pt flick, then jumps of 159 and 477 — each one exactly 3x its
+        // predecessor and dead straight, so every one of them continues the
+        // established direction. Only the cap on the reference stops the
+        // allowance from tripling per accepted jump; without it the chain
+        // walks itself arbitrarily far off the key.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 53, y: 0),
+            CGPoint(x: 106, y: 0),
+            CGPoint(x: 159, y: 0),
+            CGPoint(x: 318, y: 0), // 159pt in one sample
+            CGPoint(x: 795, y: 0) // 477pt in the next
+        ]
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(filtered == Array(points.prefix(4)))
+    }
+
+    @Test func outlierFilterPrefersTheEstablishedStepOverTheFollowingRawStep() {
+        let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // The glitch is followed by more fast motion rather than a dwell, so
+        // the two candidate references disagree: the 12pt step the accepted
+        // path established refuses the 120pt jump, the 60pt step that follows
+        // it would wave it through. The established one has to win — the step
+        // after a glitch is part of the same unverified excursion.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 12, y: 0),
+            CGPoint(x: 24, y: 0),
+            CGPoint(x: 144, y: 0), // glitch: 120pt in one sample
+            CGPoint(x: 204, y: 0)
+        ]
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(filtered == Array(points.prefix(3)))
     }
 
     @Test func outlierFilterKeepsSustainedFarRun() {

--- a/wurstfingerTests/GestureTeardownWiringTests.swift
+++ b/wurstfingerTests/GestureTeardownWiringTests.swift
@@ -1,0 +1,163 @@
+//
+//  GestureTeardownWiringTests.swift
+//  WurstfingerTests
+//
+//  Pins the `onDisappear` teardown of both gesture modifiers.
+//
+//  `LongPressSchedulerTests` covers the primitive — `abandon()` drops the
+//  armed work item and the consumed flag — but nothing covered the wiring that
+//  calls it. A mutation run removed the `abandonSequence()` call from both
+//  `onDisappear` hooks and the entire test target stayed green (review
+//  2026-08-09, finding 15), which is exactly the regression that lets a key
+//  torn down mid-hold fire its digit 0.7 s later into whatever mode replaced
+//  it.
+//
+//  The hook only runs on a real view lifecycle, so these tests drive one:
+//  the modifier goes on screen in its own window and is then removed. Arming
+//  the long press through the real gesture would need touch events this target
+//  cannot synthesize, so the scheduler is injected pre-armed instead — that
+//  injection point exists for this test and is documented as such on both
+//  initializers.
+//
+
+import Foundation
+import SwiftUI
+import Testing
+import UIKit
+@testable import WurstfingerApp
+
+@MainActor
+@Suite(.serialized)
+struct GestureTeardownWiringTests {
+    @Test func keyGestureRecognizerTeardownDisarmsTheLongPress() {
+        let scheduler = armedScheduler()
+        defer { scheduler.cancel() }
+
+        let lifecycle = hostThenRemove(
+            Color.clear.modifier(KeyGestureRecognizer(
+                onGestureRecognized: { _ in },
+                onTouchDown: {},
+                aspectRatio: 1,
+                onLongPress: { false },
+                trail: nil,
+                isActive: .constant(false),
+                longPress: scheduler
+            ))
+        )
+
+        expectRanTeardown(lifecycle)
+        #expect(!scheduler.isScheduled)
+        #expect(!scheduler.consumedTouch)
+    }
+
+    @Test func slideGestureHandlerTeardownDisarmsTheLongPress() {
+        let scheduler = armedScheduler()
+        defer { scheduler.cancel() }
+
+        let lifecycle = hostThenRemove(
+            Color.clear.modifier(SlideGestureHandler(
+                slideType: .moveCursor,
+                onSlide: { _ in },
+                onTouchDown: {},
+                onLongPress: { false },
+                trail: nil,
+                isActive: .constant(false),
+                longPress: scheduler
+            ))
+        )
+
+        expectRanTeardown(lifecycle)
+        #expect(!scheduler.isScheduled)
+        #expect(!scheduler.consumedTouch)
+    }
+
+    // MARK: - Fixtures
+
+    /// A scheduler armed far beyond the test's own lifetime and already
+    /// carrying the consumed flag. Both halves are what `abandon()` clears,
+    /// and the delay makes sure a *fired* timer can never be mistaken for a
+    /// teardown that disarmed one.
+    private func armedScheduler() -> LongPressScheduler {
+        let scheduler = LongPressScheduler()
+        scheduler.runFire { true }
+        scheduler.schedule(after: 60) { false }
+        #expect(scheduler.isScheduled)
+        #expect(scheduler.consumedTouch)
+        return scheduler
+    }
+
+    /// Records the SwiftUI lifecycle the host actually delivered, so a
+    /// failure distinguishes "the teardown did not disarm the scheduler" from
+    /// "this environment never tore the view down at all".
+    private final class Lifecycle {
+        var appeared = false
+        var disappeared = false
+    }
+
+    private func expectRanTeardown(_ lifecycle: Lifecycle) {
+        #expect(lifecycle.appeared, "the hosted view never rendered, so no teardown hook could run")
+        #expect(lifecycle.disappeared, "SwiftUI never delivered onDisappear to the hosted view")
+    }
+
+    // MARK: - View lifecycle
+
+    /// Puts `content` on screen in its own window, waits for it to appear,
+    /// then removes it and waits for the teardown to land.
+    private func hostThenRemove(_ content: some View) -> Lifecycle {
+        let lifecycle = Lifecycle()
+        let window = makeWindow()
+        let host = UIHostingController(
+            rootView: AnyView(
+                content
+                    .onAppear { lifecycle.appeared = true }
+                    .onDisappear { lifecycle.disappeared = true }
+            )
+        )
+        defer {
+            window.rootViewController = nil
+            window.isHidden = true
+        }
+
+        window.rootViewController = host
+        window.isHidden = false
+        host.view.frame = window.bounds
+        host.view.layoutIfNeeded()
+        drainRunLoop(until: { lifecycle.appeared })
+
+        // Removed twice over, because either route reaches the hook and which
+        // one SwiftUI takes is a version detail: first the content is replaced
+        // inside the same host, then the whole hierarchy is dropped.
+        host.rootView = AnyView(Color.clear)
+        host.view.layoutIfNeeded()
+        drainRunLoop(until: { lifecycle.disappeared })
+        window.rootViewController = nil
+        drainRunLoop(until: { lifecycle.disappeared })
+
+        return lifecycle
+    }
+
+    /// A window of the host app's scene when there is one — a scene-less
+    /// window does not reliably run SwiftUI's appearance callbacks.
+    private func makeWindow() -> UIWindow {
+        let bounds = CGRect(x: 0, y: 0, width: 320, height: 240)
+        guard let scene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first
+        else {
+            return UIWindow(frame: bounds)
+        }
+        let window = UIWindow(windowScene: scene)
+        window.frame = bounds
+        return window
+    }
+
+    /// Drains the main runloop in short slices until `condition` holds or the
+    /// deadline passes. Fast when SwiftUI delivers promptly, tolerant when a
+    /// loaded CI runner delays a render pass.
+    private func drainRunLoop(deadline: TimeInterval = 2.0, until condition: () -> Bool) {
+        let end = Date().addingTimeInterval(deadline)
+        while !condition(), Date() < end {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        }
+    }
+}

--- a/wurstfingerTests/KeyboardHealthLogTests.swift
+++ b/wurstfingerTests/KeyboardHealthLogTests.swift
@@ -9,6 +9,12 @@ import Foundation
 import Testing
 @testable import WurstfingerApp
 
+/// Serialized: every instance shares one static serial io queue, and the
+/// deferred-sample cases below both assert on wall-clock timing and (in
+/// `staleDeferredSampleIsDiscarded`) deliberately park in that queue. Running
+/// them against each other would make one test's blockage the other's missing
+/// entry.
+@Suite(.serialized)
 struct KeyboardHealthLogTests {
     /// Isolated file URL per test so parallel tests cannot interfere.
     private func makeTestFileURL() -> URL {
@@ -234,6 +240,116 @@ struct KeyboardHealthLogTests {
         #expect(perLine.map(\.label) == ["viewWillAppear", "hostDidEnterBackground"])
     }
 
+    /// The deferred sample rides on the suspension path, so it must cost the
+    /// caller nothing and must genuinely read the footprint *late*: sampling
+    /// at the call site like `record`/`recordAndFlush` would defeat its whole
+    /// purpose (the reclaim it waits for is what the entry is about). The
+    /// entry's own `date` is the witness — it is stamped in the same step as
+    /// the footprint, so a call-site sample would carry the call time.
+    @Test func recordDeferredWritesLateWithoutBlockingTheCaller() async throws {
+        let url = makeTestFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let log = KeyboardHealthLog(fileURL: url)
+
+        let started = Date()
+        log.recordDeferred("postShedSettled", after: 0.5)
+        let elapsed = Date().timeIntervalSince(started)
+
+        #expect(elapsed < 0.1)
+        // `entries()` syncs through the same serial queue, so an entry written
+        // as part of the call would already be visible here.
+        #expect(log.entries().isEmpty)
+
+        try await Task.sleep(for: .milliseconds(1000))
+        let entries = log.entries()
+        #expect(entries.map(\.label) == ["postShedSettled"])
+        let entry = try #require(entries.first)
+        #expect(entry.usedMB > 0)
+        // Slightly under the delay: the timer never fires early, but wall
+        // clock and dispatch's uptime clock are not the same ruler.
+        #expect(entry.date.timeIntervalSince(started) > 0.4)
+    }
+
+    /// The suspension path writes both entries for the same event — the
+    /// guaranteed flushed one and the settled one 2 s later — and forensics
+    /// reads them as a pair, so the deferred entry must land *after* the
+    /// flushed one even though it was queued while that write was in flight.
+    /// The delay doubles as the discard window (see `recordDeferred`), so it
+    /// is kept well above the scheduling jitter of a loaded test machine.
+    @Test func deferredSampleAppendsAfterTheFlushedSuspensionEntry() async throws {
+        let url = makeTestFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let log = KeyboardHealthLog(fileURL: url)
+
+        log.recordAndFlush("viewDidDisappear")
+        log.recordDeferred("postShedSettled", after: 0.2)
+
+        try await Task.sleep(for: .milliseconds(500))
+        #expect(log.entries().map(\.label) == ["viewDidDisappear", "postShedSettled"])
+    }
+
+    /// A frozen process does not lose a pending deferred sample — libdispatch
+    /// runs the overdue block as soon as the process is scheduled again, and
+    /// the extension process is reused across host cycles, so the sample can
+    /// arrive against a keyboard that has nothing to do with its label. It has
+    /// to be discarded instead. Modelled by parking in the shared io queue
+    /// past the discard window: from the block's side that is the same
+    /// situation — enqueued on time, given CPU far too late.
+    @Test func staleDeferredSampleIsDiscarded() async throws {
+        let url = makeTestFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let log = KeyboardHealthLog(fileURL: url)
+
+        // A second instance parks in the one io queue every instance shares:
+        // its provider is called on that queue and does not return.
+        let parked = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+        let blocker = KeyboardHealthLog(fileURLProvider: {
+            parked.signal()
+            release.wait()
+            return nil
+        })
+        blocker.record("occupies the io queue")
+        // Also releases when an expectation below fails early: an io queue
+        // left parked would hang every later test in this process.
+        defer { release.signal() }
+        if case .timedOut = parked.wait(timeout: .now() + 5) {
+            Issue.record("the io queue never picked up the blocking record")
+            return
+        }
+
+        log.recordDeferred("postShedSettled", after: 0.1)
+        // Past the deadline plus the delay again — from there on the sample no
+        // longer describes the moment its label names.
+        try await Task.sleep(for: .milliseconds(400))
+        release.signal()
+
+        // `entries()` syncs through the same queue behind the released blocker
+        // and behind the overdue sample, so this reads the outcome, not a race.
+        #expect(log.entries().isEmpty)
+    }
+
+    /// Without a container there is nowhere to write, and the deferred sample
+    /// must neither trap nor find somewhere else to put itself. An empty
+    /// `entries()` cannot witness that alone — a nil provider returns `[]`
+    /// whatever the block did — so the provider counts its calls: the timer
+    /// has to have fired, asked where to write, and then written nothing.
+    @Test func recordDeferredWithoutAFileIsANoOp() async throws {
+        let consulted = CallCounter()
+        let log = KeyboardHealthLog(fileURLProvider: {
+            consulted.increment()
+            return nil
+        })
+
+        log.recordDeferred("postShedSettled", after: 0.2)
+
+        try await Task.sleep(for: .milliseconds(700))
+        // Snapshot before `entries()`, which consults the provider itself.
+        let consultedByTheSample = consulted.count
+        #expect(log.entries().isEmpty)
+        #expect(consultedByTheSample >= 1)
+    }
+
     /// The file URL provider must not be invoked at construction — that is
     /// what keeps the shared instance's `containerURL(...)` IPC off the
     /// main/spawn thread. It is resolved lazily on first file access.
@@ -252,5 +368,24 @@ struct KeyboardHealthLogTests {
         _ = log.entries() // ioQueue.sync — any deferred resolution has completed
 
         #expect(resolveCount >= 1)
+    }
+
+    /// Counts provider calls made on the io queue and read from the test
+    /// thread, so the increment is not the data race a captured `var` would be.
+    private final class CallCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var calls = 0
+
+        func increment() {
+            lock.lock()
+            calls += 1
+            lock.unlock()
+        }
+
+        var count: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return calls
+        }
     }
 }

--- a/wurstfingerTests/LanguageAlphabetCoverageTests.swift
+++ b/wurstfingerTests/LanguageAlphabetCoverageTests.swift
@@ -7,10 +7,47 @@
 //  structure only, so a layout can ship with an untypeable letter and still
 //  pass CI.
 //
+//  Coverage alone is not enough, though: the 🅒 accent cycle reaches almost
+//  every Latin variant from its base letter, so "reachable" would still hold
+//  after a layout lost a key. The tests below therefore pin the *route* — a
+//  character is expected to have a key of its own unless its inventory names
+//  the detour it takes instead.
+//
 
 import Foundation
 import Testing
 @testable import WurstfingerApp
+
+/// How a definition puts a character into the document, from the most direct
+/// route to the least. `ReachabilityIndex.route(for:)` always reports the best
+/// available one, so a character that still has a key never looks like a
+/// compose-key or cycle character.
+private enum CharacterRoute: CustomStringConvertible {
+    /// A key commits the character outright — one gesture, in some mode.
+    case keyBinding
+    /// A compose (dead) key the layout binds, plus the base letter: `¨` then
+    /// `e` gives `ë`. Two deliberate gestures, both discoverable from the hints.
+    case composeKey
+    /// The layout's own sequential-combine table, e.g. kana + `゛` → voiced kana.
+    /// Like `composeKey`, but driven by a committed character rather than a
+    /// `.compose` action.
+    case combineRule
+    /// The 🅒 key alone: type the base letter, then tap 🅒 until the variant
+    /// comes up. Everything on a reachable character's accent cycle qualifies,
+    /// which makes this the weakest possible claim — the position in the cycle
+    /// is neither shown nor stable, so a layout may only lean on it for
+    /// characters its script barely uses.
+    case accentCycle
+
+    var description: String {
+        switch self {
+        case .keyBinding: "a key binding"
+        case .composeKey: "a compose key"
+        case .combineRule: "a combine rule"
+        case .accentCycle: "the 🅒 accent cycle"
+        }
+    }
+}
 
 /// One layout's required characters and where that list comes from. Characters
 /// a layout knowingly does not provide are named in the entry's comment —
@@ -22,6 +59,16 @@ private struct AlphabetInventory {
     /// scripts use combining marks, which grapheme iteration would fuse with
     /// the preceding letter).
     let groups: [String]
+    /// The characters from `groups` that deliberately have **no key of their
+    /// own**, mapped to the route that produces them instead. Everything not
+    /// listed here must be committed by a binding.
+    ///
+    /// This is an allowlist, and the test enforces it in both directions: a
+    /// character listed here that regains a key fails just as loudly as one
+    /// that loses it. Keeping it exact is the point — an entry that covered
+    /// more than it has to would hand back exactly the hole it closes, because
+    /// the accent cycle reaches nearly every Latin variant.
+    var indirectRoutes: [CharacterRoute: String] = [:]
 }
 
 struct LanguageAlphabetCoverageTests {
@@ -31,43 +78,91 @@ struct LanguageAlphabetCoverageTests {
             Self.inventories.first(where: { $0.id == descriptor.id }),
             "No alphabet inventory for \(descriptor.id) — add one to `inventories`"
         )
-        let producible = Self.producibleText(of: descriptor.makeDefinition())
-        let missing = inventory.groups
-            .flatMap(\.unicodeScalars)
-            .map { String($0) }
-            .filter { !producible.contains($0) }
+        let index = Self.reachability(of: descriptor.makeDefinition())
+        let missing = Self.requiredCharacters(of: inventory).filter { index.route(for: $0) == nil }
         #expect(
             missing.isEmpty,
             "[\(descriptor.id)] cannot produce \(Self.describe(missing)) — inventory: \(inventory.source)"
         )
     }
 
-    /// Names the missing characters by code point as well: ZWNJ, the Thai tone
-    /// marks and the Devanagari matras are invisible on their own.
-    private static func describe(_ characters: [String]) -> String {
-        characters
-            .map { character in
-                let scalars = character.unicodeScalars
-                    .map { String(format: "U+%04X", $0.value) }
-                    .joined(separator: " ")
-                return "\(character) (\(scalars))"
-            }
-            .joined(separator: ", ")
+    /// The cycle-closure guard: every required character needs a key unless the
+    /// inventory declares the detour. Without this, dropping a letter's binding
+    /// stays invisible — `é` would simply fall back to the acute compose key,
+    /// `ż` to a few taps on 🅒, and coverage would still pass.
+    @Test(arguments: LanguageDefinitions.all)
+    func layoutBindsEveryCharacterItDoesNotDeclareAsIndirect(descriptor: LanguageDescriptor) throws {
+        let inventory = try #require(
+            Self.inventories.first(where: { $0.id == descriptor.id }),
+            "No alphabet inventory for \(descriptor.id) — add one to `inventories`"
+        )
+        let index = Self.reachability(of: descriptor.makeDefinition())
+        let required = Self.requiredCharacters(of: inventory)
+
+        // The table itself has to stay meaningful: no character under two
+        // routes (the expectation would depend on dictionary order), and no
+        // leftover entry for a character the inventory stopped requiring.
+        let declaredCharacters = inventory.indirectRoutes.values.flatMap(\.unicodeScalars).map { String($0) }
+        #expect(
+            Set(declaredCharacters).count == declaredCharacters.count,
+            "[\(descriptor.id)] a character appears under two routes in `indirectRoutes`"
+        )
+        let strays = declaredCharacters.filter { !required.contains($0) }
+        #expect(
+            strays.isEmpty,
+            "[\(descriptor.id)] `indirectRoutes` names \(Self.describe(strays)), which this inventory does not require"
+        )
+
+        let declared = Self.declaredRoutes(of: inventory)
+        let mismatches = required.compactMap { character -> String? in
+            // Unreachable characters are `layoutProducesItsAlphabet`'s report.
+            guard let actual = index.route(for: character) else { return nil }
+            let expected = declared[character] ?? .keyBinding
+            guard actual != expected else { return nil }
+            return "\(Self.describe(character)) declared as \(expected), reachable via \(actual)"
+        }
+        #expect(
+            mismatches.isEmpty,
+            """
+            [\(descriptor.id)] \(mismatches.joined(separator: "; ")). \
+            Either restore whatever produced it, or record the route it really takes \
+            in the inventory's `indirectRoutes` — with a comment saying why.
+            """
+        )
     }
 
-    /// Everything the definition can put into the document: every `commitText`
-    /// (primary and return swipe, all modes), every output of a compose rule
-    /// whose trigger is actually bound, every sequential-combine result, and
-    /// everything reachable from those through the 🅒 accent-cycle key.
-    private static func producibleText(of definition: KeyboardDefinition) -> Set<String> {
-        var direct: Set<String> = []
+    // MARK: - Reachability
+
+    /// Every route a definition offers, kept apart instead of merged into one
+    /// "producible" set so the tests can tell a key from a fallback.
+    private struct ReachabilityIndex {
+        /// Characters some key commits outright (primary or return swipe, any mode).
+        let bound: Set<String>
+        /// Outputs of the compose triggers this layout actually binds.
+        let composed: Set<String>
+        /// Outputs of the layout's sequential-combine table.
+        let combined: Set<String>
+        /// Closure of all of the above under the 🅒 accent cycle.
+        let cycled: Set<String>
+
+        func route(for character: String) -> CharacterRoute? {
+            if bound.contains(character) { return .keyBinding }
+            if composed.contains(character) { return .composeKey }
+            if combined.contains(character) { return .combineRule }
+            if cycled.contains(character) { return .accentCycle }
+            return nil
+        }
+    }
+
+    private static func reachability(of definition: KeyboardDefinition) -> ReachabilityIndex {
+        var bound: Set<String> = []
         var composeTriggers: Set<String> = []
         for mode in definition.modes.values {
             for key in mode.keys.values {
                 for binding in key.bindings.values {
-                    collect(binding.action, into: &direct, triggers: &composeTriggers)
+                    collect(binding.action, into: &bound, triggers: &composeTriggers)
                     if let returnAction = binding.returnAction {
-                        collect(returnAction, into: &direct, triggers: &composeTriggers)
+                        collect(returnAction, into: &bound, triggers: &composeTriggers)
                     }
                 }
             }
@@ -75,24 +170,34 @@ struct LanguageAlphabetCoverageTests {
 
         let engine = definition.settings.composeRuleOverrides
             .map { ComposeEngine.withGlobalRules(overrides: $0) } ?? ComposeEngine.shared
+        var composed: Set<String> = []
         for trigger in composeTriggers {
             if let outputs = engine.ruleSet.rules[trigger]?.values {
-                direct.formUnion(outputs)
+                composed.formUnion(outputs)
             }
         }
+        // A combine rule fires on a *committed* trigger character (kana + ゛),
+        // so its outputs only count while the layout still binds that trigger —
+        // otherwise losing the ゛ key would leave the voiced kana looking
+        // producible.
+        var combined: Set<String> = []
         if let combine = definition.settings.combineRuleSet {
-            for map in combine.rules.values {
-                direct.formUnion(map.values)
+            for (trigger, map) in combine.rules where bound.contains(trigger) {
+                combined.formUnion(map.values)
             }
         }
-        return cycleClosure(of: direct, engine: engine)
+
+        return ReachabilityIndex(
+            bound: bound, composed: composed, combined: combined,
+            cycled: cycleClosure(of: bound.union(composed).union(combined), engine: engine)
+        )
     }
 
     private static func collect(
-        _ action: KeyAction, into direct: inout Set<String>, triggers: inout Set<String>
+        _ action: KeyAction, into bound: inout Set<String>, triggers: inout Set<String>
     ) {
         switch action {
-        case let .commitText(text): direct.insert(text)
+        case let .commitText(text): bound.insert(text)
         case let .compose(trigger): triggers.insert(trigger)
         default: break
         }
@@ -112,6 +217,38 @@ struct LanguageAlphabetCoverageTests {
         return result
     }
 
+    // MARK: - Inventory helpers
+
+    private static func requiredCharacters(of inventory: AlphabetInventory) -> [String] {
+        inventory.groups.flatMap(\.unicodeScalars).map { String($0) }
+    }
+
+    /// Flattens `indirectRoutes` into a character → route lookup. Double
+    /// declarations are caught by the caller, which can report them; here the
+    /// last one simply wins.
+    private static func declaredRoutes(of inventory: AlphabetInventory) -> [String: CharacterRoute] {
+        var routes: [String: CharacterRoute] = [:]
+        for (route, characters) in inventory.indirectRoutes {
+            for scalar in characters.unicodeScalars {
+                routes[String(scalar)] = route
+            }
+        }
+        return routes
+    }
+
+    /// Names the missing characters by code point as well: ZWNJ, the Thai tone
+    /// marks and the Devanagari matras are invisible on their own.
+    private static func describe(_ characters: [String]) -> String {
+        characters.map(describe).joined(separator: ", ")
+    }
+
+    private static func describe(_ character: String) -> String {
+        let scalars = character.unicodeScalars
+            .map { String(format: "U+%04X", $0.value) }
+            .joined(separator: " ")
+        return "\(character) (\(scalars))"
+    }
+
     // MARK: - Inventories
 
     private static let latin = "abcdefghijklmnopqrstuvwxyz"
@@ -123,27 +260,54 @@ struct LanguageAlphabetCoverageTests {
         AlphabetInventory(id: "fi_FI", source: "Finnish alphabet", groups: [latin, "äöå"]),
         AlphabetInventory(
             id: "fr_FR", source: "French accented letters and ligatures",
-            groups: [latin, "àâçèéêëîïôùûüÿœæ"]
+            groups: [latin, "àâçèéêëîïôùûüÿœæ"],
+            // The main mode spends its ¨ slot on ê, so the diaeresis sits
+            // on the numeric mode's punctuation ring — ë ï ü ÿ come from there,
+            // î ô from the circumflex key. œ and æ are outputs of the `!` compose
+            // table, which no key triggers (see `ComposeRuleSet.global`), leaving
+            // the cycle as their only route.
+            indirectRoutes: [.composeKey: "ëîïôüÿ", .accentCycle: "œæ"]
         ),
         AlphabetInventory(id: "de_DE", source: "German umlauts and ß", groups: [latin, "äöüß"]),
         AlphabetInventory(id: "it_IT", source: "Italian accented vowels", groups: [latin, "àèéìòù"]),
         AlphabetInventory(id: "pl_PL", source: "Polish alphabet", groups: [latin, "ąćęłńóśźż"]),
-        AlphabetInventory(id: "pt_PT", source: "Portuguese diacritics", groups: [latin, "àáâãçéêíóôõú"]),
+        AlphabetInventory(
+            id: "pt_PT", source: "Portuguese diacritics", groups: [latin, "àáâãçéêíóôõú"],
+            // à is the rarest Portuguese diacritic (the crasis contraction), so
+            // the layout keeps the key for á and leaves à to the grave key.
+            indirectRoutes: [.composeKey: "à"]
+        ),
         AlphabetInventory(id: "es_ES", source: "Spanish diacritics", groups: [latin, "áéíñóúü"]),
-        AlphabetInventory(id: "ca_ES", source: "Spanish and Catalan diacritics", groups: [latin, "àáçèéíïñòóúü"]),
+        AlphabetInventory(
+            id: "ca_ES", source: "Spanish and Catalan diacritics", groups: [latin, "àáçèéíïñòóúü"],
+            // Shared Spanish/Catalan layout: the nine keys carry the Spanish
+            // acutes, and the two Catalan-only graves ride on the grave key.
+            indirectRoutes: [.composeKey: "èò"]
+        ),
         AlphabetInventory(id: "sv_SE", source: "Swedish alphabet", groups: [latin, "åäö"]),
         AlphabetInventory(id: "tl_PH", source: "Filipino alphabet", groups: [latin, "ñ"]),
         // Base letters only: the tone marks come from the Telex input method and
         // are covered by TelexTypingTests, not by a binding.
         AlphabetInventory(
             id: "vi_VN", source: "Vietnamese 29-letter alphabet",
-            groups: ["abcdeghiklmnopqrstuvxy", "ăâđêôơư"]
+            groups: ["abcdeghiklmnopqrstuvxy", "ăâđêôơư"],
+            // The modified vowels have no keys either: Telex types them as
+            // aa/ee/oo (circumflex) and aw/ow/uw (breve and horn), which
+            // TelexTypingTests pins. The circumflex three double as compose-key
+            // output; the breve and horn three are only on the accent cycle,
+            // because neither `˘` nor a horn trigger is bound anywhere.
+            indirectRoutes: [.composeKey: "âêô", .accentCycle: "ăơư"]
         ),
         AlphabetInventory(id: "ru_RU", source: "Russian alphabet", groups: ["абвгдеёжзийклмнопрстуфхцчшщъыьэюя"]),
         AlphabetInventory(id: "uk_UA", source: "Ukrainian alphabet", groups: ["абвгґдеєжзиіїйклмнопрстуфхцчшщьюя"]),
         AlphabetInventory(
             id: "el_GR", source: "Greek alphabet, final sigma, monotonic accented vowels",
-            groups: ["αβγδεζηθικλμνξοπρστυφχψω", "ς", "άέήίόύώϊϋΐΰ"]
+            groups: ["αβγδεζηθικλμνξοπρστυφχψω", "ς", "άέήίόύώϊϋΐΰ"],
+            // Monotonic Greek accents every stressed vowel, so binding all of
+            // them would cost more slots than the grid has: the tonos vowels
+            // come from the acute key, the dialytika ones from the diaeresis key
+            // (ΐ and ΰ from either, applied to the other mark's output).
+            indirectRoutes: [.composeKey: "άέήίόύώϊϋΐΰ"]
         ),
         AlphabetInventory(
             id: "he_IL", source: "Hebrew alphabet, final forms, geresh and gershayim",
@@ -190,7 +354,12 @@ struct LanguageAlphabetCoverageTests {
             groups: [
                 "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん",
                 "がぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽ", "ぁぃぅぇぉゃゅょっ", "ゝゞ", "ー、。",
-            ]
+            ],
+            // Voicing is a key of its own (゛) rather than 21 more slots: the
+            // dakuten kana come from `hiraganaCombineRules`, a second ゛ cascades
+            // the ha row on to its handakuten form. ぐ ず ど ぶ are the exception —
+            // the reference layout does put those four on keys.
+            indirectRoutes: [.combineRule: "がぎげござじぜぞだぢづでばびべぼぱぴぷぺぽ"]
         ),
         AlphabetInventory(
             id: "ja_JP_katakana",
@@ -198,7 +367,10 @@ struct LanguageAlphabetCoverageTests {
             groups: [
                 "アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン",
                 "ガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポ", "ァィゥェォャュョッヮ", "ヽヾ", "ー、。・",
-            ]
+            ],
+            // Same voicing story as hiragana, via `katakanaCombineRules`;
+            // グ ズ ド ブ are the four the reference layout binds directly.
+            indirectRoutes: [.combineRule: "ガギゲゴザジゼゾダヂヅデバビベボパピプペポ"]
         ),
     ]
 }

--- a/wurstfingerTests/OnboardingProgressTests.swift
+++ b/wurstfingerTests/OnboardingProgressTests.swift
@@ -49,6 +49,22 @@ struct OnboardingProgressTests {
         #expect(!local.bool(forKey: AppSettingsKey.onboardingFullAccessEnabled.rawValue))
     }
 
+    /// An isolated UI-test launch really does hand both arguments the same
+    /// object — `OnboardingProgress.store` resolves to `SharedDefaults.store`
+    /// there. Aliased, the copy would be skipped because the value is already
+    /// under that key and the removal would take it with it, so passing one
+    /// store as both must leave it exactly as it was.
+    @Test func migrationLeavesASingleAliasedStoreUntouched() {
+        let aliased = InMemoryUserDefaults()
+        aliased.set(true, forKey: AppSettingsKey.onboardingKeyboardInstalled.rawValue)
+        aliased.set(true, forKey: AppSettingsKey.onboardingFullAccessEnabled.rawValue)
+
+        OnboardingProgress.migrateFromSharedStoreIfNeeded(from: aliased, to: aliased)
+
+        #expect(aliased.bool(forKey: AppSettingsKey.onboardingKeyboardInstalled.rawValue))
+        #expect(aliased.bool(forKey: AppSettingsKey.onboardingFullAccessEnabled.rawValue))
+    }
+
     /// A key owned by both enums would be written to the app's own defaults by
     /// the host and read from the app group by the keyboard, which is the split
     /// this store move removes.

--- a/wurstfingerTests/SharedDefaultsIsolationTests.swift
+++ b/wurstfingerTests/SharedDefaultsIsolationTests.swift
@@ -14,10 +14,16 @@ struct SharedDefaultsIsolationTests {
     /// `UITestApp.isolatedDefaultsArgument` repeats this literal. Renaming the
     /// argument without updating that copy would point every UI test launch
     /// back at the real app-group store, silently.
+    ///
+    /// This pins one side of that pair. A rename on the *other* side compiles
+    /// and runs happily, which is why the UI target additionally proves the
+    /// argument arrives at runtime (`testLaunchArgumentIsolatesDefaultsFromTheRealStore`).
     @Test func isolationArgumentLiteralIsStable() {
         #expect(SharedDefaults.isolatedStoreArgument == "ISOLATED_DEFAULTS")
     }
 
+    /// `SharedDefaults.store` feeds the *resolved* name to `isWipeableSuite`, so
+    /// this equality is also what points the launch wipe at the throwaway suite.
     @Test func isolationArgumentSelectsThrowawaySuite() {
         let resolved = SharedDefaults.resolvedSuiteName(
             arguments: ["ISOLATED_DEFAULTS", "-AppleLanguages", "(en)"]
@@ -32,10 +38,34 @@ struct SharedDefaultsIsolationTests {
 
     /// The isolated suite must not be an app group (the extension would then
     /// share it) and must not be the host bundle id, which
-    /// `UserDefaults(suiteName:)` rejects.
+    /// `UserDefaults(suiteName:)` rejects. An overlap with the app group costs
+    /// no data — `isWipeableSuite` refuses that name — but it would silently
+    /// stop isolating anything, which is what this pins.
     @Test func isolatedSuiteIsAppLocal() {
         #expect(!SharedDefaults.isolatedSuiteName.hasPrefix("group."))
         #expect(SharedDefaults.isolatedSuiteName != SharedDefaults.suiteName)
         #expect(SharedDefaults.isolatedSuiteName != Bundle.main.bundleIdentifier)
+    }
+
+    /// The launch wipe is a `removePersistentDomain` with no undo, compiled into
+    /// the app *and* the extension, so it must not depend on two constants
+    /// staying different. Converged names have to switch it off rather than aim
+    /// it at the user's app group — that is the case the last expectation drives,
+    /// since the shipped constants cannot express it.
+    @Test func onlyTheThrowawaySuiteIsEverWiped() {
+        #expect(SharedDefaults.isWipeableSuite(SharedDefaults.isolatedSuiteName))
+        #expect(!SharedDefaults.isWipeableSuite(SharedDefaults.suiteName))
+        #expect(!SharedDefaults.isWipeableSuite("group.same", appGroup: "group.same", isolated: "group.same"))
+    }
+
+    /// The onboarding checklist is app-private state the UI tests tap directly,
+    /// so the same argument has to move it too — and to the very store the
+    /// launch wipes, not to some third suite nothing cleans up.
+    @Test func isolationArgumentMovesTheOnboardingChecklistToo() {
+        let isolated = OnboardingProgress.resolvedStore(arguments: [SharedDefaults.isolatedStoreArgument])
+        #expect(isolated === SharedDefaults.store)
+
+        let plain = OnboardingProgress.resolvedStore(arguments: ["-AppleLanguages", "(en)"])
+        #expect(plain === UserDefaults.standard)
     }
 }

--- a/wurstfingerUITests/UITestApp.swift
+++ b/wurstfingerUITests/UITestApp.swift
@@ -8,15 +8,28 @@
 import XCTest
 
 enum UITestApp {
-    /// Redirects the app's `SharedDefaults.store` to a throwaway suite. Every
-    /// UI launch must carry it: the settings and onboarding screens write
-    /// straight through to the app group the user's own keyboard reads, and
-    /// `continueAfterFailure = false` means a mid-test failure never reaches
-    /// whatever restore step the test had planned.
+    /// Redirects the defaults the app writes to a throwaway suite that the app
+    /// wipes on every isolated launch. Every UI launch must carry it: the
+    /// settings screens write straight through to the app group the user's own
+    /// keyboard reads, and `continueAfterFailure = false` means a mid-test
+    /// failure never reaches whatever restore step the test had planned.
+    ///
+    /// Two things worth knowing before relying on it:
+    ///
+    /// - It covers `SharedDefaults.store` and, through the same argument, the
+    ///   app-private `OnboardingProgress.store` — the checklist tapped in
+    ///   `testOnboardingCheckboxesAreToggleable`. Anything that reaches
+    ///   `UserDefaults.standard` by a third route is still the tester's own.
+    /// - Wiping is the app's job, not the runner's. The runner is its own
+    ///   sandboxed process, so the suite it would reach under this name is a
+    ///   different file from the app's.
     ///
     /// Mirrors `SharedDefaults.isolatedStoreArgument`. The UI test target cannot
-    /// import the app module, so the literal is duplicated here and pinned by
-    /// `SharedDefaultsIsolationTests`.
+    /// import the app module, so the literal is duplicated here: the app-side
+    /// spelling is pinned by `SharedDefaultsIsolationTests`, and that this copy
+    /// still *reaches* the app is proven at runtime by
+    /// `testLaunchArgumentIsolatesDefaultsFromTheRealStore` — a rename here
+    /// compiles and runs, it just silently stops isolating anything.
     static let isolatedDefaultsArgument = "ISOLATED_DEFAULTS"
 
     /// Pins the app to English regardless of the simulator's locale, for suites

--- a/wurstfingerUITests/wurstfingerUITests.swift
+++ b/wurstfingerUITests/wurstfingerUITests.swift
@@ -77,9 +77,11 @@ final class wurstfingerUITests: XCTestCase {
         let newValue = firstToggle.value as? String
         XCTAssertNotEqual(initialValue, newValue, "Toggle value should change after tap")
 
-        // Toggling back must return the original value. Either state is safe:
-        // the app under test writes to the isolated defaults suite, not the
-        // app group the user's own keyboard reads.
+        // Toggling back must return the original value. Both taps write real
+        // persisted checklist state, but the isolation launch argument routes
+        // `OnboardingProgress.store` into the throwaway suite along with
+        // `SharedDefaults.store`, so a failure between them leaves a ticked step
+        // there rather than in the tester's own app defaults.
         firstToggle.tap()
         let restoredValue = firstToggle.value as? String
         XCTAssertEqual(initialValue, restoredValue, "Toggle must return to its original state")
@@ -152,47 +154,107 @@ final class wurstfingerUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Drag Feedback"].exists, "Drag Feedback control missing")
     }
 
+    /// The "Utility Keys on Left" row. It has no stable accessibility
+    /// identifier (adding one would be a production change, out of scope here),
+    /// so match on the pinned-English label. The SwiftUI Toggle label combines
+    /// title + subtitle, hence CONTAINS rather than an exact subscript match.
+    @MainActor
+    private func utilityKeysToggle() -> XCUIElement {
+        app.switches
+            .matching(NSPredicate(format: "label CONTAINS %@", "Utility Keys on Left"))
+            .firstMatch
+    }
+
+    /// SwiftUI exposes the whole row as the switch element; tapping its center
+    /// hits the label, not the UISwitch. Tap the nested switch when present,
+    /// otherwise the trailing edge where the UISwitch sits.
+    @MainActor
+    private func flip(_ toggle: XCUIElement) {
+        let inner = toggle.switches.firstMatch
+        if inner.exists {
+            inner.tap()
+        } else {
+            toggle
+                .coordinate(withNormalizedOffset: CGVector(dx: 0.93, dy: 0.5))
+                .tap()
+        }
+    }
+
     @MainActor
     func testSettingsUtilityKeysToggle() {
         app.tabBars.buttons["Settings"].tap()
 
-        // Find the "Utility Keys on Left" toggle. The row has no stable
-        // accessibility identifier (adding one would be a production change,
-        // out of scope here), so match on the pinned-English label. The
-        // SwiftUI Toggle label combines title + subtitle, hence CONTAINS
-        // rather than an exact subscript match.
-        let utilityToggle = app.switches
-            .matching(NSPredicate(format: "label CONTAINS %@", "Utility Keys on Left"))
-            .firstMatch
+        let utilityToggle = utilityKeysToggle()
         XCTAssertTrue(
             utilityToggle.waitForExistence(timeout: 2),
             "Utility Keys on Left toggle must exist in Settings"
         )
 
-        // SwiftUI exposes the whole row as the switch element; tapping its
-        // center hits the label, not the UISwitch. Tap the nested switch when
-        // present, otherwise the trailing edge where the UISwitch sits.
-        func flip() {
-            let inner = utilityToggle.switches.firstMatch
-            if inner.exists {
-                inner.tap()
-            } else {
-                utilityToggle
-                    .coordinate(withNormalizedOffset: CGVector(dx: 0.93, dy: 0.5))
-                    .tap()
-            }
-        }
-
         let initialValue = utilityToggle.value as? String
-        flip()
+        flip(utilityToggle)
         let newValue = utilityToggle.value as? String
         XCTAssertNotEqual(initialValue, newValue, "Toggle should change state")
 
         // Toggling back must return the original value; both writes land in the
         // isolated defaults suite, not the real app-group store.
-        flip()
+        flip(utilityToggle)
         let restoredValue = utilityToggle.value as? String
         XCTAssertEqual(initialValue, restoredValue, "Toggle must return to its original state")
+    }
+
+    // MARK: - Defaults Isolation
+
+    /// Runtime proof that the isolation launch argument still reaches the app.
+    ///
+    /// `UITestApp.isolatedDefaultsArgument` is a copy of
+    /// `SharedDefaults.isolatedStoreArgument` across a boundary no compiler
+    /// checks — this target cannot import the app module. `SharedDefaultsIsolationTests`
+    /// pins the app-side spelling, but a rename on *this* side keeps compiling
+    /// and every UI test would quietly go back to writing the user's real
+    /// app-group settings. Only the running app can testify, so ask it: flip a
+    /// setting, relaunch, and see whether the value survived.
+    ///
+    /// It survives exactly when isolation is broken — the real store is never
+    /// wiped — or when the app stopped wiping the throwaway suite on launch
+    /// (`SharedDefaults.store`), which would let UI tests inherit each other's
+    /// leftovers. Both are worth failing over.
+    @MainActor
+    func testLaunchArgumentIsolatesDefaultsFromTheRealStore() {
+        app.tabBars.buttons["Settings"].tap()
+        let toggle = utilityKeysToggle()
+        XCTAssertTrue(toggle.waitForExistence(timeout: 2), "Utility Keys on Left toggle must exist in Settings")
+
+        let valueAtLaunch = toggle.value as? String
+        flip(toggle)
+        XCTAssertNotEqual(valueAtLaunch, toggle.value as? String, "Toggle should change state")
+
+        app.terminate()
+        app.launch()
+        app.tabBars.buttons["Settings"].tap()
+        let toggleAfterRelaunch = utilityKeysToggle()
+        XCTAssertTrue(
+            toggleAfterRelaunch.waitForExistence(timeout: 5),
+            "Settings must be reachable again after the relaunch"
+        )
+        let valueAfterRelaunch = toggleAfterRelaunch.value as? String
+
+        // Undo first, assert second: `continueAfterFailure = false` stops the
+        // test at the assertion, and in the failing case the flip landed in the
+        // user's real app-group store, which nothing else will clean up.
+        if valueAfterRelaunch != valueAtLaunch {
+            flip(toggleAfterRelaunch)
+        }
+
+        XCTAssertEqual(
+            valueAfterRelaunch, valueAtLaunch,
+            """
+            A flipped setting survived a relaunch. Either \
+            UITestApp.isolatedDefaultsArgument no longer matches \
+            SharedDefaults.isolatedStoreArgument — every UI test is then writing the \
+            real app-group store — or SharedDefaults.store stopped wiping the \
+            isolated suite on launch.
+            """
+        )
     }
 
     // MARK: - Test Area Tests


### PR DESCRIPTION
Implements every finding and nitpick from the 2026-08-09 follow-up review of `develop` — 18 findings across P3 robustness, P4 hygiene, P5 localization/metadata/privacy and P6 test gaps. The review reported no new P1/P2, so this is stabilization-release material.

Each change was then adversarially re-reviewed and the 31 confirmed defects that pass found in the *fixes themselves* were fixed in a second round; the details of both rounds are below.

## Behavior

**A fast flick no longer commits the center letter (finding 3).** The outlier filter judged every sample by where it landed, so a fling covering more than `maxJumpDistance` per sample had all of its samples discarded — the gesture trail drew the full swipe, the classifier saw a tap. `filterOutliers` now also asks *how* the finger got there: a jump that continues the movement the accepted path established, within 45° and 3× its step, is motion rather than a teleport, with the reference step capped so an admitted jump cannot raise the budget for the next one.

The first attempt at this was too permissive and flipped the committed direction on ordinary fast swipes carrying one trailing glitch. The parameters are now chosen by sweep, not judgement — over 609,552 synthetic paths, measured against the real files compiled three ways (`origin/develop`, first attempt, final):

| | regressions vs. `develop` | tap → wrong swipe | flicks rescued |
| --- | --- | --- | --- |
| first attempt | 12,704 | 6,852 | 111,958 |
| **final** | **0** | **0** | **118,810** |

All 21 pre-existing gesture pins stay green, including the two that deliberately defend the glitch-during-tap case.

**VoiceOver can reach shift, the sentence punctuation and the mode keys (finding 1, partial + finding 11).** Custom actions are opt-in by carrying a label and #283 labelled only the utility set, so VoiceOver announced the mode switches as the number *123* and the letters *abc*, and offered no way at all to reach shift or `, . ?`. Seven bindings gain semantic names, including both shift affordances — naming only shift-up would leave a VoiceOver user in caps lock with no way back.

Deliberately **not** the full fix: labelling every letter swipe would put 8–16 unnamed rotor entries on every key, which is the reason the opt-in exists. The review scopes that as follow-up design work, and on-device VoiceOver verification is still required before the next submission.

**The health log says what it measured (findings 5, 6, 2).** The dismissal entry read the footprint before the reclaim after `teardownHosting()` finished, overstating the surviving footprint by 1.3–3.3 MB. The guaranteed synchronous flush stays; a best-effort `postShedSettled` sample follows 2 s later — cancellable, cancelled when the keyboard comes back first, and discarded when it starts too late to describe the shed it belongs to. That last guard matters: a frozen process *resumes* an overdue timer rather than dropping it, so without it the entry could be taken minutes later against a rebuilt keyboard.

Two documentation contracts were wrong: an open→close cycle does not always write its closing entry (an abruptly killed host skips the shed entirely), and the comment about the `NSExtensionHost*` notifications had it backwards for what was measured. The health view now teaches how to read both shapes instead of asserting what a device does — which remains unverified.

**Settings layout (findings 9.1, 10).** The aspect-ratio subtitle interpolated only the number, so `:1` reordered under RTL and the value read `1:1.00`; the ratio is one substitution now. The Size & Position screen compressed its explanation to a single truncated line in every language — the controls scroll below the pinned preview, like the other preview screens.

## Localization, privacy, metadata

70 catalog values corrected (finding 8, 9). None were visible to tooling — every one was already marked `translated`. Hebrew said "utility keys on the right" where the toggle says left; ten languages still promised the pre-#235 classic style; Arabic rendered `(1-2-3)` as `(3-2-1)`; Russian used a calque for *drag*, Korean labelled the issue tracker "troubleshooting", French and Portuguese translated the golden ratio as the colour gold, and Thai, Korean and Hindi each rendered one concept two ways. The German store description said `für Daumentypen optimiert`, which parses as *kinds of thumbs*.

Both privacy manifests declared `CA92.1` alone — the reason that explicitly *excludes* cross-app access — while the dominant use on both sides is the shared app group, verbatim the `1C8F.1` case. The extension declares the app group; the host declares both, because its onboarding checklist really is app-private.

## Tests

- **Alphabet coverage (finding 16)** counted a character as produced when an accent cycle could reach it, so dropping the French `é` binding passed the whole suite. Coverage now pins the *route* each character takes, with a derived allowlist for the legitimately cycle-only ones.
- **The #282 long-press teardown wiring (finding 15)** was unprotected — mutation M7 reverted it and the suite stayed green. Both gesture modifiers now take their scheduler by injection so a real view teardown can be observed.
- **UI-test isolation (finding 17).** The onboarding test claimed to write a throwaway suite and did not: the checklist was hardcoded to the standard store, so a run left a step ticked in the tester's own defaults. It honours the isolation argument now, the throwaway suite is wiped per launch, and a runtime probe fails loudly if the launch-argument literal is renamed on the test side.
- **The clipboard suite (finding 18)** shares the process-global pasteboard; on a host whose pasteboard service is wedged a single write blocks for tens of minutes and then succeeds — one run of this review measured 2268 s, and a run while preparing this PR measured 59 minutes for the same test. A bounded probe now runs first. It **writes**, deliberately: a read of an empty pasteboard answers instantly on a host whose write path is stuck, so the original read-only probe certified an environment it never exercised — measured, with one parallel clone gating correctly while the next one hung for the hour. A wedged host now costs 30 s and one loud failure instead of an hour of silence.

## Verification

- `WurstfingerTests`: **1209 passed, 0 failed, 38 s** (iPhone 17 Pro, iOS 26.5), clipboard suite included.
- SwiftFormat, SwiftLint `--strict` and markdownlint clean on every changed file.
- Every finding was verified by an independent adversarial pass that re-derived the mechanics rather than reading the diff; 31 confirmed defects in the first round's fixes were fixed, 21 further claims were refuted and dropped.

## Deliberately not in this PR

- **Finding 1's full fix** — generated rotor actions with spoken glyph names for every swipe. Scoped as design work by the review; ~21 of 26 German letters stay swipe-only under VoiceOver.
- **Finding 3's alternative (c)** — clamping the gesture trail to post-filter samples, which would also close baseline finding 25 (a sloppy tap flashes a streak while committing correctly). The trail is fed live per sample while filtering is retrospective, so clamping needs a one-sample delay and a different design.
- **Finding 14** — the long-press timer surviving a mid-hold *language* switch. Re-derived exhaustively and recorded as a documented tradeoff, with the complete harm bound in the code.
- **The two on-device items** the review lists: end-to-end VoiceOver, and whether the `NSExtensionHost*` notifications fire on real hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer VoiceOver labels and actions for punctuation, keyboard modes, and utility keys across supported languages.
  * Added an explanatory “How to read a cycle” legend to keyboard health history.
  * Improved keyboard size and position settings with a fixed preview and fully visible translated guidance.

* **Bug Fixes**
  * Improved fast swipe recognition and gesture behavior.
  * Preserved onboarding settings correctly during isolated launches.
  * Corrected aspect-ratio formatting in right-to-left languages.
  * Updated compose-key behavior and accessibility translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->