### PR TITLE
Fix Simulator Identity Mismatch in Screenshot Generation

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -51,22 +51,10 @@ jobs:
           sudo xcode-select -s "$XCODE_APP/Contents/Developer"
           xcodebuild -version
 
-      # Warm-boot only: the script detects and boots its own simulator, so a
-      # missing preferred device must not fail the job (this step used to
-      # hard-fail on an empty UDID when the hardcoded device was absent).
-      - name: Boot iOS Simulator
-        run: |
-          DEVICE_UDID=$(xcrun simctl list devices available | grep -E "iPhone" | grep -v "SE" | head -n 1 | grep -oE '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}' || true)
-          if [ -z "$DEVICE_UDID" ]; then
-            echo "No iPhone simulator found to warm-boot; the script will handle device selection"
-            xcrun simctl list devices available
-            exit 0
-          fi
-          echo "Booting simulator: $DEVICE_UDID"
-          xcrun simctl boot "$DEVICE_UDID" 2>/dev/null || true
-          # Wait for simulator to be ready
-          xcrun simctl bootstatus "$DEVICE_UDID" -b
-          echo "Simulator ready"
+      # No boot step here: the script resolves one UDID and boots exactly that
+      # device itself. A separate name-based warm-boot can pick the same-named
+      # device of a *different* iOS runtime on multi-runtime runner images,
+      # leaving the script's target shutdown (SimError 405).
 
       - name: Save existing screenshots for comparison
         run: |

--- a/scripts/generate-screenshots.sh
+++ b/scripts/generate-screenshots.sh
@@ -31,7 +31,15 @@ else
     echo "📱 Detected simulator: $DEVICE_NAME"
 fi
 
-DESTINATION="platform=iOS Simulator,name=$DEVICE_NAME"
+# Address the simulator by UDID from here on: with several iOS runtimes
+# installed the same device name exists once per runtime, and booting, the
+# status-bar override, and the test run must all hit the same device.
+TARGET_UDID=$(sim_udid_for_name "$DEVICE_NAME")
+if [ -n "$TARGET_UDID" ]; then
+    DESTINATION="platform=iOS Simulator,id=$TARGET_UDID"
+else
+    DESTINATION="platform=iOS Simulator,name=$DEVICE_NAME"
+fi
 TEST_TARGET="WurstfingerUITests/ScreenshotTests/testGenerateScreenshots"
 DOCS_DIR="$PROJECT_ROOT/docs/images"
 DERIVED_DATA="/tmp/WurstfingerScreenshots"
@@ -44,9 +52,6 @@ echo "  Scheme: $SCHEME"
 echo "  Destination: $DESTINATION"
 echo "  Output: $DOCS_DIR"
 echo ""
-
-# Find target simulator UDID by name
-TARGET_UDID=$(sim_udid_for_name "$DEVICE_NAME")
 
 # Marker file so we can count only screenshots created by this run
 # (pre-existing .webp files in $DOCS_DIR must not count as success).
@@ -63,6 +68,14 @@ cleanup() {
     rm -f "$RUN_MARKER"
 }
 trap cleanup EXIT
+
+# Boot the resolved device ourselves — the status-bar override below requires
+# a booted simulator, and relying on someone else having booted "the right one"
+# is exactly what broke under multi-runtime CI images.
+if [ -n "$TARGET_UDID" ]; then
+    echo -e "${BLUE}🚀 Booting simulator $TARGET_UDID ($DEVICE_NAME)...${NC}"
+    sim_boot_and_wait "$TARGET_UDID"
+fi
 
 # Override status bar to get consistent screenshots (Apple's standard 9:41)
 echo -e "${BLUE}⏰ Setting consistent status bar...${NC}"

--- a/scripts/lib/simulator-capture.sh
+++ b/scripts/lib/simulator-capture.sh
@@ -25,17 +25,21 @@ NC='\033[0m' # No Color
 
 # Resolves a simulator UDID by exact device name (available devices only).
 # Prints the UDID, or nothing if no matching available device exists.
+# With several iOS runtimes installed the same name exists once per runtime,
+# each with its own UDID — an already-booted match wins so all callers end up
+# addressing the device that is actually running.
 sim_udid_for_name() {
     local name="$1"
     xcrun simctl list devices available -j | python3 -c "
 import json, sys
 name = sys.argv[1]
 devices = json.load(sys.stdin)['devices']
-for runtime_devices in devices.values():
-    for d in runtime_devices:
-        if d.get('name') == name and d.get('isAvailable', True):
-            print(d['udid'])
-            raise SystemExit(0)
+matches = [d for runtime_devices in devices.values() for d in runtime_devices
+           if d.get('name') == name and d.get('isAvailable', True)]
+booted = [d for d in matches if d.get('state') == 'Booted']
+for d in booted or matches[:1]:
+    print(d['udid'])
+    raise SystemExit(0)
 raise SystemExit(1)
 " "$name" 2>/dev/null || true
 }


### PR DESCRIPTION
## What

Makes `generate-screenshots.sh` resolve one simulator UDID up front and use it for everything — boot, status-bar override, and the xcodebuild destination (`id=` instead of `name=`). `sim_udid_for_name` now prefers an already-booted device over the first listed match, and the workflow's separate name-based warm-boot step is removed since the script boots its target itself (adopting the pattern `generate-appstore-screenshots.sh` already uses).

## Why

The update-screenshots workflow has failed on every run since 2026-07-09 (last green: 2026-07-08) with `SimError 405: Unable to lookup in current state: Shutdown` at the status-bar step. No repo change caused it — the macos-latest image update that night started shipping several Xcode 26.x versions, so the same device name ("iPhone 17 Pro") now exists once per iOS runtime with different UDIDs. The workflow's warm-boot step picked its device from `simctl list` text output while the script resolved the name via the JSON output; with duplicate names the two can disagree, so the script targeted the shutdown twin of the booted device.

## Test plan

- Reproduced the mechanism locally (iOS 26.2 + 26.5 runtimes, two "iPhone 17 Pro" devices): without the fix the resolver returns the first listed match regardless of state; with the fix it returns the booted device when one exists.
- shellcheck + bash -n clean.
- Will trigger `workflow_dispatch` on this branch to verify the workflow end to end on the CI image.