### PR TITLE
Tighten Test Guards and Document Their Environment Couplings

### DIFF
--- a/wurstfingerTests/AccessibilityLabelTests.swift
+++ b/wurstfingerTests/AccessibilityLabelTests.swift
@@ -19,11 +19,34 @@ import Foundation
 import Testing
 @testable import WurstfingerApp
 
-struct AccessibilityLabelTests {
-    private var definitions: [KeyboardDefinition] {
-        KeyboardRegistry.available.compactMap { KeyboardRegistry.load(id: $0.id) }
+/// Every registered layout, loaded — with the count pinned to the registry.
+///
+/// A plain `compactMap` over `KeyboardRegistry.available` would let a layout
+/// whose `load` returns nil vanish from every pinning test in this file instead
+/// of failing one, and the tests would stay green while pinning less. Nothing
+/// can drop out today — `available` and the registry's descriptor index are both
+/// built from `LanguageDefinitions.all`, and `makeDefinition()` neither throws
+/// nor returns an optional — so this guards the silent-drop pattern against the
+/// day that stops being true, not a hole in today's suite.
+///
+/// Throwing (rather than a computed property) is what `#require` needs; every
+/// test in both suites below goes through here.
+private func loadedDefinitions() throws -> [KeyboardDefinition] {
+    let loaded = KeyboardRegistry.available.map {
+        (id: $0.id, definition: KeyboardRegistry.load(id: $0.id))
     }
+    let missing = loaded.filter { $0.definition == nil }.map(\.id).sorted()
+    try #require(
+        missing.isEmpty,
+        """
+        \(missing.count) of \(loaded.count) registered layouts do not load and would \
+        silently drop out of these tests: \(missing.joined(separator: ", "))
+        """
+    )
+    return loaded.compactMap(\.definition)
+}
 
+struct AccessibilityLabelTests {
     /// Mirrors KeyView's accessibility-label resolution
     /// (custom accessibility label → tap label → slot id fallback).
     private func accessibilityLabel(for key: KeyConfig) -> String {
@@ -33,12 +56,13 @@ struct AccessibilityLabelTests {
         return key.id
     }
 
-    @Test func definitionsLoad() {
+    @Test func definitionsLoad() throws {
+        let definitions = try loadedDefinitions()
         #expect(!definitions.isEmpty, "Expected registered languages to load")
     }
 
-    @Test func everyKeyHasATapBinding() {
-        for def in definitions {
+    @Test func everyKeyHasATapBinding() throws {
+        for def in try loadedDefinitions() {
             for (modeName, mode) in def.modes {
                 for (keyId, key) in mode.keys {
                     #expect(
@@ -50,8 +74,8 @@ struct AccessibilityLabelTests {
         }
     }
 
-    @Test func everyKeyHasANonEmptyAccessibilityLabel() {
-        for def in definitions {
+    @Test func everyKeyHasANonEmptyAccessibilityLabel() throws {
+        for def in try loadedDefinitions() {
             for (modeName, mode) in def.modes {
                 for (keyId, key) in mode.keys {
                     let label = accessibilityLabel(for: key)
@@ -64,9 +88,9 @@ struct AccessibilityLabelTests {
         }
     }
 
-    @Test func accessibilityLabelNeverFallsBackToSlotId() {
+    @Test func accessibilityLabelNeverFallsBackToSlotId() throws {
         let slotIds = Set(GridSlot.allSlots.flatMap(\.self))
-        for def in definitions {
+        for def in try loadedDefinitions() {
             for (modeName, mode) in def.modes {
                 for (keyId, key) in mode.keys where slotIds.contains(keyId) {
                     let label = accessibilityLabel(for: key)
@@ -85,8 +109,8 @@ struct AccessibilityLabelTests {
     /// inert is unreachable unless it declares a substitute gesture. Also the
     /// guard for the derived layers: shifted/capsLock keys are made by copying,
     /// so a copy site that drops the declaration fails here.
-    @Test func everyKeyIsOperableWithoutGestures() {
-        for def in definitions {
+    @Test func everyKeyIsOperableWithoutGestures() throws {
+        for def in try loadedDefinitions() {
             for (modeName, mode) in def.modes {
                 for (keyId, key) in mode.keys {
                     let tapAction: KeyAction = key.bindings[.tap]?.action ?? .none
@@ -99,8 +123,8 @@ struct AccessibilityLabelTests {
         }
     }
 
-    @Test func globeActivationAdvancesTheInputMode() {
-        for def in definitions {
+    @Test func globeActivationAdvancesTheInputMode() throws {
+        for def in try loadedDefinitions() {
             for (modeName, mode) in def.modes {
                 guard let globe = mode.keys[UtilitySlot.globe] else { continue }
                 #expect(
@@ -115,8 +139,8 @@ struct AccessibilityLabelTests {
     /// Reachability is by name, not by gesture: bindings sharing a label
     /// collapse into one rotor entry, so the entry must dispatch the same
     /// action for every gesture that folded into it.
-    @Test func everyLabelledNonTapBindingIsReachableAsAnAction() {
-        for def in definitions {
+    @Test func everyLabelledNonTapBindingIsReachableAsAnAction() throws {
+        for def in try loadedDefinitions() {
             for (modeName, mode) in def.modes {
                 for (keyId, key) in mode.keys {
                     let offered = Dictionary(
@@ -144,8 +168,8 @@ struct AccessibilityLabelTests {
 
     /// Cut-all is bound to both circle directions under one name; two
     /// identical rotor entries read as a bug.
-    @Test func accessibilityActionNamesAreUnique() {
-        for def in definitions {
+    @Test func accessibilityActionNamesAreUnique() throws {
+        for def in try loadedDefinitions() {
             for (modeName, mode) in def.modes {
                 for (keyId, key) in mode.keys {
                     let names = key.accessibilityActions.map(\.name)
@@ -182,10 +206,6 @@ struct AccessibilityLabelTests {
 /// prevent). The reasoning behind the selection lives on
 /// `CommonKeys.defaultSlotBindings`.
 struct NamedAccessibilityBindingTests {
-    private var definitions: [KeyboardDefinition] {
-        KeyboardRegistry.available.compactMap { KeyboardRegistry.load(id: $0.id) }
-    }
-
     /// Every grid-key gesture allowed to carry a name. Letter gestures are
     /// absent on purpose: a key's own center letter is reachable by activating
     /// it, and naming the other eight on all nine keys is the flooding case.
@@ -229,8 +249,8 @@ struct NamedAccessibilityBindingTests {
         )
     }
 
-    @Test func noGridBindingIsNamedOutsideThePolicySet() {
-        for def in definitions {
+    @Test func noGridBindingIsNamedOutsideThePolicySet() throws {
+        for def in try loadedDefinitions() {
             for (modeName, mode) in def.modes {
                 for (keyId, key) in mode.keys where Self.gridSlotIds.contains(keyId) {
                     let unexpected = namedGestures(of: key)
@@ -250,8 +270,8 @@ struct NamedAccessibilityBindingTests {
 
     /// The gap the review found: `, . ?` were swipe-only and had no name, so a
     /// VoiceOver user could not end a sentence at all.
-    @Test func sentencePunctuationIsNamedInEveryModeOfEveryLayout() {
-        for def in definitions {
+    @Test func sentencePunctuationIsNamedInEveryModeOfEveryLayout() throws {
+        for def in try loadedDefinitions() {
             for (modeName, mode) in def.modes {
                 for (slot, gesture) in Self.sentencePunctuation {
                     // A layout is free to place a letter here instead; only the
@@ -273,8 +293,8 @@ struct NamedAccessibilityBindingTests {
     ///
     /// A binding that switches to the mode it already lives in is the one
     /// exception, pinned separately below.
-    @Test func theShiftAffordanceIsNamedWhereverItExists() {
-        for def in definitions {
+    @Test func theShiftAffordanceIsNamedWhereverItExists() throws {
+        for def in try loadedDefinitions() {
             for (modeName, mode) in def.modes {
                 for gesture in [GestureType.swipeUp, .swipeDown] {
                     guard let binding = mode.keys[GridSlot.midRight]?.bindings[gesture],
@@ -294,8 +314,8 @@ struct NamedAccessibilityBindingTests {
     /// binding that switches to the mode it is invoked from must stay unnamed.
     /// The caps-lock `⇪` is the only one — activating it would return the
     /// VoiceOver user exactly where they were.
-    @Test func aModeSwitchOntoItsOwnModeOffersNoAction() {
-        for def in definitions {
+    @Test func aModeSwitchOntoItsOwnModeOffersNoAction() throws {
+        for def in try loadedDefinitions() {
             for (modeName, mode) in def.modes {
                 for (gesture, binding) in mode.keys[GridSlot.midRight]?.bindings ?? [:] {
                     guard case let .switchMode(target) = binding.action, target == modeName
@@ -313,7 +333,7 @@ struct NamedAccessibilityBindingTests {
     /// switches to the mode it is already in, so `⇩` is the only way out. Naming
     /// only `⇧` would hand VoiceOver users a one-way door into caps lock.
     @Test func capsLockIsNotAOneWayDoorForVoiceOver() throws {
-        for def in definitions {
+        for def in try loadedDefinitions() {
             guard let capsLock = def.modes[ModeNames.capsLock] else { continue }
             let midRight = try #require(
                 capsLock.keys[GridSlot.midRight], "\(def.id) caps lock has no midRight key"
@@ -331,7 +351,7 @@ struct NamedAccessibilityBindingTests {
     /// Finding 11: VoiceOver read "123" as the number one hundred twenty-three
     /// and "abc"/"абв"/"कखग" as a word, instead of naming what the key does.
     @Test func theModeSwitchKeysAreNamedSemantically() throws {
-        for def in definitions {
+        for def in try loadedDefinitions() {
             let toNumeric = try requireBinding(def.id, ModeNames.main, UtilitySlot.symbols, .tap)
             let toLetters = try requireBinding(def.id, ModeNames.numeric, UtilitySlot.symbols, .tap)
             for (key, mode) in [(toNumeric, ModeNames.main), (toLetters, ModeNames.numeric)] {

--- a/wurstfingerTests/AdvancedTextMiddlewareTests.swift
+++ b/wurstfingerTests/AdvancedTextMiddlewareTests.swift
@@ -336,6 +336,11 @@ private enum PasteboardWarmUp {
     ///
     /// The restore is inside the probe because nothing else can do it: the
     /// suite's own capture/restore only runs once this has resolved.
+    ///
+    /// The probe's own write resolves during trait evaluation, outside the
+    /// serialized suite and therefore possibly while other suites run — it is
+    /// covered by the same invariant as the tests below: nothing else in the
+    /// target touches `UIPasteboard.general`.
     static let didAnswer: Bool = {
         let answered = DispatchSemaphore(value: 0)
         // Detached on purpose: a stuck call owns its thread until the service
@@ -379,6 +384,17 @@ struct PasteboardEnvironmentTests {
 // instance is created per test, so capturing the pasteboard in `init` and
 // restoring it in `deinit` reverts any clipboard writes and prevents leaking
 // process-global state into later tests.
+//
+// `.serialized` only orders this suite against itself, so the capture/restore
+// holds exactly as long as this stays the **only** place in the target that
+// touches `UIPasteboard.general` — every other suite runs in parallel with it
+// and would read or clobber a value mid-test. The invariant holds today:
+// `CircularCutAllBindingTests` is the one other suite that could dispatch
+// cut-all, and it deliberately asserts on the definition instead of running the
+// action (see the comment on that struct). Re-verify with
+// `grep -rn UIPasteboard wurstfingerTests` — the only other hit must be that
+// comment. A new test that needs the real pasteboard belongs in this suite, not
+// beside it.
 //
 // Gated on the warm-up rather than warmed up inside `init`, because a condition
 // trait is the only hook that can still *decline* to run: once the daemon has

--- a/wurstfingerTests/AdvancedTextMiddlewareTests.swift
+++ b/wurstfingerTests/AdvancedTextMiddlewareTests.swift
@@ -392,9 +392,10 @@ struct PasteboardEnvironmentTests {
 // `CircularCutAllBindingTests` is the one other suite that could dispatch
 // cut-all, and it deliberately asserts on the definition instead of running the
 // action (see the comment on that struct). Re-verify with
-// `grep -rn UIPasteboard wurstfingerTests` — the only other hit must be that
-// comment. A new test that needs the real pasteboard belongs in this suite, not
-// beside it.
+// `grep -rn UIPasteboard wurstfingerTests --exclude=AdvancedTextMiddlewareTests.swift`
+// — this file is excluded because it is the one place allowed to match, and the
+// only remaining hit must be that comment in `CircularGesturePipelineTests.swift`.
+// A new test that needs the real pasteboard belongs in this suite, not beside it.
 //
 // Gated on the warm-up rather than warmed up inside `init`, because a condition
 // trait is the only hook that can still *decline* to run: once the daemon has

--- a/wurstfingerTests/AspectRatioSubtitleTests.swift
+++ b/wurstfingerTests/AspectRatioSubtitleTests.swift
@@ -127,8 +127,7 @@ struct AspectRatioSubtitleTests {
                 Issue.record("\(language): '\(value)' has no %@ placeholder")
                 continue
             }
-            let suffix = Array(value[placeholder.upperBound...])
-            #expect(suffix.first == ":", "\(language): '\(value)' must continue with ':' right after %@")
+            let suffix = String(value[placeholder.upperBound...])
             // The `1` is a literal, not a localizable digit, and it stays ASCII
             // in all 22 translations — which is what the fix restored. `%@`
             // always receives ASCII digits (`String(format: "%.2f")`), and the
@@ -142,7 +141,15 @@ struct AspectRatioSubtitleTests {
             // legitimately, because they wrap the digit run in LRI/PDI — an
             // isolate this subtitle cannot use without splitting the very run
             // it exists to glue.
-            #expect(suffix.dropFirst().first == "1", "\(language): '\(value)' must end in the ASCII ':1'")
+            //
+            // Asserted as the whole remainder rather than character by
+            // character: the ratio has to *end* at the `1`, so a trailing
+            // digit or a stray word after it would break the same rendering
+            // a wrong digit shape does.
+            #expect(
+                suffix == ":1",
+                "\(language): '\(value)' must continue with the ASCII ':1' right after %@ and end there"
+            )
         }
     }
 }

--- a/wurstfingerTests/AspectRatioSubtitleTests.swift
+++ b/wurstfingerTests/AspectRatioSubtitleTests.swift
@@ -29,6 +29,16 @@ import Testing
 private let aspectRatioKey = "Current: %@:1"
 
 /// Repo root: this file lives in `wurstfingerTests/`, so go up two levels.
+///
+/// Two of the tests below read `Localizable.xcstrings` and `SettingsView.swift`
+/// as source files rather than as bundled resources, because the contract they
+/// pin (a translation glues `:1` to the placeholder; `SettingsView` looks the
+/// subtitle up under this key) exists in the checkout, not in the built product.
+/// `#filePath` is baked in at compile time, so this assumes the tests run from
+/// the tree they were compiled in — true for `xcodebuild test`, the only
+/// supported path; re-running built products against a moved or absent source
+/// tree fails these two with a file-not-found error, loudly and in the safe
+/// direction.
 private func projectDir(file: String = #filePath) -> URL {
     URL(fileURLWithPath: file)
         .deletingLastPathComponent()
@@ -119,9 +129,20 @@ struct AspectRatioSubtitleTests {
             }
             let suffix = Array(value[placeholder.upperBound...])
             #expect(suffix.first == ":", "\(language): '\(value)' must continue with ':' right after %@")
-            // The `1` of the ratio may be written in the local digit shapes
-            // (Persian uses ۱), which resolve as a number just like ASCII.
-            #expect(suffix.dropFirst().first?.isNumber == true, "\(language): '\(value)' must end in ':<digit>'")
+            // The `1` is a literal, not a localizable digit, and it stays ASCII
+            // in all 22 translations — which is what the fix restored. `%@`
+            // always receives ASCII digits (`String(format: "%.2f")`), and the
+            // bidi algorithm only folds the `:` between them into one number
+            // run while both sides resolve to the same numeric class (rule W4).
+            // A local digit shape does not: U+06F1 (۱) is class EN but resolves
+            // to AN beside Arabic-script letters (rule W2), U+0661 (١) is AN
+            // outright — and the mismatch splits the ratio apart again into the
+            // `1:1.00` rendering. Not a blanket ban on local digits: the Persian
+            // numpad-type labels in Settings (`تلفن (⁦۱-۲-۳⁩)`) carry them
+            // legitimately, because they wrap the digit run in LRI/PDI — an
+            // isolate this subtitle cannot use without splitting the very run
+            // it exists to glue.
+            #expect(suffix.dropFirst().first == "1", "\(language): '\(value)' must end in the ASCII ':1'")
         }
     }
 }

--- a/wurstfingerTests/GestureTeardownWiringTests.swift
+++ b/wurstfingerTests/GestureTeardownWiringTests.swift
@@ -138,6 +138,14 @@ struct GestureTeardownWiringTests {
 
     /// A window of the host app's scene when there is one — a scene-less
     /// window does not reliably run SwiftUI's appearance callbacks.
+    ///
+    /// The fallback is therefore an environment in which these tests could
+    /// never pass, not merely a slower one: without a scene `onAppear` may
+    /// never fire, and `expectRanTeardown` then fails on "the hosted view never
+    /// rendered". It is unreachable while the target runs in the host app
+    /// (`xcodebuild test` with the app as test host always has a window scene);
+    /// a future host-less test configuration would have to skip this suite
+    /// rather than let the fallback run.
     private func makeWindow() -> UIWindow {
         let bounds = CGRect(x: 0, y: 0, width: 320, height: 240)
         guard let scene = UIApplication.shared.connectedScenes
@@ -154,6 +162,13 @@ struct GestureTeardownWiringTests {
     /// Drains the main runloop in short slices until `condition` holds or the
     /// deadline passes. Fast when SwiftUI delivers promptly, tolerant when a
     /// loaded CI runner delays a render pass.
+    ///
+    /// The 2 s deadline is the one wall-clock coupling in this suite: it is the
+    /// budget for SwiftUI to deliver an appearance callback, not for anything
+    /// the tests assert about. A machine loaded enough to blow it fails
+    /// `expectRanTeardown` — loudly, in the safe direction, and with a message
+    /// that names the environment rather than the wiring. Widen it before
+    /// suspecting the teardown when a run fails only under parallel load.
     private func drainRunLoop(deadline: TimeInterval = 2.0, until condition: () -> Bool) {
         let end = Date().addingTimeInterval(deadline)
         while !condition(), Date() < end {


### PR DESCRIPTION
## Summary

Three P4 items from the 2026-08-29 review of `develop` (`docs/code-review-develop-2026-08-29.md`), all confined to `wurstfingerTests/`. Two tighten what the suite actually pins; the third makes the tests' remaining environment couplings visible where a future reader meets them. No production code is touched and no test behavior changes beyond the two assertions named below.

Base: `origin/develop` (`d2d8e37`). Full `WurstfingerTests` run on iPhone 17 Pro / iOS 26.5: **1452 tests, 0 failed** — the same count the review recorded for the baseline.

## Finding 3 (P4) — a comment invited a translator to reintroduce the bug the test guards

`wurstfingerTests/AspectRatioSubtitleTests.swift`

The comment above the translation guard said the ratio's `1` "may be written in the local digit shapes (Persian uses ۱)", and the assertion (`isNumber`) would have accepted such a change. All 22 translations carry the ASCII `1` (`فعلی: %@:1`) — exactly what the 2026-08-09 RTL fix restored.

**Changed**

- The assertion now requires the ASCII digit: `#expect(suffix.dropFirst().first == "1", …)` instead of `first?.isNumber == true`.
- The comment states the bidi reason: `%@` always receives ASCII digits (`String(format: "%.2f", ratio)`), and the bidi algorithm only folds the `:` between the two halves into one number run while both sides resolve to the same numeric class (rule W4). A local digit shape does not follow the value: U+06F1 (`۱`) is bidi class EN but resolves to AN beside Arabic-script letters (rule W2), U+0661 (`١`) is AN outright — and the mismatch is what brings the `1:1.00` rendering back.
- It also says explicitly that this is *not* a blanket ban on local digits: the Arabic and Persian numpad-type labels in Settings (`تلفن (⁦۱-۲-۳⁩)`) carry them legitimately because they wrap the digit run in LRI/PDI — an isolate this one-run subtitle cannot use without splitting the run it exists to glue.

**Deliberately not done:** `#expect(aspectRatioKey.hasSuffix("%@:1"))` is untouched. The review withdrew the claim that it is tautological; paired with the expectation above it, it is the only guard on the key constant.

## Finding 7 (P4) — the pinning suites silently dropped layouts that fail to load

`wurstfingerTests/AccessibilityLabelTests.swift`

Both `AccessibilityLabelTests` and `NamedAccessibilityBindingTests` built their definition list as `KeyboardRegistry.available.compactMap { KeyboardRegistry.load(id: $0.id) }`. A layout whose `load` returned nil would have disappeared from every pinning test in the file instead of failing one — the tests would stay green while pinning less.

**Changed:** one file-private `loadedDefinitions() throws` replaces the two `definitions` computed properties. It pairs each registered id with its load result and `#require`s that none is missing, naming the offenders in the message. Every test in both structs goes through it (a computed property cannot `#require`, so the tests that did not already throw now do).

**How it is pinned:** verified by making one id fail to load on purpose (`$0.id == "de_DE" ? nil : …`) — all 14 tests that use the helper failed loudly with the require message; reverted afterwards.

**Scope note:** this is unreachable today, as the review says — `available` and the registry's descriptor index both derive from `LanguageDefinitions.all`, and `makeDefinition()` neither throws nor returns an optional. The change guards the silent-drop pattern outliving that guarantee; the doc comment says so, so nobody reads it as a fix for a live hole.

## Finding 8, bullets 1, 2 and 4 (P4) — documentation only

The review demands no code change here; these are couplings that were correct but invisible. Bullet 3 (`KeyboardHealthLogTests`) is not part of this branch.

- `wurstfingerTests/GestureTeardownWiringTests.swift` — the 2 s drain deadline is now named as the suite's one wall-clock coupling: it is SwiftUI's budget for delivering an appearance callback, not anything the tests assert about, and an overloaded machine fails `expectRanTeardown` loudly and in the safe direction. The scene-less `makeWindow` fallback is documented as an environment in which these tests could *never* pass (rather than merely a slower one), unreachable while the target runs in the host app, and what a future host-less configuration would have to do instead.
- `wurstfingerTests/AspectRatioSubtitleTests.swift` — the `#filePath`-derived checkout access is recorded as an assumption: two tests read `Localizable.xcstrings` and `SettingsView.swift` as *sources*, because the contract they pin lives in the checkout, not in the built product. Correct for `xcodebuild test`, the only supported path; built products run against a moved source tree fail with a file-not-found error.
- `wurstfingerTests/AdvancedTextMiddlewareTests.swift` — the clipboard suite header now carries the invariant the review asked to keep visible: `.serialized` only orders the suite against itself, so the capture/restore holds exactly as long as this stays the only place in the target touching `UIPasteboard.general`. The invariant was re-verified before writing it down (`grep -rn UIPasteboard wurstfingerTests`): the only other hit is the comment on `CircularCutAllBindingTests`, which deliberately asserts on the definition instead of dispatching cut-all. The header also says where a new pasteboard test belongs and how to re-check. A short note on `PasteboardWarmUp.didAnswer` records that the probe's own write resolves during trait evaluation, outside the serialized suite, and is covered by the same invariant.

## Testing

```
xcodebuild test -scheme Wurstfinger -only-testing:WurstfingerTests \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
```

1452 tests, 0 failed. SwiftFormat and SwiftLint (`--strict`) clean on all four files; the pre-commit hooks ran normally and reformatted nothing.

## Not in scope

- Findings 1, 2, 4, 5, 6, 9 and finding 8's third bullet — other branches / other agents.
- No production code, no new tests, no renames.

---

https://claude.ai/code/session_01FZsR6M9vvyUkUHADuVJDnX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Accessibility tests now fail clearly when a registered layout cannot be loaded, preventing incomplete validation.
  - Translation checks now require the ratio suffix to use the expected ASCII “1” format.

- **Documentation**
  - Added guidance clarifying clipboard test isolation, environment assumptions, source-file dependencies, and timeout behavior.
  - Documented localization and bidirectional-text considerations for ratio formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->