### PR TITLE
Rename Legacy Types to Glossary Names (Phase 1)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -108,7 +108,7 @@ to be able to tell from the name alone which of several classifications applies.
 | action | `KeyAction` | the command enum — `commitText`, `compose`, `cycleAccents`, `switchMode`, `capitalizeWord`, `advanceToNextInputMode`, `dismissKeyboard`, `switchToNextLanguage`, `deleteBackward`, `deleteForward`, `space`, `newline`, `moveCursor`, `copy`, `paste`, `cut`, `cutAll`, `none` |
 | label | `KeyBinding.label` | the text drawn on the key. May differ from the output (`"⇧"` for shift) and is empty for icon-driven utility keys |
 | compose | `ComposeRuleSet`, `ComposeEngine` | table-driven character composition (`' + a → á`) |
-| input method | `InputMethodKind` | stateful transformation of committed text: `direct`, `telex`, `hangul` |
+| input method | `InputMethodType` | stateful transformation of committed text: `direct`, `telex`, `hangul` |
 | descriptor | `LanguageDescriptor` | lazy handle to a language: cheap metadata plus a builder that materializes the definition on demand |
 
 ### Layout (`Definition/Layout/`)
@@ -228,7 +228,6 @@ will be brought in line in its own dedicated changes. This list is not exhaustiv
 | `NumpadStyle`, `CursorMovementStyle` | behavioral variants carrying a visual suffix; would be `…Type` |
 | `GesturePreprocessorConfig`, `KeyConfig`, `LanguageConfig` | abbreviated suffix |
 | `KeyConfig`, `LanguageConfig` | declarative data carrying the runtime-parameter suffix on top of that |
-| `InputMethodKind` | would be `…Type` |
 | `KeyboardInfo` | `…Info` says nothing about the contents; would be `…Metadata` |
 | `LanguageConfig` / `LanguageDescriptor` / `KeyboardInfo` | three near-identical language metadata types; the latter two are field-identical. A merge, not a rename |
 | `hideLetters`, `hideStandardSymbols`, `hideExtraSymbols`, `longPressNumbersEnabled` | booleans that do not read as assertions |

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -231,6 +231,5 @@ will be brought in line in its own dedicated changes. This list is not exhaustiv
 | `KeyboardInfo` | `…Info` says nothing about the contents; would be `…Metadata` |
 | `LanguageConfig` / `LanguageDescriptor` / `KeyboardInfo` | three near-identical language metadata types; the latter two are field-identical. A merge, not a rename |
 | `hideLetters`, `hideStandardSymbols`, `hideExtraSymbols`, `longPressNumbersEnabled` | booleans that do not read as assertions |
-| `HapticFeedbackManager` | `…Manager` |
 | `slotId` in `GridKeyboardFactory` and `NumericLayouts` | alias for `keyId` |
 | ~70 comment lines saying "layer" | pre-date this glossary |

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -69,9 +69,8 @@ about the *thing bound to it* ("the `topLeft` key commits `q`").
 ### `…Style` is visual only
 
 `KeyStyle` (`.primary`, `.utility`, `.spacebar`, …) and `KeyboardStyle` (`.classic`,
-`.liquidGlass`) are appearance. `NumpadStyle` (digit order) and `CursorMovementStyle`
-(drag behavior) are **not** visual and are misnamed — see
-[Legacy exceptions](#7-legacy-exceptions).
+`.liquidGlass`) are appearance. `NumpadType` (digit order) and `CursorMovementType`
+(drag behavior) are **not** visual and therefore carry `…Type`.
 
 For new code: `…Style` = how it looks, `…Type` = a closed set of behavioral variants (as in
 `GestureType`, `SlideType`). Never `…Mode` for either — that word belongs to keyboard
@@ -225,7 +224,6 @@ will be brought in line in its own dedicated changes. This list is not exhaustiv
 
 | Name | Problem |
 | --- | --- |
-| `NumpadStyle`, `CursorMovementStyle` | behavioral variants carrying a visual suffix; would be `…Type` |
 | `GesturePreprocessorConfig`, `KeyConfig`, `LanguageConfig` | abbreviated suffix |
 | `KeyConfig`, `LanguageConfig` | declarative data carrying the runtime-parameter suffix on top of that |
 | `KeyboardInfo` | `…Info` says nothing about the contents; would be `…Metadata` |

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -29,10 +29,10 @@ struct SettingsView: View {
     private var hapticDragIntensity = Double(HapticSettings.defaultDragIntensity)
 
     @AppStorage(SettingsKey.numpadStyle.rawValue, store: SharedDefaults.store)
-    private var numpadStyleRaw = NumpadStyle.phone.rawValue
+    private var numpadTypeRaw = NumpadType.phone.rawValue
 
     @AppStorage(SettingsKey.cursorMovementStyle.rawValue, store: SharedDefaults.store)
-    private var cursorMovementStyleRaw = CursorMovementStyle.continuous.rawValue
+    private var cursorMovementTypeRaw = CursorMovementType.continuous.rawValue
 
     @AppStorage(SettingsKey.keyboardStyle.rawValue, store: SharedDefaults.store)
     private var keyboardStyleRaw = KeyboardStyle.classic.rawValue
@@ -129,14 +129,14 @@ struct SettingsView: View {
                 )
             }
 
