### PR TITLE
Recognize Flicks That Launch Out of a Rolling Start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Flicks that launch out of a rolling start are recognized again. The v1.4.1 fix rescued a flick from a finger that was standing still; one that follows a slight drag — settling on the key, then flicking — still lost every fast sample, because the filter measured the flick against the drift and a drift is slow by definition. The letter that got committed came from the drift instead: the key's center letter while the drift was short, and, once it was long enough to count as a swipe, a swipe in the drift's own direction — so a drift running across the flick typed a neighbouring letter rather than nothing. A jump is now measured against the longer of the movement already established and the movement it leads into (#303)
+- Flicks that launch out of a rolling start are recognized again. A flick that follows a slight drag — settling on the key, then flicking — lost every one of its fast samples, because the filter measured them against the drift and a drift is slow by definition. The letter that got committed came from the drift instead, which for a drift running across the flick is a neighbouring letter rather than the center one. A jump is now measured against the longer of the movement already established and the movement it leads into (#303)
 
 ## v1.4.1 — 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Flicks that launch out of a rolling start are recognized again. The v1.4.1 fix rescued a flick from a finger that was standing still; one that follows a slight drag — settling on the key, then flicking — still lost every fast sample, because the filter measured the flick against the drift and a drift is slow by definition. The letter that got committed came from the drift instead: the key's center letter while the drift was short, and, once it was long enough to count as a swipe, a swipe in the drift's own direction — so a drift running across the flick typed a neighbouring letter rather than nothing. A jump is now measured against the longer of the movement already established and the movement it leads into
+- Flicks that launch out of a rolling start are recognized again. The v1.4.1 fix rescued a flick from a finger that was standing still; one that follows a slight drag — settling on the key, then flicking — still lost every fast sample, because the filter measured the flick against the drift and a drift is slow by definition. The letter that got committed came from the drift instead: the key's center letter while the drift was short, and, once it was long enough to count as a swipe, a swipe in the drift's own direction — so a drift running across the flick typed a neighbouring letter rather than nothing. A jump is now measured against the longer of the movement already established and the movement it leads into (#303)
 
 ## v1.4.1 — 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Flicks that launch out of a rolling start are recognized again. The v1.4.1 fix rescued a flick from a finger that was standing still; one that follows a slight drag — settling on the key, then flicking — still lost every fast sample, because the filter measured the flick against the drift and a drift is slow by definition. The letter that got committed came from the drift instead: the key's center letter while the drift was short, and, once it was long enough to count as a swipe, a swipe in the drift's own direction — so a drift running across the flick typed a neighbouring letter rather than nothing. A jump is now measured against the longer of the movement already established and the movement it leads into
+
 ## v1.4.1 — 2026-08-09
 
 ### Added

--- a/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
@@ -451,10 +451,9 @@ struct GesturePreprocessor {
     /// What the longer reference costs is that the origin's ambiguity now
     /// applies along the whole path rather than only at touch-down: two
     /// spurious samples travelling coherently at flick speed are
-    /// byte-identical to a finger accelerating into one, and mid-path the
-    /// established step used to refuse them. That refusal was never evidence —
-    /// a rolling start *is* a slow step followed by a fast one — so the two
-    /// cases cannot be told apart here either way. The shapes this filter was
+    /// byte-identical to a finger accelerating into one. The established step
+    /// is no evidence against them — a rolling start *is* a slow step followed
+    /// by a fast one — so the two cases cannot be told apart here. The shapes this filter was
     /// actually built against are unaffected: a ghost cluster's own step is a
     /// few points, so it establishes no reference to ride in on, and an
     /// out-and-back teleport is opposed to both candidate references and fails

--- a/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
+++ b/wurstfingerKeyboard/Runtime/Gesture/GesturePreprocessor.swift
@@ -47,9 +47,10 @@
 //       gap cannot cascade and discard the rest of a genuine fast swipe
 //     - Velocity-aware: a jump that continues the movement the finger was
 //       already making — same direction to within 45°, at most three times
-//       the established step and never beyond 3x maxJumpDistance — is kept,
-//       so a flick covering more than maxJumpDistance per sample is not read
-//       as a teleport
+//       the reference step (the longer of the step the accepted path
+//       established and the raw step the jump leads into) and never beyond
+//       3x maxJumpDistance — is kept, so a flick covering more than
+//       maxJumpDistance per sample is not read as a teleport
 //
 //  3. **Aspect Ratio Normalization**: Divides X by aspect ratio
 //     - Makes horizontal and vertical movements comparable on non-square keys
@@ -280,18 +281,22 @@ struct GesturePreprocessor {
     /// Accepting a point moves the anchor onto it, so a glitch let in here is
     /// paid for twice: the genuine sample after it is then measured from the
     /// glitch and can fail every criterion. That is why `isSameMovement` is
-    /// deliberately narrow — a jump has to continue the established direction
-    /// to within 45° and stay inside three times the established step.
+    /// deliberately narrow — a jump has to continue the reference direction to
+    /// within 45° and stay inside three times the reference step.
     ///
-    /// The one shape it cannot resolve is a jump straight out of the origin.
-    /// How long the finger rested there would separate a tap from a launch,
-    /// but the jitter filter has already collapsed that dwell by the time this
-    /// filter runs, so a tap followed by two consistently-moving interference
-    /// samples arrives byte-identical to a finger that landed already flying.
-    /// Both are accepted; what bounds the damage is the magnitude ceiling in
-    /// `isSameMovement`, not the shape. Separating them needs the pipeline
-    /// order changed (or the trail clamped to post-filter samples), which is
-    /// the structural half of finding 3 and is not attempted here.
+    /// The one shape it cannot resolve is a burst of consistently-moving
+    /// interference: two samples travelling coherently at flick speed arrive
+    /// byte-identical to a finger that accelerated into a flick. How long the
+    /// finger rested first would separate them, but the jitter filter has
+    /// already collapsed that dwell by the time this filter runs. Because
+    /// `continuesEstablishedMotion` takes the longer of its two candidate
+    /// references, the ambiguity is uniform along the path instead of confined
+    /// to the origin — deliberately, since the established step is no evidence
+    /// against a real flick either. Both are accepted; what bounds the damage
+    /// is the magnitude ceiling and the direction cone in `isSameMovement`,
+    /// not the shape. Separating them needs the pipeline order changed (or the
+    /// trail clamped to post-filter samples), which is the structural half of
+    /// finding 3 and is not attempted here.
     func filterOutliers(_ points: [CGPoint]) -> [CGPoint] {
         guard points.count >= 2 else { return points }
 
@@ -384,28 +389,54 @@ struct GesturePreprocessor {
     /// for.
     private static let velocityToleranceFactor: CGFloat = 3
 
-    /// How far a jump may turn away from the established direction and still
-    /// count as the same movement, as a cosine: one swipe sector (45°).
+    /// How far a jump may turn away from the reference direction and still
+    /// count as the same movement, as a cosine: 45° of *raw* screen turn.
+    ///
+    /// That is one swipe sector only on square keys. This test runs before
+    /// `normalizeAspectRatio`, while the classifier's 45° sectors are measured
+    /// after it, so the widest admitted turn opens up with the key's aspect
+    /// ratio: 45° raw is 46.7° normalized at the 1.06:1 keys the extension
+    /// renders, 52.4° at 1.3:1 and 63.4° at 2:1. Testing direction
+    /// post-normalization would close that gap, but it is a behavior change
+    /// and not a comment fix, so the number stated here is the raw one.
     ///
     /// A finger that crosses a key in a single frame does not also change
     /// direction in it. The half-plane this replaced — any angle short of a
     /// right angle — admitted a near-perpendicular jump at three times the
-    /// established step, which flipped the committed direction of ordinary
-    /// fast swipes carrying one trailing glitch sample (review 2026-08-09).
+    /// reference step, which flipped the committed direction of ordinary fast
+    /// swipes carrying one trailing glitch sample (review 2026-08-09).
     private static let minimumDirectionCosine = CGFloat(cos(Double.pi / 4))
 
     /// Whether the jump onto `points[i]` continues the movement the finger was
     /// already making.
     ///
-    /// `previousStep` is the velocity the accepted path established, and it
-    /// wins whenever there is one. Before that — the first sample after
-    /// touch-down, where the whole accepted path is the origin — the only
-    /// available evidence is the step that *follows*: a finger that lands
+    /// Two steps can speak for the jump: the one the accepted path has
+    /// established (`previousStep`) and the raw one that leads away from
+    /// `points[i]`. The reference is whichever of the two is longer.
+    ///
+    /// Letting the established step win whenever it exists — the rule this
+    /// replaced — loses every flick that launches out of a rolling start, a
+    /// finger that settles on the key with a slow drift and only then flicks.
+    /// The drift establishes a step of a few points, the first fast sample is
+    /// more than three times it, and because a rejected sample leaves the
+    /// anchor and the reference alone, every sample after it fails the same
+    /// way: the classifier only ever sees the drift. Measured over three drift
+    /// samples followed by three 80 pt flick samples at the default config,
+    /// that starts at roughly 1 pt per sample of drift — below it the jitter
+    /// filter still collapses the drift — and never stops. What gets committed
+    /// is the key's center letter while the drift is shorter than
+    /// `minSwipeLength`, and from about 8 pt per sample a swipe in the
+    /// *drift's* direction: a drift running across the flick therefore types a
+    /// different letter than the one the finger drew, at any drift rate, since
+    /// the cone rejects the turn from drift into flick however fast the drift
+    /// was. Taking the longer step fixes the whole band — the flick's own
+    /// following step vouches for its first sample.
+    ///
+    /// Before there is an established step at all — the first sample after
+    /// touch-down, where the whole accepted path is the origin — the following
+    /// raw step is the only evidence there is anyway: a finger that lands
     /// already moving keeps moving at a comparable rate, whereas a glitch
-    /// lands once and stops. That premise is an assumption, and a glitch that
-    /// moves consistently for two samples defeats it — see `filterOutliers`
-    /// for why nothing available here can tell that case from a real launch,
-    /// and what bounds it instead.
+    /// lands once and stops.
     ///
     /// A trailing jump has no following step, so it is judged against
     /// `previousStep` alone, and only when the accepted path is still just the
@@ -416,14 +447,37 @@ struct GesturePreprocessor {
     /// `maxJumpDistance`. A finger already travelling `maxJumpDistance`/3 per
     /// sample does carry a trailing jump in — deliberately, since the last
     /// sample of a genuine flick is itself one.
+    ///
+    /// What the longer reference costs is that the origin's ambiguity now
+    /// applies along the whole path rather than only at touch-down: two
+    /// spurious samples travelling coherently at flick speed are
+    /// byte-identical to a finger accelerating into one, and mid-path the
+    /// established step used to refuse them. That refusal was never evidence —
+    /// a rolling start *is* a slow step followed by a fast one — so the two
+    /// cases cannot be told apart here either way. The shapes this filter was
+    /// actually built against are unaffected: a ghost cluster's own step is a
+    /// few points, so it establishes no reference to ride in on, and an
+    /// out-and-back teleport is opposed to both candidate references and fails
+    /// the cone. See `filterOutliers` for what bounds the residue.
     private func continuesEstablishedMotion(
         _ step: CGVector,
         after previousStep: CGVector?,
         in points: [CGPoint],
         at i: Int
     ) -> Bool {
-        guard let reference = previousStep ?? followingRawStep(in: points, at: i) else { return false }
+        guard let reference = longerStep(previousStep, followingRawStep(in: points, at: i)) else {
+            return false
+        }
         return isSameMovement(reference, step)
+    }
+
+    /// Whichever of the two candidate references is longer, or the only one
+    /// that exists. Nil when neither does — a trailing sample on a path whose
+    /// accepted part is still just the origin.
+    private func longerStep(_ first: CGVector?, _ second: CGVector?) -> CGVector? {
+        guard let first else { return second }
+        guard let second else { return first }
+        return hypot(first.dx, first.dy) >= hypot(second.dx, second.dy) ? first : second
     }
 
     /// The raw step leading away from `points[i]`, or nil when it is the last
@@ -448,6 +502,20 @@ struct GesturePreprocessor {
     /// reference establishes no direction; the guard says so rather than
     /// leaning on the magnitude test, which happens to reject it too because a
     /// zero budget admits no step.
+    ///
+    /// The corroboration this asks for is the inverse of the rule it replaced,
+    /// and the trade is deliberate. The old filter wanted a raw neighbor
+    /// within `maxJumpDistance` and ignored direction; this one wants
+    /// direction and ignores neighbors, so a single sample inside the cone is
+    /// now trusted on its own evidence. That is what buys the flick rescue,
+    /// and it is paid for at the cone's edge: a fast swipe with a short prefix
+    /// carrying one trailing glitch just inside 45° commits the neighbouring
+    /// sector where the old filter kept the right one — measured at 3 of 960
+    /// swept shapes, e.g. two 45 pt steps followed by 120 pt at 40°, which
+    /// commits `swipeDownRight` instead of `swipeRight`. A tighter cone would
+    /// buy that class back and lose flick rescues in exchange, so the angle
+    /// stays where it is; this is a choice about `minimumDirectionCosine`, not
+    /// a defect to patch here.
     private func isSameMovement(_ reference: CGVector, _ step: CGVector) -> Bool {
         let referenceLength = hypot(reference.dx, reference.dy)
         let stepLength = hypot(step.dx, step.dy)

--- a/wurstfingerTests/GesturePreprocessorSweepTests.swift
+++ b/wurstfingerTests/GesturePreprocessorSweepTests.swift
@@ -182,9 +182,26 @@ struct GesturePreprocessorSweepTests {
     /// reference differs: a trailing glitch is judged against the step the
     /// accepted path established, a mid-path one against the longer of that
     /// and the raw step leading back to the path.
+    ///
+    /// Two assertions, because the classification alone is the weaker one: a
+    /// glitch can be admitted and still leave the sector intact. The sweep
+    /// therefore also requires the filter to *drop* the sample, which is the
+    /// cone's property directly.
+    ///
+    /// A mid-path glitch only reaches the cone while both its raw neighbours
+    /// are farther than `maxJumpDistance`. Closer than that, `filterOutliers`
+    /// admits it through `nearRawNext` before direction is ever consulted —
+    /// a different rule, deliberately, and one the dropped-frame families
+    /// sweep. Those shapes would pin nothing here, so they are skipped by
+    /// construction rather than silently passing; `skipped` counts them and
+    /// the expectations name the number.
     @Test func aDirectionAdversarialGlitchNeverChangesTheClassification() {
+        let maxJump = GesturePreprocessorConfig.default.maxJumpDistance
+        let preprocessor = GesturePreprocessor(config: .default)
         var mismatches: [String] = []
+        var survivors: [String] = []
         var count = 0
+        var skipped = 0
         for degrees in stride(from: CGFloat(0), to: 360, by: 45) {
             let expected = KeyGestureRecognizer.gestureType(forDegrees: degrees)
             for gait: CGFloat in [40, 50] {
@@ -195,22 +212,41 @@ struct GesturePreprocessorSweepTests {
                         let displaced = { (anchor: CGPoint) in
                             CGPoint(x: anchor.x + offset.dx * jump, y: anchor.y + offset.dy * jump)
                         }
-                        var midPath = base
-                        midPath.insert(displaced(base[2]), at: 3)
-                        let shapes = [("trailing", base + [displaced(base[4])]), ("mid-path", midPath)]
-                        for (position, points) in shapes {
+                        let midGlitch = displaced(base[2])
+                        var shapes = [("trailing", base + [displaced(base[4])], displaced(base[4]))]
+                        // Only the cone can reject this one; see the doc above.
+                        if hypot(midGlitch.x - base[3].x, midGlitch.y - base[3].y) > maxJump {
+                            var midPath = base
+                            midPath.insert(midGlitch, at: 3)
+                            shapes.append(("mid-path", midPath, midGlitch))
+                        } else {
+                            skipped += 1
+                        }
+                        for (position, points, glitch) in shapes {
                             count += 1
+                            let shape = "\(Int(degrees))° gait \(Int(gait)) \(position) "
+                                + "\(Int(jump))pt@+\(Int(turn))°"
                             let actual = classify(points)
                             if actual != expected {
-                                let shape = "\(Int(degrees))° gait \(Int(gait)) \(position)"
-                                mismatches.append("\(shape) \(Int(jump))pt@+\(Int(turn))°: \(actual) ≠ \(expected)")
+                                mismatches.append("\(shape): \(actual) ≠ \(expected)")
+                            }
+                            if preprocessor.filterOutliers(points).contains(glitch) {
+                                survivors.append(shape)
                             }
                         }
                     }
                 }
             }
         }
-        #expect(mismatches.isEmpty, "\(mismatches.count) of \(count) in-budget turns reclassified: \(mismatches.prefix(5))")
+        #expect(
+            mismatches.isEmpty,
+            "\(mismatches.count) of \(count) in-budget turns reclassified: \(mismatches.prefix(5))"
+        )
+        #expect(
+            survivors.isEmpty,
+            "\(survivors.count) of \(count) in-budget turns survived the filter: \(survivors.prefix(5))"
+        )
+        #expect(skipped == 16, "\(skipped) mid-path shapes are raw-neighbor admissible, expected 16")
     }
 
     /// A teleport sample in the middle of an ordinary swipe — interference

--- a/wurstfingerTests/GesturePreprocessorSweepTests.swift
+++ b/wurstfingerTests/GesturePreprocessorSweepTests.swift
@@ -8,6 +8,17 @@
 //  sector), and a glitch is never promoted (a teleport sample changes no
 //  classification, in whatever direction it points).
 //
+//  Both halves of the admission rule are swept, because they fail
+//  independently. The glitch families whose jumps are large sweep the
+//  magnitude ceiling: they would be rejected on length alone, so they pass
+//  under a direction test of any width — including the half-plane the 45°
+//  cone replaced. `aDirectionAdversarialGlitchNeverChangesTheClassification`
+//  is the family that needs the cone: its glitches stay inside the velocity
+//  budget and are rejected only because they turn too far, so weakening
+//  `isSameMovement` back towards a half-plane or a magnitude-only test fails
+//  it (measured: 29 and 48 of its 768 shapes reclassify) while every other
+//  family here stays green.
+//
 //  The parameters of the velocity rule were originally chosen against an
 //  ad-hoc sweep of ~600k synthetic paths that compared three compiled
 //  variants of the filter; that harness was never part of the repo, so its
@@ -156,6 +167,50 @@ struct GesturePreprocessorSweepTests {
             }
         }
         #expect(mismatches.isEmpty, "\(mismatches.count) of \(count) glitched paths reclassified: \(mismatches.prefix(5))")
+    }
+
+    /// A glitch that stays *inside* the velocity budget and is rejected only
+    /// because it turns too far — the property the direction cone exists for,
+    /// and the one no other family here sweeps.
+    ///
+    /// The base swipes travel 40 or 50 pt per sample, so the budget is 120 or
+    /// 150 pt (three times the reference step, itself capped at
+    /// `maxJumpDistance`); every glitch is 60–110 pt, i.e. beyond
+    /// `maxJumpDistance` — so it reaches the velocity rule at all — and inside
+    /// that budget. What has to reject it is the 45° cone, at turns from 50°
+    /// (just outside it) to 300°. Swept in both positions, because the
+    /// reference differs: a trailing glitch is judged against the step the
+    /// accepted path established, a mid-path one against the longer of that
+    /// and the raw step leading back to the path.
+    @Test func aDirectionAdversarialGlitchNeverChangesTheClassification() {
+        var mismatches: [String] = []
+        var count = 0
+        for degrees in stride(from: CGFloat(0), to: 360, by: 45) {
+            let expected = KeyGestureRecognizer.gestureType(forDegrees: degrees)
+            for gait: CGFloat in [40, 50] {
+                let base = straightPath(degrees: degrees, step: gait, samples: 5)
+                for jump: CGFloat in [60, 90, 110] {
+                    for turn: CGFloat in [50, 60, 75, 90, 120, 180, 240, 300] {
+                        let offset = unit(degrees + turn)
+                        let displaced = { (anchor: CGPoint) in
+                            CGPoint(x: anchor.x + offset.dx * jump, y: anchor.y + offset.dy * jump)
+                        }
+                        var midPath = base
+                        midPath.insert(displaced(base[2]), at: 3)
+                        let shapes = [("trailing", base + [displaced(base[4])]), ("mid-path", midPath)]
+                        for (position, points) in shapes {
+                            count += 1
+                            let actual = classify(points)
+                            if actual != expected {
+                                let shape = "\(Int(degrees))° gait \(Int(gait)) \(position)"
+                                mismatches.append("\(shape) \(Int(jump))pt@+\(Int(turn))°: \(actual) ≠ \(expected)")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        #expect(mismatches.isEmpty, "\(mismatches.count) of \(count) in-budget turns reclassified: \(mismatches.prefix(5))")
     }
 
     /// A teleport sample in the middle of an ordinary swipe — interference

--- a/wurstfingerTests/GesturePreprocessorTests.swift
+++ b/wurstfingerTests/GesturePreprocessorTests.swift
@@ -298,20 +298,20 @@ struct GesturePreprocessorTests {
         #expect(filtered == Array(points.prefix(4)))
     }
 
+    /// The two candidate references disagree: the 12pt step the accepted
+    /// path established refuses the 120pt jump, the 60pt step the jump
+    /// leads into carries it. The longer one wins. Preferring the
+    /// established step reads as the safer choice and is not: a slow step
+    /// is no evidence against acceleration, since a flick launching out of
+    /// a rolling start is exactly a slow step followed by a fast one, and
+    /// preferring the established step lost every one of those (review
+    /// 2026-08-29, finding 1). What still separates a glitch from a launch
+    /// is the direction cone and the magnitude ceiling, pinned by the
+    /// tests around this one.
     @Test func outlierFilterMeasuresAJumpAgainstTheLongerCandidateStep() {
         let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
         let preprocessor = GesturePreprocessor(config: config)
 
-        // The two candidate references disagree: the 12pt step the accepted
-        // path established refuses the 120pt jump, the 60pt step the jump
-        // leads into carries it. The longer one wins. Preferring the
-        // established step reads as the safer choice and is not: a slow step
-        // is no evidence against acceleration, since a flick launching out of
-        // a rolling start is exactly a slow step followed by a fast one, and
-        // preferring the established step lost every one of those (review
-        // 2026-08-29, finding 1). What still separates a glitch from a launch
-        // is the direction cone and the magnitude ceiling, pinned by the
-        // tests around this one.
         let points: [CGPoint] = [
             CGPoint(x: 0, y: 0),
             CGPoint(x: 12, y: 0),
@@ -325,16 +325,16 @@ struct GesturePreprocessorTests {
         #expect(filtered == points)
     }
 
+    /// A finger that settles on the key with a slow drift and only then
+    /// flicks. The drift establishes a 5pt step, so measuring the first
+    /// 80pt sample against it rejects the jump — and since a rejection
+    /// leaves both the anchor and the established step alone, every later
+    /// flick sample fails the same way and the classifier only ever saw
+    /// the drift. The flick's own following step is what vouches for it.
     @Test func outlierFilterKeepsAFlickThatLaunchesOutOfARollingStart() {
         let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
         let preprocessor = GesturePreprocessor(config: config)
 
-        // A finger that settles on the key with a slow drift and only then
-        // flicks. The drift establishes a 5pt step, so measuring the first
-        // 80pt sample against it rejects the jump — and since a rejection
-        // leaves both the anchor and the established step alone, every later
-        // flick sample fails the same way and the classifier only ever saw
-        // the drift. The flick's own following step is what vouches for it.
         let points: [CGPoint] = [
             CGPoint(x: 0, y: 0),
             CGPoint(x: 5, y: 0), // drift…
@@ -349,17 +349,17 @@ struct GesturePreprocessorTests {
         #expect(filtered == points)
     }
 
+    /// The out-and-back shape with the excursion in the middle of the path
+    /// rather than on the first sample. This is the position where taking
+    /// the longer candidate step changes the reference: the 138pt step
+    /// leading back to the finger outweighs the 12pt gait, so magnitude
+    /// alone would admit the teleport. It is opposed to that reference, so
+    /// the direction cone rejects it — the criterion the mid-path case
+    /// rests on entirely.
     @Test func outlierFilterRejectsAMidPathTeleportThatReturnsToThePath() {
         let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
         let preprocessor = GesturePreprocessor(config: config)
 
-        // The out-and-back shape with the excursion in the middle of the path
-        // rather than on the first sample. This is the position where taking
-        // the longer candidate step changes the reference: the 138pt step
-        // leading back to the finger outweighs the 12pt gait, so magnitude
-        // alone would admit the teleport. It is opposed to that reference, so
-        // the direction cone rejects it — the criterion the mid-path case
-        // rests on entirely.
         let points: [CGPoint] = [
             CGPoint(x: 0, y: 0),
             CGPoint(x: 12, y: 0),
@@ -374,17 +374,17 @@ struct GesturePreprocessorTests {
         #expect(filtered == [points[0], points[1], points[2], points[4], points[5]])
     }
 
+    /// Two ghost samples far off the path, each far enough from its
+    /// neighbors that raw-neighbor support cannot admit them, and moving
+    /// fast enough that magnitude alone would. They do not travel
+    /// together: the 100pt step between them is perpendicular to the 200pt
+    /// jump onto the first, so the reference the first would ride in on
+    /// does not point its way, and the second is past the ceiling by the
+    /// time the first is refused.
     @Test func outlierFilterRejectsAGhostBurstThatTurnsBetweenItsSamples() {
         let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
         let preprocessor = GesturePreprocessor(config: config)
 
-        // Two ghost samples far off the path, each far enough from its
-        // neighbors that raw-neighbor support cannot admit them, and moving
-        // fast enough that magnitude alone would. They do not travel
-        // together: the 100pt step between them is perpendicular to the 200pt
-        // jump onto the first, so the reference the first would ride in on
-        // does not point its way, and the second is past the ceiling by the
-        // time the first is refused.
         let points: [CGPoint] = [
             CGPoint(x: 0, y: 0),
             CGPoint(x: 12, y: 0),
@@ -409,6 +409,8 @@ struct GesturePreprocessorTests {
     /// where the drift is itself long enough to classify.
     private static let rollingStartDriftRates: [CGFloat] = [1, 2, 3, 5, 8, 12, 20, 26]
 
+    /// That shape for one drift direction and rate: three drift samples,
+    /// then three 80 pt flick samples leaving the last of them.
     private func rollingStartPath(driftDegrees: CGFloat, driftRate: CGFloat) -> [CGPoint] {
         let drift = CGVector(dx: cos(driftDegrees * .pi / 180), dy: sin(driftDegrees * .pi / 180))
         var points: [CGPoint] = [.zero]
@@ -426,10 +428,19 @@ struct GesturePreprocessorTests {
         return points
     }
 
+    /// The gesture the recognizer commits for a raw path, production config.
     private func classify(_ points: [CGPoint]) -> GestureType {
         KeyGestureRecognizer.classify(positions: points, config: .default, thresholds: .default).gesture
     }
 
+    /// A flick launching out of a drift that runs *along* it commits the
+    /// flick's direction at every drift rate the sweep covers.
+    ///
+    /// Taken alone this direction looks healthy whether the flick survives or
+    /// not: a lost flick below 5 pt per sample leaves a drift shorter than
+    /// `minSwipeLength`, so the key commits its center letter, and from 8 pt
+    /// the drift itself classifies — as a swipe that happens to point the
+    /// right way. The across-drift case is what tells the two apart.
     @Test func aFlickOutOfADriftAlongItCommitsTheFlickDirection() {
         var mismatches: [String] = []
         for rate in Self.rollingStartDriftRates {
@@ -437,14 +448,16 @@ struct GesturePreprocessorTests {
             if actual != .swipeRight { mismatches.append("drift \(rate)pt: \(actual)") }
         }
 
-        // Before the fix every rate here lost the flick: up to 5pt per sample
-        // the drift was shorter than minSwipeLength and the key committed its
-        // center letter, from 8pt the drift itself classified — as a swipe
-        // that happens to point the right way, which is why this direction
-        // alone would look healthy.
         #expect(mismatches.isEmpty, "flick lost at: \(mismatches)")
     }
 
+    /// A flick launching out of a drift that runs *across* it commits the
+    /// flick's direction, not the drift's.
+    ///
+    /// This is the case that types a *different* letter rather than the
+    /// center one: a drift that survives at 8 pt per sample or more
+    /// classifies as `swipeDown`, and no drift rate is fast enough to carry
+    /// the turn into the flick through the 45° cone.
     @Test func aFlickOutOfADriftAcrossItCommitsTheFlickDirection() {
         var mismatches: [String] = []
         for rate in Self.rollingStartDriftRates {
@@ -452,11 +465,6 @@ struct GesturePreprocessorTests {
             if actual != .swipeRight { mismatches.append("drift \(rate)pt: \(actual)") }
         }
 
-        // The case that types a *different* letter rather than the center
-        // one: with the drift running across the flick, the surviving drift
-        // classified as swipeDown from 8pt per sample upwards, at any rate —
-        // no drift is ever fast enough to carry the turn into the flick
-        // through the 45° cone.
         #expect(mismatches.isEmpty, "flick lost at: \(mismatches)")
     }
 

--- a/wurstfingerTests/GesturePreprocessorTests.swift
+++ b/wurstfingerTests/GesturePreprocessorTests.swift
@@ -298,26 +298,166 @@ struct GesturePreprocessorTests {
         #expect(filtered == Array(points.prefix(4)))
     }
 
-    @Test func outlierFilterPrefersTheEstablishedStepOverTheFollowingRawStep() {
+    @Test func outlierFilterMeasuresAJumpAgainstTheLongerCandidateStep() {
         let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
         let preprocessor = GesturePreprocessor(config: config)
 
-        // The glitch is followed by more fast motion rather than a dwell, so
-        // the two candidate references disagree: the 12pt step the accepted
-        // path established refuses the 120pt jump, the 60pt step that follows
-        // it would wave it through. The established one has to win — the step
-        // after a glitch is part of the same unverified excursion.
+        // The two candidate references disagree: the 12pt step the accepted
+        // path established refuses the 120pt jump, the 60pt step the jump
+        // leads into carries it. The longer one wins. Preferring the
+        // established step reads as the safer choice and is not: a slow step
+        // is no evidence against acceleration, since a flick launching out of
+        // a rolling start is exactly a slow step followed by a fast one, and
+        // preferring the established step lost every one of those (review
+        // 2026-08-29, finding 1). What still separates a glitch from a launch
+        // is the direction cone and the magnitude ceiling, pinned by the
+        // tests around this one.
         let points: [CGPoint] = [
             CGPoint(x: 0, y: 0),
             CGPoint(x: 12, y: 0),
             CGPoint(x: 24, y: 0),
-            CGPoint(x: 144, y: 0), // glitch: 120pt in one sample
-            CGPoint(x: 204, y: 0)
+            CGPoint(x: 144, y: 0), // 120pt in one sample…
+            CGPoint(x: 204, y: 0) // …and the finger keeps going at 60pt
         ]
 
         let filtered = preprocessor.filterOutliers(points)
 
-        #expect(filtered == Array(points.prefix(3)))
+        #expect(filtered == points)
+    }
+
+    @Test func outlierFilterKeepsAFlickThatLaunchesOutOfARollingStart() {
+        let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // A finger that settles on the key with a slow drift and only then
+        // flicks. The drift establishes a 5pt step, so measuring the first
+        // 80pt sample against it rejects the jump — and since a rejection
+        // leaves both the anchor and the established step alone, every later
+        // flick sample fails the same way and the classifier only ever saw
+        // the drift. The flick's own following step is what vouches for it.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 5, y: 0), // drift…
+            CGPoint(x: 10, y: 0),
+            CGPoint(x: 90, y: 0), // …then the flick launches
+            CGPoint(x: 170, y: 0),
+            CGPoint(x: 250, y: 0)
+        ]
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(filtered == points)
+    }
+
+    @Test func outlierFilterRejectsAMidPathTeleportThatReturnsToThePath() {
+        let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // The out-and-back shape with the excursion in the middle of the path
+        // rather than on the first sample. This is the position where taking
+        // the longer candidate step changes the reference: the 138pt step
+        // leading back to the finger outweighs the 12pt gait, so magnitude
+        // alone would admit the teleport. It is opposed to that reference, so
+        // the direction cone rejects it — the criterion the mid-path case
+        // rests on entirely.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 12, y: 0),
+            CGPoint(x: 24, y: 0),
+            CGPoint(x: 174, y: 0), // out…
+            CGPoint(x: 36, y: 0), // …and back to where the finger was
+            CGPoint(x: 48, y: 0)
+        ]
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(filtered == [points[0], points[1], points[2], points[4], points[5]])
+    }
+
+    @Test func outlierFilterRejectsAGhostBurstThatTurnsBetweenItsSamples() {
+        let config = GesturePreprocessorConfig.default // maxJumpDistance = 50
+        let preprocessor = GesturePreprocessor(config: config)
+
+        // Two ghost samples far off the path, each far enough from its
+        // neighbors that raw-neighbor support cannot admit them, and moving
+        // fast enough that magnitude alone would. They do not travel
+        // together: the 100pt step between them is perpendicular to the 200pt
+        // jump onto the first, so the reference the first would ride in on
+        // does not point its way, and the second is past the ceiling by the
+        // time the first is refused.
+        let points: [CGPoint] = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: 12, y: 0),
+            CGPoint(x: 24, y: 0),
+            CGPoint(x: 24, y: 200), // ghost…
+            CGPoint(x: 124, y: 200), // …turning 90° between its two samples
+            CGPoint(x: 36, y: 0), // real motion resumes
+            CGPoint(x: 48, y: 0)
+        ]
+
+        let filtered = preprocessor.filterOutliers(points)
+
+        #expect(filtered == [points[0], points[1], points[2], points[5], points[6]])
+    }
+
+    // MARK: - Rolling-Start Classification Tests
+
+    /// Three drift samples followed by three 80pt flick samples, the shape
+    /// review 2026-08-29 finding 1 measured. Both bands it names are covered:
+    /// 1–5 pt per sample, where the drift stays under `minSwipeLength` and the
+    /// lost flick committed the key's center letter, and 8–26 pt per sample,
+    /// where the drift is itself long enough to classify.
+    private static let rollingStartDriftRates: [CGFloat] = [1, 2, 3, 5, 8, 12, 20, 26]
+
+    private func rollingStartPath(driftDegrees: CGFloat, driftRate: CGFloat) -> [CGPoint] {
+        let drift = CGVector(dx: cos(driftDegrees * .pi / 180), dy: sin(driftDegrees * .pi / 180))
+        var points: [CGPoint] = [.zero]
+        for sample in 1 ... 3 {
+            points.append(CGPoint(
+                x: drift.dx * driftRate * CGFloat(sample),
+                y: drift.dy * driftRate * CGFloat(sample)
+            ))
+        }
+        // Safe: the loop above appended three points.
+        let launch = points[points.count - 1]
+        for sample in 1 ... 3 {
+            points.append(CGPoint(x: launch.x + 80 * CGFloat(sample), y: launch.y))
+        }
+        return points
+    }
+
+    private func classify(_ points: [CGPoint]) -> GestureType {
+        KeyGestureRecognizer.classify(positions: points, config: .default, thresholds: .default).gesture
+    }
+
+    @Test func aFlickOutOfADriftAlongItCommitsTheFlickDirection() {
+        var mismatches: [String] = []
+        for rate in Self.rollingStartDriftRates {
+            let actual = classify(rollingStartPath(driftDegrees: 0, driftRate: rate))
+            if actual != .swipeRight { mismatches.append("drift \(rate)pt: \(actual)") }
+        }
+
+        // Before the fix every rate here lost the flick: up to 5pt per sample
+        // the drift was shorter than minSwipeLength and the key committed its
+        // center letter, from 8pt the drift itself classified — as a swipe
+        // that happens to point the right way, which is why this direction
+        // alone would look healthy.
+        #expect(mismatches.isEmpty, "flick lost at: \(mismatches)")
+    }
+
+    @Test func aFlickOutOfADriftAcrossItCommitsTheFlickDirection() {
+        var mismatches: [String] = []
+        for rate in Self.rollingStartDriftRates {
+            let actual = classify(rollingStartPath(driftDegrees: 90, driftRate: rate))
+            if actual != .swipeRight { mismatches.append("drift \(rate)pt: \(actual)") }
+        }
+
+        // The case that types a *different* letter rather than the center
+        // one: with the drift running across the flick, the surviving drift
+        // classified as swipeDown from 8pt per sample upwards, at any rate —
+        // no drift is ever fast enough to carry the turn into the flick
+        // through the 45° cone.
+        #expect(mismatches.isEmpty, "flick lost at: \(mismatches)")
     }
 
     @Test func outlierFilterKeepsSustainedFarRun() {


### PR DESCRIPTION
Fixes findings 1, 4, 5 and 6 of `docs/code-review-develop-2026-08-29.md` — the residual holes in the #295 flick fix and the test/comment precision items around it. One behavior change (finding 1), one new sweep family (finding 4), two doc-comment corrections (findings 5 and 6).

## Finding 1 (P3) — flicks that launch out of a rolling start

**What it was.** `continuesEstablishedMotion` used `previousStep ?? followingRawStep(...)`, so the step the accepted path had established won unconditionally. A finger that settles on the key with a slow drift and only then flicks establishes a step of a few points; the first fast sample is more than three times it, and because a rejection leaves both the anchor and the established step untouched, every later flick sample fails the same way. The classifier only ever sees the drift.

Measured over three drift samples followed by three 80 pt flick samples at the default config (`jitterThreshold` 3, `maxJumpDistance` 50, `minSwipeLength` 20):

| drift (pt/sample) | drift along the flick | drift across the flick (90°) |
| --- | --- | --- |
| ≤0.9 | rescued (the jitter filter collapses the drift) | rescued |
| 1–5 | `tap` — the key's centre letter | `tap` |
| 8–26 | `swipeRight`, but from the drift, not the flick | **`swipeDown` — a different letter** |
| ≥26.7 | fully accepted | `swipeDown` at any rate |

**What changed.** The reference is now the longer of the established step and the raw step the jump leads into (`longerStep(_:_:)`), so a flick's own following step vouches for its first sample. Every row of that table becomes `swipeRight`.

**How it is pinned.**

- `aFlickOutOfADriftAlongItCommitsTheFlickDirection` / `aFlickOutOfADriftAcrossItCommitsTheFlickDirection` — classification level, over both measured bands (1, 2, 3, 5 and 8, 12, 20, 26 pt/sample) with a ~80 pt flick.
- `outlierFilterKeepsAFlickThatLaunchesOutOfARollingStart` — filter level.
- `outlierFilterMeasuresAJumpAgainstTheLongerCandidateStep` — replaces `outlierFilterPrefersTheEstablishedStepOverTheFollowingRawStep`, which pinned exactly the rule this change reverses (see *Reality vs. the review* below).
- Regression pins for the two shapes the longer reference could have opened: `outlierFilterRejectsAMidPathTeleportThatReturnsToThePath` (the mid-path out-and-back was unpinned — only the origin variant had a test) and `outlierFilterRejectsAGhostBurstThatTurnsBetweenItsSamples`.

**Adversarial check (measured, not argued).** `GesturePreprocessor` and the classifier were compiled standalone (the harness the review describes) so the current filter, the pre-#295 filter and the candidate could be run side by side over the same paths:

| family | shapes | current | with the fix |
| --- | ---: | ---: | ---: |
| straight flicks above the jump threshold | 672 | 0 bad | 0 bad |
| ordinary swipes | 144 | 0 | 0 |
| trailing glitches | 576 | 0 | 0 |
| mid-path teleports | 48 | 0 | 0 |
| out-and-back teleports (8 angles × 6 gaits × 3 lengths × 4 positions × 4 distances × 8 turns) | 18 432 | 15 bad | **8 bad** |
| direction-adversarial glitches (new sweep family) | 768 | 0 | 0 |

No regression in any of those, and out-and-back teleports get better. Two-sample ghost bursts split in two:

- a burst that lands and stops, or whose two samples are mutually close (the shape `outlierFilterRemovesClusteredGlitchPair` pins): unchanged, still rejected — its own step is a few points, so it establishes no reference to ride in on.
- a burst whose two samples themselves travel ≥60 pt apart and coherently: **now admitted mid-path where the current filter refused it** (612–756 of 1728 shapes per insert position). This is the documented origin ambiguity relocated: the current filter already gets 1000 of the same 1728 shapes wrong when the burst lands on the first sample after touch-down, where it has no established step to prefer. It is shipped rather than treated as a blocker because the established step was never evidence against the burst either — a rolling start *is* a slow step followed by a fast one, so the two cases are not separable at this point in the pipeline — and because no known iOS touch artefact produces two coherent flick-speed samples (single-frame coordinate spikes and stuck/duplicated touches both stay rejected). The trade is stated in the `filterOutliers` and `continuesEstablishedMotion` doc blocks rather than left to be rediscovered.

## Finding 4 (P4) — the sweep did not sweep the direction cone

Every injected glitch in the existing families exceeds its velocity budget by construction (smallest glitch 55 pt against budgets of 24/42/36 pt), so magnitude alone rejects them and all four families pass under the half-plane rule #295 replaced. The cone was pinned only by two named tests.

Added `aDirectionAdversarialGlitchNeverChangesTheClassification`: 768 shapes whose glitches are 60–110 pt — beyond `maxJumpDistance`, so they reach the velocity rule, and inside the 120/150 pt budget of the 40/50 pt gaits — turning 50° to 300° off the established direction, swept both trailing and mid-path (the reference differs between the two). Verified to actually bite: 29 of its 768 shapes reclassify under a half-plane rule, 48 under a magnitude-only test, while all four existing families stay green under both. Runtime 0.63 s, in line with the other families. The file header now explains which family sweeps which half of the admission rule.

## Finding 5 (P4) — "one swipe sector (45°)" is exact only on square keys

The cone runs pre-normalization on raw screen vectors; the classifier's 45° sectors are post-normalization. The `minimumDirectionCosine` comment now states the raw angle and what it becomes normalized: 46.7° at the 1.06:1 keys the extension renders, 52.4° at 1.3:1, 63.4° at 2:1, and records that moving the test post-normalization would be a behavior change rather than a comment fix. No code change.

## Finding 6 (P4) — the cone-angle trade is now named

`isSameMovement`'s doc block records that the corroboration direction inverted (old: any raw neighbour within `maxJumpDistance`, direction ignored; new: direction required, neighbours ignored), that a lone in-cone sample is therefore trusted on its own, and the one measured class that classifies worse than at `0a2cbb5` — a fast swipe with a short prefix carrying a trailing glitch just inside the cone, 3 of 960 swept shapes, e.g. `2×45 pt + 120 pt @40°` committing `swipeDownRight` where the old filter kept `swipeRight`. Stated as a deliberate choice about the cone angle. The angle is unchanged.

## CHANGELOG

The 1.4.1 flick sentence overstated what was fixed (it rescues a flick from a standing finger, not from a rolling start). 1.4.1 is shipped, so its notes are untouched; a new `## Unreleased` entry describes the rolling-start fix instead, including the across-drift case where a neighbouring letter was typed rather than nothing.

## Reality vs. the review

The review states that with this fix direction "all four pinned unit-test shapes still pass". One existing test does not: `outlierFilterPrefersTheEstablishedStepOverTheFollowingRawStep` pins the rule this change reverses (12 pt gait, 120 pt jump, 60 pt continuation — rejected under the old rule, accepted under the new one). It is rewritten as `outlierFilterMeasuresAJumpAgainstTheLongerCandidateStep` with the reasoning inverted; the shape and the numbers are kept so the diff shows exactly what flipped. Every other filter test in the suite passes unchanged.

The review's finding-1 table reproduced exactly on the standalone harness, including the `flickStep / 3` top edge and the across-drift row.

## Deliberately not done

- The cone angle is unchanged, so finding 6's 3-of-960 class is documented, not fixed.
- The direction test stays pre-normalization (finding 5 explicitly scopes this to the comment).
- The structural half of the 2026-08-09 finding 3 (trail draws the raw stream, the classifier reads the filtered one) is untouched.
- The review document itself is not modified.
- The CHANGELOG entry carries no PR number yet — add `(#NNN)` at the end of the line once this PR has one, to match the file's convention.

## Test result

`xcodebuild test -scheme Wurstfinger -only-testing:WurstfingerTests -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — **1458 test cases, 0 failed** (1452 on `origin/develop` plus the 6 added here). SwiftFormat, SwiftLint and markdownlint clean; the pre-commit hooks reformatted nothing.

---

https://claude.ai/code/session_01FZsR6M9vvyUkUHADuVJDnX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Flicks launched from a rolling start are now classified in the flick’s direction instead of the preceding drift.
  * Gesture filtering better recognizes continued motion and handles abrupt direction changes without misclassification.
  * Improved detection of valid fast movements following slower gestures.

* **Tests**
  * Added coverage for rolling-start flicks, mid-path reversals, direction changes, and adversarial gesture glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->