### PR TITLE
Widen the Deferred-Sample Test Margins and Tombstone a Cleared Health Log

### DIFF
--- a/wurstfinger/KeyboardHealthView.swift
+++ b/wurstfinger/KeyboardHealthView.swift
@@ -14,9 +14,20 @@ import SwiftUI
 struct KeyboardHealthView: View {
     @State private var entries: [KeyboardHealthLog.Entry] = []
 
+    /// Everything the keyboard process itself recorded — the log minus the
+    /// tombstone `KeyboardHealthLog.clear()` leaves behind. That tombstone
+    /// exists to date the entries around it, not to be one: it carries no
+    /// footprint and describes no keyboard cycle, so the empty state, the
+    /// event count and the peak all ignore it and a freshly cleared log still
+    /// reads as empty. The rows below do show it — that is where it earns its
+    /// keep.
+    private var recordedEntries: [KeyboardHealthLog.Entry] {
+        entries.filter { $0.label != KeyboardHealthLog.clearedLabel }
+    }
+
     var body: some View {
         List {
-            if entries.isEmpty {
+            if recordedEntries.isEmpty {
                 emptySection
             } else {
                 summarySection
@@ -28,7 +39,7 @@ struct KeyboardHealthView: View {
         .onAppear(perform: reload)
         .refreshable { reload() }
         .toolbar {
-            if !entries.isEmpty {
+            if !recordedEntries.isEmpty {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Clear") {
                         KeyboardHealthLog.shared.clear()
@@ -51,11 +62,11 @@ struct KeyboardHealthView: View {
 
     private var summarySection: some View {
         Section {
-            LabeledContent("Events", value: "\(entries.count)")
-            if let peak = entries.max(by: { $0.usedMB < $1.usedMB }) {
+            LabeledContent("Events", value: "\(recordedEntries.count)")
+            if let peak = recordedEntries.max(by: { $0.usedMB < $1.usedMB }) {
                 LabeledContent("Peak memory", value: memoryText(for: peak))
             }
-            if let last = entries.last {
+            if let last = recordedEntries.last {
                 LabeledContent("Last event", value: last.date.formatted(date: .abbreviated, time: .standard))
             }
         } header: {
@@ -84,10 +95,14 @@ struct KeyboardHealthView: View {
                         Text(entry.label)
                             .font(.callout.monospaced())
                         Spacer()
-                        Text(memoryText(for: entry))
-                            .font(.callout)
-                            .monospacedDigit()
-                            .foregroundColor(memoryColor(for: entry))
+                        // The tombstone has no memory column: it was stamped
+                        // by this app, not by the keyboard process.
+                        if entry.label != KeyboardHealthLog.clearedLabel {
+                            Text(memoryText(for: entry))
+                                .font(.callout)
+                                .monospacedDigit()
+                                .foregroundColor(memoryColor(for: entry))
+                        }
                     }
                     Text(entry.date.formatted(date: .abbreviated, time: .standard))
                         .font(.caption)
@@ -121,6 +136,12 @@ struct KeyboardHealthView: View {
     hostDidEnterBackground and hostWillEnterForeground did not appear in any \
     measured cycle on the iOS 26 Simulator; whether a real device delivers \
     them at all is unverified. Their absence says nothing either way.
+
+    logCleared is not a keyboard event: it marks where this screen wiped the \
+    log. An entry shown above it — a postShedSettled, typically — is a sample \
+    that a dismissal had already queued inside the keyboard process finally \
+    landing, not a clear that failed. Clearing runs here and cannot reach \
+    across into that process.
     """
 
     private func reload() {

--- a/wurstfinger/KeyboardHealthView.swift
+++ b/wurstfinger/KeyboardHealthView.swift
@@ -25,6 +25,12 @@ struct KeyboardHealthView: View {
         entries.filter { $0.label != KeyboardHealthLog.clearedLabel }
     }
 
+    /// Two different lists, deliberately: the empty state and the summary
+    /// key off `recordedEntries`, the rows off `entries`. A log holding
+    /// nothing but the tombstone is therefore *empty* here — the clear did
+    /// take, and saying otherwise would undo what the tombstone is for. The
+    /// tombstone becomes visible at the moment it explains something: once a
+    /// sample queued before the clear lands behind it, the rows show both.
     var body: some View {
         List {
             if recordedEntries.isEmpty {
@@ -60,6 +66,9 @@ struct KeyboardHealthView: View {
         }
     }
 
+    /// Counts and peak over the keyboard's own events only. The tombstone
+    /// carries no footprint, so including it would report an event that never
+    /// happened and a 0 MB peak.
     private var summarySection: some View {
         Section {
             LabeledContent("Events", value: "\(recordedEntries.count)")
@@ -79,6 +88,8 @@ struct KeyboardHealthView: View {
         }
     }
 
+    /// The rows, newest first — over `entries`, so the tombstone appears
+    /// among them and dates the entries on either side of it.
     private var entriesSection: some View {
         Section {
             // The legend sits above the rows, not in the section footer: the

--- a/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
+++ b/wurstfingerKeyboard/Settings/KeyboardHealthLog.swift
@@ -69,6 +69,13 @@ struct KeyboardHealthLog {
 
     static let fileName = "keyboard-health-log.json"
 
+    /// Label of the tombstone entry `clear()` leaves behind — see there for
+    /// why a cleared log is not simply an empty one. Consumers key off this
+    /// constant rather than the literal: `KeyboardHealthView` folds the
+    /// tombstone away while it is the only entry, and keeps it out of the
+    /// summary figures.
+    static let clearedLabel = "logCleared"
+
     /// Shared instance persisting into the app group container. The
     /// `containerURL(...)` lookup is out-of-process IPC; it is deferred into a
     /// provider closure so it runs lazily inside the `ioQueue` on first file
@@ -197,6 +204,15 @@ struct KeyboardHealthLog {
         return entry
     }
 
+    /// The tombstone `clear()` leaves behind: the clear's own timestamp, no
+    /// footprint. Deliberately not `makeEntry`, which would sample the host
+    /// app's memory here — a figure that belongs to no keyboard cycle and
+    /// would still be compared against the extension's budget by every
+    /// consumer of this log.
+    private func makeClearedEntry() -> Entry {
+        Entry(id: UUID(), date: Date(), label: Self.clearedLabel, usedMB: 0, availableMB: 0)
+    }
+
     /// All recorded entries, oldest first, capped at `maxEntries`. Empty when
     /// the file is missing or unreadable (corruption is silently discarded —
     /// this is diagnostics, it must never take the keyboard down).
@@ -210,11 +226,30 @@ struct KeyboardHealthLog {
         }
     }
 
-    /// Removes all recorded entries.
+    /// Removes all recorded entries and stamps a tombstone in their place, so
+    /// that an entry arriving afterwards reads as the first event *after* the
+    /// clear instead of as a clear that did not take.
+    ///
+    /// The tombstone is not bookkeeping for its own sake. `clear()` is invoked
+    /// from the **host app**, while the deferred `postShedSettled` sample is
+    /// queued in the **extension process** two seconds before it writes (see
+    /// `KeyboardViewController.shedMemoryBeforeSuspension`). Clearing the log
+    /// shortly after a dismissal therefore reliably grows one entry in the
+    /// file that was just emptied, and no cancellation can prevent it: the
+    /// pending work item lives in another process, and the log has no channel
+    /// to reach across. Marking where the clear happened is the honest fix;
+    /// cancelling in-process would only look like one.
+    ///
+    /// The tombstone deliberately carries no memory figures. It is stamped by
+    /// the host app, whose footprint says nothing about the extension's jetsam
+    /// budget, and a host-sized number in that column would skew the peak.
+    /// `KeyboardHealthView` folds it away while it is the only entry, so a
+    /// cleared log still reads as empty.
     func clear() {
         Self.ioQueue.sync {
             guard let fileURL = fileURLProvider() else { return }
             try? FileManager.default.removeItem(at: fileURL)
+            appendEntry(makeClearedEntry())
         }
     }
 

--- a/wurstfingerTests/KeyboardHealthLogTests.swift
+++ b/wurstfingerTests/KeyboardHealthLogTests.swift
@@ -14,6 +14,18 @@ import Testing
 /// `staleDeferredSampleIsDiscarded`) deliberately park in that queue. Running
 /// them against each other would make one test's blockage the other's missing
 /// entry.
+///
+/// **Invariant this suite rests on: nothing outside it touches
+/// `KeyboardHealthLog`.** The queue it parks is process-wide — one
+/// `KeyboardHealthLog.ioQueue` for every log instance in the process — while
+/// `.serialized` only orders this suite against itself, not against the rest
+/// of the run. A test in another suite that recorded, read or cleared a health
+/// log, directly or by driving a `KeyboardViewController` path that does,
+/// could therefore be scheduled straight into the park below and inherit the
+/// stall: ~0.5 s normally, up to the 5 s its watchdog allows. It would show up
+/// as a slow suite rather than as this, which is why the invariant is written
+/// down instead of merely holding. Before adding such a test, put it in this
+/// suite or give the parking case a queue of its own.
 @Suite(.serialized)
 struct KeyboardHealthLogTests {
     /// Isolated file URL per test so parallel tests cannot interfere.
@@ -21,6 +33,32 @@ struct KeyboardHealthLogTests {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("health-log-test-\(UUID().uuidString).json")
     }
+
+    /// Fire delay for the deferred-sample cases that have to *observe* the
+    /// entry they queue.
+    ///
+    /// `recordDeferred` derives its discard window from the fire delay
+    /// (`discardAfter = deadline + delay`), so the delay is also the budget a
+    /// loaded runner has for getting the utility-QoS block onto the io queue.
+    /// At the 200 ms these tests used to pass, a runner 400 ms behind turned a
+    /// correct implementation red — never green, the direction is safe, but
+    /// `recordDeferredWithoutAFileIsANoOp` had already flaked that way on CI.
+    /// One second buys a full second of slack for one second of runtime per
+    /// test.
+    ///
+    /// Raising the delay is deliberately preferred over handing
+    /// `recordDeferred` an explicit discard-window parameter: the window is
+    /// production behavior *derived* from the delay, and a parameter existing
+    /// only for these three call sites would widen the production surface
+    /// while stopping the tests from exercising the derivation they are here
+    /// for. `staleDeferredSampleIsDiscarded` pins the other end of it.
+    private static let deferredFireDelay: TimeInterval = 1
+
+    /// When those cases read the log: one discard window past the fire delay,
+    /// so a sample the runner held back by up to `deferredFireDelay` has still
+    /// landed before the assertion looks — the same slack the discard guard
+    /// gets, on the observation side.
+    private static let deferredObservationDelay = Duration.seconds(2)
 
     @Test func recordAppendsEntryWithLabelAndFootprint() {
         let url = makeTestFileURL()
@@ -58,7 +96,12 @@ struct KeyboardHealthLogTests {
         #expect(log.entries().map(\.label) == ["event-2", "event-3", "event-4"])
     }
 
-    @Test func clearRemovesAllEntries() {
+    /// A clear empties the log down to its tombstone and nothing else — the
+    /// marker takes the place of what it removed. Everything downstream keys
+    /// off that being the whole content of a freshly cleared log:
+    /// `KeyboardHealthView` folds a tombstone-only log back into its empty
+    /// state.
+    @Test func clearReplacesAllEntriesWithATombstone() throws {
         let url = makeTestFileURL()
         defer { try? FileManager.default.removeItem(at: url) }
         let log = KeyboardHealthLog(fileURL: url)
@@ -66,7 +109,32 @@ struct KeyboardHealthLogTests {
         log.record("event")
         log.clear()
 
-        #expect(log.entries().isEmpty)
+        let entries = log.entries()
+        #expect(entries.map(\.label) == [KeyboardHealthLog.clearedLabel])
+        let tombstone = try #require(entries.first)
+        // Stamped in the host app: its footprint is not the extension's, and
+        // a number here would be read against the extension's jetsam budget
+        // and counted into the peak.
+        #expect(tombstone.usedMB == 0)
+        #expect(tombstone.availableMB == 0)
+    }
+
+    /// The case the tombstone exists for. `clear()` runs in the host app while
+    /// the extension process may already have a `postShedSettled` sample
+    /// queued from a dismissal seconds earlier, and nothing crosses between
+    /// the two, so the freshly emptied log does grow that entry. Ordering it
+    /// behind the tombstone is what makes it read as the first event *after*
+    /// the clear rather than as a clear that did not take.
+    @Test func anEntryArrivingAfterAClearIsOrderedBehindTheTombstone() {
+        let url = makeTestFileURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let log = KeyboardHealthLog(fileURL: url)
+
+        log.record("viewDidDisappear")
+        log.clear()
+        log.record("postShedSettled")
+
+        #expect(log.entries().map(\.label) == [KeyboardHealthLog.clearedLabel, "postShedSettled"])
     }
 
     @Test func entriesAreEmptyWhenFileIsMissing() {
@@ -252,39 +320,45 @@ struct KeyboardHealthLogTests {
         let log = KeyboardHealthLog(fileURL: url)
 
         let started = Date()
-        log.recordDeferred("postShedSettled", after: 0.5)
+        log.recordDeferred("postShedSettled", after: Self.deferredFireDelay)
         let elapsed = Date().timeIntervalSince(started)
 
-        #expect(elapsed < 0.1)
+        // A quarter of the delay, so it still witnesses "the call did not
+        // wait for the sample" while leaving a descheduled test thread room to
+        // be late.
+        #expect(elapsed < 0.25)
         // `entries()` syncs through the same serial queue, so an entry written
         // as part of the call would already be visible here.
         #expect(log.entries().isEmpty)
 
-        try await Task.sleep(for: .milliseconds(1000))
+        try await Task.sleep(for: Self.deferredObservationDelay)
         let entries = log.entries()
         #expect(entries.map(\.label) == ["postShedSettled"])
         let entry = try #require(entries.first)
         #expect(entry.usedMB > 0)
-        // Slightly under the delay: the timer never fires early, but wall
-        // clock and dispatch's uptime clock are not the same ruler.
-        #expect(entry.date.timeIntervalSince(started) > 0.4)
+        // Half the delay, not a hair under it: the timer never fires early,
+        // but this compares wall clock against dispatch's uptime clock, which
+        // are not the same ruler. The gap only has to separate a late sample
+        // from a call-site one, and a call-site sample would read ~0.
+        #expect(entry.date.timeIntervalSince(started) > Self.deferredFireDelay / 2)
     }
 
     /// The suspension path writes both entries for the same event — the
     /// guaranteed flushed one and the settled one 2 s later — and forensics
     /// reads them as a pair, so the deferred entry must land *after* the
     /// flushed one even though it was queued while that write was in flight.
-    /// The delay doubles as the discard window (see `recordDeferred`), so it
-    /// is kept well above the scheduling jitter of a loaded test machine.
+    /// The delay doubles as the discard window (see `recordDeferred` and
+    /// `deferredFireDelay`), so it is kept a full second above the scheduling
+    /// jitter of a loaded test machine.
     @Test func deferredSampleAppendsAfterTheFlushedSuspensionEntry() async throws {
         let url = makeTestFileURL()
         defer { try? FileManager.default.removeItem(at: url) }
         let log = KeyboardHealthLog(fileURL: url)
 
         log.recordAndFlush("viewDidDisappear")
-        log.recordDeferred("postShedSettled", after: 0.2)
+        log.recordDeferred("postShedSettled", after: Self.deferredFireDelay)
 
-        try await Task.sleep(for: .milliseconds(500))
+        try await Task.sleep(for: Self.deferredObservationDelay)
         #expect(log.entries().map(\.label) == ["viewDidDisappear", "postShedSettled"])
     }
 
@@ -295,6 +369,15 @@ struct KeyboardHealthLogTests {
     /// to be discarded instead. Modelled by parking in the shared io queue
     /// past the discard window: from the block's side that is the same
     /// situation — enqueued on time, given CPU far too late.
+    ///
+    /// This is the one case that keeps the short delay the positive cases gave
+    /// up (see `deferredFireDelay`), and it needs no margin: a slower machine
+    /// only releases the block later, i.e. further past the discard window, so
+    /// load pushes this test towards passing for the right reason. Keeping it
+    /// short also keeps the park — the whole suite's blocking cost, see the
+    /// suite header — down to ~0.5 s. Together with the positive cases it is
+    /// what pins the production window at `deadline + delay`: on-time samples
+    /// are written, samples more than their own delay overdue are not.
     @Test func staleDeferredSampleIsDiscarded() async throws {
         let url = makeTestFileURL()
         defer { try? FileManager.default.removeItem(at: url) }
@@ -341,9 +424,9 @@ struct KeyboardHealthLogTests {
             return nil
         })
 
-        log.recordDeferred("postShedSettled", after: 0.2)
+        log.recordDeferred("postShedSettled", after: Self.deferredFireDelay)
 
-        try await Task.sleep(for: .milliseconds(700))
+        try await Task.sleep(for: Self.deferredObservationDelay)
         // Snapshot before `entries()`, which consults the provider itself.
         let consultedByTheSample = consulted.count
         #expect(log.entries().isEmpty)

--- a/wurstfingerTests/KeyboardHealthLogTests.swift
+++ b/wurstfingerTests/KeyboardHealthLogTests.swift
@@ -40,11 +40,11 @@ struct KeyboardHealthLogTests {
     /// `recordDeferred` derives its discard window from the fire delay
     /// (`discardAfter = deadline + delay`), so the delay is also the budget a
     /// loaded runner has for getting the utility-QoS block onto the io queue.
-    /// At the 200 ms these tests used to pass, a runner 400 ms behind turned a
-    /// correct implementation red — never green, the direction is safe, but
-    /// `recordDeferredWithoutAFileIsANoOp` had already flaked that way on CI.
-    /// One second buys a full second of slack for one second of runtime per
-    /// test.
+    /// A 200 ms delay therefore leaves 200 ms of budget, and a runner that far
+    /// behind turns a correct implementation red — never green, the direction
+    /// is safe, but `recordDeferredWithoutAFileIsANoOp` has flaked that way on
+    /// CI. One second buys a full second of slack for one second of runtime
+    /// per test.
     ///
     /// Raising the delay is deliberately preferred over handing
     /// `recordDeferred` an explicit discard-window parameter: the window is


### PR DESCRIPTION
Fixes findings **2**, **8 (third bullet)** and **9** of the 2026-08-29 review of `develop`
(`docs/code-review-develop-2026-08-29.md`). All three sit on `KeyboardHealthLog` and its test
suite; nothing else is touched.

## Finding 2 (P3) — the deferred health-log tests hung their green status on a 400 ms wall

`recordDeferred` derives its discard window from the fire delay: `discardAfter = deadline + delay`.
Both positive tests fired the timer at 200 ms, so the utility-QoS block had 400 ms to reach the io
queue before the production guard threw the sample away. A loaded runner past that produced a
missing entry and a red test — never a false green, but `recordDeferredWithoutAFileIsANoOp` is
already a known flake on GitHub runners for exactly this reason.

**Changed** — route (a) of the two the review offered, i.e. purely test-side:

| test | fire delay | observation | discard window | slack |
| --- | --- | --- | --- | --- |
| `recordDeferredWritesLateWithoutBlockingTheCaller` | 0.5 s → **1 s** | 1.0 s → **2 s** | 1.0 s → **2 s** | 0.5 s → **1 s** |
| `deferredSampleAppendsAfterTheFlushedSuspensionEntry` | 0.2 s → **1 s** | 0.5 s → **2 s** | 0.4 s → **2 s** | 0.2 s → **1 s** |
| `recordDeferredWithoutAFileIsANoOp` | 0.2 s → **1 s** | 0.7 s → **2 s** | 0.4 s → **2 s** | 0.2 s → **1 s** |

Both ends were widened, not just the discard window: the observation point moved out with the
delay, so a sample the runner holds back by up to a second still lands before the assertion looks.
The two delays are now named constants (`deferredFireDelay`, `deferredObservationDelay`) carrying
the reasoning in one place.

Route (b) — an explicit discard-window parameter on `recordDeferred` — was rejected deliberately,
and the code comment says so: the window is production behavior *derived* from the delay, a
parameter existing only for three test call sites widens the production surface, and it would stop
the tests from exercising the derivation they are there for.

Two smaller margins in the same file, per the review's `:255-263`:

- the wall-clock-vs-dispatch-uptime margin (`entry.date` against a `DispatchTime` delay) goes from
  100 ms to half the delay (500 ms). It only has to separate a late sample from a call-site one,
  and a call-site sample reads ~0.
- the "the call did not block" bound goes from 100 ms to 250 ms — still a quarter of the delay.

**Pinning kept intact.** `staleDeferredSampleIsDiscarded` still pins the negative direction with its
short (0.1 s) delay and needs no margin: a slower machine only releases the parked block further
past the discard window, so load pushes it towards passing for the right reason. Together with the
positive cases it is what pins the production window at `deadline + delay` — on-time samples are
written, samples more than their own delay overdue are not. No production default was moved.

## Finding 8, third bullet (P4) — documentation only

`staleDeferredSampleIsDiscarded` parks the *process-wide* static `ioQueue` for ~0.5 s. That is
bounded harm only while this suite is the sole consumer of `KeyboardHealthLog` in the target:
`.serialized` orders the suite against itself, not against the rest of the run, so a future test
elsewhere that recorded, read or cleared a health log could be scheduled straight into the park and
inherit the stall. The suite header now states the invariant, what breaking it costs (~0.5 s,
up to the 5 s the park's watchdog allows), and that it would present as "the suite got slow"
rather than as this. No behavior change.

## Finding 9 (P5) — a cleared log grew a `postShedSettled` entry and read as a failed clear

`clear()` emptied the file but could not stop the deferred sample a dismissal had queued ~2 s
earlier, so the freshly wiped log grew one entry right after the user wiped it.

The review's first fix direction (cancel-on-clear) cannot work here and was not implemented:
`clear()` is invoked from the **host app** (`KeyboardHealthView`), the sample is queued in the
**keyboard extension process**, and the two share a file, not a work item. An in-process
cancellation would only appear to fix the case that actually happens.

**Implemented instead — the review's second direction, a tombstone:**

- `KeyboardHealthLog.clearedLabel` (`"logCleared"`) is a new public constant; `clear()` removes the
  file and then appends one tombstone entry, still inside the same `ioQueue.sync`.
- The tombstone carries `usedMB = 0, availableMB = 0` and is built by a separate
  `makeClearedEntry()`, deliberately not `makeEntry` — the latter would sample the *host app's*
  footprint, a figure that belongs to no keyboard cycle and would still be compared against the
  extension's jetsam budget and counted into the peak.
- `KeyboardHealthView` folds it: a tombstone-only log still renders the empty state and hides the
  Clear button, the summary (event count, peak, last event) ignores it, its row shows no memory
  column, and the "How to read a cycle" legend explains that an entry above a `logCleared` is a
  sample the keyboard process had already queued, not a clear that failed.
- The `clear()` doc comment now states the cross-process reasoning, why cancellation is not
  available, and the folding contract the view relies on.

**Tests:** `clearRemovesAllEntries` becomes `clearReplacesAllEntriesWithATombstone` (asserts the
tombstone is the *whole* content of a cleared log, and that it carries no memory figures); new
`anEntryArrivingAfterAClearIsOrderedBehindTheTombstone` pins the case the tombstone exists for.

## Deliberately not done

- No cancel-on-clear hook in `KeyboardViewController`: it cannot reach the other process (see above).
- The clear does not re-stamp on an already-cleared log, and nothing garbage-collects old
  tombstones; they are one bounded entry each and age out via `maxEntries` like everything else.
- Findings 1, 3, 4, 5, 6, 7 and the other bullets of 8 are out of scope for this branch.

## Verification

- `WurstfingerTests/KeyboardHealthLogTests` — 20 tests, all pass.
- The three widened cases plus `staleDeferredSampleIsDiscarded` run five times over
  (`-test-iterations 5 -run-tests-until-failure`) under 8 spinning CPU hogs (load average >100):
  green. Repeated verbose under 16 hogs: 2.06 s / 2.02 s / 2.02 s / 0.41–0.48 s, all passing.
- Full unit suite `-only-testing:WurstfingerTests` on iPhone 17 Pro: **1453 test-case results,
  0 failed** (the review's baseline was 1452; this branch adds one test).
- SwiftFormat and SwiftLint clean on all three changed files; pre-commit hooks passed without
  `--no-verify`.

---

https://claude.ai/code/session_01FZsR6M9vvyUkUHADuVJDnX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleared keyboard health logs now correctly appear empty, even when delayed samples arrive afterward.
  * Clear markers no longer appear as keyboard events or display misleading memory data.
  * Health metrics, event counts, and latest-event details now exclude clear markers.

* **Documentation**
  * Added clarification explaining how cleared logs and late-arriving samples are represented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->