-            Picker(selection: $cursorMovementStyleRaw) {
-                Text("Continuous").tag(CursorMovementStyle.continuous.rawValue)
-                Text("Step-by-step").tag(CursorMovementStyle.discrete.rawValue)
+            Picker(selection: $cursorMovementTypeRaw) {
+                Text("Continuous").tag(CursorMovementType.continuous.rawValue)
+                Text("Step-by-step").tag(CursorMovementType.discrete.rawValue)
             } label: {
                 SettingsRow(
                     icon: "cursor.rays", color: .green,
                     title: "Cursor Movement",
-                    subtitle: cursorMovementStyleDescription
+                    subtitle: cursorMovementTypeDescription
                 )
             }
         } header: {
@@ -199,11 +199,11 @@ struct SettingsView: View {
                 )
             }
 
-            Picker(selection: $numpadStyleRaw) {
-                Text("Phone (1-2-3)").tag(NumpadStyle.phone.rawValue)
-                Text("Classic (7-8-9)").tag(NumpadStyle.classic.rawValue)
+            Picker(selection: $numpadTypeRaw) {
+                Text("Phone (1-2-3)").tag(NumpadType.phone.rawValue)
+                Text("Classic (7-8-9)").tag(NumpadType.classic.rawValue)
             } label: {
-                SettingsRow(icon: "number.square", color: .purple, title: "Numpad Style", subtitle: numpadStyleDescription)
+                SettingsRow(icon: "number.square", color: .purple, title: "Numpad Style", subtitle: numpadTypeDescription)
             }
         } header: {
             Text("Appearance")
@@ -350,8 +350,8 @@ struct SettingsView: View {
         return String(localized: "Hiding \(hidden.joined(separator: ", "))")
     }
 
-    private var cursorMovementStyleDescription: String {
-        let style = CursorMovementStyle(rawValue: cursorMovementStyleRaw) ?? .continuous
+    private var cursorMovementTypeDescription: String {
+        let style = CursorMovementType(rawValue: cursorMovementTypeRaw) ?? .continuous
         switch style {
         case .continuous:
             return String(localized: "Drag to move cursor")
@@ -381,8 +381,8 @@ struct SettingsView: View {
         """)
     }
 
-    private var numpadStyleDescription: String {
-        let style = NumpadStyle(rawValue: numpadStyleRaw) ?? .phone
+    private var numpadTypeDescription: String {
+        let style = NumpadType(rawValue: numpadTypeRaw) ?? .phone
         switch style {
         case .phone:
             return String(localized: "Phone layout (1-2-3)")

--- a/wurstfinger/SettingsView.swift
+++ b/wurstfinger/SettingsView.swift
@@ -351,8 +351,8 @@ struct SettingsView: View {
     }
 
     private var cursorMovementTypeDescription: String {
-        let style = CursorMovementType(rawValue: cursorMovementTypeRaw) ?? .continuous
-        switch style {
+        let cursorMovementType = CursorMovementType(rawValue: cursorMovementTypeRaw) ?? .continuous
+        switch cursorMovementType {
         case .continuous:
             return String(localized: "Drag to move cursor")
         case .discrete:
@@ -382,8 +382,8 @@ struct SettingsView: View {
     }
 
     private var numpadTypeDescription: String {
-        let style = NumpadType(rawValue: numpadTypeRaw) ?? .phone
-        switch style {
+        let numpadType = NumpadType(rawValue: numpadTypeRaw) ?? .phone
+        switch numpadType {
         case .phone:
             return String(localized: "Phone layout (1-2-3)")
         case .classic:

--- a/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
+++ b/wurstfingerKeyboard/Definition/Language/GridKeyboardFactory.swift
@@ -58,7 +58,7 @@ enum GridKeyboardFactory {
         supportsCapitalization: Bool = true,
         numericBackToAlphaLabel: String = NumericLayouts.defaultBackToAlphaLabel,
         numericDigits: [String] = NumericLayouts.westernDigits,
-        inputMethod: InputMethodKind = .direct,
+        inputMethod: InputMethodType = .direct,
         combineRuleSet: ComposeRuleSet? = nil
     ) -> KeyboardDefinition {
         precondition(

--- a/wurstfingerKeyboard/Definition/Language/KeyboardDefinition.swift
+++ b/wurstfingerKeyboard/Definition/Language/KeyboardDefinition.swift
@@ -100,7 +100,7 @@ enum ModeNames {
 /// transformation over recent document context — Vietnamese Telex being
 /// the first real example. Making this a data-driven enum on the keyboard
 /// definition keeps language activation out of view-controller locale checks.
-enum InputMethodKind: String, Codable, Equatable {
+enum InputMethodType: String, Codable, Equatable {
     /// Characters are committed verbatim. Default.
     case direct
 
@@ -128,7 +128,7 @@ struct KeyboardDefinitionSettings: Codable, Equatable {
 
     /// Which input method to apply to committed characters. Defaults to
     /// `.direct`; set to `.telex` for Vietnamese Telex composition.
-    let inputMethod: InputMethodKind
+    let inputMethod: InputMethodType
 
     /// Sequential-combine rules (`trigger → base → result`) applied by
     /// `SequentialCompositionMiddleware` (via `sequentialCombiner`): when the
@@ -142,7 +142,7 @@ struct KeyboardDefinitionSettings: Codable, Equatable {
     init(
         autoCapitalize: Bool,
         composeRuleOverrides: ComposeRuleSet?,
-        inputMethod: InputMethodKind = .direct,
+        inputMethod: InputMethodType = .direct,
         combineRuleSet: ComposeRuleSet? = nil
     ) {
         self.autoCapitalize = autoCapitalize

--- a/wurstfingerKeyboard/KeyboardViewController.swift
+++ b/wurstfingerKeyboard/KeyboardViewController.swift
@@ -169,12 +169,12 @@ final class KeyboardViewController: UIInputViewController {
         // back the same way `primaryLanguage` does (system language, then
         // English) instead of leaving loadDefinition a no-op.
         let languageId = selectedLanguageId
-        let numpadStyle = SharedDefaults.store.string(
+        let numpadType = SharedDefaults.store.string(
             forKey: SettingsKey.numpadStyle.rawValue
         )
         let signature = KeyboardViewModel.definitionSignature(
             languageId: languageId,
-            numpadStyle: numpadStyle
+            numpadType: numpadType
         )
         // Compare against the view model's record of what it actually loaded —
         // a controller-side cache desyncs when the user cycles languages via

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -150,7 +150,7 @@ final class KeyboardViewModel: ObservableObject {
     /// Peak signed displacement during the current space drag. Used by the
     /// discrete cursor-movement mode to classify regular vs. return swipes.
     var spaceDragPeak: CGFloat = 0
-    /// Cursor-movement style captured at the start of the current space drag, so
+    /// Cursor-movement type captured at the start of the current space drag, so
     /// a mid-drag settings change cannot switch classification mode mid-gesture.
     var spaceDragCursorType: CursorMovementType = .continuous
     var isDeleteDragging = false

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -82,7 +82,7 @@ final class KeyboardViewModel: ObservableObject {
 
     var currentDefinition: KeyboardDefinition?
     /// Signature of the inputs that produced `currentDefinition` (see
-    /// `definitionSignature(languageId:numpadStyle:)`). Kept on the view model
+    /// `definitionSignature(languageId:numpadType:)`). Kept on the view model
     /// — not the controller — so in-keyboard language switches, which load a
     /// new definition directly, keep it in sync.
     var loadedDefinitionSignature: String?
@@ -152,7 +152,7 @@ final class KeyboardViewModel: ObservableObject {
     var spaceDragPeak: CGFloat = 0
     /// Cursor-movement style captured at the start of the current space drag, so
     /// a mid-drag settings change cannot switch classification mode mid-gesture.
-    var spaceDragCursorStyle: CursorMovementStyle = .continuous
+    var spaceDragCursorType: CursorMovementType = .continuous
     var isDeleteDragging = false
     var deleteDragResidual: CGFloat = 0
     private var userDefaultsObserver: NSObjectProtocol?

--- a/wurstfingerKeyboard/KeyboardViewModel.swift
+++ b/wurstfingerKeyboard/KeyboardViewModel.swift
@@ -107,7 +107,7 @@ final class KeyboardViewModel: ObservableObject {
 
     let hapticSettings: HapticSettings
     let layoutSettings: LayoutSettings
-    private let hapticManager: HapticFeedbackManager
+    private let hapticPlayer: HapticFeedbackPlayer
 
     // MARK: - Computed Properties for Backward Compatibility
 
@@ -170,7 +170,7 @@ final class KeyboardViewModel: ObservableObject {
         // Initialize extracted settings classes
         hapticSettings = HapticSettings(defaults: defaults, shouldPersist: shouldPersistSettings)
         layoutSettings = LayoutSettings(defaults: defaults, shouldPersist: shouldPersistSettings)
-        hapticManager = HapticFeedbackManager(settings: hapticSettings)
+        hapticPlayer = HapticFeedbackPlayer(settings: hapticSettings)
 
         enabledLanguageIds = LanguageSettings.normalizedEnabledLanguageIds(from: defaults)
 
@@ -291,7 +291,7 @@ final class KeyboardViewModel: ObservableObject {
     /// Text actions stay silent — their haptic fires on touch-down.
     func triggerHaptic(for action: KeyAction) {
         guard let event = KeyboardHapticEvent.forPipelineAction(action) else { return }
-        hapticManager.trigger(event)
+        hapticPlayer.trigger(event)
     }
 
     func reloadSettings() {
@@ -338,19 +338,19 @@ final class KeyboardViewModel: ObservableObject {
         return LanguageSettings.label(for: locale)
     }
 
-    // MARK: - Haptic Feedback (delegated to HapticFeedbackManager)
+    // MARK: - Haptic Feedback (delegated to HapticFeedbackPlayer)
 
     /// Haptic feedback for key touch-down — called by button views on first contact
     func feedbackTap() {
-        hapticManager.tap()
+        hapticPlayer.tap()
     }
 
     func feedbackDrag() {
-        hapticManager.drag()
+        hapticPlayer.drag()
     }
 
     /// Confirmation tick for explicit layer/language switches.
     func feedbackStateChange() {
-        hapticManager.stateChange()
+        hapticPlayer.stateChange()
     }
 }

--- a/wurstfingerKeyboard/Runtime/Pipeline/HapticMiddleware.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/HapticMiddleware.swift
@@ -13,7 +13,7 @@ import Foundation
 /// silent because their haptic already fired on touch-down.
 ///
 /// The concrete feedback implementation is injected as a closure so this
-/// file stays free of UIKit/`HapticFeedbackManager` dependencies. Wiring
+/// file stays free of UIKit/`HapticFeedbackPlayer` dependencies. Wiring
 /// happens in `KeyboardViewModel` when the pipeline is assembled.
 struct HapticMiddleware: ActionMiddleware {
     /// Called with the action before it is forwarded.

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -21,14 +21,14 @@ extension KeyboardViewModel {
         guard let base = KeyboardRegistry.load(id: id)
             ?? KeyboardRegistry.load(id: LanguageConfig.english.id)
         else { return }
-        let definition = applyNumpadStyle(to: base)
+        let definition = applyNumpadType(to: base)
         currentDefinition = definition
         // Record the signature of what was actually loaded (the id may differ
         // from the requested one after the English fallback) so the controller
         // can skip redundant rebuilds on the next appearance.
         loadedDefinitionSignature = Self.definitionSignature(
             languageId: definition.id,
-            numpadStyle: sharedDefaults.string(forKey: SettingsKey.numpadStyle.rawValue)
+            numpadType: sharedDefaults.string(forKey: SettingsKey.numpadStyle.rawValue)
         )
         activeModeName = definition.defaultMode
         pipelineLocale = definition.locale
@@ -40,16 +40,16 @@ extension KeyboardViewModel {
     /// numpad style). Pure so the desync-free comparison between the
     /// controller's desired inputs and the view model's loaded state can be
     /// unit-tested without a UIKit lifecycle.
-    static func definitionSignature(languageId: String, numpadStyle: String?) -> String {
-        "\(languageId)|\(numpadStyle ?? "")"
+    static func definitionSignature(languageId: String, numpadType: String?) -> String {
+        "\(languageId)|\(numpadType ?? "")"
     }
 
     /// Swaps the numeric layer to the classic (7-8-9) ordering when the user
     /// selected it. The registry caches the phone-style definition, so this
     /// always derives from the canonical phone layout and never mutates the cache.
-    private func applyNumpadStyle(to definition: KeyboardDefinition) -> KeyboardDefinition {
+    private func applyNumpadType(to definition: KeyboardDefinition) -> KeyboardDefinition {
         let raw = sharedDefaults.string(forKey: SettingsKey.numpadStyle.rawValue)
-        let style = raw.flatMap(NumpadStyle.init(rawValue:)) ?? .phone
+        let style = raw.flatMap(NumpadType.init(rawValue:)) ?? .phone
         guard style == .classic else { return definition }
         let classicNumeric = NumericLayouts.classic(
             digits: definition.numericDigits,
@@ -438,9 +438,9 @@ extension KeyboardViewModel {
 
     /// Cursor-movement style for the space-bar drag. Read per gesture (stable
     /// for the duration of a drag); defaults to `.continuous`.
-    var cursorMovementStyle: CursorMovementStyle {
+    var cursorMovementType: CursorMovementType {
         let raw = sharedDefaults.string(forKey: SettingsKey.cursorMovementStyle.rawValue)
-        return raw.flatMap(CursorMovementStyle.init(rawValue:)) ?? .continuous
+        return raw.flatMap(CursorMovementType.init(rawValue:)) ?? .continuous
     }
 
     func handleSpaceSlide(phase: SlidePhase, key: KeyConfig) {
@@ -451,11 +451,11 @@ extension KeyboardViewModel {
             spaceDragPeak = 0
             // Snapshot the style once so a mid-drag settings change can't switch
             // this gesture between discrete and continuous classification.
-            spaceDragCursorStyle = cursorMovementStyle
+            spaceDragCursorType = cursorMovementType
         case let .changed(deltaX):
             guard isSpaceDragging, deltaX != 0 else { return }
             spaceDragResidual += deltaX
-            if spaceDragCursorStyle == .discrete {
+            if spaceDragCursorType == .discrete {
                 // Track the peak; movement is deferred to `.ended` so the whole
                 // swipe counts as a single discrete step.
                 if abs(spaceDragResidual) > abs(spaceDragPeak) {
@@ -465,7 +465,7 @@ extension KeyboardViewModel {
                 stepContinuousCursor()
             }
         case .ended:
-            if spaceDragCursorStyle == .discrete {
+            if spaceDragCursorType == .discrete {
                 finishDiscreteSpaceSlide()
             }
             isSpaceDragging = false

--- a/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
+++ b/wurstfingerKeyboard/Runtime/Pipeline/KeyboardViewModel+Pipeline.swift
@@ -37,7 +37,7 @@ extension KeyboardViewModel {
     }
 
     /// Signature of the inputs that determine a loaded definition (language +
-    /// numpad style). Pure so the desync-free comparison between the
+    /// numpad type). Pure so the desync-free comparison between the
     /// controller's desired inputs and the view model's loaded state can be
     /// unit-tested without a UIKit lifecycle.
     static func definitionSignature(languageId: String, numpadType: String?) -> String {
@@ -49,8 +49,8 @@ extension KeyboardViewModel {
     /// always derives from the canonical phone layout and never mutates the cache.
     private func applyNumpadType(to definition: KeyboardDefinition) -> KeyboardDefinition {
         let raw = sharedDefaults.string(forKey: SettingsKey.numpadStyle.rawValue)
-        let style = raw.flatMap(NumpadType.init(rawValue:)) ?? .phone
-        guard style == .classic else { return definition }
+        let numpadType = raw.flatMap(NumpadType.init(rawValue:)) ?? .phone
+        guard numpadType == .classic else { return definition }
         let classicNumeric = NumericLayouts.classic(
             digits: definition.numericDigits,
             backToAlphaLabel: definition.numericBackToAlphaLabel
@@ -436,7 +436,7 @@ extension KeyboardViewModel {
         }
     }
 
-    /// Cursor-movement style for the space-bar drag. Read per gesture (stable
+    /// Cursor-movement type for the space-bar drag. Read per gesture (stable
     /// for the duration of a drag); defaults to `.continuous`.
     var cursorMovementType: CursorMovementType {
         let raw = sharedDefaults.string(forKey: SettingsKey.cursorMovementStyle.rawValue)
@@ -449,7 +449,7 @@ extension KeyboardViewModel {
             isSpaceDragging = true
             spaceDragResidual = 0
             spaceDragPeak = 0
-            // Snapshot the style once so a mid-drag settings change can't switch
+            // Snapshot the type once so a mid-drag settings change can't switch
             // this gesture between discrete and continuous classification.
             spaceDragCursorType = cursorMovementType
         case let .changed(deltaX):

--- a/wurstfingerKeyboard/Settings/HapticFeedbackPlayer.swift
+++ b/wurstfingerKeyboard/Settings/HapticFeedbackPlayer.swift
@@ -1,5 +1,5 @@
 //
-//  HapticFeedbackManager.swift
+//  HapticFeedbackPlayer.swift
 //  Wurstfinger
 //
 //  Extracted from KeyboardViewModel to improve separation of concerns.
@@ -76,7 +76,7 @@ enum HapticIntensityLevel: Int, CaseIterable, Equatable {
 /// Requires Full Access to be enabled — without it, `UIFeedbackGenerator` silently
 /// fails because the underlying `CHHapticEngine` is blocked by the keyboard sandbox.
 /// The host app settings UI prevents enabling haptics when Full Access is not granted.
-final class HapticFeedbackManager {
+final class HapticFeedbackPlayer {
     private let settings: HapticSettings
 
     /// Cached generators per feedback style to avoid per-event allocation

--- a/wurstfingerKeyboard/Settings/HapticFeedbackPlayer.swift
+++ b/wurstfingerKeyboard/Settings/HapticFeedbackPlayer.swift
@@ -71,7 +71,7 @@ enum HapticIntensityLevel: Int, CaseIterable, Equatable {
     }
 }
 
-/// Manages haptic feedback generation for keyboard events.
+/// Plays haptic feedback for keyboard events.
 ///
 /// Requires Full Access to be enabled — without it, `UIFeedbackGenerator` silently
 /// fails because the underlying `CHHapticEngine` is blocked by the keyboard sandbox.

--- a/wurstfingerKeyboard/Settings/KeyboardSettings.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardSettings.swift
@@ -14,6 +14,8 @@ import Foundation
 
 /// Centralized storage for all UserDefaults keys used by the keyboard.
 /// Using an enum prevents typos and makes refactoring easier.
+/// The rawValues are persisted storage keys — never rename a case, even when
+/// the type it points to is renamed.
 enum SettingsKey: String, CaseIterable {
     case hapticIntensityTap
     case hapticIntensityDrag
@@ -327,17 +329,17 @@ final class LayoutSettings: ObservableObject {
     }
 }
 
-// MARK: - Numpad Style
+// MARK: - Numpad Type
 
-enum NumpadStyle: String, CaseIterable {
+enum NumpadType: String, CaseIterable {
     case phone // 1-2-3 / 4-5-6 / 7-8-9 (default, like phone keypad)
     case classic // 7-8-9 / 4-5-6 / 1-2-3 (like calculator)
 }
 
-// MARK: - Cursor Movement Style
+// MARK: - Cursor Movement Type
 
-/// Space bar cursor movement style
-enum CursorMovementStyle: String, CaseIterable {
+/// Space bar cursor movement type
+enum CursorMovementType: String, CaseIterable {
     case continuous // Joystick-style: drag distance controls cursor position
     case discrete // MessagEase-style: one swipe = one character, return-swipe = one word
 }

--- a/wurstfingerTests/CursorMovementTests.swift
+++ b/wurstfingerTests/CursorMovementTests.swift
@@ -96,7 +96,7 @@ struct DiscreteCursorMovementTests {
     private func makeDiscreteViewModel() -> (KeyboardViewModel, MockTextTarget) {
         let defaults = InMemoryUserDefaults()
         defaults.set(
-            CursorMovementStyle.discrete.rawValue,
+            CursorMovementType.discrete.rawValue,
             forKey: SettingsKey.cursorMovementStyle.rawValue
         )
         let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)

--- a/wurstfingerTests/KeyboardStateHygieneTests.swift
+++ b/wurstfingerTests/KeyboardStateHygieneTests.swift
@@ -33,41 +33,41 @@ private func makeMultiLanguageViewModel(
 
 @Suite(.serialized)
 struct DefinitionSignatureTests {
-    @Test func signatureCombinesLanguageAndNumpadStyle() {
+    @Test func signatureCombinesLanguageAndNumpadType() {
         #expect(
-            KeyboardViewModel.definitionSignature(languageId: "de_DE", numpadStyle: "classic")
+            KeyboardViewModel.definitionSignature(languageId: "de_DE", numpadType: "classic")
                 == "de_DE|classic"
         )
         #expect(
-            KeyboardViewModel.definitionSignature(languageId: "en_US", numpadStyle: nil)
+            KeyboardViewModel.definitionSignature(languageId: "en_US", numpadType: nil)
                 == "en_US|"
         )
     }
 
     @Test func signatureDiffersWhenAnyInputDiffers() {
-        let base = KeyboardViewModel.definitionSignature(languageId: "de_DE", numpadStyle: nil)
-        #expect(base != KeyboardViewModel.definitionSignature(languageId: "en_US", numpadStyle: nil))
-        #expect(base != KeyboardViewModel.definitionSignature(languageId: "de_DE", numpadStyle: "classic"))
+        let base = KeyboardViewModel.definitionSignature(languageId: "de_DE", numpadType: nil)
+        #expect(base != KeyboardViewModel.definitionSignature(languageId: "en_US", numpadType: nil))
+        #expect(base != KeyboardViewModel.definitionSignature(languageId: "de_DE", numpadType: "classic"))
     }
 
     @Test func loadDefinitionRecordsSignature() {
         let (vm, _) = makeViewModel(languageId: "de_DE")
         #expect(
             vm.loadedDefinitionSignature
-                == KeyboardViewModel.definitionSignature(languageId: "de_DE", numpadStyle: nil)
+                == KeyboardViewModel.definitionSignature(languageId: "de_DE", numpadType: nil)
         )
     }
 
-    @Test func loadDefinitionRecordsNumpadStyleInSignature() {
+    @Test func loadDefinitionRecordsNumpadTypeInSignature() {
         let defaults = InMemoryUserDefaults()
-        defaults.set(NumpadStyle.classic.rawValue, forKey: SettingsKey.numpadStyle.rawValue)
+        defaults.set(NumpadType.classic.rawValue, forKey: SettingsKey.numpadStyle.rawValue)
         let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
         vm.loadDefinition(for: "de_DE")
         #expect(
             vm.loadedDefinitionSignature
                 == KeyboardViewModel.definitionSignature(
                     languageId: "de_DE",
-                    numpadStyle: NumpadStyle.classic.rawValue
+                    numpadType: NumpadType.classic.rawValue
                 )
         )
     }
@@ -84,7 +84,7 @@ struct DefinitionSignatureTests {
         // viewWillAppear.
         #expect(
             vm.loadedDefinitionSignature
-                == KeyboardViewModel.definitionSignature(languageId: "en_US", numpadStyle: nil)
+                == KeyboardViewModel.definitionSignature(languageId: "en_US", numpadType: nil)
         )
     }
 
@@ -98,7 +98,7 @@ struct DefinitionSignatureTests {
             vm.loadedDefinitionSignature
                 == KeyboardViewModel.definitionSignature(
                     languageId: LanguageConfig.english.id,
-                    numpadStyle: nil
+                    numpadType: nil
                 )
         )
     }

--- a/wurstfingerTests/LongPressNumberTests.swift
+++ b/wurstfingerTests/LongPressNumberTests.swift
@@ -73,9 +73,9 @@ struct LongPressNumberPipelineTests {
         }
     }
 
-    @Test func longPressFollowsClassicNumpadStyle() {
+    @Test func longPressFollowsClassicNumpadType() {
         let defaults = InMemoryUserDefaults()
-        defaults.set(NumpadStyle.classic.rawValue, forKey: SettingsKey.numpadStyle.rawValue)
+        defaults.set(NumpadType.classic.rawValue, forKey: SettingsKey.numpadStyle.rawValue)
         let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
         let target = MockTextTarget()
         vm.bindTextInputTarget(target)

--- a/wurstfingerTests/ModeDefinitionValidationTests.swift
+++ b/wurstfingerTests/ModeDefinitionValidationTests.swift
@@ -207,13 +207,13 @@ struct NativeDigitLayerTests {
         #expect(digitTap(def.mode(ModeNames.numeric), GridSlot.zero) == "٠")
     }
 
-    @Test func numericDigitsSurviveNumpadStyleSwap() {
+    @Test func numericDigitsSurviveNumpadTypeSwap() {
         let def = GridKeyboardFactory.layout(
             id: "test_ar", title: "Test", localeIdentifier: "ar",
             centerCharacters: [["ا", "ب", "ت"], ["ث", "ج", "ح"], ["خ", "د", "ذ"]],
             numericDigits: NumericLayouts.arabicIndicDigits
         )
-        // Mirror KeyboardViewModel+Pipeline.applyNumpadStyle's classic rebuild.
+        // Mirror KeyboardViewModel+Pipeline.applyNumpadType's classic rebuild.
         let swapped = def.replacingMode(
             ModeNames.numeric,
             with: NumericLayouts.classic(

--- a/wurstfingerTests/SequentialCompositionMiddlewareTests.swift
+++ b/wurstfingerTests/SequentialCompositionMiddlewareTests.swift
@@ -178,7 +178,7 @@ struct SequentialCompositionMiddlewareTests {
 
 struct SequentialCombinerResolutionTests {
     private func settings(
-        inputMethod: InputMethodKind = .direct,
+        inputMethod: InputMethodType = .direct,
         combineRuleSet: ComposeRuleSet? = nil
     ) -> KeyboardDefinitionSettings {
         KeyboardDefinitionSettings(

--- a/wurstfingerTests/SlideGestureStateTests.swift
+++ b/wurstfingerTests/SlideGestureStateTests.swift
@@ -531,8 +531,8 @@ struct SpaceLabelTogglePipelineTests {
         #expect(defaults.bool(forKey: SettingsKey.hideStandardSymbols.rawValue))
     }
 
-    @Test(arguments: [CursorMovementStyle.continuous, .discrete])
-    func upSwipeTogglesExtraSymbolsWithoutTextInput(style: CursorMovementStyle) throws {
+    @Test(arguments: [CursorMovementType.continuous, .discrete])
+    func upSwipeTogglesExtraSymbolsWithoutTextInput(style: CursorMovementType) throws {
         let (vm, target) = makeViewModel(languageId: "de_DE")
         vm.sharedDefaults.set(style.rawValue, forKey: SettingsKey.cursorMovementStyle.rawValue)
         let spaceKey = try #require(vm.activeModeFromDefinition?.key(for: UtilitySlot.space))

--- a/wurstfingerTests/ViewModelPipelineTests.swift
+++ b/wurstfingerTests/ViewModelPipelineTests.swift
@@ -306,7 +306,7 @@ struct ViewModelVCActionTests {
     }
 }
 
-// MARK: - Numpad style wiring
+// MARK: - Numpad type wiring
 
 @Suite(.serialized)
 struct ViewModelNumpadTypeTests {

--- a/wurstfingerTests/ViewModelPipelineTests.swift
+++ b/wurstfingerTests/ViewModelPipelineTests.swift
@@ -309,11 +309,11 @@ struct ViewModelVCActionTests {
 // MARK: - Numpad style wiring
 
 @Suite(.serialized)
-struct ViewModelNumpadStyleTests {
-    private func loadedNumericTopLeftDigit(numpadStyle: String?) -> String? {
+struct ViewModelNumpadTypeTests {
+    private func loadedNumericTopLeftDigit(numpadType: String?) -> String? {
         let defaults = InMemoryUserDefaults()
-        if let numpadStyle {
-            defaults.set(numpadStyle, forKey: SettingsKey.numpadStyle.rawValue)
+        if let numpadType {
+            defaults.set(numpadType, forKey: SettingsKey.numpadStyle.rawValue)
         }
         let vm = KeyboardViewModel(userDefaults: defaults, shouldPersistSettings: false)
         vm.loadDefinition(for: "de_DE")
@@ -325,11 +325,11 @@ struct ViewModelNumpadStyleTests {
 
     @Test func defaultNumpadIsPhone() {
         // Phone layout: 1-2-3 in the top row.
-        #expect(loadedNumericTopLeftDigit(numpadStyle: nil) == "1")
+        #expect(loadedNumericTopLeftDigit(numpadType: nil) == "1")
     }
 
     @Test func classicNumpadSwapsTopRow() {
         // Classic calculator layout: 7-8-9 in the top row.
-        #expect(loadedNumericTopLeftDigit(numpadStyle: NumpadStyle.classic.rawValue) == "7")
+        #expect(loadedNumericTopLeftDigit(numpadType: NumpadType.classic.rawValue) == "7")
     }
 }


### PR DESCRIPTION
## Summary

First batch of bringing grandfathered names in line with `docs/GLOSSARY.md` (follow-up to #291). Purely mechanical — **zero behavior change, zero changed string literals**.

- `InputMethodKind` → `InputMethodType` (`…Kind` is banned; behavioral variants take `…Type`)
- `HapticFeedbackManager` → `HapticFeedbackPlayer` (no `…Manager`; the class caches feedback generators and plays pulses), file renamed accordingly
- `NumpadStyle` → `NumpadType`, `CursorMovementStyle` → `CursorMovementType` (`…Style` is reserved for visual appearance; these are behavioral variants), plus derived identifiers (`applyNumpadType`, `definitionSignature(languageId:numpadType:)`, `spaceDragCursorType`, `numpadTypeRaw`, …)
- A final commit aligns doc comments and local variable names that still said "style" next to the renamed identifiers

Each rename commit also updates `docs/GLOSSARY.md`: the section-2 table and section-1 prose now reference the new names, and the three corresponding rows are removed from the legacy-exceptions list.

## Deliberately unchanged (persisted data / records)

- `SettingsKey` cases `numpadStyle` / `cursorMovementStyle` — their raw values are UserDefaults storage keys; a comment on the enum now documents this
- All enum case raw values (`phone`/`classic`, `continuous`/`discrete`, `direct`/`telex`/`hangul`) and every `@AppStorage` key — byte-identical, so existing user settings survive
- The user-facing "Numpad Style" settings label (product string, localized)
- Historical CHANGELOG entries mentioning the old names

## Verification

- Full unit suite green: 1176 passed, 0 failed
- `git grep` for all four old type names over tracked files: no hits left
- Adversarially reviewed (behavior-change, persisted-data, completeness lenses); the pbxproj needed no edit (filesystem-synchronized groups) and contains no stale references