### PR TITLE
Drop the Circumflex Glyph From the Release Notes

### DIFF
--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -7,7 +7,7 @@ Neu:
 Verbessert:
 • Schnelle Wischer werden wieder als Wischgeste erkannt, statt den mittleren Buchstaben der Taste zu tippen
 • Zeichen, die auf den neuen Layouts gar nicht tippbar waren: Thai ฬ ฒ ฑ ฏ und ฿, die japanischen 、 und 。 samt kleiner Kana, das Halbleerzeichen in Persisch und Urdu, die arabische Interpunktion, das Hindi-₹, die hebräischen ׳ und ״ sowie die Kana-Wiederholungszeichen ゞ und ヾ
-• č ď ě ň ř š ť ž sind direkt erreichbar: das Hatschek liegt jetzt auf dem Rück-Wisch der ^-Taste und ersetzt dort das alleinstehende Akzentzeichen ˆ (das ^ selbst bleibt unverändert)
+• č ď ě ň ř š ť ž sind direkt erreichbar: das Hatschek liegt jetzt auf dem Rück-Wisch der ^-Taste und ersetzt dort den bisherigen alleinstehenden Zirkumflex-Akzent (das ^ selbst bleibt unverändert)
 • Diagonales Ziehen auf der Löschtaste löscht, statt gar nichts zu tun
 • Ein gehaltener Tastendruck über einen Modus- oder Sprachwechsel hinweg tippt nicht mehr die Ziffer der alten Taste
 • Doppel-Leerzeichen tippt einen Punkt nur bei zwei aufeinanderfolgenden Leerzeichen; gesetzt wird das Satzzeichen der jeweiligen Schrift

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -7,7 +7,7 @@ New:
 Improved:
 • Fast flicks are recognized as swipes again instead of typing the key's center letter
 • Characters that could not be typed at all on the new layouts: Thai ฬ ฒ ฑ ฏ and ฿, the Japanese 、 and 。 with the small kana, the half-space in Persian and Urdu, Arabic-script punctuation, the Hindi ₹, the Hebrew ׳ and ״, and the voiced kana iteration marks ゞ and ヾ
-• č ď ě ň ř š ť ž are directly reachable: the caron now sits on the return swipe of the ^ key, replacing the stand-alone accent mark ˆ that swipe used to type (the ^ itself is unchanged)
+• č ď ě ň ř š ť ž are directly reachable: the caron now sits on the return swipe of the ^ key, replacing the stand-alone circumflex accent that swipe used to type (the ^ itself is unchanged)
 • Diagonal drags on the delete key delete instead of doing nothing
 • A long press held across a mode or language switch no longer types the old key's digit
 • Double-space types a period only on two consecutive spaces, and inserts the sentence mark of the script you are typing


### PR DESCRIPTION
The v1.4.1 App Store Release run (31336500145) failed uploading the de-DE
metadata: App Store Connect rejects the modifier letter circumflex U+02C6 in
*What's New* ("can't contain the following character(s): &circ;"). Both
release notes carried the raw glyph since #299's follow-up commit; the en-US
file would have failed the same way.

Spell the character out in prose instead — "stand-alone circumflex accent" /
"alleinstehender Zirkumflex-Akzent". The ASCII ^ passes validation and stays.
The CHANGELOG keeps the glyph; the restriction applies only to the What's New
field.

After the merge: force-update the v1.4.1 tag to this commit and re-trigger the
App Store Release workflow via workflow_dispatch (RELEASE.md troubleshooting
procedure). The failed run uploaded no metadata and no binary; build number 40
was only computed, not used.